### PR TITLE
Workaround for issue #378 handling pwd -W on root folder inconsistency.

### DIFF
--- a/mingw-w64-pkg-config/0005-mangle.mingw.patch
+++ b/mingw-w64-pkg-config/0005-mangle.mingw.patch
@@ -12,28 +12,28 @@ diff --git a/check/check-sysroot b/check/check-sysroot
 index 0820206..d03d1c7 100755
 --- a/check/check-sysroot
 +++ b/check/check-sysroot
-@@ -6,6 +6,11 @@ set -e
- 
+@@ -6,6 +6,12 @@ set -e
+
  export PKG_CONFIG_SYSROOT_DIR=/sysroot
- 
+
 +# MSYS mangles / paths to its own root in windows format. This probably
 +# means sysroot doesn't work there, but match what pkg-config passes
 +# back anyway.
 +[ "x$OSTYPE" = "xmsys" ] && root=$(cd / && pwd -W) || root=
++root=${root%/}
 +
  RESULT=""
  run_test --cflags simple
- 
+
 @@ -20,8 +25,8 @@ if [ "$list_indirect_deps" = yes ]; then
  fi
  run_test --libs --static simple
- 
+
 -RESULT="-I/sysroot/public-dep/include"
 +RESULT="-I$root/sysroot/public-dep/include"
  run_test --cflags public-dep
- 
+
 -RESULT="-L/sysroot/public-dep/lib -lpublic-dep"
 +RESULT="-L$root/sysroot/public-dep/lib -lpublic-dep"
  run_test --libs public-dep
 -- 1.8.1.4
-

--- a/mingw-w64-pkg-config/PKGBUILD
+++ b/mingw-w64-pkg-config/PKGBUILD
@@ -24,15 +24,15 @@ source=(http://pkgconfig.freedesktop.org/releases/${_realname}-${pkgver}.tar.gz
         0011-platform-dependent-separator-and-adjustable-prefix.mingw.patch
         0099-no-prefix-on.mingw.patch)
 md5sums=('aa3c86e67551adc3ac865160e34a2a0d'
-         'd4cf66f456cc80466c553ccd96c0c0a1'
-         '986d72727b4899a18106bd581f2cce34'
-         '0620261f077b3c0dc1622ff3a6e3b87d'
-         'f2332f2111ea6fc6c096249ccad297b1'
-         '8c3fafdb507b0f01bfb2f13dd7747752'
-         '58b709c3d9bc6285b9496ee449084b02'
-         '079c1a68d297a8062fe620c302b9781f'
-         '432aaf4ccaf70b093bc90cabd8c995e0'
-         '43deff1cc78f45f7e3d6b9fee96de0e3'
+         '073729fca79eb7415a88eec68504dc92'
+         'a14107b8eb8640aac2e59798467128a3'
+         'a605f371133ea78af740109a2b690a69'
+         '0824f3b39004b24168b98280160e4045'
+         '27602f99a978c28f963afe9313fd1604'
+         'e1b804a1b0a15e9af895f6fd92907f23'
+         '2ba25b1a52a48afa0d2e1b0e06aaa07c'
+         '377256964716a68e8fe170e8df157641'
+         'cb65caa60584d471aa6f76b181790ee1'
          'd6b6acdb90f93c35378f53e34e7cd6fa'
          'd61554e8456fa9f67fbf90c8219dd2bf')
 


### PR DESCRIPTION
This is a workaround for the inconsistency with pwd -W in patch 0005-mangle.mingw.patch, for the package "pkg-config". By removing the trailing slash generated when setting root=$(cd / pwd -W) the check succeeds and the build is able to complete.