### PR TITLE
Fix Allegro 5 License is ZLIB

### DIFF
--- a/mingw-w64-allegro/PKGBUILD
+++ b/mingw-w64-allegro/PKGBUILD
@@ -7,7 +7,7 @@ pkgrel=2
 pkgdesc="Portable library mainly aimed at video game and multimedia programming (mingw-w64)"
 arch=(any)
 url="http://alleg.sourceforge.net"
-license=("custom")
+license=("ZLIB")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
       "${MINGW_PACKAGE_PREFIX}-cmake"
       "${MINGW_PACKAGE_PREFIX}-freetype"


### PR DESCRIPTION
Allegro 5 is licensed under ZLIB
http://alleg.sourceforge.net/license.html
https://en.wikipedia.org/wiki/Zlib_License#Text

https://wiki.archlinux.org/index.php/PKGBUILD#license