### PR TITLE
Fix configuration directory in dmake

### DIFF
--- a/mingw-w64-dmake/003-fix-config-location.patch
+++ b/mingw-w64-dmake/003-fix-config-location.patch
@@ -1,0 +1,47 @@
+diff -aur 002/startup/Makefile.in 003/startup/Makefile.in
+--- 002/startup/Makefile.in	2012-02-07 12:36:47.000000000 -0200
++++ 003/startup/Makefile.in	2015-01-10 17:51:06.418945300 -0200
+@@ -163,7 +163,7 @@
+ sharedstatedir = @sharedstatedir@
+ sysconfdir = @sysconfdir@
+ target_alias = @target_alias@
+-startupdir = $(datadir)/startup
++startupdir = $(datadir)
+ startup_DATA = startup.mk config.mk
+ DIST_SUBDIRS = unix winnt
+ SUBDIRS = @OS_TYPE@ 
+diff -aur 002/startup/winnt/Makefile.in 003/startup/winnt/Makefile.in
+--- 002/startup/winnt/Makefile.in	2012-02-07 12:36:46.000000000 -0200
++++ 003/startup/winnt/Makefile.in	2015-01-10 18:12:18.143554600 -0200
+@@ -162,7 +162,7 @@
+ sharedstatedir = @sharedstatedir@
+ sysconfdir = @sysconfdir@
+ target_alias = @target_alias@
+-startupdir = $(datadir)/startup/winnt
++startupdir = $(datadir)/winnt
+ startup_DATA = macros.mk recipes.mk
+ DIST_SUBDIRS = mingw msvc6
+ SUBDIRS = @OS_VERSION@
+diff -aur 002/startup/winnt/mingw/Makefile.in 003/startup/winnt/mingw/Makefile.in
+--- 002/startup/winnt/mingw/Makefile.in	2012-02-07 12:36:46.000000000 -0200
++++ 003/startup/winnt/mingw/Makefile.in	2015-01-10 18:12:24.551757800 -0200
+@@ -154,7 +154,7 @@
+ sharedstatedir = @sharedstatedir@
+ sysconfdir = @sysconfdir@
+ target_alias = @target_alias@
+-startupdir = $(datadir)/startup/winnt/mingw
++startupdir = $(datadir)/winnt/mingw
+ startup_DATA = macros.mk 
+ all: all-am
+ 
+diff -aur 002/winnt/startup.h 003/winnt/startup.h
+--- 002/winnt/startup.h	2012-02-07 12:36:53.000000000 -0200
++++ 003/winnt/startup.h	2015-01-10 18:01:16.400390600 -0200
+@@ -24,6 +24,6 @@
+ --      Use cvs log to obtain detailed change logs.
+ */
+ 
+-"DMAKEROOT *= $(ABSMAKECMD:d)startup",
++"DMAKEROOT *= $(ABSMAKECMD:d)..\\etc\\dmake",
+ "MAKESTARTUP := $(DMAKEROOT)\\startup.mk",
+ 

--- a/mingw-w64-dmake/PKGBUILD
+++ b/mingw-w64-dmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=dmake
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.12.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Dmake is a make utility similar to GNU make or the Workshop dmake (mingw-w64)"
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
@@ -14,24 +14,27 @@ license=('GPL')
 url="https://code.google.com/a/apache-extras.org/p/dmake/"
 source=("http://dmake.apache-extras.org.codespot.com/files/dmake-${pkgver}.tar.bz2"
         '001-detect-mingw.patch'
-        '002-disable-shell-environment-variable.patch')
+        '002-disable-shell-environment-variable.patch'
+        '003-fix-config-location.patch')
 md5sums=('9194f727c31d1db18bf5dd02e7b2dd09'
          'a39a65958762b2877c994428978d0c3d'
-         '08c08cf2432bd7ffdce6759d4f6974d4')
+         '08c08cf2432bd7ffdce6759d4f6974d4'
+         'a1f153d6c8199c11344027a18a4baa26')
 
 prepare() {
   cd ${srcdir}/dmake-${pkgver}
   patch -p1 -i ${srcdir}/001-detect-mingw.patch
   patch -p1 -i ${srcdir}/002-disable-shell-environment-variable.patch
+  patch -p1 -i ${srcdir}/003-fix-config-location.patch
 }
 
 build() {
-  unset SHELL
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
-  MSYSTEM=MINGW ../dmake-${pkgver}/configure \
+  ../dmake-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
+    --datarootdir=${MINGW_PREFIX}/etc/dmake \
     --build=${MINGW_CHOST}
 
   make
@@ -40,5 +43,4 @@ build() {
 package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
-  mv "${pkgdir}${MINGW_PREFIX}/share/startup" "${pkgdir}${MINGW_PREFIX}/bin"
 }


### PR DESCRIPTION
Configuration is now loaded from `/mingw*/etc/dmake` instead of `/mingw*/bin/startup`. Some testing:

    $ mv /mingw32/etc/dmake .
    $ dmake
    dmake.exe:  Error: -- Configuration file `C:\MSYS2\mingw32\bin\..\etc\dmake\startup.mk' not found

    $ mv dmake /mingw32/etc
    $ dmake
    sample makefile executed

