### PR TITLE
New package: osmgpsmap-git

### DIFF
--- a/mingw-w64-osmgpsmap-git/PKGBUILD
+++ b/mingw-w64-osmgpsmap-git/PKGBUILD
@@ -1,0 +1,46 @@
+# Contributor: Josip <bpisoj@gmail.com>
+
+_realname=osm-gps-map
+pkgname="${MINGW_PACKAGE_PREFIX}-osmgpsmap-git"
+provides=("${MINGW_PACKAGE_PREFIX}-osmgpsmap")
+conflicts=("${MINGW_PACKAGE_PREFIX}-osmgpsmap")
+pkgver=r439.834bed2
+pkgrel=1
+pkgdesc="A Gtk+ Widget for Displaying OpenStreetMap tiles"
+url="http://nzjrs.github.io/osm-gps-map/"
+arch=('any')
+license=('GPLv2+')
+depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
+                "${MINGW_PACKAGE_PREFIX}-libsoup"
+                "${MINGW_PACKAGE_PREFIX}-python2"
+                "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gnome-common"
+                        "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+                        "git")
+options=('staticlibs' 'strip' '!debug')
+source=("git://github.com/nzjrs/osm-gps-map")
+md5sums=("SKIP")
+
+pkgver() {
+  cd $_realname
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  export CC=gcc
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  "${srcdir}"/${_realname}/autogen.sh \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-gtk-doc=no \
+    --enable-shared=yes \
+    --enable-static=yes
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="$pkgdir" install
+}


### PR DESCRIPTION
osm-gps-map is a Gtk+ widget for displaying OpenStreetMap tiles