### PR TITLE
perl and dmake: Fix issues with mkstemp

### DIFF
--- a/mingw-w64-dmake/004-disable-mkstemp-detection.patch
+++ b/mingw-w64-dmake/004-disable-mkstemp-detection.patch
@@ -1,0 +1,12 @@
+diff -aur 003/configure 004/configure
+--- 003/configure	2015-01-13 17:50:23.916015600 -0200
++++ 004/configure	2015-01-13 17:55:46.017578100 -0200
+@@ -5397,7 +5397,7 @@
+ done
+ 
+ 
+-for ac_func in getcwd getwd strerror setvbuf tzset settz mkstemp tempnam gettimeofday setenv
++for ac_func in getcwd getwd strerror setvbuf tzset settz tempnam gettimeofday setenv
+ do :
+   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/mingw-w64-dmake/PKGBUILD
+++ b/mingw-w64-dmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=dmake
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.12.2
-pkgrel=4
+pkgrel=5
 pkgdesc="Dmake is a make utility similar to GNU make or the Workshop dmake (mingw-w64)"
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
@@ -15,17 +15,20 @@ url="https://code.google.com/a/apache-extras.org/p/dmake/"
 source=("http://dmake.apache-extras.org.codespot.com/files/dmake-${pkgver}.tar.bz2"
         '001-detect-mingw.patch'
         '002-disable-shell-environment-variable.patch'
-        '003-fix-config-location.patch')
+        '003-fix-config-location.patch'
+        '004-disable-mkstemp-detection.patch')
 md5sums=('9194f727c31d1db18bf5dd02e7b2dd09'
          'a39a65958762b2877c994428978d0c3d'
          '08c08cf2432bd7ffdce6759d4f6974d4'
-         'a1f153d6c8199c11344027a18a4baa26')
+         'a1f153d6c8199c11344027a18a4baa26'
+         '36a84a7e83bc5b56de691e1da50c6f5f')
 
 prepare() {
   cd ${srcdir}/dmake-${pkgver}
   patch -p1 -i ${srcdir}/001-detect-mingw.patch
   patch -p1 -i ${srcdir}/002-disable-shell-environment-variable.patch
   patch -p1 -i ${srcdir}/003-fix-config-location.patch
+  patch -p1 -i ${srcdir}/004-disable-mkstemp-detection.patch
 }
 
 build() {

--- a/mingw-w64-perl/005-disable-custom-mkstemp.patch
+++ b/mingw-w64-perl/005-disable-custom-mkstemp.patch
@@ -1,0 +1,58 @@
+Author: Alexey Pavlov <Alexpux@gmail.com>
+diff -aur 004/win32/config.gc 005/win32/config.gc
+--- 004/win32/config.gc
++++ 005/win32/config.gc
+@@ -310,7 +310,7 @@
+ d_mkdir='define'
+ d_mkdtemp='undef'
+ d_mkfifo='undef'
+-d_mkstemp='undef'
++d_mkstemp='define'
+ d_mkstemps='undef'
+ d_mktime64='undef'
+ d_mktime='define'
+diff -aur 004/win32/config_H.gc 005/win32/config_H.gc
+--- 004/win32/config_H.gc
++++ 005/win32/config_H.gc
+@@ -1973,7 +1973,7 @@
+  *	available to exclusively create and open a uniquely named
+  *	temporary file.
+  */
+-/*#define HAS_MKSTEMP		/ **/
++#define HAS_MKSTEMP		/**/
+ 
+ /* HAS_MMAP:
+  *	This symbol, if defined, indicates that the mmap system call is
+diff -aur 004/win32/win32.c 005/win32/win32.c
+--- 004/win32/win32.c
++++ 005/win32/win32.c
+@@ -1142,6 +1142,7 @@
+  * XXX this needs strengthening  (for PerlIO)
+  *   -- BKS, 11-11-200
+ */
++#if !defined(HAS_MKSTEMP)
+ int mkstemp(const char *path)
+ {
+     dTHX;
+@@ -1162,6 +1163,7 @@
+ 	goto retry;
+     return fd;
+ }
++#endif
+ 
+ static long
+ find_pid(pTHX_ int pid)
+diff -aur 004/win32/win32.h 005/win32/win32.h
+--- 004/win32/win32.h
++++ 005/win32/win32.h
+@@ -331,8 +331,10 @@
+ #endif
+ extern	char *	getlogin(void);
+ extern	int	chown(const char *p, uid_t o, gid_t g);
++#if !defined(HAS_MKSTEMP)
+ extern  int	mkstemp(const char *path);
+ #endif
++#endif
+ 
+ #undef	 Stat
+ #define  Stat		win32_stat

--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -21,13 +21,15 @@ source=("http://www.cpan.org/src/5.0/perl-${pkgver}.tar.bz2"
         001-fhs-directory-structure.patch
         002-relocate-html-documentation.patch
         003-replace-batch-scripts-with-bare-perl.patch
-        004-fix-cpan-external-programs.patch)
+        004-fix-cpan-external-programs.patch
+        005-disable-custom-mkstemp.patch)
 
-md5sums=(ede5166f949d9a07163bc5b086be9759
-         a5d3b17a98cb29226cf1b2ec2b760302
-         e5fcd10ee424f2f19188d0e63cf2305c
-         9db723a4fadcad7169c0617ff408c753
-         cd49b29a251adcc21fe87c66110cdc3a)
+md5sums=('ede5166f949d9a07163bc5b086be9759'
+         'a5d3b17a98cb29226cf1b2ec2b760302'
+         'e5fcd10ee424f2f19188d0e63cf2305c'
+         '9db723a4fadcad7169c0617ff408c753'
+         'cd49b29a251adcc21fe87c66110cdc3a'
+         '5c0ebe22ef7928a16c1597c2a62781ec')
 
 prepare() {
     cd "${srcdir}/${_name}-${pkgver}"
@@ -36,6 +38,7 @@ prepare() {
     patch -p1 < "${startdir}"/002-relocate-html-documentation.patch
     patch -p1 < "${startdir}"/003-replace-batch-scripts-with-bare-perl.patch
     patch -p1 < "${startdir}"/004-fix-cpan-external-programs.patch
+    patch -p1 < "${startdir}"/005-disable-custom-mkstemp.patch
 }
 
 _build() {


### PR DESCRIPTION
Perl should now build with new patch and after dmake is rebuilt. Test case for dmake:

    echo $(shell echo "%USERPROFILE%")
    echo $(SHELL)