### PR TITLE
breakpad-svn: Install headers and sample

### DIFF
--- a/mingw-w64-breakpad-svn/Makefile
+++ b/mingw-w64-breakpad-svn/Makefile
@@ -1,0 +1,18 @@
+CXX=g++
+WINDRES=windres
+CXXFLAGS=-DUNICODE -D_UNICODE
+LDFLAGS=-mwindows -municode
+
+OBJS=abstract_class.o crash_generation_app.o resource.o
+LIBS=-lbreakpad_client
+
+all: crash_generation_app.exe
+
+resource.o: resource.rc small.ico crash_generation_app.ico
+	$(WINDRES) resource.rc $@
+
+crash_generation_app.exe: $(OBJS)
+	$(CXX) -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
+
+clean:
+	${RM} ${OBJS}

--- a/mingw-w64-breakpad-svn/PKGBUILD
+++ b/mingw-w64-breakpad-svn/PKGBUILD
@@ -37,7 +37,9 @@ source=(${_name}.svn::"svn+http://google-breakpad.googlecode.com/svn/trunk"
         0023-Fix-a-missing-r-in-crash_generation_app.patch
         0024-Disable-timeout-waiting-for-crash-reporting-server.patch
         0026-Fixes-for-sign-compare-warnings-due-to-signedness-of.patch
-        gyp-regenerate-no-circular-check.patch)
+        gyp-regenerate-no-circular-check.patch
+        Makefile
+        README.sample)
 
 pkgver() {
     cd "${srcdir}/${_name}.svn"
@@ -78,7 +80,33 @@ package() {
     cd "${srcdir}/${_name}.build.${CARCH}"
     make CXXFLAGS="-Wno-error=reorder -DUNICODE -D_UNICODE -g" AR=${MINGW_PREFIX}/bin/ar RC=${MINGW_PREFIX}/bin/windres DESTDIR="${pkgdir}" install
 
-    # headers aren't really designed to be installed, so we need to do some
+    # Install headers
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad"
+    cd "${pkgdir}${MINGW_PREFIX}/include/breakpad"
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/common/"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/google_breakpad/common/* common/
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/common/scoped_ptr.h common/
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/common/windows"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/common/windows/string_utils-inl.h common/windows/
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/client/windows/crash_generation"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/crash_generation/client_info.h client/windows/crash_generation/
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/crash_generation/crash_generation_client.h client/windows/crash_generation/
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/crash_generation/crash_generation_server.h client/windows/crash_generation/
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/crash_generation/minidump_generator.h client/windows/crash_generation/
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/client/windows/common"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/common/ipc_protocol.h client/windows/common/
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/client/windows/handler"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/handler/exception_handler.h client/windows/handler/
+
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/include/breakpad/client/windows/sender"
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/sender/crash_report_sender.h client/windows/sender/
+
+    # Headers aren't really designed to be installed, so we need to do some
     # rewriting to make them usefully included using "include <breakpad/somepath/someheader>"
     find ${pkgdir} -name *.h -exec sed -i -e's#client/windows/#breakpad/client/windows/#' {} \;
     find ${pkgdir} -name *.h -exec sed -i -e's#common/scoped_ptr#breakpad/common/scoped_ptr#' {} \;
@@ -99,6 +127,7 @@ SAVE
 END
 EOF
 
+    # Install the pkgconfig file
     cp -v "${srcdir}/${_name}.build.${CARCH}/breakpad-client.pc" pkgconfig
 
     # License
@@ -106,6 +135,24 @@ EOF
     mkdir -p licenses/${_name}
     mv doc/${_name}-0.1 doc/${_name}
     mv -v doc/${_name}/LICENSE licenses/${_name}/LICENSE
+
+    # Install crash_generation_app sample source and instructions
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_name}/sample"
+    cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_name}/sample"
+    cp -v ${srcdir}/README.sample .
+    cp -v ${srcdir}/Makefile .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/abstract_class.cc .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/abstract_class.h .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/crash_generation_app.cc .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/crash_generation_app.h .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/crash_generation_app.ico .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/resource.h .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/resource.rc .
+    cp -v ${srcdir}/${_name}.build.${CARCH}/src/client/windows/tests/crash_generation_app/small.ico .
+
+    # Rewrite includes in sample for the rewritten installed headers
+    sed -i -e's#client/windows/tests/crash_generation_app/##' ${pkgdir}${MINGW_PREFIX}/share/doc/${_name}/sample/*
+    sed -i -e's#client/windows/#breakpad/client/windows/#' ${pkgdir}${MINGW_PREFIX}/share/doc/${_name}/sample/*
 }
 
 md5sums=('SKIP'
@@ -133,4 +180,6 @@ md5sums=('SKIP'
          '6d60d14c043a16deed5152455b6ce5c1'
          'e49ab09a126650a2890d50eb9dadeee4'
          '4b5a73a41be9f4909feb952c3ec5086f'
-         '58e93eee7934e96ede810bbfd42374ca')
+         '58e93eee7934e96ede810bbfd42374ca'
+         '7fa446492cfb06497a57e68a416b1087'
+         '577c35acf8ddcf504dab502c30fceea4')

--- a/mingw-w64-breakpad-svn/README.sample
+++ b/mingw-w64-breakpad-svn/README.sample
@@ -1,0 +1,67 @@
+Getting Started with Breakpad
+=============================
+
+Run the sample executable crash_generation_app.exe click Menu->Server->Start.
+This is now the 'Server'.
+
+Run the executable AGAIN (a second instance). This is now the 'Client'.  You
+should see a message like "Client connected" in the Server.  In the Client,
+click Menu->Client->Deref Zero
+
+The client should crash, and you should see a message like "Client requested
+dump" in the server.
+
+In c:\dumps you now have a .dmp file.  You can inspect that with
+minidump_stackwalk or open in it WinDbg.
+
+Integrating BreakPad into your application
+==========================================
+
+See http://code.google.com/p/google-breakpad/wiki/WindowsClientIntegration
+
+In your main() function (or equivalent), before your program does any real work,
+add the following:
+
+#include <google_breakpad/client/windows/handler/exception_handler.h>
+
+int main() {
+   ...
+
+   static wstring prod = get_myapp_name();
+   static wstring ver = get_myapp_version();
+   static wstring subver = get_myapp_subversion();
+
+   static int google_custom_count = 3;
+   static google_breakpad::CustomInfoEntry google_custom_entries[] = {
+     google_breakpad::CustomInfoEntry(L"prod", prod.c_str()),
+     google_breakpad::CustomInfoEntry(L"ver", ver.c_str()),
+     google_breakpad::CustomInfoEntry(L"subver", subver.c_str()),
+   };
+
+   google_breakpad::CustomClientInfo custom_info = {google_custom_entries,
+     google_custom_count};
+
+   google_breakpad::ExceptionHandler * google_pad = new
+     google_breakpad::ExceptionHandler(
+       L"C:\\dumps\\", // dump path
+       NULL, // filter callback
+       NULL, // MinidumpCallback,
+       NULL, // callback context
+       google_breakpad::ExceptionHandler::HANDLER_ALL, // handler types
+       MiniDumpNormal, // or for a larger dump: MiniDumpWithFullMemory
+       NULL, // pipe name
+       &custom_info); // custom info
+
+    ...
+ }
+
+If you define MinidumpCallback, the signature is like so: bool
+MinidumpCallback(const wchar_t* dump_path, const wchar_t* minidump_id, void*
+context, EXCEPTION_POINTERS* exinfo, MDRawAssertionInfo* assertion, bool
+succeeded);
+
+The callback is the point where you could spawn another program that tells the
+user that the program has crashed etc.
+
+The above code will generate dumps in the c:\dumps folder.  MAKE SURE the folder
+is created first.


### PR DESCRIPTION
Install windows-specific headers
Install sample so correct installation of library and headers can be validated
by trying to build it by running make in /mingw(32|64)/share/doc/breakpad/sample