### PR TITLE
cyrus-sasl: Restore libdigestmd5

### DIFF
--- a/mingw-w64-cyrus-sasl/PKGBUILD
+++ b/mingw-w64-cyrus-sasl/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 # There's an ugliness issue in cyrus-sasl's build system.
 # It builds libsasl2.dll with some compat objects, somehow
@@ -23,7 +24,7 @@
 _realname=cyrus-sasl
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.1.26
-pkgrel=3
+pkgrel=4
 pkgdesc="Cyrus Simple Authentication Service Layer (SASL) library"
 arch=('any')
 url="http://cyrusimap.web.cmu.edu/"
@@ -126,6 +127,14 @@ build() {
   # --enable-sql
   # --without-saslauthd because it needs sockaddr_un.
 
+  # We disable OpenSSL (--without-openssl --without-des) so that applications
+  # with licenses incompatible with OpenSSL (such as GPL applications) do not
+  # end up linked with OpenSSL if they use and redistribute Cyrus SASL outside
+  # MSYS2. See these links:
+  #
+  #     * https://www.openssl.org/support/faq.html#LEGAL2
+  #     * http://en.wikipedia.org/wiki/OpenSSL#Licensing
+
   ../$_realname-$pkgver/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -139,7 +148,7 @@ build() {
     --without-saslauthd \
     --without-pwcheck \
     --without-openssl \
-    --disable-digest \
+    --without-des \
     --without-authdaemond \
     --with-dblib=gdbm
 


### PR DESCRIPTION
This library was not included in the package anymore when OpenSSL was disabled. Now OpenSSL is still disabled, with reason provided in comments, but libdigestmd5 has been restored.