### PR TITLE
python-ipython: Added (still has an issue with built in terminal)

### DIFF
--- a/mingw-w64-python-ipython/0001-unimplemented-readline-calls.patch
+++ b/mingw-w64-python-ipython/0001-unimplemented-readline-calls.patch
@@ -1,0 +1,33 @@
+--- ipython-2.3.1/IPython/utils/rlineimpl.py.orig	2014-11-12 18:08:55.000000000 -0500
++++ ipython-2.3.1/IPython/utils/rlineimpl.py	2015-01-19 22:45:58.690179800 -0500
+@@ -27,13 +27,6 @@
+         have_readline = True
+         break
+
+-if have_readline and (sys.platform == 'win32' or sys.platform == 'cli'):
+-    try:
+-        _outputfile=_rl.GetOutputFile()
+-    except AttributeError:
+-        warnings.warn("Failed GetOutputFile")
+-        have_readline = False
+-
+ # Test to see if libedit is being used instead of GNU readline.
+ # Thanks to Boyd Waters for the original patch.
+ uses_libedit = False
+
+--- ipython-2.3.1/IPython/core/interactiveshell.py.orig	2015-01-19 23:27:23.065906800 -0500
++++ ipython-2.3.1/IPython/core/interactiveshell.py	2015-01-19 23:28:02.695374400 -0500
+@@ -657,11 +657,8 @@
+         # override sys.stdout and sys.stderr themselves, you need to do that
+         # *before* instantiating this class, because io holds onto
+         # references to the underlying streams.
+-        if (sys.platform == 'win32' or sys.platform == 'cli') and self.has_readline:
+-            io.stdout = io.stderr = io.IOStream(self.readline._outputfile)
+-        else:
+-            io.stdout = io.IOStream(sys.stdout)
+-            io.stderr = io.IOStream(sys.stderr)
++        io.stdout = io.IOStream(sys.stdout)
++        io.stderr = io.IOStream(sys.stderr)
+
+     def init_prompts(self):
+         self.prompt_manager = PromptManager(shell=self, parent=self)

--- a/mingw-w64-python-ipython/PKGBUILD
+++ b/mingw-w64-python-ipython/PKGBUILD
@@ -1,0 +1,98 @@
+# Maintainer: Kyle Kauffman <kyle.j.kauffman@gmail.com>
+
+_realname=ipython
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
+pkgver=2.3.1
+pkgrel=1
+pkgdesc="An enhanced Interactive Python shell."
+arch=('any')
+url="http://ipython.org"
+license=('BSD')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-sqlite3"
+  "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+  "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+)
+
+source=("https://pypi.python.org/packages/source/i/ipython/$_realname-$pkgver.tar.gz")
+md5sums=('2b7085525dac11190bfb45bb8ec8dcbf')
+
+prepare() {
+  cd "$srcdir"
+  patch -p0 < ../0001-unimplemented-readline-calls.patch
+}
+
+all_build() {
+  cd "$srcdir/$_realname-$pkgver"
+
+  # see https://github.com/ipython/ipython/issues/2057
+  #export LC_ALL=en_US.UTF-8
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/${interpreter} setup.py install  \
+  --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+
+  find "$pkgdir/" -name '*.pyc' -delete
+  find "$pkgdir/" -type d -empty -delete
+
+  # setuptools doesnt see mingw-w64-python's readline
+  find "$pkgdir/" -name 'requires.txt' -delete
+
+  install -Dm644 docs/source/about/license_and_copyright.rst "$pkgdir${MINGW_PREFIX}/share/licenses/ipython/LICENSE"
+
+  cd "$srcdir/$_realname-$pkgver/examples/IPython Kernel/"
+  install -Dm644 ipython.desktop "$pkgdir${MINGW_PREFIX}/share/applications/ipython.desktop"
+  install -Dm644 ipython-qtconsole.desktop "${pkgdir}${MINGW_PREFIX}/share/applications/ipython-qtconsole.desktop"
+}
+
+package_python3-ipython() {
+  interpreter=python3
+  depends=("${MINGW_PACKAGE_PREFIX}-sqlite3"
+           "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-nose: for IPython's test suite"
+              "${MINGW_PACKAGE_PREFIX}-python3-pyqt4: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python3-sip: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python3-pygments: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python3-jinja: for ipython notebook")
+#              "${MINGW_PACKAGE_PREFIX}-haskell-pandoc: ipython notebook conversion"
+#              "${MINGW_PACKAGE_PREFIX}-python3-pyzmq: ipython notebook and ipython qtconcole"
+#              "${MINGW_PACKAGE_PREFIX}-python3-tornado: for ipython notebook"
+
+  all_build
+}
+
+package_python2-ipython() {
+  interpreter=python2
+  depends=("${MINGW_PACKAGE_PREFIX}-sqlite3"
+           "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose: for IPython's test suite"
+              "${MINGW_PACKAGE_PREFIX}-python2-pyqt4: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python2-sip: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python2-pygments: for ipython qtconsole"
+              "${MINGW_PACKAGE_PREFIX}-python2-jinja: for ipython notebook")
+#              "${MINGW_PACKAGE_PREFIX}-haskell-pandoc: ipython notebook conversion"
+#              "${MINGW_PACKAGE_PREFIX}-python2-pyzmq: ipython notebook and ipython qtconcole"
+#              "${MINGW_PACKAGE_PREFIX}-python2-tornado: for ipython notebook"
+
+  all_build
+}
+
+
+package_mingw-w64-i686-python2-ipython() {
+  conflicts=("mingw-w64-i686-python3-ipython")
+  package_python2-ipython
+}
+
+package_mingw-w64-i686-python3-ipython() {
+  conflicts=("mingw-w64-i686-python2-ipython")
+  package_python3-ipython
+}
+
+package_mingw-w64-x86_64-python2-ipython() {
+  conflicts=("mingw-w64-x86_64-python3-ipython")
+  package_python2-ipython
+}
+
+package_mingw-w64-x86_64-python3-ipython() {
+  conflicts=("mingw-w64-x86_64-python2-ipython")
+  package_python3-ipython
+}

--- a/mingw-w64-python-ipython/PKGBUILD
+++ b/mingw-w64-python-ipython/PKGBUILD
@@ -36,12 +36,6 @@ all_build() {
 
   # setuptools doesnt see mingw-w64-python's readline
   find "$pkgdir/" -name 'requires.txt' -delete
-
-  install -Dm644 docs/source/about/license_and_copyright.rst "$pkgdir${MINGW_PREFIX}/share/licenses/ipython/LICENSE"
-
-  cd "$srcdir/$_realname-$pkgver/examples/IPython Kernel/"
-  install -Dm644 ipython.desktop "$pkgdir${MINGW_PREFIX}/share/applications/ipython.desktop"
-  install -Dm644 ipython-qtconsole.desktop "${pkgdir}${MINGW_PREFIX}/share/applications/ipython-qtconsole.desktop"
 }
 
 package_python3-ipython() {
@@ -58,6 +52,9 @@ package_python3-ipython() {
 #              "${MINGW_PACKAGE_PREFIX}-python3-tornado: for ipython notebook"
 
   all_build
+
+  install -Dm644 docs/source/about/license_and_copyright.rst "$pkgdir${MINGW_PREFIX}/share/licenses/ipython/LICENSE"
+
 }
 
 package_python2-ipython() {
@@ -74,25 +71,35 @@ package_python2-ipython() {
 #              "${MINGW_PACKAGE_PREFIX}-python2-tornado: for ipython notebook"
 
   all_build
+
+  install -Dm644 docs/source/about/license_and_copyright.rst "$pkgdir${MINGW_PREFIX}/share/licenses/ipython2/LICENSE"
+
+  # Fix bin collisions
+  find "$pkgdir${MINGW_PREFIX}/bin/" -type f -regex '.*[^2].exe$' -delete
+  find "$pkgdir${MINGW_PREFIX}/bin/" -type f -regex '.*[^2]-script.py$' -delete
+
+  # Fix manpage collisions
+  cd "$pkgdir${MINGW_PREFIX}/share/man/man1/"
+  for i in *; do
+    mv $i ${i/%.1/2.1}
+  done
+
+
 }
 
 
 package_mingw-w64-i686-python2-ipython() {
-  conflicts=("mingw-w64-i686-python3-ipython")
   package_python2-ipython
 }
 
 package_mingw-w64-i686-python3-ipython() {
-  conflicts=("mingw-w64-i686-python2-ipython")
   package_python3-ipython
 }
 
 package_mingw-w64-x86_64-python2-ipython() {
-  conflicts=("mingw-w64-x86_64-python3-ipython")
   package_python2-ipython
 }
 
 package_mingw-w64-x86_64-python3-ipython() {
-  conflicts=("mingw-w64-x86_64-python2-ipython")
   package_python3-ipython
 }


### PR DESCRIPTION
Added an ipython package. Split package for python2/3. It works well for the most part, with one lingering issue:

I could only get prompt coloring to work when readline was enabled. However, by default ipython stops using readline when it tries and fails to call pyreadline's GetOutputFile()-- I guess the readline in mingw-w64-python doesnt have this function? I'm new to the platform so I don't know why this function would be missing, but from reading through the project history it looks like you guys have had your fair share of readline fun, so maybe one of you knows.

To fix this issue, I patched ipython to continue using readline but use the fallback IOStream whenever it would have used the outputfile. This works fine for ConEmu, but the built in msys2_shell.bat it won't display colored output until command output is displayed. I'm guessing this is a cache flushing issue? Let me know if anyone has an idea of whats going on, my terminal/readline knowledge is fairly limited. 

Other than that I don't know of any major issues. One minor issue is that --pylab defaults to 'qt5', but the matplotlib currently in the repo doesn't support this option.