### PR TITLE
gtk3: backport wintab fixes for missing pressure

### DIFF
--- a/mingw-w64-gtk3/0056-fix-create-window-for-wintab.patch
+++ b/mingw-w64-gtk3/0056-fix-create-window-for-wintab.patch
@@ -1,0 +1,42 @@
+From 5b7ff8abead59d86c9d81a60e82f0317189a74bd Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Mon, 26 Jan 2015 14:26:34 +0000
+Subject: [PATCH] win32: Ensure we can create a window for wintab
+
+The window used NULL as a parent window, which defaults internally to
+using the root window of the default screen. But at the time wintab is
+initialized, there is no default display/screen yet.
+
+Fix this by retrieving this information from the given GdkDeviceManager,
+so we don't have to wait for the display to be in place before
+initialization.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=743330
+---
+ gdk/win32/gdkdevicemanager-win32.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/gdk/win32/gdkdevicemanager-win32.c b/gdk/win32/gdkdevicemanager-win32.c
+index 41433a8..a645c10 100644
+--- a/gdk/win32/gdkdevicemanager-win32.c
++++ b/gdk/win32/gdkdevicemanager-win32.c
+@@ -371,6 +371,8 @@ void
+ _gdk_input_wintab_init_check (GdkDeviceManager *_device_manager)
+ {
+   GdkDeviceManagerWin32 *device_manager = (GdkDeviceManagerWin32 *)_device_manager;
++  GdkDisplay *display = gdk_device_manager_get_display (_device_manager);
++  GdkWindow *root = gdk_screen_get_root_window (gdk_display_get_default_screen (display));
+   static gboolean wintab_initialized = FALSE;
+   GdkDeviceWintab *device;
+   GdkWindowAttr wa;
+@@ -459,7 +461,7 @@ _gdk_input_wintab_init_check (GdkDeviceManager *_device_manager)
+   wa.x = -100;
+   wa.y = -100;
+   wa.window_type = GDK_WINDOW_TOPLEVEL;
+-  if ((wintab_window = gdk_window_new (NULL, &wa, GDK_WA_X|GDK_WA_Y)) == NULL)
++  if ((wintab_window = gdk_window_new (root, &wa, GDK_WA_X | GDK_WA_Y)) == NULL)
+     {
+       g_warning ("gdk_input_wintab_init: gdk_window_new failed");
+       return;
+-- 
+2.1.0

--- a/mingw-w64-gtk3/0057-wintab-dont-check-position-of-null-device.patch
+++ b/mingw-w64-gtk3/0057-wintab-dont-check-position-of-null-device.patch
@@ -1,0 +1,43 @@
+From 3c5e1781e8286da5cb6acf991eebfff58fc1a8d0 Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Tue, 27 Jan 2015 11:24:18 +0000
+Subject: [PATCH] win32: Don't check the position of a NULL device
+
+This function is given a barely setup GdkEvent, so the GdkDevice field
+is still unset, causing warnings and misbehaviors when the position
+is queried for it.
+
+Given that the wintab GTK+ code seems to rely somewhat hard on the wintab
+device managing the pointer cursor, query the pointer position from the
+pointer itself.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=743330
+---
+ gdk/win32/gdkdevicemanager-win32.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/gdk/win32/gdkdevicemanager-win32.c b/gdk/win32/gdkdevicemanager-win32.c
+index a645c10..7eba80b 100644
+--- a/gdk/win32/gdkdevicemanager-win32.c
++++ b/gdk/win32/gdkdevicemanager-win32.c
+@@ -886,7 +886,6 @@ _gdk_input_other_event (GdkEvent  *event,
+   GdkDeviceManagerWin32 *device_manager;
+   GdkDeviceWintab *source_device = NULL;
+   GdkDeviceGrabInfo *last_grab;
+-  GdkDevice *device = NULL;
+   GdkEventMask masktest;
+   guint key_state;
+   POINT pt;
+@@ -908,9 +907,7 @@ _gdk_input_other_event (GdkEvent  *event,
+     }
+ 
+   device_manager = GDK_DEVICE_MANAGER_WIN32 (gdk_display_get_device_manager (_gdk_display));
+-
+-  device = gdk_event_get_device (event);
+-  window = gdk_device_get_window_at_position (device, &x, &y);
++  window = gdk_device_get_window_at_position (device_manager->core_pointer, &x, &y);
+   if (window == NULL)
+     window = _gdk_root;
+ 
+-- 
+2.1.0

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.14.6
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -32,6 +32,8 @@ source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}
         0037-W32-better-dwm-loading-and-support-dwm-detection.all.patch
         0054-no-transparency-for-children.all.patch
         0055-skip-testsuite.all.patch
+        0056-fix-create-window-for-wintab.patch
+        0057-wintab-dont-check-position-of-null-device.patch
         Make-reftest-plugins-W32-compatible.patch)
 md5sums=('34340b3ede9c1cfee3c6e2ec5f6eccc5'
          '9e0296da2986be7697cf343563b85d1f'
@@ -40,6 +42,8 @@ md5sums=('34340b3ede9c1cfee3c6e2ec5f6eccc5'
          'ad383a497a9134355e0a549f844c3a33'
          '31d098e6856ddc8dde7259ae572f8bf1'
          '751ee83452f3e06a460a8867f8e479b8'
+         '959d0ec6f48ce8771d22ef8b5f07613c'
+         '6f66a0ad137853e21a523eab729bf638'
          '864d4b2cd6f72115cc78a393ccd96b47')
 
 prepare() {
@@ -50,6 +54,8 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0037-W32-better-dwm-loading-and-support-dwm-detection.all.patch
   patch -Np1 -i "${srcdir}"/0054-no-transparency-for-children.all.patch
   patch -Np1 -i "${srcdir}"/0055-skip-testsuite.all.patch
+  patch -Np1 -i "${srcdir}"/0056-fix-create-window-for-wintab.patch
+  patch -Np1 -i "${srcdir}"/0057-wintab-dont-check-position-of-null-device.patch
   #patch -Np1 -i "${srcdir}"/Make-reftest-plugins-W32-compatible.patch
 
   autoreconf -i


### PR DESCRIPTION
(Asking for this may be a little cheeky, but these are fixes we very much do want in the MyPaint camp. I'd understand if you say to just wait for 3.14.8.)

Backport upstream fixes for failed initialization of input devices which rely on wintab.dll, resulting in no pressure on tablets and Gdk-CRITICAL errors. Affects MyPaint, and will affect GIMP too.

https://bugzilla.gnome.org/show_bug.cgi?id=743330
https://github.com/mypaint/mypaint/issues/178

These will hopefully hit stable in 3.14.8, https://git.gnome.org/browse/gtk+/log/?h=gtk-3-14 , so please revert this patch when that arrives in MSYS2.