### PR TITLE
Add/fix licenses for some packages

### DIFF
--- a/mingw-w64-bzip2/PKGBUILD
+++ b/mingw-w64-bzip2/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=bzip2
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.6
-pkgrel=2
+pkgrel=3
 pkgdesc="A high-quality data compression program (mingw-w64)"
 arch=('any')
 url="http://sources.redhat.com/bzip2"
@@ -62,4 +63,5 @@ package() {
   #make PREFIX="${pkgdir}${MINGW_PREFIX}" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
   #rm "${pkgdir}${MINGW_PREFIX}/bin/bz"{diff,grep,more}
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-expat/PKGBUILD
+++ b/mingw-w64-expat/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=expat
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="An XML parser library (mingw-w64)"
 arch=('any')
 url="http://expat.sourceforge.net"
-license=("custom")
+license=(MIT)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' 'staticlibs')
 source=("http://downloads.sourceforge.net/expat/expat-${pkgver}.tar.gz")
@@ -30,4 +31,5 @@ package() {
     cd "${srcdir}/${pkgname}-${pkgver}-build-${CARCH}"
     make DESTDIR="$pkgdir" install
     mv "${pkgdir}${MINGW_PREFIX}/bin/xmlwf" "${pkgdir}${MINGW_PREFIX}/bin/xmlwf.exe"
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=fontconfig
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.11.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 url="http://www.fontconfig.org/release"
@@ -47,4 +48,5 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 DESTDIR="$pkgdir" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=harfbuzz
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.38
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 url="http://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -49,4 +50,5 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="$pkgdir" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-hunspell/PKGBUILD
+++ b/mingw-w64-hunspell/PKGBUILD
@@ -1,14 +1,18 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=hunspell
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.3
-pkgrel=7
+pkgrel=8
 pkgdesc="Spell checker and morphological analyzer library and program (mingw-w64)"
 arch=('any')
 url="http://hunspell.sourceforge.net/"
-license=("BSD")
+
+# We omit MPL because it cannot be applied to the whole source, see COPYING
+license=(GPL2+ LGPL2.1+)
+
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
         ${MINGW_PACKAGE_PREFIX}-gettext)
@@ -61,4 +65,10 @@ package() {
   MSYS2_ARG_CONV_EXCL="-DBINDIR=;-DDATA_DIR=" \
   make DESTDIR="${pkgdir}" install
   cp ${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}-${pkgver%.*}.dll.a ${pkgdir}${MINGW_PREFIX}/lib/lib${_realname}.dll.a
+
+  # Licenses
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -Dm644 COPYING      "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING"
+  install -Dm644 COPYING.LGPL "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING.LGPL"
+  install -Dm644 COPYING.MPL  "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING.MPL"
 }

--- a/mingw-w64-libffi/PKGBUILD
+++ b/mingw-w64-libffi/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libffi
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A portable, high level programming interface to various calling conventions (mingw-w64)"
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
@@ -32,4 +33,5 @@ build() {
 package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-libtre-git/PKGBUILD
+++ b/mingw-w64-libtre-git/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
  
 _realname=libtre
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=r122.c2f5d13
-pkgrel=1
+pkgrel=2
 pkgdesc="The approximate regex matching library and agrep command line tool (mingw-w64)"
 url="https://github.com/laurikari/tre"
 arch=('any')
@@ -50,4 +51,5 @@ build() {
 package() {
   cd build-${MINGW_CHOST}
   make DESTDIR=${pkgdir} install
+  install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-nspr/PKGBUILD
+++ b/mingw-w64-nspr/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=nspr
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.10.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Netscape Portable Runtime (mingw-w64)"
 arch=('any')
 url="http://www.mozilla.org/projects/nspr/"
-license=('MPL')
+license=(MPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "zip")
 options=('staticlibs' 'strip' '!emptydirs')
@@ -72,4 +73,6 @@ package() {
   ln -s nspr.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/mozilla-nspr.pc"
   rm -r ${pkgdir}${MINGW_PREFIX}/bin/{compile-et.pl,prerr.properties} \
         ${pkgdir}${MINGW_PREFIX}/include/nspr/md
+
+  install -Dm644 nspr/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-nss/PKGBUILD
+++ b/mingw-w64-nss/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=nss
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.17.2
 _nsprver=4.10.7
-pkgrel=1
+pkgrel=2
 pkgdesc="Mozilla Network Security Services (mingw-w64)"
 arch=('any')
 url="http://www.mozilla.org/projects/security/pki/nss/"
-license=('MPL')
+license=(MPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-nspr"
         "${MINGW_PACKAGE_PREFIX}-sqlite3"
         "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -144,4 +145,6 @@ package() {
     install -m 644 $file ${pkgdir}${MINGW_PREFIX}/include/nss3
   done
 
+  # License
+  install -Dm644 nss/COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-pixman/PKGBUILD
+++ b/mingw-w64-pixman/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=pixman
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.32.6
-pkgrel=1
+pkgrel=2
 pkgdesc="The pixel-manipulation library for X and cairo (mingw-w64)"
 arch=('any')
 url="http://xorg.freedesktop.org"
-license=("custom")
+license=(MIT)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-libpng")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
@@ -28,4 +29,5 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="$pkgdir" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
 # Contributor: Martell Malone <martellmalone@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=zlib
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2.8
-pkgrel=5
+pkgrel=6
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP (mingw-w64)"
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
-license=('custom')
+license=(ZLIB)
 url="http://www.zlib.net/"
 depends=("${MINGW_PACKAGE_PREFIX}-bzip2")
 options=('staticlibs')
@@ -85,4 +86,5 @@ package() {
   pushd contrib/minizip > /dev/null
   make install DESTDIR="${pkgdir}"
   popd > /dev/null
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
License files have been added to the following packages:

* bzip2
* fontconfig
* harfbuzz
* libffi
* libtre-git

These packages now have a license file as well, with additional changes:

* zlib: license specified as ZLIB.
* expat and pixman: license specified as MIT.
* nspr and nss: license specified as MPL2.
* hunspell: license fixed, it is not BSD but GPL2+/LGPL2.1+ (or MPL1.1+ partially).