### PR TITLE
openocd-git: remove patches included by upstream

### DIFF
--- a/mingw-w64-openocd-git/PKGBUILD
+++ b/mingw-w64-openocd-git/PKGBUILD
@@ -5,7 +5,7 @@ _realname=openocd
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=r6612.1663a17
+pkgver=v0.8.0.r268.ga9c90a0
 pkgrel=1
 pkgdesc="OpenOCD - Open On-Chip Debugger (mingw-w64)"
 arch=('any')
@@ -18,22 +18,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-hidapi"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "pkg-config"
              "git")
-source=("${_realname}::git+http://git.code.sf.net/p/openocd/code"
-        "0001-Win32-Define-WIN32_LEAN_AND_MEAN-in-config.h.patch"
-        "0002-Makefile.am-link-libusb-1.0-after-libusb-0.1-to-fix-.patch")
-md5sums=('SKIP'
-         '4c56994d66389afeb8a942514a1f7628'
-         '1a7bc00cd8d7ecea09130a52af66d916')
+source=("${_realname}::git+http://git.code.sf.net/p/openocd/code")
+md5sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}"/${_realname}
-  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  git describe --long --tags 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 prepare() {
   cd "${srcdir}"/${_realname}
-  git am "${srcdir}"/0001-Win32-Define-WIN32_LEAN_AND_MEAN-in-config.h.patch
-  git am "${srcdir}"/0002-Makefile.am-link-libusb-1.0-after-libusb-0.1-to-fix-.patch
   ./bootstrap
 }
 
@@ -63,17 +57,7 @@ package() {
   cd "${srcdir}"/build-${CARCH}
   make DESTDIR="${pkgdir}" install
 
-  # bsdtar doesn't like (some?) utf-8 in filenames
-  # rename the known problematic utf-8 substrings.
-  declare -A _renames
-  _renames[be1t]=BE1T
-  _renames[к]=k
-  _renames[xб1я]=XB1R
-  for _renamekey in ${!_renames[@]}; do
-    _filenames=$(find . -name "*${_renamekey}*")
-    _renameto=${_renames[${_renamekey}]}
-    for _filename in ${_filenames}; do
-      mv ${_filename} ${_filename//${_renamekey}/${_renameto}}
-    done
-  done
+  # bsdtar can't convert non-ascii filenames to UTF-8 when run in
+  # non-UTF-8 locale. It proceeds to pack them anyway embedding raw
+  # binary filenames in the traditional tar headers.
 }


### PR DESCRIPTION
This removes the patches since they're no longer needed, as the latest
git version merged the fixes.

This also changes pkgver() to use tags instead of plain rev-list
--count and removes the tricky renaming that should no longer be
needed.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>