### PR TITLE
More license fixes

### DIFF
--- a/mingw-w64-atk/PKGBUILD
+++ b/mingw-w64-atk/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=atk
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library providing a set of interfaces for accessibility (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
-license=("LGPL")
+license=(LGPL2)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
@@ -41,4 +42,5 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 DESTDIR="$pkgdir" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=cairo
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.14.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 url="http://cairographics.org"
-license=("LGPL, MPL")
+license=(LGPL2.1 MPL1.1)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
     "${MINGW_PACKAGE_PREFIX}-pkg-config"
     "${MINGW_PACKAGE_PREFIX}-glib2"
@@ -83,4 +84,9 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="$pkgdir" install
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING"          "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING-LGPL-2.1" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING-LGPL-2.1"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING-MPL-1.1"  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING-MPL-1.1"  
 }

--- a/mingw-w64-drmingw-git/PKGBUILD
+++ b/mingw-w64-drmingw-git/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=drmingw
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r182.867ab17
-pkgrel=1
+pkgrel=2
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')
-license=('GPL' 'LGPL')
+license=(LGPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")

--- a/mingw-w64-drmingw/PKGBUILD
+++ b/mingw-w64-drmingw/PKGBUILD
@@ -4,10 +4,10 @@
 _realname=drmingw
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 pkgver=0.6.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')
-license=('GPL' 'LGPL')
+license=(LGPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
 url=('https://github.com/jrfonseca/drmingw')

--- a/mingw-w64-enchant/PKGBUILD
+++ b/mingw-w64-enchant/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=enchant
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.0
-pkgrel=6
+pkgrel=7
 pkgdesc="Enchanting Spell Checking Library (mingw-w64)"
 arch=('any')
 url="http://www.abisource.com/"
-license=("LGPL-2.1+")
+license=(LGPL2.1)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
         ${MINGW_PACKAGE_PREFIX}-glib2
@@ -59,4 +60,5 @@ package() {
   cd "${srcdir}/${_realname}-${pkgver}-build-${CARCH}"
   # MSYS2_ARG_CONV_EXCL="-DENCHANT_USPELL_DICT_DIR=;-DENCHANT_MYSPELL_DICT_DIR=;-DENCHANT_ISPELL_DICT_DIR=;-DENCHANT_PREFIX_DIR=;-DENCHANT_GLOBAL_MODULE_DIR=;-DENCHANT_GLOBAL_ORDERING=;-DENCHANT_BIN_DIR="
   make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
 }

--- a/mingw-w64-freetype/PKGBUILD
+++ b/mingw-w64-freetype/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=freetype
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.5.5
-pkgrel=1
+pkgrel=2
 pkgdesc="TrueType font rendering library (mingw-w64)"
 arch=('any')
 url="http://www.freetype.org/"
-license=('GPL')
+license=(GPL2+ custom:FreeType)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-libpng"
@@ -59,4 +60,9 @@ build() {
 package () {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR="${pkgdir}" install
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/docs/LICENSE.TXT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.TXT"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/docs/GPLv2.TXT"   "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/GPLv2.TXT"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/docs/FTL.TXT"     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/FTL.TXT"
 }

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Alexey Borzenkov <snaury@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=gcc
 pkgname=(
@@ -12,7 +13,7 @@ pkgname=(
         "${MINGW_PACKAGE_PREFIX}-${_realname}-objc"
         )
 pkgver=4.9.2
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="http://gcc.gnu.org"
@@ -242,6 +243,27 @@ build() {
 package_mingw-w64-gcc-libs() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-gmp" "${MINGW_PACKAGE_PREFIX}-libwinpthread")
+
+  # Licensing information
+
+  # Part of the package is GCCRLE, part is LGPL2+, see README generation below.
+  # Since the packaged GCCRLE libraries are also GPL3+, and LGPL2+ is compatible
+  # with GPL3+, the whole package can be redistributed under GPL3+.
+  license=(GPL3+ partial:'GCCRLE' partial:'LGPL2+')
+
+  # We explain the licensing in this generated README file
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs"
+  cat << ENDFILE > "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/README"
+The libgcc, libssp, libstdc++, libgomp and libatomic libraries are covered by
+GPL3+ with the GCC Runtime Library Exception. The libquadmath library is covered
+by LGPL2+. The package as a whole can be redistributed under GPL3+.
+ENDFILE
+
+  # License files
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING3"        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING3"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB"     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.LIB"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.RUNTIME" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}-libs/COPYING.RUNTIME"
+
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
 
   cd ${srcdir}${MINGW_PREFIX}

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=gdk-pixbuf2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.31.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
-license=("LGPL")
+license=(LGPL2)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
         "${MINGW_PACKAGE_PREFIX}-glib2>=2.37.2"
@@ -50,4 +51,5 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="$pkgdir" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/gdk-pixbuf-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -1,16 +1,20 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=gettext
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.4
-pkgrel=1
+pkgrel=2
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libiconv") # "${MINGW_PACKAGE_PREFIX}-termcap"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-ncurses")
 options=('strip' 'staticlibs')
-license=('GPL' 'LGPL')
+
+# GPL3 for the package as a whole and LGPL for some parts, see the license files
+license=(GPL3 partial:'LGPL2.1')
+
 url="http://www.gnu.org/software/gettext/"
 source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-$pkgver.tar.gz"{,.sig}
         00-relocatex-libintl-0.18.3.1.patch
@@ -70,4 +74,15 @@ build()
 package() {
   cd $srcdir/build-${MINGW_CHOST}
   make DESTDIR="$pkgdir" install
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING"                                 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/COPYING"                 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/intl/COPYING.LIB"        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/intl/COPYING.LIB"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING"     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/libasprintf/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-runtime/libasprintf/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-runtime/libasprintf/COPYING.LIB"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/COPYING"                   "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-tools/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gettext-tools/gnulib-lib/libxml/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gettext-tools/gnulib-lib/libxml/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/gnulib-local/lib/libxml/COPYING"         "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gnulib-local/lib/libxml/COPYING"
+  rm "${pkgdir}${MINGW_PREFIX}/share/${_realname}/intl/COPYING.LIB"
 }

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=glib2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.42.1
-pkgrel=2
+pkgrel=3
 url="http://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
-license=('LGPL')
+license=(LGPL2)
 options=('!debug' 'strip' 'staticlibs')
 install=glib2-${CARCH}.install
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -110,4 +111,6 @@ package() {
 
   #rm -f "${pkgdir}${MINGW_PREFIX}/bin/gdbus-codegen"
   #rm -rf "${pkgdir}${MINGW_PREFIX}/lib/gdbus-2.0"
+
+  install -Dm644 "${srcdir}/glib-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=gtk2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.25
-pkgrel=1
+pkgrel=2
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
-license=("LGPL")
+license=(LGPL2)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -90,4 +91,5 @@ package() {
   make -j1 DESTDIR="$pkgdir" install
   install -Dm644 "$srcdir/gtkrc" "${pkgdir}${MINGW_PREFIX}/share/gtk-2.0/gtkrc.example"
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/gtk+-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-gtkspell/PKGBUILD
+++ b/mingw-w64-gtkspell/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=gtkspell
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.16
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides word-processor-style highlighting and replacement of misspelled words in a GtkTextView widget (mingw-w64)"
 arch=('any')
 url="http://gtkspell.sourceforge.net/"
-license=("GPL")
+license=(GPL2)
 makedepends=("gtk-doc"
             "${MINGW_PACKAGE_PREFIX}-gcc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -43,4 +44,5 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="$pkgdir" install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-hunspell/PKGBUILD
+++ b/mingw-w64-hunspell/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=hunspell
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.3
-pkgrel=8
+pkgrel=9
 pkgdesc="Spell checker and morphological analyzer library and program (mingw-w64)"
 arch=('any')
 url="http://hunspell.sourceforge.net/"
@@ -68,7 +68,7 @@ package() {
 
   # Licenses
   cd "${srcdir}/${_realname}-${pkgver}"
-  install -Dm644 COPYING      "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING"
-  install -Dm644 COPYING.LGPL "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING.LGPL"
-  install -Dm644 COPYING.MPL  "${pkgdir}${MINGW_PREFIX}/share/licenses/COPYING.MPL"
+  install -Dm644 COPYING      "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 COPYING.LGPL "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LGPL"
+  install -Dm644 COPYING.MPL  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.MPL"
 }

--- a/mingw-w64-libiconv/PKGBUILD
+++ b/mingw-w64-libiconv/PKGBUILD
@@ -1,15 +1,21 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libiconv
 
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.14
-pkgrel=2
+pkgrel=3
 pkgdesc='Libiconv is a conversion library'
 groups=("${MINGW_PACKAGE_PREFIX}")
 arch=('any')
 url='http://www.gnu.org/software/libiconv/'
-license=('LGPL')
+
+# Some parts are GPL3, some parts are LGPL2, see README.
+# TODO: what is the license for the package as a whole? Is LGPL 2.0 compatible
+# with GPL3, so that GPL3 could be applied?
+license=(partial:'GPL3' partial:'LGPL2')
+
 source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-compile-relocatable-in-gnulib.mingw.patch
         0002-fix-cr-for-awk-in-configure.all.patch)
@@ -49,4 +55,10 @@ package() {
   cd ${srcdir}/${_realname}-${pkgver}
   make install DESTDIR="${pkgdir}"
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/charset.alias
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README"                 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING"                "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB"            "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/libcharset/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/libcharset/COPYING.LIB"
 }

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -1,16 +1,17 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libxml2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.9.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gettext" "${MINGW_PACKAGE_PREFIX}-zlib" "${MINGW_PACKAGE_PREFIX}-xz")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-python2")
 options=('strip' 'staticlibs')
-license=('LGPL')
+license=(MIT)
 url="http://www.xmlsoft.org/"
 install=${_realname}-${CARCH}.install
 source=("http://xmlsoft.org/sources/libxml2-${pkgver}.tar.gz"
@@ -159,4 +160,8 @@ package()
   cd ${srcdir}/build-static-${CARCH}
 
   install -m 0644 .libs/libxml2.a "${pkgdir}${MINGW_PREFIX}"/lib/
+  
+  # License
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  mv "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}-${pkgver}/Copyright" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/Copyright"
 }

--- a/mingw-w64-meanwhile/PKGBUILD
+++ b/mingw-w64-meanwhile/PKGBUILD
@@ -2,15 +2,16 @@
 # Contributor: Marek Skrobacki <skrobul@skrobul.com>
 # Contributor: Alasdair Haswell <ali at arhaswell dot co dot uk>
 # Maintainer: Zach Bacon <11doctorwhocanada@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=meanwhile
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Meanwhile libraries (mingw64)"
 arch=('any')
 url="http://sourceforge.net/projects/meanwhile"
-license=('GPL')
+license=(LGPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-glib2")
 conflicts=('meanwhile-svn')
 source=(http://downloads.sourceforge.net/sourceforge/meanwhile/${_realname}-$pkgver.tar.gz
@@ -51,4 +52,5 @@ build() {
 package() {
   cd "${srcdir}"/build-${CARCH}
   make DESTDIR=$pkgdir install
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -1,13 +1,22 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=pango
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.36.8
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 url="http://www.pango.org"
-license=("LGPL")
+
+# TODO: what is the license for the package as a whole? The README file says
+# that most of the code is LGPL but some parts are "GPL/FreeType". However this
+# non-LGPL note makes reference to non-existing files, so would LGPL apply to
+# the whole code? If this note is still correct, are the GPL/FreeType parts
+# under either or both of these licenses, and which versions? What license is
+# compatible with the answers?
+license=(partial:'LGPL2')
+
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
@@ -56,4 +65,8 @@ package() {
   make DESTDIR="$pkgdir" install
   install -m755 -d "${pkgdir}${MINGW_PREFIX}/etc/pango"
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+
+  # License
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README"  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-perl/PKGBUILD
+++ b/mingw-w64-perl/PKGBUILD
@@ -4,10 +4,10 @@
 _name=perl
 url='http://www.perl.org'
 pkgdesc='A highly capable, feature-rich programming language (mingw-w64)'
-license=(GPL PerlArtistic)
+license=(GPL1+ Artistic1)
 arch=(any)
 pkgver=5.20.1
-pkgrel=1
+pkgrel=2
 
 install="perl-${CARCH}.install"
 options=(staticlibs strip '!purge')
@@ -61,6 +61,11 @@ package() {
     cd "${pkgdir}${MINGW_PREFIX}"
     mkdir -p lib/perl5/vendor_perl
     attrib.exe -r //s
+
+    # Licenses
+    install -Dm644 "${srcdir}/${_name}-${pkgver}/README"   share/licenses/${_name}/README
+    install -Dm644 "${srcdir}/${_name}-${pkgver}/Copying"  share/licenses/${_name}/Copying
+    install -Dm644 "${srcdir}/${_name}-${pkgver}/Artistic" share/licenses/${_name}/Artistic
 
     # Path relocation. This is done by replacing hard-coded paths with relocate
     # patterns that will be resolved on package installation. The HTML

--- a/mingw-w64-shared-mime-info/PKGBUILD
+++ b/mingw-w64-shared-mime-info/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=shared-mime-info
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Freedesktop.org Shared MIME Info (mingw-w64)"
 arch=('any')
-license=('GPL')
+license=(GPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-libxml2" "${MINGW_PACKAGE_PREFIX}-glib2")
 makedepends=('intltool' "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-gettext")
 install=${_realname}-${CARCH}.install
@@ -45,4 +46,5 @@ package() {
   sed -e "s|%PROGNAME%|GNU.update-mime-database|g" \
       -e "s|%ARCH%|${_arch}|g" \
       -i ${pkgdir}${MINGW_PREFIX}/bin/update-mime-database.exe.manifest
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Martell Malone <martellmalone@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=winpthreads
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
 _ver_base=4.0.0
-pkgver=4.0.0.4402.95c900f
+pkgver=4.0.0.4443.54a3822
 pkgrel=1
 pkgdesc="MinGW-w64 winpthreads library"
 arch=('any')
 url="http://mingw-w64.sourceforge.net"
-license=('custom')
+license=(custom:'Permissive-like') # TODO: clarify
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain" "${MINGW_PACKAGE_PREFIX}")
 makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-gcc"
@@ -66,6 +67,12 @@ build() {
   make
 }
 
+_install_licenses() {
+  # TODO: any more license files?
+  install -Dm644 ${srcdir}/${_realname}/COPYING                                 ${pkgdir}${MINGW_PREFIX}/share/licenses/$1/COPYING
+  install -Dm644 ${srcdir}/${_realname}/mingw-w64-libraries/winpthreads/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/$1/mingw-w64-libraries/winpthreads/COPYING
+}
+
 package_winpthreads() {
   depends=("${MINGW_PACKAGE_PREFIX}-crt-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git=${pkgver}")
   replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
@@ -80,7 +87,7 @@ package_winpthreads() {
   mv ${pkgdir}${MINGW_PREFIX}/lib ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/
   rm -rf ${pkgdir}${MINGW_PREFIX}/bin
   
-  install -Dm644 ${srcdir}/${_realname}/mingw-w64-libraries/winpthreads/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  _install_licenses ${_realname}
 }
 
 package_libwinpthread() {
@@ -93,6 +100,8 @@ package_libwinpthread() {
   
   rm -rf ${pkgdir}${MINGW_PREFIX}/include
   rm -rf ${pkgdir}${MINGW_PREFIX}/lib
+
+  _install_licenses libwinpthread
 }
 
 # Wrappers for package functions


### PR DESCRIPTION
Fixes and/or improvements for the packages below. See commit messages for more details.

* atk
* cairo
* drmingw
* drmingw-git
* enchant
* freetype
* gcc-libs
* gdk-pixbuf2
* gettext
* glib2
* gtk2
* gtkspell
* hunspell
* libiconv
* libxml2
* meanwhile
* pango
* perl
* shared-mime-info
* winpthreads-git