### PR TITLE
gtk-doc: Update to 1.21

### DIFF
--- a/mingw-w64-gtk-doc/PKGBUILD
+++ b/mingw-w64-gtk-doc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk-doc
 
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.20
+pkgver=1.21
 pkgrel=1
 pkgdesc="Documentation tool for public library API (mingw-w64)"
 arch=('any')
@@ -28,7 +28,7 @@ optdepends=(#"${MINGW_PACKAGE_PREFIX}-jade: SGML support"
       )
 url="http://www.gtk.org/gtk-doc/"
 source=(http://ftp.gnome.org/pub/gnome/sources/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.xz)
-md5sums=('58532fed036f72fc3bfd4fe79473247b')
+md5sums=('e361de4750b707590d9ea1b5550fa738')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
The `chunk.xsl` stylesheet is now imported from local file instead of HTTP. This
stylesheet is provided by the docbook-xsl package.