### PR TITLE
apr: Added

### DIFF
--- a/mingw-w64-apr/PKGBUILD
+++ b/mingw-w64-apr/PKGBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Drew Waranis <drew@waran.is>
+
+_realname=apr
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.5.1
+pkgrel=1
+pkgdesc="The Apache Portable Runtime (mingw-w64)"
+arch=('any')
+url="https://apr.apache.org/"
+license=('APACHE')
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+            )
+
+source=("http://www.apache.org/dist/apr/apr-${pkgver}-win32-src.zip"
+        'apr_ssize_t.patch'
+        'apr_wtypes.patch')
+md5sums=('684a3756a2f8955e837b53e8089e10b0'
+         'b91081b97f838246446c5795371faf6a'
+         '0326d335f035f8f13dea4296efb1faab')
+
+prepare() {
+  cd "${srcdir}/apr-${pkgver}"
+
+  patch -p0 -i ${srcdir}/apr_ssize_t.patch
+  patch -p0 -i ${srcdir}/apr_wtypes.patch
+
+  autoreconf -fi
+}
+
+build() {
+  cd "${srcdir}/apr-${pkgver}"
+
+  ./buildconf
+  # Disable IPv6.
+  ./configure --prefix="${MINGW_PREFIX}" \
+    --includedir="${MINGW_PREFIX}/include/apr-1" \
+    --with-installbuilddir="${MINGW_PREFIX}/share/apr-1/build" \
+    --enable-nonportable-atomics \
+    --with-devrandom=/dev/urandom \
+    --disable-ipv6
+  make -j7
+}
+
+#check() {
+#  cd "${srcdir}/apr-${pkgver}"
+#  make -j1 check
+#}
+
+package() {
+  cd "${srcdir}/apr-${pkgver}"
+  make -j7 DESTDIR="$pkgdir" install
+
+  #pushd "${pkgdir}${MINGW_PREFIX}" > /dev/null
+  #export PREFIX_WIN=`pwd -W`
+  #popd > /dev/null
+  #sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+  #  -i "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/apr-1.pc"
+}

--- a/mingw-w64-apr/apr_ssize_t.patch
+++ b/mingw-w64-apr/apr_ssize_t.patch
@@ -1,0 +1,24 @@
+Index: configure.in
+===================================================================
+--- configure.in	(revision 1161414)
++++ configure.in	(working copy)
+@@ -1643,6 +1643,9 @@
+ elif test "$ac_cv_sizeof_ssize_t" = "$ac_cv_sizeof_long"; then
+     ssize_t_fmt="ld"
+     AC_MSG_RESULT(%ld)
++elif test "$ac_cv_sizeof_ssize_t" = "$ac_cv_sizeof_long_long"; then
++    ssize_t_fmt="lld"
++    AC_MSG_RESULT(%lld)
+ else
+     AC_ERROR([could not determine the proper format for apr_ssize_t])
+ fi
+@@ -1660,6 +1663,9 @@
+ elif test "$ac_cv_sizeof_size_t" = "$ac_cv_sizeof_long"; then
+     size_t_fmt="ld"
+     AC_MSG_RESULT(%ld)
++elif test "$ac_cv_sizeof_size_t" = "$ac_cv_sizeof_long_long"; then
++    size_t_fmt="lld"
++    AC_MSG_RESULT(%lld)
+ else
+     AC_ERROR([could not determine the proper format for apr_size_t])
+ fi

--- a/mingw-w64-apr/apr_wtypes.patch
+++ b/mingw-w64-apr/apr_wtypes.patch
@@ -1,0 +1,30 @@
+--- include/arch/win32/apr_private.h.orig	2014-07-03 14:34:47 -0500
++++ include/arch/win32/apr_private.h	2014-07-03 14:35:51 -0500
+@@ -45,13 +45,9 @@
+  */
+ #ifndef _WIN32_WCE
+ #define HAVE_ACLAPI 1
+-#ifdef __wtypes_h__
++#define COM_NO_WINDOWS_H
+ #include <accctrl.h>
+-#else
+-#define __wtypes_h__
+-#include <accctrl.h>
+-#undef __wtypes_h__
+-#endif
++#undef COM_NO_WINDOWS_H
+ #else
+ #define HAVE_ACLAPI 0
+ #endif
+--- file_io/win32/filestat.c.orig	2014-07-03 14:42:41 -0500
++++ file_io/win32/filestat.c	2014-07-03 14:43:09 -0500
+@@ -15,7 +15,9 @@
+  */
+ 
+ #include "apr.h"
++#define COM_NO_WINDOWS_H
+ #include <aclapi.h>
++#undef COM_NO_WINDOWS_H
+ #include "apr_private.h"
+ #include "apr_arch_file_io.h"
+ #include "apr_file_io.h"


### PR DESCRIPTION
This isn't quite ready to be merged and is a work in progress.

The main problem that I'm running into are compilation timing issues that are resolved (somehow) by running *makepkg-mingw* again until it succeeds. There's also a couple tests that exhibit the same phenomenon. It is strange because (after a couple patches) it compiles and links normally in a MINGW64 shell.

After this is up and running I can submit *apr-util*.