### PR TITLE
Some small fixes

### DIFF
--- a/mingw-w64-atom-editor/PKGBUILD
+++ b/mingw-w64-atom-editor/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=atom-editor
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r18372.d4f7e71
-pkgrel=1
+pkgrel=2
 pkgdesc='Cross-platform desktop application shell (mingw-w64)'
 source=("${_realname}-${CARCH}"::"git://github.com/atom/atom#branch=master")
 arch=('any')
@@ -57,7 +57,7 @@ package() {
   install -Dm644 resources/linux/Atom.desktop "${INSTALL_PREFIX}/share/applications/Atom.desktop"
 
   install -Dm644 resources/atom.png "${INSTALL_PREFIX}/share/pixmaps/atom.png"
-  install -Dm644 LICENSE.md "${INSTALL_PREFIX}/share/licenses/$pkgname/LICENSE.md"
+  install -Dm644 LICENSE.md "${INSTALL_PREFIX}/share/licenses/${_realname}/LICENSE.md"
 }
 
 md5sums=('SKIP')

--- a/mingw-w64-breakpad-svn/PKGBUILD
+++ b/mingw-w64-breakpad-svn/PKGBUILD
@@ -1,4 +1,6 @@
-# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+# Maintainer: Jon Turney <jon.turney@dronecode.org.uk>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Alexey Pavlov <alexpux@gmail.com>
 
 _name=breakpad
 url='https://code.google.com/p/google-breakpad'

--- a/mingw-w64-docbook-xsl/PKGBUILD
+++ b/mingw-w64-docbook-xsl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=docbook-xsl
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.78.1
-pkgrel=4
+pkgrel=5
 pkgdesc='XML stylesheets for Docbook-xml transformations (mingw-w64)'
 arch=('any')
 license=('custom')
@@ -31,6 +31,6 @@ package() {
 
   install -Dm644 catalog.xml ${_pkgroot}/catalog.xml
   install -dm755 ${pkgdir}${MINGW_PREFIX}/etc/xml
-  install -Dm644 COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE
+  install -Dm644 COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
 
 }

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -4,11 +4,15 @@
 _realname=gtk2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.25
-pkgrel=2
+pkgrel=3
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
-license=(LGPL2)
+
+# According to gtk/gtk.h, this is either LGPL2+ or LGPL2.1+, if that makes any
+# difference. So let's stick to LGPL2.1+ for safety.
+license=(LGPL2.1+)
+
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -6,7 +6,7 @@ replaces="${MINGW_PACKAGE_PREFIX}-${_realname}-svn"
 pkgdesc="MinGW-w64 headers for Windows"
 _ver_base=4.0.0
 pkgver=4.0.0.4421.7a87c02
-pkgrel=1
+pkgrel=2
 arch=('any')
 url="http://mingw-w64.sourceforge.net"
 license=('custom')
@@ -50,7 +50,7 @@ package() {
   rm ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include/pthread_unistd.h
 
   msg "Installing MinGW-w64 licenses"
-  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/ddk/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/ddk-readme.txt
-  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/direct-x/COPYING.LIB ${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/direct-x-COPYING.LIB
-  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/direct-x/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/direct-x-readme.txt
+  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/ddk/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/ddk-readme.txt
+  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/direct-x/COPYING.LIB ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/direct-x-COPYING.LIB
+  install -Dm644 ${srcdir}/${_realname}/mingw-w64-headers/direct-x/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/direct-x-readme.txt
 }

--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=libxml2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.9.2
-pkgrel=4
+pkgrel=5
 arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}")
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
@@ -149,5 +149,5 @@ package()
 
   # License
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
-  mv "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}-${pkgver}/Copyright" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/Copyright"
+  rm "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}-${pkgver}/Copyright" # This is the same file as COPYING
 }

--- a/mingw-w64-openshadinglanguage-git/PKGBUILD
+++ b/mingw-w64-openshadinglanguage-git/PKGBUILD
@@ -4,7 +4,7 @@ _realname=openshadinglanguage
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 _ver_base=1.5
 pkgver=1.5.1381.52ba3ae
-pkgrel=1
+pkgrel=2
 pkgdesc="Advanced shading language for production GI renderers (mingw-w64)"
 arch=('any')
 url="https://github.com/imageworks/OpenShadingLanguage/"
@@ -96,8 +96,8 @@ package() {
   make install
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/OSL/
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/licenses/$pkgname
-  mv "${pkgdir}${MINGW_PREFIX}"/LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/$pkgname # TODO: Tell upstream about this shit
+  mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}
+  mv "${pkgdir}${MINGW_PREFIX}"/LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname} # TODO: Tell upstream about this shit
   mv "${pkgdir}${MINGW_PREFIX}"/{CHANGES,README.md,INSTALL} "${pkgdir}${MINGW_PREFIX}"/share/OSL/
   mv "${pkgdir}${MINGW_PREFIX}"/doc "${pkgdir}${MINGW_PREFIX}"/share/OSL/doc
   #mv "${pkgdir}${MINGW_PREFIX}"/shaders "${pkgdir}${MINGW_PREFIX}"/share/OSL/shadersE

--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=docutils
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.12
-pkgrel=2
+pkgrel=3
 pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
 arch=('any')
 license=('custom')
@@ -59,8 +59,8 @@ package_python3-docutils() {
     ln -s "$(basename $f)" "${pkgdir}${MINGW_PREFIX}/bin/$(basename $f .py)"
   done
   # setup license
-  install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/COPYING.txt"
-  install -D -m644 licenses/python* "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/"
+  install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.txt"
+  install -D -m644 licenses/python* "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }
 
 package_python2-docutils() {
@@ -86,8 +86,8 @@ package_python2-docutils() {
     ln -s "$(basename $_f)" "${pkgdir}${MINGW_PREFIX}/bin/$(basename $_f .py)"
   done
   # setup license
-  install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/COPYING.txt"
-  install -D -m644 licenses/python* "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/"
+  install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.txt"
+  install -D -m644 licenses/python* "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
 }
 
 package_mingw-w64-i686-python2-docutils() {

--- a/mingw-w64-speex/PKGBUILD
+++ b/mingw-w64-speex/PKGBUILD
@@ -4,7 +4,7 @@ _realname=speex
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.2rc1
-pkgrel=2
+pkgrel=3
 pkgdesc="A free codec for free speech (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -34,5 +34,5 @@ build() {
 package() {
   cd ${srcdir}/build-${MINGW_CHOST}
   make DESTDIR="${pkgdir}" install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE"
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-waf/PKGBUILD
+++ b/mingw-w64-waf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=waf
 
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7.15
-pkgrel=1
+pkgrel=2
 pkgdesc="General-purpose build system modelled after Scons (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -52,6 +52,6 @@ package() {
   mv "${pkgdir}${MINGW_PREFIX}/bin/.waf3-$pkgver-"* "${pkgdir}${MINGW_PREFIX}/lib/waf/"
   setconf "${pkgdir}${MINGW_PREFIX}/bin/waf" base '"${MINGW_PREFIX}/lib/waf"'
 
-  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 
 }


### PR DESCRIPTION
* Some packages were using `${pkgname}` instead of `${_realname}` for license paths.
* libxml2: Remove the Copyright file as this is the same as COPYING.
* breakpad: Adjust maintainer/contributor lines.
* gtk2: Specify license as LGPL2.1+.