### PR TITLE
curl: add winssl variant

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -1,4 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+_variant=-openssl
+#_variant=-winssl
+#_variant=-gnutls
 
 _realname=curl
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -11,13 +14,17 @@ license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-c-ares"
-         "${MINGW_PACKAGE_PREFIX}-ca-certificates"
-         "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libidn"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-rtmpdump")
+         "${MINGW_PACKAGE_PREFIX}-rtmpdump"
+         $([[ "$_variant" == "-openssl" ]] && echo \
+            "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
+            "${MINGW_PACKAGE_PREFIX}-openssl")
+         $([[ "$_variant" == "-gnutls" ]] && echo \
+            "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
+            "${MINGW_PACKAGE_PREFIX}-gnutls")
+         )
 options=('staticlibs')
 source=("$url/download/${_realname}-$pkgver.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
@@ -44,16 +51,33 @@ build() {
     extra_config+=( --disable-debug )
   fi
   mkdir -p "${srcdir}/build-${CARCH}"
+
+  local -a _variant_config
+  if [ "${_variant}" = "-winssl" ]; then
+    _variant_config+=("--without-ssl")
+    _variant_config+=("--without-gnutls")
+    _variant_config+=("--with-winssl")
+    _variant_config+=("--without-ca-bundle")
+    _variant_config+=("--without-ca-path")
+  elif [ "${_variant}" = "-gnutls" ]; then
+    _variant_config+=("--without-ssl")
+    _variant_config+=("--with-gnutls")
+    _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
+  elif [ "${_variant}" = "-openssl" ]; then
+    _variant_config+=("--without-gnutls")
+    _variant_config+=("--with-ssl")
+    _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
+  fi
   cd "${srcdir}/build-${CARCH}"
   "${srcdir}"/${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
-    --with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt \
     --without-random \
     --enable-static \
     --enable-shared \
+    "${_variant_config[@]}" \
     "${extra_config[@]}"
   make
 }


### PR DESCRIPTION
configuring with gnutls is conflict with openssl or winssl option.
removing it should be safe.