### PR TITLE
glib2: fix not showing folder icons in gtkfilechooserdialog

### DIFF
--- a/mingw-w64-glib2/0028-inode_directory.patch
+++ b/mingw-w64-glib2/0028-inode_directory.patch
@@ -1,0 +1,11 @@
+--- a/gio/glocalfileinfo.c	2015-02-26 03:57:52.000000000 +0100
++++ b/gio/glocalfileinfo.c	2015-03-14 14:04:17.044446300 +0100
+@@ -1220,7 +1220,7 @@
+       (symlink_broken || (flags & G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS)))
+     return g_content_type_from_mime_type ("inode/symlink");
+   else if (statbuf != NULL && S_ISDIR(statbuf->st_mode))
+-    return g_content_type_from_mime_type ("inode/directory");
++    return g_strdup ("inode/directory");
+ #ifndef G_OS_WIN32
+   else if (statbuf != NULL && S_ISCHR(statbuf->st_mode))
+     return g_content_type_from_mime_type ("inode/chardevice");

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=glib2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.42.2
-pkgrel=2
+pkgrel=3
 url="http://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -27,7 +27,8 @@ source=("http://ftp.gnome.org/pub/GNOME/sources/glib/${pkgver%.*}/glib-$pkgver.t
         0023-print-in-binary-more-for-testing.all.patch
         0024-return-actually-written-data-in-printf.all.patch
         0001-gsocket-block-when-errno-says-it-will-block.patch
-        0027-no_sys_if_nametoindex.patch)
+        0027-no_sys_if_nametoindex.patch
+        0028-inode_directory.patch)
 md5sums=('ae9ee104932657ed08ef4679556be07f'
          '98c7778b5e8a30dbcdb86bcd15f9c11d'
          '6eb9d56028ea3bbec3d053254a00a04b'
@@ -39,7 +40,8 @@ md5sums=('ae9ee104932657ed08ef4679556be07f'
          '217a997ede1b93ac06f96ed869b74378'
          '500f39baea98d98e4a2f877ad56f55a5'
          'c8942cf5035f97ade5ab9c757a210f01'
-         'd06748f2891e1f4e6db5684d5935aefc')
+         'd06748f2891e1f4e6db5684d5935aefc'
+         '6c06cdfcbf877fb560e0be393a043d56')
 
 prepare() {
   cd "$srcdir/glib-$pkgver"
@@ -55,6 +57,7 @@ prepare() {
   patch -Np1 -i "$srcdir/0024-return-actually-written-data-in-printf.all.patch"
   patch -Np1 -i "$srcdir/0001-gsocket-block-when-errno-says-it-will-block.patch"
   patch -Np1 -i "$srcdir/0027-no_sys_if_nametoindex.patch"
+  patch -Np1 -i "$srcdir/0028-inode_directory.patch"
 
   NOCONFIGURE=1 ./autogen.sh
 }


### PR DESCRIPTION
gio's g_content_type_from_mime_type ("inode/directory")
not working in windows so reverting that