### PR TITLE
db: bump version and use unicode flags to build

### DIFF
--- a/mingw-w64-db/PKGBUILD
+++ b/mingw-w64-db/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=db
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.0.19
-pkgrel=1
+pkgrel=2
 pkgdesc="The Berkeley DB embedded database system (mingw-w64)"
 arch=('any')
 url="http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/overview/index.html"
@@ -24,6 +24,8 @@ prepare()
 }
 
 build() {
+  CFLAGS+=" -DUNICODE -D_UNICODE"
+  CXXFLAGS+=" -DUNICODE -D_UNICODE"
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
   ../${_realname}-${pkgver}/dist/configure \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Build without -DUNICODE -D_UNICODE flags can't work with non-ascii path