### PR TITLE
Add coq and its dependencies

### DIFF
--- a/mingw-w64-coq/0001-Guess-the-libraries-are-located-at-lib-coq-instead-o.patch
+++ b/mingw-w64-coq/0001-Guess-the-libraries-are-located-at-lib-coq-instead-o.patch
@@ -1,0 +1,26 @@
+From dab04e936fd8c195843ac0b4a40201c46142da4a Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Sun, 5 Apr 2015 16:46:03 +0800
+Subject: [PATCH] Guess the libraries are located at lib/coq/ instead of lib/
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ lib/envars.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/envars.ml b/lib/envars.ml
+index 3040dd4..3a25e9c 100644
+--- a/lib/envars.ml
++++ b/lib/envars.ml
+@@ -34,7 +34,7 @@ let reldir instdir testfile oth =
+ 
+ let guess_coqlib () =
+   let file = "states/initial.coq" in
+-    reldir (if Coq_config.arch = "win32" then ["lib"] else ["lib";"coq"]) file
++    reldir (if Coq_config.arch = "win32" then ["lib";"coq"] else ["lib";"coq"]) file
+       (fun () ->
+         let coqlib = match Coq_config.coqlib with
+           | Some coqlib -> coqlib
+-- 
+2.3.4
+

--- a/mingw-w64-coq/PKGBUILD
+++ b/mingw-w64-coq/PKGBUILD
@@ -1,0 +1,69 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=coq
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=8.4pl5
+pkgrel=1
+pkgdesc='A formal proof management system'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='https://coq.inria.fr/'
+license=('LGPL 2.1')
+depends=("${MINGW_PACKAGE_PREFIX}-ocaml"
+	 "${MINGW_PACKAGE_PREFIX}-ocaml-camlp4"
+	 "${MINGW_PACKAGE_PREFIX}-ocaml-lablgtk")
+source=("https://coq.inria.fr/distrib/V8.4pl5/files/coq-8.4pl5.tar.gz"
+	"0001-Guess-the-libraries-are-located-at-lib-coq-instead-o.patch")
+sha1sums=('107717cbaef3a469e8ff775ae54dbbc457935816'
+          '5683480358e92b4eb38adc2402dd0febf37ebb2e')
+
+env=${MINGW_PREFIX#/}
+_pkg="${_realname}-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+
+  cd ${srcdir}
+  mv ${_pkg} ${_pkgsrc}
+  cd ${_pkgsrc}
+
+  patch -p1 -i ${srcdir}/0001-Guess-the-libraries-are-located-at-lib-coq-instead-o.patch
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+  export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
+  ./configure -prefix ${MINGW_PREFIX} \
+	      -bindir ${MINGW_PREFIX}/bin \
+	      -libdir ${MINGW_PREFIX}/lib/coq \
+	      -mandir ${MINGW_PREFIX}/share/man \
+	      -configdir ${MINGW_PREFIX}/etc/xdg/coq \
+	      -datadir ${MINGW_PREFIX}/share/coq \
+	      -docdir ${MINGW_PREFIX}/share/doc/coq \
+	      -emacslib ${MINGW_PREFIX}/share/emacs/site-lisp/coq \
+	      -coqdocdir ${MINGW_PREFIX}/share/texmf/tex \
+	      -usecamlp4 -arch win32
+  make revision
+  make coq
+  make coqide -j1
+}
+
+check() {
+  # Some tests fail due to the following reasons:
+  #   * Some signals are not available
+  #   * lockf (lock a file region) fails
+  # These cases also fail with the official binaries.
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+  export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
+  make install COQINSTALLPREFIX=${pkgdir}/ OLDROOT=$(cygpath -m /)
+  [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  [ -f COPYRIGHT ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  [ -f CREDITS ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-flexdll/0001-Fix-the-List.hd-exception.patch
+++ b/mingw-w64-flexdll/0001-Fix-the-List.hd-exception.patch
@@ -1,0 +1,30 @@
+From 504e2c48dd2ae889f5b76efcde5da18580dcbab3 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Thu, 2 Apr 2015 19:18:55 +0800
+Subject: [PATCH] Fix the 'List.hd []' exception
+
+get_output may return [] if the cmd prints nothing, leading get_output1
+to fail due to a 'List.hd []'. 'gcc -print-sysroot' is such a case.
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ reloc.ml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/reloc.ml b/reloc.ml
+index e175802..5f92e10 100644
+--- a/reloc.ml
++++ b/reloc.ml
+@@ -85,7 +85,9 @@ let get_output ?(use_bash = false) ?(accept_error=false) cmd =
+       r
+
+ let get_output1 ?use_bash cmd =
+-  List.hd (get_output ?use_bash cmd)
++  match (get_output ?use_bash cmd) with
++  | [] -> ""
++  | h :: t -> h
+
+
+ (* Preparing command line *)
+--
+2.3.4

--- a/mingw-w64-flexdll/0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch
+++ b/mingw-w64-flexdll/0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch
@@ -1,0 +1,25 @@
+From 862fa31ae745b9fecf8a5663a1ff1c757ca18a9d Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Sat, 4 Apr 2015 18:49:50 +0800
+Subject: [PATCH] Add path to libcrt2.o into the default library search
+ path
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ reloc.ml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/reloc.ml b/reloc.ml
+index 5f92e10..b4b96bd 100644
+--- a/reloc.ml
++++ b/reloc.ml
+@@ -1059,6 +1059,7 @@ let setup_toolchain () =
+       [
+        Filename.dirname (get_output1 (!gcc ^ " -print-libgcc-file-name"));
+        get_output1 (!gcc ^ " -print-sysroot") ^ "/mingw/lib";
++       (match !toolchain with | `MINGW -> "/mingw32" | `MINGW64 -> "/mingw64" | _ -> "") ^ "/" ^ pre ^ "/lib";
+       ];
+     default_libs :=
+       ["-lmingw32"; "-lgcc"; "-lmoldname"; "-lmingwex"; "-lmsvcrt";
+--
+2.3.4

--- a/mingw-w64-flexdll/0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch
+++ b/mingw-w64-flexdll/0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch
@@ -1,0 +1,38 @@
+From d5c628a8b9a263a74874612638ff5426c4eff36a Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Sat, 4 Apr 2015 19:08:51 +0800
+Subject: [PATCH] Remove the usages of stdout to workaround the missing of
+ __getreent
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ test/dump.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/test/dump.c b/test/dump.c
+index 0d6d700..bb4abe7 100644
+--- a/test/dump.c
++++ b/test/dump.c
+@@ -25,9 +25,9 @@ int main(int argc, char **argv)
+   int i;
+   torun *torun;
+
+-  printf("INIT\n"); fflush(stdout);
++  printf("INIT\n");
+   flexdll_dump_exports(NULL);
+-  printf("OK\n"); fflush(stdout);
++  printf("OK\n");
+   for (i = 1; i < argc; i++) {
+     printf("** Loading %s\n", argv[i]);
+     handle = flexdll_dlopen(argv[i], FLEXDLL_RTLD_GLOBAL);
+@@ -39,7 +39,7 @@ int main(int argc, char **argv)
+     if (NULL == handle) { printf("error: %s\n", flexdll_dlerror()); exit(2); }
+
+     torun = flexdll_dlsym(handle, "torun");
+-    printf("Now running %p...\n", torun); fflush(stdout);
++    printf("Now running %p...\n", torun);
+     if (torun) torun();
+   }
+   exit(0);
+--
+2.3.4

--- a/mingw-w64-flexdll/PKGBUILD
+++ b/mingw-w64-flexdll/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=flexdll
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.31
+pkgrel=1
+pkgdesc='An implementation of a dlopen-like API for Windows'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://alain.frisch.fr/flexdll.html'
+license=('zlib/libpng License')
+makedepends=("${MINGW_PACKAGE_PREFIX}-ocaml")
+source=("http://alain.frisch.fr/flexdll/${_realname}-${pkgver}.tar.gz"
+        "0001-Fix-the-List.hd-exception.patch"
+        "0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch"
+        "0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch")
+sha1sums=('7ca63bf8d6c731fd95e0d434a8cfbcc718b99d62'
+          '642c99ad0d2035ef028254aff41dbff49014bed3'
+          '31ebdca246a4df6069d733350c9a2b8c94d33dec'
+          '43f232f04934a0c7797f05e8db03f04ae156d8c4')
+
+env=${MINGW_PREFIX#/}
+if [ "${env}" == "mingw32" ]; then
+  chain="mingw"
+else
+  chain="mingw64"
+fi
+_pkg="${_realname}-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+
+  cd ${srcdir}
+  mv ${_realname} ${_pkgsrc}
+  cd ${_pkgsrc}
+
+  patch -p1 -i ${srcdir}/0001-Fix-the-List.hd-exception.patch
+  patch -p1 -i ${srcdir}/0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch
+  patch -p1 -i ${srcdir}/0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+
+  export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
+  make flexlink.exe -j1
+  make build_${chain} -j1
+}
+
+check() {
+  # The test demo works on x86_64 but fails on i686. Root causes of the failure
+  # is still unknown, but the tool is good enough to be used in other
+  # applications such as ocaml and coq.
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin/
+  install flexlink.exe ${pkgdir}${MINGW_PREFIX}/bin/
+  install flexdll_${chain}.o ${pkgdir}${MINGW_PREFIX}/bin/
+  install flexdll_initer_${chain}.o ${pkgdir}${MINGW_PREFIX}/bin/
+  for f in flexdll.h flexdll.c flexdll_initer.c default.manifest default_amd64.manifest; do
+    install ${f} ${pkgdir}${MINGW_PREFIX}/bin/
+  done
+  [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+  [ -f CHANGES ] && install -Dm644 CHANGES ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/CHANGES
+}

--- a/mingw-w64-libart_lgpl/0001-Fix-an-installation-path-bug.patch
+++ b/mingw-w64-libart_lgpl/0001-Fix-an-installation-path-bug.patch
@@ -1,0 +1,26 @@
+From 6d7c1a8ba616351711829f26b36ff18f5e18ee10 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Fri, 3 Apr 2015 20:45:14 +0800
+Subject: [PATCH] Fix an installation path bug
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index f60343d..4501dd8 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -919,7 +919,7 @@ art_config.h:	gen_art_config$(EXEEXT)
+ 	./gen_art_config > art_config.h
+ 
+ @OS_WIN32_TRUE@install-libtool-import-lib:
+-@OS_WIN32_TRUE@	$(INSTALL) .libs/libart_lgpl_2.dll.a $(DESTDIR)$(libdir)
++@OS_WIN32_TRUE@	$(INSTALL) -D .libs/libart_lgpl_2.dll.a $(DESTDIR)$(libdir)/libart_lgpl_2.dll.a
+ @OS_WIN32_TRUE@uninstall-libtool-import-lib:
+ @OS_WIN32_TRUE@	-rm $(DESTDIR)$(libdir)/libart_lgpl_2.dll.a
+ @OS_WIN32_FALSE@install-libtool-import-lib:
+-- 
+2.3.4
+

--- a/mingw-w64-libart_lgpl/PKGBUILD
+++ b/mingw-w64-libart_lgpl/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=libart_lgpl
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.3.19
+pkgrel=1
+pkgdesc='library for high-performance 2D graphics'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://www.levien.com/libart'
+license=('custom')
+source=("http://ftp.gnome.org/pub/gnome/sources/libart_lgpl/2.3/libart_lgpl-2.3.19.tar.bz2"
+	"http://www.linuxfromscratch.org/patches/blfs/6.3/libart_lgpl-2.3.19-upstream_fix-1.patch"
+	"0001-Fix-an-installation-path-bug.patch")
+sha1sums=('7f1ff36c91cdc8f14b62acb50836f52a0c735b9e'
+          'b901b64b6ef370ef1eeeb5aa374b91c7fed5534f'
+          '1079fcc8b813ce55b445278493fb831a91e347e6')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/libart_lgpl-2.3.19-upstream_fix-1.patch
+  patch -p1 -i ${srcdir}/0001-Fix-an-installation-path-bug.patch
+}
+
+build() {
+  [ -d "${srcdir}"/build-${CARCH} ] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+     --prefix=${MINGW_PREFIX} \
+     --exec-prefix=${MINGW_PREFIX} \
+     --build=${MINGW_CHOST} \
+     --host=${MINGW_CHOST} \
+     --target=${MINGW_CHOST} \
+     --enable-static \
+     --enable-shared
+  cp ../${_realname}-${pkgver}/libart.def libart.def
+  make
+}
+
+check() {
+  # The package ships with some test tools but provides no automatic check mechanisms
+  plain "skip"
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+
+  cd "$srcdir"/${_realname}-${pkgver}
+  [ -f COPYING ] && install -Dm644 COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  [ -f AUTHORS ] && install -Dm644 AUTHORS ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/AUTHORS
+  [ -f NEWS ] && install -Dm644 NEWS ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/NEWS
+}

--- a/mingw-w64-libart_lgpl/libart_lgpl-2.3.19-upstream_fix-1.patch
+++ b/mingw-w64-libart_lgpl/libart_lgpl-2.3.19-upstream_fix-1.patch
@@ -1,0 +1,28 @@
+Submitted By:            Randy McMurchy <randy_at_linuxfromscratch_dot_org>
+Date:                    2007-04-09
+Initial Package Version: 2.3.19
+Upstream Status:         In upstream CVS
+Origin:                  Upstream
+Description:             Fixes an error during the installation of KDE-Libs
+
+
+diff -Naur libart_lgpl-2.3.19.orig/art_misc.h libart_lgpl-2.3.19/art_misc.h
+--- libart_lgpl-2.3.19.orig/art_misc.h  2007-01-01 18:59:22.000000000 -0500
++++ libart_lgpl-2.3.19/art_misc.h       2007-03-20 23:04:52.000000000 -0400
+@@ -34,9 +34,15 @@
+ #include <libart_lgpl/art_config.h>
+ #endif
+
++#ifdef __cplusplus
++extern "C" {
++#endif
+ void *art_alloc(size_t size);
+ void art_free(void *ptr);
+ void *art_realloc(void *ptr, size_t size);
++#ifdef __cplusplus
++}
++#endif /* __cplusplus */
+
+ /* These aren't, strictly speaking, configuration macros, but they're
+    damn handy to have around, and may be worth playing with for
+

--- a/mingw-w64-libgnomecanvas/PKGBUILD
+++ b/mingw-w64-libgnomecanvas/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=libgnomecanvas
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.30.3
+pkgrel=1
+pkgdesc='The GNOME canvas library'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+depends=("${MINGW_PACKAGE_PREFIX}-libglade"
+	 "${MINGW_PACKAGE_PREFIX}-libart_lgpl"
+	 "${MINGW_PACKAGE_PREFIX}-gtk2"
+	 "intltool")
+url='https://developer.gnome.org/libgnomecanvas/stable/GnomeCanvas.html'
+license=('LGPL2')
+source=("http://ftp.acc.umu.se/pub/gnome/sources/libgnomecanvas/2.30/libgnomecanvas-2.30.3.tar.gz")
+sha1sums=('e73e0739d28c0772728621ae151c9a7d9b6d3dfd')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+}
+
+build() {
+  [ -d "${srcdir}"/build-${CARCH} ] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+     --prefix=${MINGW_PREFIX} \
+     --exec-prefix=${MINGW_PREFIX} \
+     --build=${MINGW_CHOST} \
+     --host=${MINGW_CHOST} \
+     --target=${MINGW_CHOST} \
+     --enable-static \
+     --enable-shared \
+     --enable-glade
+  make
+}
+
+check() {
+  # The test case fails due to a warning on a deprecated property
+  plain "skip"
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+
+  cd "$srcdir"/${_realname}-${pkgver}
+  [ -f COPYING.LIB ] && install -Dm644 COPYING.LIB ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB
+  [ -f AUTHORS ] && install -Dm644 AUTHORS ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/AUTHORS
+  [ -f NEWS ] && install -Dm644 NEWS ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/NEWS
+}

--- a/mingw-w64-ocaml-camlp4/0001-Properly-quote-preprocessor-command-to-ocamldep.patch
+++ b/mingw-w64-ocaml-camlp4/0001-Properly-quote-preprocessor-command-to-ocamldep.patch
@@ -1,0 +1,29 @@
+From b50f443639a6d6c36d5cd492d8f8da81b5beb5ce Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Fri, 3 Apr 2015 09:58:18 +0800
+Subject: [PATCH] Properly quote preprocessor command to ocamldep
+
+Build in msys2 fails with not able to execute
+''''camlp4\boot\camlp4boot.native' -D OPT' as the preprocessor for
+ocamldep because the path is outside the quotes.
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ myocamlbuild.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/myocamlbuild.ml b/myocamlbuild.ml
+index 0573bef..d318c64 100644
+--- a/myocamlbuild.ml
++++ b/myocamlbuild.ml
+@@ -84,7 +84,7 @@ let () =
+         let dep = "camlp4"/"boot"/exe in
+         let cmd =
+           let ( / ) = Filename.concat in
+-          "camlp4"/"boot"/exe
++          "'" ^ "camlp4"/"boot"/exe ^ "'"
+         in
+         (Some dep, cmd)
+     in
+--
+2.3.4

--- a/mingw-w64-ocaml-camlp4/0002-Add-DESTDIR-in-configure.patch
+++ b/mingw-w64-ocaml-camlp4/0002-Add-DESTDIR-in-configure.patch
@@ -1,0 +1,83 @@
+From 528dc19da11d3b35e61a81b142430252db1db30b Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Fri, 3 Apr 2015 10:53:09 +0800
+Subject: [PATCH] Add DESTDIR in configure
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ Makefile         | 4 ++--
+ build/install.sh | 4 ++--
+ configure        | 8 +++++++-
+ 3 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c8bd7a4..0ee0046 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,8 +23,8 @@ install:
+
+ .PHONY: install-META
+ install-META: camlp4/META
+-	mkdir -p ${PKGDIR}/camlp4/
+-	cp -f camlp4/META ${PKGDIR}/camlp4/
++	mkdir -p ${DESTDIR}${PKGDIR}/camlp4/
++	cp -f camlp4/META ${DESTDIR}${PKGDIR}/camlp4/
+
+ camlp4/META: camlp4/META.in
+ 	sed -e s/@@VERSION@@/${version}/g $? > $@
+diff --git a/build/install.sh b/build/install.sh
+index 9d98d6c..220e878 100644
+--- a/build/install.sh
++++ b/build/install.sh
+@@ -26,8 +26,8 @@ SAVED_LIBDIR="${LIBDIR}"
+
+ . ./config.sh
+
+-BINDIR="${SAVED_BINDIR:-${BINDIR}}"
+-LIBDIR="${SAVED_LIBDIR:-${LIBDIR}}"
++BINDIR="$DESTDIR${SAVED_BINDIR:-${BINDIR}}"
++LIBDIR="$DESTDIR${SAVED_LIBDIR:-${LIBDIR}}"
+
+ not_installed=$PWD/_build/not_installed
+
+diff --git a/configure b/configure
+index e859501..551f46e 100644
+--- a/configure
++++ b/configure
+@@ -17,8 +17,11 @@ for i in "$@"; do
+     --pkgdir=*)
+       PKGDIR=${i##*=}
+       ;;
++    --destdir=*)
++      DESTDIR=${i##*=}
++      ;;
+     *)
+-      echo "usage: ./configure [--bindir=<dir>] [--libdir=<dir>] [--pkgdir=<dir>]" 1>&2
++      echo "usage: ./configure [--bindir=<dir>] [--libdir=<dir>] [--pkgdir=<dir>] [--destdir=<dir>]" 1>&2
+       exit 2
+       ;;
+   esac
+@@ -44,6 +47,7 @@ OCAMLC="`which ocamlc`"
+ LIBDIR="${LIBDIR:-$standard_library}"
+ BINDIR="${BINDIR:-`dirname $OCAMLC`}"
+ PKGDIR="${PKGDIR:-$standard_library}"
++DESTDIR="${DESTDIR}"
+
+ if [ -x "`which ocamlopt`" ]; then
+     OB_FLAGS=""
+@@ -58,6 +62,7 @@ EXE="$ext_exe"
+ LIBDIR="$LIBDIR"
+ BINDIR="$BINDIR"
+ PKGDIR="$PKGDIR"
++DESTDIR="$DESTDIR"
+ OB_FLAGS=$OB_FLAGS
+ EOF
+
+@@ -65,4 +70,5 @@ cat >> myocamlbuild_config.ml <<EOF
+ let libdir="$LIBDIR"
+ let bindir="$BINDIR"
+ let pkgdir="$PKGDIR"
++let destdir="$DESTDIR"
+ EOF
+--
+2.3.4

--- a/mingw-w64-ocaml-camlp4/PKGBUILD
+++ b/mingw-w64-ocaml-camlp4/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=ocaml-camlp4
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.02.1
+pkgrel=1
+pkgdesc='Pre-Processor-Pretty-Printer for OCaml'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='https://github.com/ocaml/camlp4'
+license=('LGPL2')
+depends=("${MINGW_PACKAGE_PREFIX}-ocaml")
+makedepends=("${MINGW_PACKAGE_PREFIX}-flexdll")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/ocaml/camlp4/archive/4.02.1.tar.gz"
+	"0001-Properly-quote-preprocessor-command-to-ocamldep.patch"
+	"0002-Add-DESTDIR-in-configure.patch")
+sha1sums=('c16d9ae3693612c71e12d2880ec911772b8d23c3'
+          'eb7a59d2e184f368d735670bea96571aa861f97b'
+          '6aa01135f05a5e943412bf728f90ced871c6a064')
+
+env=${MINGW_PREFIX#/}
+_pkg="${_realname}-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+  cd ${srcdir}
+  mv camlp4-${pkgver} ${_pkgsrc}
+  cd ${_pkgsrc}
+
+  patch -p1 -i ${srcdir}/0001-Properly-quote-preprocessor-command-to-ocamldep.patch
+  patch -p1 -i ${srcdir}/0002-Add-DESTDIR-in-configure.patch
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+  export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
+  ./configure --bindir=${MINGW_PREFIX}/bin \
+              --libdir=${MINGW_PREFIX}/lib/ocaml \
+              --pkgdir=${MINGW_PREFIX}/lib/ocaml \
+              --destdir=${pkgdir}
+  make all -j1
+}
+
+check() {
+  # The package does not include an automatic test process
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+  make install -j1
+  make install-META -j1
+  [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  mkdir -p ${pkgdir}/etc/profile.d
+  echo '[ "$MSYSTEM" = "'$(echo ${env} | tr "[:lower:]" "[:upper:]")'" ] && export CAMLP4LIB='${MINGW_PREFIX}'/lib/ocaml' > ${pkgdir}/etc/profile.d/camlp4.${env}.sh
+}

--- a/mingw-w64-ocaml-findlib/PKGBUILD
+++ b/mingw-w64-ocaml-findlib/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=ocaml-findlib
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.5.5
+pkgrel=1
+pkgdesc='OCaml library manager'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://projects.camlcity.org/projects/findlib.html'
+license=('custom')
+depends=("${MINGW_PACKAGE_PREFIX}-ocaml")
+source=("http://download.camlcity.org/download/findlib-1.5.5.tar.gz")
+sha1sums=('3221121c4b5adacc050aa361475eee59b2698afa')
+
+env=${MINGW_PREFIX#/}
+_pkg="findlib-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+
+  cd ${srcdir}
+  mv ${_pkg} ${_pkgsrc}
+  cd ${_pkgsrc}
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+  export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
+  ./configure -system win32 \
+              -sitelib ${MINGW_PREFIX}/lib/ocaml \
+              -mandir ${MINGW_PREFIX}/share/man \
+              -no-camlp4
+  make all -j1
+  make opt -j1
+}
+
+check() {
+  # The package does not include a testsuite
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+  make install prefix=${pkgdir}
+  [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}

--- a/mingw-w64-ocaml-lablgtk/0001-Fix-a-path-issue-during-installation.patch
+++ b/mingw-w64-ocaml-lablgtk/0001-Fix-a-path-issue-during-installation.patch
@@ -1,0 +1,29 @@
+From 322d53d676ec55a4b28e8d24787e54e97c2fc140 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Sun, 5 Apr 2015 10:51:34 +0800
+Subject: [PATCH] Fix a path issue during installation
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 8cdc264..39f59e5 100644
+--- a/configure
++++ b/configure
+@@ -2677,9 +2677,9 @@ if test "$OCAMLFIND" = no; then
+ FINDLIBDIR=""
+ OCAMLLDCONF=""
+ else
+-FINDLIBDIR="`ocamlfind printconf destdir | tr -d '\\r'`"
++FINDLIBDIR="`ocamlfind printconf destdir | sed 's/\\\\/\\\\\\\\/g' | xargs cygpath -u`"
+ echo "$OCAMLFIND library path is $FINDLIBDIR"
+-OCAMLLDCONF="`ocamlfind printconf ldconf | tr -d '\\r'`"
++OCAMLLDCONF="`ocamlfind printconf ldconf | sed 's/\\\\/\\\\\\\\/g' | xargs cygpath -u`"
+ echo "$OCAMLFIND ldconf path is $OCAMLLDCONF"
+ fi
+ 
+-- 
+2.3.4
+

--- a/mingw-w64-ocaml-lablgtk/PKGBUILD
+++ b/mingw-w64-ocaml-lablgtk/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=ocaml-lablgtk
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.18.3
+pkgrel=1
+pkgdesc='An Ocaml interface to the GIMP Tool Kit.'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://lablgtk.forge.ocamlcore.org/'
+license=('LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-ocaml"
+	 "${MINGW_PACKAGE_PREFIX}-gtk2"
+	 "${MINGW_PACKAGE_PREFIX}-libglade"
+	 "${MINGW_PACKAGE_PREFIX}-librsvg"
+	 "${MINGW_PACKAGE_PREFIX}-gtksourceview2"
+	 "${MINGW_PACKAGE_PREFIX}-gtkspell"
+	 "${MINGW_PACKAGE_PREFIX}-pkg-config"
+	 "${MINGW_PACKAGE_PREFIX}-ocaml-findlib"
+	 )
+makedepends=("${MINGW_PACKAGE_PREFIX}-flexdll")
+source=("https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
+	"0001-Fix-a-path-issue-during-installation.patch")
+sha1sums=('b8ecc3b160fcbce73062f3bad23a2a3b1c2735d3'
+          '8aae142b4c50038f9284c3427b22d75df6f3018e')
+
+env=${MINGW_PREFIX#/}
+_pkg="lablgtk-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+
+  cd ${srcdir}
+  mv ${_pkg} ${_pkgsrc}
+  cd ${_pkgsrc}
+
+  patch -p1 -i ${srcdir}/0001-Fix-a-path-issue-during-installation.patch
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared \
+    --disable-gtktest
+  sed -i "s/-pthread/-lpthread/g" config.make
+  make
+  make opt
+}
+
+check() {
+  # The package does not include an automatic test process
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+  make install DESTDIR="${pkgdir}"
+
+  for f in COPYING LGPL; do
+    [ -f ${f} ] && install -Dm644 ${f} ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/${f}
+  done
+
+  # do not append to ld.conf
+  rm ${pkgdir}${MINGW_PREFIX}/lib/ocaml/ld.conf
+}

--- a/mingw-w64-ocaml/0001-Rename-Makefile.mingw-to-Makefile.mingw32.patch
+++ b/mingw-w64-ocaml/0001-Rename-Makefile.mingw-to-Makefile.mingw32.patch
@@ -1,0 +1,381 @@
+From 360ad82fa708c1d4456d09ba8f76d10962ea55d6 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Wed, 1 Apr 2015 08:47:09 +0800
+Subject: [PATCH] Rename Makefile.mingw to Makefile.mingw32
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ config/Makefile.mingw   | 177 ------------------------------------------------
+ config/Makefile.mingw32 | 177 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 177 insertions(+), 177 deletions(-)
+ delete mode 100644 config/Makefile.mingw
+ create mode 100644 config/Makefile.mingw32
+
+diff --git a/config/Makefile.mingw b/config/Makefile.mingw
+deleted file mode 100644
+index c204980..0000000
+--- a/config/Makefile.mingw
++++ /dev/null
+@@ -1,177 +0,0 @@
+-#########################################################################
+-#                                                                       #
+-#                                 OCaml                                 #
+-#                                                                       #
+-#            Xavier Leroy, projet Cristal, INRIA Rocquencourt           #
+-#                                                                       #
+-#   Copyright 1999 Institut National de Recherche en Informatique et    #
+-#   en Automatique.  All rights reserved.  This file is distributed     #
+-#   under the terms of the GNU Library General Public License, with     #
+-#   the special exception on linking described in file ../LICENSE.      #
+-#                                                                       #
+-#########################################################################
+-
+-# Configuration for Windows, Mingw compiler
+-
+-######### General configuration
+-
+-PREFIX=C:/ocamlmgw
+-
+-### Remove this to disable compiling ocamldebug
+-WITH_DEBUGGER=ocamldebugger
+-
+-### Remove this to disable compiling ocamlbuild
+-WITH_OCAMLBUILD=ocamlbuild
+-
+-### Remove this to disable compiling ocamldoc
+-WITH_OCAMLDOC=ocamldoc
+-
+-### Where to install the binaries
+-BINDIR=$(PREFIX)/bin
+-
+-### Where to install the standard library
+-LIBDIR=$(PREFIX)/lib
+-
+-### Where to install the stub DLLs
+-STUBLIBDIR=$(LIBDIR)/stublibs
+-
+-### Where to install the info files
+-DISTRIB=$(PREFIX)
+-
+-### Where to install the man pages
+-MANDIR=$(PREFIX)/man
+-
+-########## Toolchain and OS dependencies
+-
+-TOOLCHAIN=mingw
+-
+-### Toolchain prefix
+-TARGET=i686-w64-mingw32
+-HOST=i686-w64-mingw32
+-
+-TOOLPREF=$(TARGET)-
+-
+-CCOMPTYPE=cc
+-O=o
+-A=a
+-S=s
+-SO=s.o
+-EXE=.exe
+-EXT_DLL=.dll
+-EXT_OBJ=.$(O)
+-EXT_LIB=.$(A)
+-EXT_ASM=.$(S)
+-MANEXT=1
+-SHARPBANGSCRIPTS=false
+-PTHREAD_LINK=
+-X11_INCLUDES=
+-X11_LINK=
+-BYTECCRPATH=
+-SUPPORTS_SHARED_LIBRARIES=true
+-SHAREDCCCOMPOPTS=
+-MKSHAREDLIBRPATH=
+-NATIVECCPROFOPTS=
+-NATIVECCRPATH=
+-ASM=$(TOOLPREF)as
+-ASPP=$(TOOLPREF)gcc -c
+-ASPPPROFFLAGS=
+-PROFILING=noprof
+-DYNLINKOPTS=
+-CC_PROFILE=
+-SYSTHREAD_SUPPORT=true
+-EXTRALIBS=
+-NATDYNLINK=true
+-CMXS=cmxs
+-RUNTIMED=noruntimed
+-ASM_CFI_SUPPORTED=false
+-UNIXLIB=win32unix
+-GRAPHLIB=win32graph
+-
+-########## Configuration for the bytecode compiler
+-
+-### Which C compiler to use for the bytecode interpreter.
+-BYTECC=$(TOOLPREF)gcc
+-
+-### Additional compile-time options for $(BYTECC).  (For static linking.)
+-BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
+-
+-### Additional link-time options for $(BYTECC).  (For static linking.)
+-BYTECCLINKOPTS=
+-
+-### Additional compile-time options for $(BYTECC).  (For building a DLL.)
+-DLLCCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused -DCAML_DLL
+-
+-### Libraries needed
+-BYTECCLIBS=-lws2_32
+-NATIVECCLIBS=-lws2_32
+-
+-### How to invoke the C preprocessor
+-CPP=$(BYTECC) -E
+-
+-### Flexlink
+-FLEXLINK=flexlink -chain mingw -stack 16777216 -link -static-libgcc
+-FLEXDIR:=$(shell $(FLEXLINK) -where)
+-IFLEXDIR=-I"$(FLEXDIR)"
+-MKDLL=$(FLEXLINK)
+-MKEXE=$(FLEXLINK) -exe
+-MKMAINDLL=$(FLEXLINK) -maindll
+-
+-### How to build a static library
+-MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
+-#ml let mklib out files opts = Printf.sprintf "rm -f %s && %sar rcs %s %s %s" out toolpref opts out files;;
+-
+-### Canonicalize the name of a system library
+-SYSLIB=-l$(1)
+-#ml let syslib x = "-l"^x;;
+-
+-### The ranlib command
+-RANLIB=$(TOOLPREF)ranlib
+-RANLIBCMD=$(TOOLPREF)ranlib
+-
+-### The ar command
+-ARCMD=$(TOOLPREF)ar
+-
+-############# Configuration for the native-code compiler
+-
+-### Name of architecture for the native-code compiler
+-ARCH=i386
+-
+-### Name of architecture model for the native-code compiler.
+-MODEL=default
+-
+-### Name of operating system family for the native-code compiler.
+-SYSTEM=mingw
+-
+-### Which C compiler to use for the native-code compiler.
+-NATIVECC=$(BYTECC)
+-
+-### Additional compile-time options for $(NATIVECC).
+-NATIVECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
+-
+-### Additional link-time options for $(NATIVECC)
+-NATIVECCLINKOPTS=
+-
+-### Build partially-linked object file
+-PACKLD=$(TOOLPREF)ld -r $(NATIVECCLINKOPTS) -o # must have a space after '-o'
+-
+-############# Configuration for the contributed libraries
+-
+-OTHERLIBRARIES=win32unix str num win32graph dynlink bigarray systhreads
+-
+-### Name of the target architecture for the "num" library
+-BNG_ARCH=ia32
+-BNG_ASM_LEVEL=1
+-
+-############# Aliases for common commands
+-
+-MAKEREC=$(MAKE) -f Makefile.nt
+-MAKECMD=$(MAKE)
+-
+-############# for the testsuite makefiles
+-#ml let topdir = "" and wintopdir = "";;
+-OTOPDIR=$(WINTOPDIR)
+-CTOPDIR=$(TOPDIR)
+-CYGPATH=cygpath -m
+-DIFF=diff -q --strip-trailing-cr
+-CANKILL=false
+-SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+diff --git a/config/Makefile.mingw32 b/config/Makefile.mingw32
+new file mode 100644
+index 0000000..c204980
+--- /dev/null
++++ b/config/Makefile.mingw32
+@@ -0,0 +1,177 @@
++#########################################################################
++#                                                                       #
++#                                 OCaml                                 #
++#                                                                       #
++#            Xavier Leroy, projet Cristal, INRIA Rocquencourt           #
++#                                                                       #
++#   Copyright 1999 Institut National de Recherche en Informatique et    #
++#   en Automatique.  All rights reserved.  This file is distributed     #
++#   under the terms of the GNU Library General Public License, with     #
++#   the special exception on linking described in file ../LICENSE.      #
++#                                                                       #
++#########################################################################
++
++# Configuration for Windows, Mingw compiler
++
++######### General configuration
++
++PREFIX=C:/ocamlmgw
++
++### Remove this to disable compiling ocamldebug
++WITH_DEBUGGER=ocamldebugger
++
++### Remove this to disable compiling ocamlbuild
++WITH_OCAMLBUILD=ocamlbuild
++
++### Remove this to disable compiling ocamldoc
++WITH_OCAMLDOC=ocamldoc
++
++### Where to install the binaries
++BINDIR=$(PREFIX)/bin
++
++### Where to install the standard library
++LIBDIR=$(PREFIX)/lib
++
++### Where to install the stub DLLs
++STUBLIBDIR=$(LIBDIR)/stublibs
++
++### Where to install the info files
++DISTRIB=$(PREFIX)
++
++### Where to install the man pages
++MANDIR=$(PREFIX)/man
++
++########## Toolchain and OS dependencies
++
++TOOLCHAIN=mingw
++
++### Toolchain prefix
++TARGET=i686-w64-mingw32
++HOST=i686-w64-mingw32
++
++TOOLPREF=$(TARGET)-
++
++CCOMPTYPE=cc
++O=o
++A=a
++S=s
++SO=s.o
++EXE=.exe
++EXT_DLL=.dll
++EXT_OBJ=.$(O)
++EXT_LIB=.$(A)
++EXT_ASM=.$(S)
++MANEXT=1
++SHARPBANGSCRIPTS=false
++PTHREAD_LINK=
++X11_INCLUDES=
++X11_LINK=
++BYTECCRPATH=
++SUPPORTS_SHARED_LIBRARIES=true
++SHAREDCCCOMPOPTS=
++MKSHAREDLIBRPATH=
++NATIVECCPROFOPTS=
++NATIVECCRPATH=
++ASM=$(TOOLPREF)as
++ASPP=$(TOOLPREF)gcc -c
++ASPPPROFFLAGS=
++PROFILING=noprof
++DYNLINKOPTS=
++CC_PROFILE=
++SYSTHREAD_SUPPORT=true
++EXTRALIBS=
++NATDYNLINK=true
++CMXS=cmxs
++RUNTIMED=noruntimed
++ASM_CFI_SUPPORTED=false
++UNIXLIB=win32unix
++GRAPHLIB=win32graph
++
++########## Configuration for the bytecode compiler
++
++### Which C compiler to use for the bytecode interpreter.
++BYTECC=$(TOOLPREF)gcc
++
++### Additional compile-time options for $(BYTECC).  (For static linking.)
++BYTECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
++
++### Additional link-time options for $(BYTECC).  (For static linking.)
++BYTECCLINKOPTS=
++
++### Additional compile-time options for $(BYTECC).  (For building a DLL.)
++DLLCCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused -DCAML_DLL
++
++### Libraries needed
++BYTECCLIBS=-lws2_32
++NATIVECCLIBS=-lws2_32
++
++### How to invoke the C preprocessor
++CPP=$(BYTECC) -E
++
++### Flexlink
++FLEXLINK=flexlink -chain mingw -stack 16777216 -link -static-libgcc
++FLEXDIR:=$(shell $(FLEXLINK) -where)
++IFLEXDIR=-I"$(FLEXDIR)"
++MKDLL=$(FLEXLINK)
++MKEXE=$(FLEXLINK) -exe
++MKMAINDLL=$(FLEXLINK) -maindll
++
++### How to build a static library
++MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
++#ml let mklib out files opts = Printf.sprintf "rm -f %s && %sar rcs %s %s %s" out toolpref opts out files;;
++
++### Canonicalize the name of a system library
++SYSLIB=-l$(1)
++#ml let syslib x = "-l"^x;;
++
++### The ranlib command
++RANLIB=$(TOOLPREF)ranlib
++RANLIBCMD=$(TOOLPREF)ranlib
++
++### The ar command
++ARCMD=$(TOOLPREF)ar
++
++############# Configuration for the native-code compiler
++
++### Name of architecture for the native-code compiler
++ARCH=i386
++
++### Name of architecture model for the native-code compiler.
++MODEL=default
++
++### Name of operating system family for the native-code compiler.
++SYSTEM=mingw
++
++### Which C compiler to use for the native-code compiler.
++NATIVECC=$(BYTECC)
++
++### Additional compile-time options for $(NATIVECC).
++NATIVECCCOMPOPTS=-O -mms-bitfields -Wall -Wno-unused
++
++### Additional link-time options for $(NATIVECC)
++NATIVECCLINKOPTS=
++
++### Build partially-linked object file
++PACKLD=$(TOOLPREF)ld -r $(NATIVECCLINKOPTS) -o # must have a space after '-o'
++
++############# Configuration for the contributed libraries
++
++OTHERLIBRARIES=win32unix str num win32graph dynlink bigarray systhreads
++
++### Name of the target architecture for the "num" library
++BNG_ARCH=ia32
++BNG_ASM_LEVEL=1
++
++############# Aliases for common commands
++
++MAKEREC=$(MAKE) -f Makefile.nt
++MAKECMD=$(MAKE)
++
++############# for the testsuite makefiles
++#ml let topdir = "" and wintopdir = "";;
++OTOPDIR=$(WINTOPDIR)
++CTOPDIR=$(TOPDIR)
++CYGPATH=cygpath -m
++DIFF=diff -q --strip-trailing-cr
++CANKILL=false
++SET_LD_PATH=PATH="$(PATH):$(LD_PATH)"
+--
+2.3.4

--- a/mingw-w64-ocaml/0002-Adapt-to-msys2-directory-layout.patch
+++ b/mingw-w64-ocaml/0002-Adapt-to-msys2-directory-layout.patch
@@ -1,0 +1,79 @@
+From aba4874ac9db486398a83608bbbce0bb5223b1b5 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Wed, 1 Apr 2015 08:53:36 +0800
+Subject: [PATCH] Adapt to msys2 directory layout
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ config/Makefile.mingw32 | 11 +++++++----
+ config/Makefile.mingw64 | 11 +++++++----
+ 2 files changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/config/Makefile.mingw32 b/config/Makefile.mingw32
+index c204980..032b8ed 100644
+--- a/config/Makefile.mingw32
++++ b/config/Makefile.mingw32
+@@ -15,7 +15,7 @@
+
+ ######### General configuration
+
+-PREFIX=C:/ocamlmgw
++PREFIX?=/mingw32
+
+ ### Remove this to disable compiling ocamldebug
+ WITH_DEBUGGER=ocamldebugger
+@@ -108,13 +108,16 @@ NATIVECCLIBS=-lws2_32
+ ### How to invoke the C preprocessor
+ CPP=$(BYTECC) -E
+
++### Additional link-time options for $(MKEXE).
++MKEXELINKOPTS=-L$(shell cygpath -m /mingw32/i686-w64-mingw32/lib)
++
+ ### Flexlink
+ FLEXLINK=flexlink -chain mingw -stack 16777216 -link -static-libgcc
+ FLEXDIR:=$(shell $(FLEXLINK) -where)
+ IFLEXDIR=-I"$(FLEXDIR)"
+-MKDLL=$(FLEXLINK)
+-MKEXE=$(FLEXLINK) -exe
+-MKMAINDLL=$(FLEXLINK) -maindll
++MKDLL=$(FLEXLINK) $(MKEXELINKOPTS)
++MKEXE=$(FLEXLINK) -exe $(MKEXELINKOPTS)
++MKMAINDLL=$(FLEXLINK) -maindll $(MKEXELINKOPTS)
+
+ ### How to build a static library
+ MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
+diff --git a/config/Makefile.mingw64 b/config/Makefile.mingw64
+index 0a3bdfb..566aab3 100644
+--- a/config/Makefile.mingw64
++++ b/config/Makefile.mingw64
+@@ -15,7 +15,7 @@
+
+ ######### General configuration
+
+-PREFIX=C:/ocamlmgw64
++PREFIX?=/mingw64
+
+ ### Remove this to disable compiling ocamldebug
+ WITH_DEBUGGER=ocamldebugger
+@@ -108,13 +108,16 @@ NATIVECCLIBS=-lws2_32
+ ### How to invoke the C preprocessor
+ CPP=$(BYTECC) -E
+
++### Additional link-time options for $(MKEXE).
++MKEXELINKOPTS=-L$(shell cygpath -m /mingw64/x86_64-w64-mingw32/lib)
++
+ ### Flexlink
+ FLEXLINK=flexlink -chain mingw64 -stack 33554432
+ FLEXDIR:=$(shell $(FLEXLINK) -where)
+ IFLEXDIR=-I"$(FLEXDIR)"
+-MKDLL=$(FLEXLINK)
+-MKEXE=$(FLEXLINK) -exe
+-MKMAINDLL=$(FLEXLINK) -maindll
++MKDLL=$(FLEXLINK) $(MKEXELINKOPTS)
++MKEXE=$(FLEXLINK) -exe $(MKEXELINKOPTS)
++MKMAINDLL=$(FLEXLINK) -maindll $(MKEXELINKOPTS)
+
+ ### How to build a static library
+ MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)
+--
+2.3.4

--- a/mingw-w64-ocaml/0003-Install-manuals-in-msys2.patch
+++ b/mingw-w64-ocaml/0003-Install-manuals-in-msys2.patch
@@ -1,0 +1,60 @@
+From 0eb523e80cfa15e7b77c250bc1b2fa8e49cfa5e6 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Fri, 3 Apr 2015 07:54:14 +0800
+Subject: [PATCH] Install manuals in msys2
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ Makefile.nt             | 2 ++
+ config/Makefile.mingw32 | 2 +-
+ config/Makefile.mingw64 | 2 +-
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.nt b/Makefile.nt
+index 16b53fe..cbc5618 100644
+--- a/Makefile.nt
++++ b/Makefile.nt
+@@ -237,6 +237,7 @@ installbyt:
+ 	mkdir -p $(INSTALL_LIBDIR)
+ 	mkdir -p $(INSTALL_STUBLIBDIR)
+ 	mkdir -p $(INSTALL_COMPLIBDIR)
++	mkdir -p $(INSTALL_MANDIR)/man$(MANEXT);
+ 	cp VERSION $(INSTALL_LIBDIR)/
+ 	cd byterun ; $(MAKEREC) install
+ 	cp ocamlc $(INSTALL_BINDIR)/ocamlc.exe
+@@ -252,6 +253,7 @@ installbyt:
+ 	cp expunge $(INSTALL_LIBDIR)/expunge.exe
+ 	cp toplevel/topdirs.cmi $(INSTALL_LIBDIR)
+ 	cd tools ; $(MAKEREC) install
++	cd man; $(MAKE) install
+ 	for i in $(OTHERLIBRARIES); do \
+ 	  $(MAKEREC) -C otherlibs/$$i install || exit $$?; \
+ 	done
+diff --git a/config/Makefile.mingw32 b/config/Makefile.mingw32
+index 032b8ed..c283724 100644
+--- a/config/Makefile.mingw32
++++ b/config/Makefile.mingw32
+@@ -39,7 +39,7 @@ STUBLIBDIR=$(LIBDIR)/stublibs
+ DISTRIB=$(PREFIX)
+
+ ### Where to install the man pages
+-MANDIR=$(PREFIX)/man
++MANDIR=$(PREFIX)/share/man
+
+ ########## Toolchain and OS dependencies
+
+diff --git a/config/Makefile.mingw64 b/config/Makefile.mingw64
+index 566aab3..a7ca30e 100644
+--- a/config/Makefile.mingw64
++++ b/config/Makefile.mingw64
+@@ -39,7 +39,7 @@ STUBLIBDIR=$(LIBDIR)/stublibs
+ DISTRIB=$(PREFIX)
+
+ ### Where to install the man pages
+-MANDIR=$(PREFIX)/man
++MANDIR=$(PREFIX)/share/man
+
+ ########## Toolchain and OS dependencies
+
+--
+2.3.4

--- a/mingw-w64-ocaml/0004-camlheader-has-the-extension-.exe-in-msys2.patch
+++ b/mingw-w64-ocaml/0004-camlheader-has-the-extension-.exe-in-msys2.patch
@@ -1,0 +1,33 @@
+From 027aac26cd33573e20f843a5ec3217c061359921 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Fri, 3 Apr 2015 08:18:50 +0800
+Subject: [PATCH] camlheader has the extension .exe in msys2
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ bytecomp/bytelink.ml | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/bytecomp/bytelink.ml b/bytecomp/bytelink.ml
+index c0f8f6a..f3216e0 100644
+--- a/bytecomp/bytelink.ml
++++ b/bytecomp/bytelink.ml
+@@ -304,7 +304,15 @@ let link_bytecode ppf tolink exec_name standalone =
+         let inchan = open_in_bin (find_in_path !load_path header) in
+         copy_file inchan outchan;
+         close_in inchan
+-      with Not_found | Sys_error _ -> ()
++      with Not_found | Sys_error _ ->
++			try
++			  let header =
++			    if String.length !Clflags.use_runtime > 0
++			    then "camlheader_ur.exe" else "camlheader" ^ !Clflags.runtime_variant ^ ".exe" in
++			  let inchan = open_in_bin (find_in_path !load_path header) in
++			  copy_file inchan outchan;
++			  close_in inchan
++			with Not_found | Sys_error _ -> ()
+     end;
+     Bytesections.init_record outchan;
+     (* The path to the bytecode interpreter (in use_runtime mode) *)
+--
+2.3.4

--- a/mingw-w64-ocaml/0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch
+++ b/mingw-w64-ocaml/0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch
@@ -1,0 +1,39 @@
+From 63eb66c59e70a8137b260e8e911350e4fd653d15 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Sat, 4 Apr 2015 10:38:46 +0800
+Subject: [PATCH] Install libraries to /lib/ocaml instead of /lib
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ config/Makefile.mingw32 | 2 +-
+ config/Makefile.mingw64 | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/config/Makefile.mingw32 b/config/Makefile.mingw32
+index c283724..1faf861 100644
+--- a/config/Makefile.mingw32
++++ b/config/Makefile.mingw32
+@@ -30,7 +30,7 @@ WITH_OCAMLDOC=ocamldoc
+ BINDIR=$(PREFIX)/bin
+
+ ### Where to install the standard library
+-LIBDIR=$(PREFIX)/lib
++LIBDIR=$(PREFIX)/lib/ocaml
+
+ ### Where to install the stub DLLs
+ STUBLIBDIR=$(LIBDIR)/stublibs
+diff --git a/config/Makefile.mingw64 b/config/Makefile.mingw64
+index a7ca30e..7442363 100644
+--- a/config/Makefile.mingw64
++++ b/config/Makefile.mingw64
+@@ -30,7 +30,7 @@ WITH_OCAMLDOC=ocamldoc
+ BINDIR=$(PREFIX)/bin
+
+ ### Where to install the standard library
+-LIBDIR=$(PREFIX)/lib
++LIBDIR=$(PREFIX)/lib/ocaml
+
+ ### Where to install the stub DLLs
+ STUBLIBDIR=$(LIBDIR)/stublibs
+--
+2.3.4

--- a/mingw-w64-ocaml/PKGBUILD
+++ b/mingw-w64-ocaml/PKGBUILD
@@ -1,0 +1,80 @@
+# Maintainer: Junjie Mao <eternal.n08@gmail.com>
+
+_realname=ocaml
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.02.1
+pkgrel=1
+pkgdesc='An industrial strength programming language supporting functional, imperative and object-oriented styles.'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://ocaml.org/'
+license=('Q Public Licence 1.0' 'GPL2')
+depends=("${MINGW_PACKAGE_PREFIX}-flexdll")
+makedepends=("diffutils")
+source=("http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
+        "0001-Rename-Makefile.mingw-to-Makefile.mingw32.patch"
+	"0002-Adapt-to-msys2-directory-layout.patch"
+	"0003-Install-manuals-in-msys2.patch"
+	"0004-camlheader-has-the-extension-.exe-in-msys2.patch"
+	"0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch")
+sha1sums=('6af8c67f2badece81d8e1d1ce70568a16e42313e'
+          '5b56a2ecff40d53158578d5a41e1eb992f3dcdc6'
+          'ee16e23932922f6f9fcc48072d564b90a3b66246'
+          'a780a6c94aaedcd0d19a7fbc26e09776b581a8af'
+          'e1f6b201c25b61d39404406c82684f6c8d70d23a'
+          '17010515bd9715ed36300165643d8f3ad01288cf')
+
+env=${MINGW_PREFIX#/}
+_pkg="${_realname}-${pkgver}"
+_pkgsrc="${env}-${_pkg}"
+noextract=(${_pkg}.tar.gz)
+prepare() {
+  for prog in ar as ld ranlib; do
+    no_prefix=${MINGW_PREFIX}/bin/${prog}.exe
+    with_prefix=${MINGW_PREFIX}/bin/${CARCH}-w64-mingw32-${prog}.exe
+    if [ -f "${no_prefix}" ] && [ ! -f "${with_prefix}" ]; then
+  	cp ${no_prefix} ${with_prefix}
+  	echo ${no_prefix}, ${with_prefix}
+    fi
+  done
+
+  cd $startdir/
+  [ -d ${srcdir}/${_pkgsrc} ] && rm -rf ${srcdir}/${_pkgsrc}
+  tar -xzf ${startdir}/${_pkg}.tar.gz -C ${srcdir}
+
+  cd ${srcdir}
+  mv ${_pkg} ${_pkgsrc}
+  cd ${_pkgsrc}
+
+  patch -p1 -i ${srcdir}/0001-Rename-Makefile.mingw-to-Makefile.mingw32.patch
+  patch -p1 -i ${srcdir}/0002-Adapt-to-msys2-directory-layout.patch
+  patch -p1 -i ${srcdir}/0003-Install-manuals.patch
+  patch -p1 -i ${srcdir}/0004-camlheader-has-the-extension-.exe-in-msys2.patch
+  patch -p1 -i ${srcdir}/0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch
+}
+
+build() {
+  cd ${srcdir}/${_pkgsrc}
+  cp config/m-nt.h config/m.h
+  cp config/s-nt.h config/s.h
+  cp config/Makefile.${env} config/Makefile
+
+  make -f Makefile.nt world PREFIX="$(cygpath -m ${MINGW_PREFIX})" -j1
+  make -f Makefile.nt bootstrap PREFIX="$(cygpath -m ${MINGW_PREFIX})" -j1
+  make -f Makefile.nt opt PREFIX="$(cygpath -m ${MINGW_PREFIX})" -j1
+  make -f Makefile.nt opt.opt PREFIX="$(cygpath -m ${MINGW_PREFIX})" -j1
+}
+
+check() {
+  # The testsuite refuses to compile due to lack of headers such as sys/resource.h
+  plain "skip"
+}
+
+package() {
+  cd ${srcdir}/${_pkgsrc}
+  make -f Makefile.nt install PREFIX="${pkgdir}${MINGW_PREFIX}" -j1
+  [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+
+  mkdir -p ${pkgdir}/etc/profile.d
+  echo '[ "$MSYSTEM" = "'$(echo ${env} | tr "[:lower:]" "[:upper:]")'" ] && export OCAMLLIB='${MINGW_PREFIX}'/lib/ocaml' > ${pkgdir}/etc/profile.d/ocaml.${env}.sh
+}


### PR DESCRIPTION
Known issues:
* Flexdll and ocaml depends on each other and thus need prebuilt packages to kick off the build. My packages can be found at https://github.com/eternalNight/MINGW-packages/raw/master/_bin/mingw-w64-i686-flexdll-0.31-1-any.pkg.tar.xz and https://github.com/eternalNight/MINGW-packages/raw/master/_bin/mingw-w64-x86_64-flexdll-0.31-1-any.pkg.tar.xz.
* When OCaml toplevel is killed by Ctrl-C, bash stops responding after displaying the "$" prompt. A normal quit from the toplevel does not trigger the issue.