### PR TITLE
lua-lpeg: updated for lua 5.3

### DIFF
--- a/mingw-w64-lua-lpeg/PKGBUILD
+++ b/mingw-w64-lua-lpeg/PKGBUILD
@@ -19,7 +19,7 @@ source=("http://www.inf.puc-rio.br/~roberto/${_realname}/${_realname}-${pkgver}.
         "LICENSE")
 md5sums=('4abb3c28cd8b6565c6a65e88f06c9162'
          '8f2f06957131ccb64413433c08e18d65'
-         'a6cfa90f0a2b4c250c0545fa773855d9'
+         '1b876fcf29e29dafae1ca8c5362236c3'
          'dccb97b431c3a3ccaacc216c6242e9fd')
 
 prepare() {
@@ -51,12 +51,14 @@ check() {
 }
 
 package_mingw-w64-lua-lpeg() {
-  pkgdesc='Pattern-matching library for Lua 5.3 (mingw-w64)'
+  pkgdesc='Pattern-matching library for Lua (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua")
 
   cd "${srcdir}/build-${CARCH}"
-  install -Dm755 lpeg.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/5.3/lpeg.dll"
-  install -Dm644 re.lua "${pkgdir}${MINGW_PREFIX}/share/lua/5.3/re.lua"
+
+  local luaver=$(pkg-config lua --modversion | sed -r 's/^([0-9]+[.][0-9]+)[.][0-9]+$/\1/')
+  install -Dm755 lpeg.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/${luaver}/lpeg.dll"
+  install -Dm644 re.lua "${pkgdir}${MINGW_PREFIX}/share/lua/${luaver}/re.lua"
   install -Dm644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lua-lpeg/LICENSE"
 }
 

--- a/mingw-w64-lua-lpeg/PKGBUILD
+++ b/mingw-w64-lua-lpeg/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: David Macek <david.macek.0@gmail.com>
 # Contributor (Arch Linux): Gustavo Alvarez <sl1pkn07@gmail.com>
+# Contributor: Felix Huettner <huettner94@gmx.de>
 
 _realname=lpeg
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lua51-${_realname}")
 pkgver=0.12
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='http://www.inf.puc-rio.br/~roberto/lpeg'
 license=('MIT')
@@ -14,14 +15,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-lua"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("http://www.inf.puc-rio.br/~roberto/${_realname}/${_realname}-${pkgver}.tar.gz"
         "lpeg-0.12-makefile.patch"
+	"lptypes-lua-503.patch"
         "LICENSE")
 md5sums=('4abb3c28cd8b6565c6a65e88f06c9162'
          '8f2f06957131ccb64413433c08e18d65'
+         'a6cfa90f0a2b4c250c0545fa773855d9'
          'dccb97b431c3a3ccaacc216c6242e9fd')
 
 prepare() {
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/lpeg-0.12-makefile.patch"
+  patch -p1 -i "${srcdir}/lptypes-lua-503.patch"
   sed -i 's/lpeg.so/lpeg.dll/' makefile
 
   mkdir -p "${srcdir}/build-${CARCH}" "${srcdir}/build-51-${CARCH}"
@@ -47,12 +51,12 @@ check() {
 }
 
 package_mingw-w64-lua-lpeg() {
-  pkgdesc='Pattern-matching library for Lua 5.2 (mingw-w64)'
+  pkgdesc='Pattern-matching library for Lua 5.3 (mingw-w64)'
   depends=("${MINGW_PACKAGE_PREFIX}-lua")
 
   cd "${srcdir}/build-${CARCH}"
-  install -Dm755 lpeg.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/5.2/lpeg.dll"
-  install -Dm644 re.lua "${pkgdir}${MINGW_PREFIX}/share/lua/5.2/re.lua"
+  install -Dm755 lpeg.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/5.3/lpeg.dll"
+  install -Dm644 re.lua "${pkgdir}${MINGW_PREFIX}/share/lua/5.3/re.lua"
   install -Dm644 "${srcdir}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/lua-lpeg/LICENSE"
 }
 

--- a/mingw-w64-lua-lpeg/lptypes-lua-503.patch
+++ b/mingw-w64-lua-lpeg/lptypes-lua-503.patch
@@ -1,0 +1,30 @@
+--- lpeg-0.12/lptypes.h	2015-04-08 08:39:37.670848100 +0200
++++ lpeg-0.12/lptypes.h	2015-04-08 08:41:08.649094600 +0200
+@@ -27,9 +27,9 @@
+ 
+ 
+ /*
+-** compatibility with Lua 5.2
++** compatibility with Lua 5.2 and higher
+ */
+-#if (LUA_VERSION_NUM == 502)
++#if (LUA_VERSION_NUM >= 502)
+ 
+ #undef lua_equal
+ #define lua_equal(L,idx1,idx2)  lua_compare(L,(idx1),(idx2),LUA_OPEQ)
+@@ -48,6 +48,15 @@
+ 
+ #endif
+ 
++/*
++** compatibility with Lua 5.3 and higher
++*/
++#if (LUA_VERSION_NUM >= 503)
++
++#undef luaL_checkint
++#define luaL_checkint luaL_checkinteger
++
++#endif
+ 
+ /* default maximum size for call/backtrack stack */
+ #if !defined(MAXBACK)


### PR DESCRIPTION
Because of the update of lua to version 5.3 (see #540) lua-lpeg needs to be updated

Changes:
 * Changed directories for "lpeg.dll" and "re.lua"
 * Enabled compatibility-defines for lua 5.2 also for later version of lua
 * Added compatiblity-defines because of a rename in lua 5.3 ("luaL_checkint" -> "luaL_checkinteger")