### PR TITLE
Guess library path in ocaml, camlp4 and flexdll

### DIFF
--- a/mingw-w64-coq/PKGBUILD
+++ b/mingw-w64-coq/PKGBUILD
@@ -3,14 +3,13 @@
 _realname=coq
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=8.4pl5
-pkgrel=1
+pkgrel=2
 pkgdesc="A formal proof management system (mingw-w64)"
 arch=('any')
 url='https://coq.inria.fr/'
 license=('LGPL 2.1')
 depends=("${MINGW_PACKAGE_PREFIX}-ocaml"
-         "${MINGW_PACKAGE_PREFIX}-ocaml-camlp4"
-         "${MINGW_PACKAGE_PREFIX}-ocaml-lablgtk")
+         "${MINGW_PACKAGE_PREFIX}-ocaml-camlp4")
 source=("https://coq.inria.fr/distrib/V8.4pl5/files/coq-8.4pl5.tar.gz"
         "0001-Guess-the-libraries-are-located-at-lib-coq-instead-o.patch")
 sha1sums=('107717cbaef3a469e8ff775ae54dbbc457935816'
@@ -25,7 +24,7 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST}
   cd ${srcdir}/build-${MINGW_CHOST}
-  
+
   export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
   ./configure -prefix ${MINGW_PREFIX} \
         -bindir ${MINGW_PREFIX}/bin \
@@ -36,11 +35,10 @@ build() {
         -docdir ${MINGW_PREFIX}/share/doc/coq \
         -emacslib ${MINGW_PREFIX}/share/emacs/site-lisp/coq \
         -coqdocdir ${MINGW_PREFIX}/share/texmf/tex \
-        -usecamlp4 -arch win32
+        -usecamlp4 -arch win32 -coqide no
 
   make revision
   make coq
-  make coqide -j1
 }
 
 check() {

--- a/mingw-w64-flexdll/0004-use-lib-flexdll-as-the-default-library-path.patch
+++ b/mingw-w64-flexdll/0004-use-lib-flexdll-as-the-default-library-path.patch
@@ -1,0 +1,26 @@
+From 0f243fb8f19bf6935c41e183a365860ae21a50d1 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Tue, 7 Apr 2015 07:34:35 +0800
+Subject: [PATCH] use lib/flexdll/ as the default library path
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ reloc.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/reloc.ml b/reloc.ml
+index b4b96bd..17eed13 100644
+--- a/reloc.ml
++++ b/reloc.ml
+@@ -29,7 +29,7 @@ let flexdir =
+     let s = Sys.getenv "FLEXDIR" in
+     if s = "" then raise Not_found else s
+   with Not_found ->
+-    Filename.dirname Sys.executable_name
++    List.fold_left (fun base dir -> Filename.concat base dir) (Filename.dirname Sys.executable_name) ["..";"lib";"flexdll"]
+ 
+ let ext_obj () =
+   if !toolchain = `MSVC || !toolchain = `MSVC64 then ".obj" else ".o"
+-- 
+2.3.4
+

--- a/mingw-w64-flexdll/PKGBUILD
+++ b/mingw-w64-flexdll/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=flexdll
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.31
+pkgver=0.34
 pkgrel=1
 pkgdesc="An implementation of a dlopen-like API for Windows (mingw-w64)"
 arch=('any')
@@ -12,11 +12,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-ocaml")
 source=("http://alain.frisch.fr/flexdll/${_realname}-${pkgver}.tar.gz"
         "0001-Fix-the-List.hd-exception.patch"
         "0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch"
-        "0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch")
-sha1sums=('7ca63bf8d6c731fd95e0d434a8cfbcc718b99d62'
+        "0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch"
+        "0004-use-lib-flexdll-as-the-default-library-path.patch")
+sha1sums=('86acfd2d965dcf7a650f3d8e8f8db7bfe99de2a0'
           '642c99ad0d2035ef028254aff41dbff49014bed3'
           '31ebdca246a4df6069d733350c9a2b8c94d33dec'
-          '43f232f04934a0c7797f05e8db03f04ae156d8c4')
+          '43f232f04934a0c7797f05e8db03f04ae156d8c4'
+          '87754de44fd9a51299e52908b5948b31383ca6eb')
 
 if [ "${CARCH}" == "i686" ]; then
   chain="mingw"
@@ -30,6 +32,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-Fix-the-List.hd-exception.patch
   patch -p1 -i ${srcdir}/0002-Add-path-to-libcrt2.o-into-the-default-library-searc.patch
   patch -p1 -i ${srcdir}/0003-Remove-the-usages-of-stdout-to-workaround-the-missin.patch
+  patch -p1 -i ${srcdir}/0004-use-lib-flexdll-as-the-default-library-path.patch
 }
 
 build() {
@@ -53,12 +56,8 @@ package() {
   cd ${srcdir}/build-${MINGW_CHOST}
 
   install -Dm755 flexlink.exe ${pkgdir}${MINGW_PREFIX}/bin/flexlink.exe
-  
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/flexdll
-  install flexdll_${chain}.o ${pkgdir}${MINGW_PREFIX}/lib/flexdll/
-  install flexdll_initer_${chain}.o ${pkgdir}${MINGW_PREFIX}/lib/flexdll/
-  for f in flexdll.h flexdll.c flexdll_initer.c default.manifest default_amd64.manifest; do
-    install ${f} ${pkgdir}${MINGW_PREFIX}/lib/flexdll/
+  for f in flexdll_${chain}.o flexdll_initer_${chain}.o flexdll.h flexdll.c flexdll_initer.c default.manifest default_amd64.manifest; do
+    install -D ${f} ${pkgdir}${MINGW_PREFIX}/lib/flexdll/${f}
   done
   [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
   [ -f CHANGES ] && install -Dm644 CHANGES ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/CHANGES

--- a/mingw-w64-ocaml-camlp4/0003-Guess-the-library-path-on-msys2.patch
+++ b/mingw-w64-ocaml-camlp4/0003-Guess-the-library-path-on-msys2.patch
@@ -1,0 +1,47 @@
+From 3c6a0990d9937551e0750ccb6b65adf00aeca091 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Thu, 9 Apr 2015 07:52:23 +0800
+Subject: [PATCH] Guess the library path on msys2
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ camlp4/config/Camlp4_config.ml | 19 +++++++++++++++++--
+ 1 file changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/camlp4/config/Camlp4_config.ml b/camlp4/config/Camlp4_config.ml
+index 88e14d6..4e7f245 100644
+--- a/camlp4/config/Camlp4_config.ml
++++ b/camlp4/config/Camlp4_config.ml
+@@ -17,12 +17,27 @@
+  * - Nicolas Pouillard: refactoring
+  *)
+ 
+-let ocaml_standard_library = Camlp4_import.standard_library;;
++let canonical_path_name p =
++  let current = Sys.getcwd () in
++  try
++    Sys.chdir p;
++    let p' = Sys.getcwd () in
++    Sys.chdir current;
++    p'
++  with Sys_error _ ->
++    (* We give up to find a canonical name and just return it... *)
++    p
++
++let camlp4bin = Filename.dirname (canonical_path_name Sys.executable_name)
++
++let camlp4root = Filename.dirname camlp4bin
++
++let ocaml_standard_library = List.fold_left (fun base dir -> Filename.concat base dir) camlp4root ["lib";"ocaml"];;
+ 
+ let camlp4_standard_library =
+   try Sys.getenv "CAMLP4LIB"
+   with Not_found ->
+-    Camlp4_import.camlp4_standard_library;;
++    Filename.concat ocaml_standard_library "camlp4";;
+ 
+ let version = Sys.ocaml_version;;
+ let program_name = ref "camlp4";;
+-- 
+2.3.4
+

--- a/mingw-w64-ocaml-camlp4/PKGBUILD
+++ b/mingw-w64-ocaml-camlp4/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ocaml-camlp4
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.02.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Pre-Processor-Pretty-Printer for OCaml (mingw-w64)"
 arch=('any')
 url='https://github.com/ocaml/camlp4'
@@ -12,22 +12,25 @@ depends=("${MINGW_PACKAGE_PREFIX}-ocaml")
 makedepends=("${MINGW_PACKAGE_PREFIX}-flexdll")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/ocaml/camlp4/archive/4.02.1.tar.gz"
         "0001-Properly-quote-preprocessor-command-to-ocamldep.patch"
-        "0002-Add-DESTDIR-in-configure.patch")
+        "0002-Add-DESTDIR-in-configure.patch"
+        "0003-Guess-the-library-path-on-msys2.patch")
 sha1sums=('c16d9ae3693612c71e12d2880ec911772b8d23c3'
           'eb7a59d2e184f368d735670bea96571aa861f97b'
-          '6aa01135f05a5e943412bf728f90ced871c6a064')
+          '6aa01135f05a5e943412bf728f90ced871c6a064'
+          'db42cb6d7dfd3862d057d1771a3cb7b4e44d930d')
 
 prepare() {
   cd ${srcdir}/camlp4-${pkgver}
 
   patch -p1 -i ${srcdir}/0001-Properly-quote-preprocessor-command-to-ocamldep.patch
   patch -p1 -i ${srcdir}/0002-Add-DESTDIR-in-configure.patch
+  patch -p1 -i ${srcdir}/0003-Guess-the-library-path-on-msys2.patch
 }
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   cp -rf camlp4-${pkgver} build-${MINGW_CHOST}
-  
+
   cd ${srcdir}/build-${MINGW_CHOST}
   export OCAMLLIB=${MINGW_PREFIX}/lib/ocaml
   ./configure --bindir=${MINGW_PREFIX}/bin \
@@ -47,7 +50,4 @@ package() {
   make install -j1
   make install-META -j1
   [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/etc/profile.d
-  echo '[ "$MSYSTEM" = "'$(echo ${MINGW_PREFIX#/} | tr "[:lower:]" "[:upper:]")'" ] && export CAMLP4LIB='${MINGW_PREFIX}'/lib/ocaml' > ${pkgdir}${MINGW_PREFIX}/etc/profile.d/camlp4.sh
 }

--- a/mingw-w64-ocaml/0006-Configure-the-relative-paths-for-ocaml-libraries-on-.patch
+++ b/mingw-w64-ocaml/0006-Configure-the-relative-paths-for-ocaml-libraries-on-.patch
@@ -1,0 +1,70 @@
+From 667abbecdaed7107c981b6527e129cc3546b8d7c Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Tue, 7 Apr 2015 11:32:02 +0800
+Subject: [PATCH] Configure the relative paths for ocaml libraries on msys2
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ utils/config.mlbuild | 17 ++++++++++++++++-
+ utils/config.mlp     | 17 ++++++++++++++++-
+ 2 files changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/utils/config.mlbuild b/utils/config.mlbuild
+index c887ac2..82ccd32 100644
+--- a/utils/config.mlbuild
++++ b/utils/config.mlbuild
+@@ -25,7 +25,22 @@ let version = Sys.ocaml_version
+ 
+ module C = Myocamlbuild_config
+ 
+-let standard_library_default = C.libdir
++let canonical_path_name p =
++  let current = Sys.getcwd () in
++  try
++    Sys.chdir p;
++    let p' = Sys.getcwd () in
++    Sys.chdir current;
++    p'
++  with Sys_error _ ->
++    (* We give up to find a canonical name and just return it... *)
++    p
++
++let ocamlbin = Filename.dirname (canonical_path_name Sys.executable_name)
++
++let ocamlroot = Filename.dirname ocamlbin
++
++let standard_library_default = List.fold_left (fun base dir -> Filename.concat base dir) ocamlroot ["lib";"ocaml"]
+ 
+ let standard_library =
+   try
+diff --git a/utils/config.mlp b/utils/config.mlp
+index db6fd20..ac97e9c 100644
+--- a/utils/config.mlp
++++ b/utils/config.mlp
+@@ -23,7 +23,22 @@
+ (* The main OCaml version string has moved to ../VERSION *)
+ let version = Sys.ocaml_version
+ 
+-let standard_library_default = "%%LIBDIR%%"
++let canonical_path_name p =
++  let current = Sys.getcwd () in
++  try
++    Sys.chdir p;
++    let p' = Sys.getcwd () in
++    Sys.chdir current;
++    p'
++  with Sys_error _ ->
++    (* We give up to find a canonical name and just return it... *)
++    p
++
++let ocamlbin = Filename.dirname (canonical_path_name Sys.executable_name)
++
++let ocamlroot = Filename.dirname ocamlbin
++
++let standard_library_default = List.fold_left (fun base dir -> Filename.concat base dir) ocamlroot ["lib";"ocaml"]
+ 
+ let standard_library =
+   try
+-- 
+2.3.4
+

--- a/mingw-w64-ocaml/0007-Convert-to-windows-path-before-checking-stats.patch
+++ b/mingw-w64-ocaml/0007-Convert-to-windows-path-before-checking-stats.patch
@@ -1,0 +1,48 @@
+From 6d9ecfddb197ff4fcfb8404f03d502501bafe411 Mon Sep 17 00:00:00 2001
+From: Junjie Mao <eternal.n08@gmail.com>
+Date: Tue, 7 Apr 2015 21:25:35 +0800
+Subject: [PATCH] Convert to windows path before checking stats
+
+Signed-off-by: Junjie Mao <eternal.n08@gmail.com>
+---
+ byterun/win32.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/byterun/win32.c b/byterun/win32.c
+index 67e9683..02d060e 100644
+--- a/byterun/win32.c
++++ b/byterun/win32.c
+@@ -59,9 +59,10 @@ char * caml_decompose_path(struct ext_table * tbl, char * path)
+ 
+ char * caml_search_in_path(struct ext_table * path, char * name)
+ {
+-  char * p, * dir, * fullname;
++  char * p, * dir, * fullname, * cmd, * output;
+   int i;
+   struct stat st;
++  FILE *pipe = NULL;
+ 
+   for (p = name; *p != 0; p++) {
+     if (*p == '/' || *p == '\\') goto not_found;
+@@ -71,6 +72,18 @@ char * caml_search_in_path(struct ext_table * path, char * name)
+     if (dir[0] == 0) continue;
+          /* not sure what empty path components mean under Windows */
+     fullname = caml_strconcat(3, dir, "\\", name);
++    cmd = caml_strconcat(2, "cygpath -w ", fullname);
++    pipe = popen(cmd, "r");
++    output = caml_stat_alloc(strlen(cmd) + 128);
++    fscanf(pipe, "%s", output);
++    pclose(pipe);
++    caml_stat_free(cmd);
++    if (output[0] != '\0') {
++      caml_stat_free(fullname);
++      fullname = output;
++    } else {
++      caml_stat_free(output);
++    }
+     caml_gc_message(0x100, "Searching %s\n", (uintnat) fullname);
+     if (stat(fullname, &st) == 0 && S_ISREG(st.st_mode))
+       return fullname;
+-- 
+2.3.4
+

--- a/mingw-w64-ocaml/PKGBUILD
+++ b/mingw-w64-ocaml/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ocaml
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.02.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An industrial strength programming language supporting functional, imperative and object-oriented styles (mingw-w64)"
 arch=('any')
 url='http://ocaml.org/'
@@ -15,12 +15,16 @@ source=("http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
         "0002-Adapt-to-msys2-directory-layout.patch"
         "0003-Install-manuals-in-msys2.patch"
         "0004-camlheader-has-the-extension-.exe-in-msys2.patch"
-        "0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch")
+        "0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch"
+        "0006-Configure-the-relative-paths-for-ocaml-libraries-on-.patch"
+        "0007-Convert-to-windows-path-before-checking-stats.patch")
 sha1sums=('6af8c67f2badece81d8e1d1ce70568a16e42313e'
           'ee16e23932922f6f9fcc48072d564b90a3b66246'
           'a780a6c94aaedcd0d19a7fbc26e09776b581a8af'
           'e1f6b201c25b61d39404406c82684f6c8d70d23a'
-          '17010515bd9715ed36300165643d8f3ad01288cf')
+          '17010515bd9715ed36300165643d8f3ad01288cf'
+          '78b69527ce8a78fbb31f7b9f3e0e04bf3ffcc165'
+          'cff96df7caef78097ac73a382e4ef50418a7583b')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -33,12 +37,14 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-Install-manuals-in-msys2.patch
   patch -p1 -i ${srcdir}/0004-camlheader-has-the-extension-.exe-in-msys2.patch
   patch -p1 -i ${srcdir}/0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch
+  patch -p1 -i ${srcdir}/0006-Configure-the-relative-paths-for-ocaml-libraries-on-.patch
+  patch -p1 -i ${srcdir}/0007-Convert-to-windows-path-before-checking-stats.patch
 }
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST}
-  
+
   cd ${srcdir}/build-${MINGW_CHOST}
   cp config/Makefile.${MINGW_PREFIX#/} config/Makefile
 
@@ -57,7 +63,4 @@ package() {
   cd ${srcdir}/build-${MINGW_CHOST}
   make -f Makefile.nt install TOOLPREF= PREFIX="${pkgdir}${MINGW_PREFIX}" -j1
   [ -f LICENSE ] && install -Dm644 LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/etc/profile.d
-  echo '[ "$MSYSTEM" = "'$(echo ${MINGW_PREFIX#/} | tr "[:lower:]" "[:upper:]")'" ] && export OCAMLLIB='${MINGW_PREFIX}'/lib/ocaml' > ${pkgdir}${MINGW_PREFIX}/etc/profile.d/ocaml.sh
 }


### PR DESCRIPTION
I've add some patches to allow flexdll, ocaml and camlp4 to guess the paths of their libraries. The patchset can be found at https://github.com/eternalNight/MINGW-packages/tree/for-alexpux.

By the way, flexdll has been updated to 0.34 to fix a bug on 64bit systems. The binary packages to kick off the build can be found at https://github.com/eternalNight/MINGW-packages/tree/master/_bin.

However, lablgtk is broken after the update. I have fired an issue to the flexdll developers and am waiting for their response. As a result, I have to remove coqide support from the coq package temporarily due to it dependency on lablgtk. Please ignore ocaml-lablgtk for now. Thanks!