### PR TITLE
New package sed

### DIFF
--- a/mingw-w64-sed/PKGBUILD
+++ b/mingw-w64-sed/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Alexey Pavlov <Alexpux@gmail.com>
+# Contributor: Paul Moore <p.f.moore@gmail.com>
+
+_realname=sed
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.2.2
+pkgrel=1
+pkgdesc='Sed is a stream editor'
+groups=("${MINGW_PACKAGE_PREFIX}")
+arch=('any')
+url='http://www.gnu.org/software/sed/'
+
+license=('GPL3')
+
+source=("http://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
+        msvc_invalid_parameter_handler.patch)
+md5sums=('4111de4faa3b9848a0686b2f260c5056'
+         'a648d571107f917f1b039a88ff45cf4a')
+options=('strip' '!libtool' 'staticlibs')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+  patch -p0 -i ${srcdir}/msvc_invalid_parameter_handler.patch
+}
+
+build() {
+  cd $srcdir/${_realname}-${pkgver}
+  ./configure --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+
+  make
+}
+
+package() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  make install DESTDIR="${pkgdir}"
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README"                 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING"                "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-sed/msvc_invalid_parameter_handler.patch
+++ b/mingw-w64-sed/msvc_invalid_parameter_handler.patch
@@ -1,0 +1,13 @@
+--- config_h.in.orig	2012-12-22 14:24:31.000000000 +0000
++++ config_h.in	2015-04-10 20:37:22.039226300 +0100
+@@ -473,7 +473,9 @@
+ 
+ /* Define to 1 on MSVC platforms that have the "invalid parameter handler"
+    concept. */
+-#undef HAVE_MSVC_INVALID_PARAMETER_HANDLER
++/* Commented out due to a gnulib bug - see
++   http://lists.gnu.org/archive/html/bug-sed/2015-01/msg00003.html */
++/* #undef HAVE_MSVC_INVALID_PARAMETER_HANDLER */
+ 
+ /* Define to 1 if you have the `nl_langinfo' function. */
+ #undef HAVE_NL_LANGINFO


### PR DESCRIPTION
A build of GNU sed for native Windows. The only dependency is libintl, and as far as I can see other packages don't explicitly declare a dependency on libintl, so I omitted that.