### PR TITLE
Fix xerces-c dependency in xalan-c

### DIFF
--- a/mingw-w64-xalan-c/PKGBUILD
+++ b/mingw-w64-xalan-c/PKGBUILD
@@ -9,8 +9,8 @@ pkgdesc="An XSLT processing library (mingw-w64)"
 arch=('any')
 url="http://xalan.apache.org/xalan-c"
 license=('APACHE')
-makedepends=("sed" "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-xerces-c=3.1.1" "${MINGW_PACKAGE_PREFIX}-tools")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-xerces-c=3.1.1")
+makedepends=("sed" "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-xerces-c=3.2.1" "${MINGW_PACKAGE_PREFIX}-tools")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-xerces-c=3.2.1")
 options=('!libtool' 'strip')
 source=(http://apache.mirror.iphh.net/xalan/xalan-c/sources/xalan_c-$pkgver-src.tar.gz
     mingw-w64-fix.patch)


### PR DESCRIPTION
Minor patch to fix dependency problem because xerces-c has been updated to 3.1.2