### PR TITLE
For utf8, fixes for #535

### DIFF
--- a/mingw-w64-gettext/01-WINDOWS_NATIVE-always-use-UTF-8-charset.patch
+++ b/mingw-w64-gettext/01-WINDOWS_NATIVE-always-use-UTF-8-charset.patch
@@ -1,0 +1,67 @@
+From 387cb468e98b7ba5f46ab0d113838f46a4b5f26c Mon Sep 17 00:00:00 2001
+From: Yonggang Luo <luoyonggang@gmail.com>
+Date: Sun, 12 Apr 2015 09:52:23 +0800
+Subject: [PATCH] WINDOWS_NATIVE always use 'UTF-8' charset.
+
+---
+ gettext-runtime/gnulib-lib/localcharset.c | 2 +-
+ gettext-runtime/intl/localcharset.c       | 2 +-
+ gettext-tools/gnulib-lib/localcharset.c   | 2 +-
+ gettext-tools/libgettextpo/localcharset.c | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/gettext-runtime/gnulib-lib/localcharset.c b/gettext-runtime/gnulib-lib/localcharset.c
+index ccfa993..d669246 100644
+--- a/gettext-runtime/gnulib-lib/localcharset.c
++++ b/gettext-runtime/gnulib-lib/localcharset.c
+@@ -490,7 +490,7 @@ locale_charset (void)
+         encoding is the best bet.  */
+       sprintf (buf, "CP%u", GetACP ());
+     }
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #elif defined OS2
+ 
+diff --git a/gettext-runtime/intl/localcharset.c b/gettext-runtime/intl/localcharset.c
+index 71be7c1..0b49abb 100644
+--- a/gettext-runtime/intl/localcharset.c
++++ b/gettext-runtime/intl/localcharset.c
+@@ -490,7 +490,7 @@ locale_charset (void)
+         encoding is the best bet.  */
+       sprintf (buf, "CP%u", GetACP ());
+     }
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #elif defined OS2
+ 
+diff --git a/gettext-tools/gnulib-lib/localcharset.c b/gettext-tools/gnulib-lib/localcharset.c
+index ccfa993..d669246 100644
+--- a/gettext-tools/gnulib-lib/localcharset.c
++++ b/gettext-tools/gnulib-lib/localcharset.c
+@@ -490,7 +490,7 @@ locale_charset (void)
+         encoding is the best bet.  */
+       sprintf (buf, "CP%u", GetACP ());
+     }
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #elif defined OS2
+ 
+diff --git a/gettext-tools/libgettextpo/localcharset.c b/gettext-tools/libgettextpo/localcharset.c
+index ccfa993..d669246 100644
+--- a/gettext-tools/libgettextpo/localcharset.c
++++ b/gettext-tools/libgettextpo/localcharset.c
+@@ -490,7 +490,7 @@ locale_charset (void)
+         encoding is the best bet.  */
+       sprintf (buf, "CP%u", GetACP ());
+     }
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #elif defined OS2
+ 
+-- 
+2.3.5.windows.8
+

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -18,6 +18,7 @@ license=(GPL3 partial:'LGPL2.1')
 url="http://www.gnu.org/software/gettext/"
 source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-$pkgver.tar.gz"{,.sig}
         00-relocatex-libintl-0.18.3.1.patch
+        01-WINDOWS_NATIVE-always-use-UTF-8-charset.patch
         120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
         04-mingw-script-slash-fix.mingw.patch
         05-always-use-libintl-vsnprintf.mingw.patch
@@ -26,6 +27,7 @@ source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-$pkgver.tar.gz"{,.
 md5sums=('d3511af1e604a3478900d2c2b4a4a48e'
          'SKIP'
          '397d7d6d4abd15a70edb3c9f2bab4cd2'
+         'e1db60c71261c71606fcb25acbc1c6cd'
          '6fc5459e5afa3f9df7602fcd1d09355b'
          '0f754bf438368854ef63886715a3b023'
          '27852a388b8cf38188dc392c244230ff'
@@ -40,6 +42,7 @@ prepare() {
          MINGW-PATCHES/README-relocatex-libintl.txt || true
 
   patch -p1 -i ${srcdir}/00-relocatex-libintl-0.18.3.1.patch
+  patch -p1 -i ${srcdir}/01-WINDOWS_NATIVE-always-use-UTF-8-charset.patch
   patch -p0 -i ${srcdir}/04-mingw-script-slash-fix.mingw.patch
   patch -p0 -i ${srcdir}/05-always-use-libintl-vsnprintf.mingw.patch
   patch -p0 -i ${srcdir}/06-dont-include-ctype-after-gnulibs-wctype.mingw.patch

--- a/mingw-w64-libiconv/0003-locale_charset-use-utf8.patch
+++ b/mingw-w64-libiconv/0003-locale_charset-use-utf8.patch
@@ -1,0 +1,13 @@
+diff --git a/libcharset/lib/localcharset.c "b/libcharset/lib/localcharset.c"
+index 3aceb42..21fba38 100644
+--- a/libcharset/lib/localcharset.c
++++ b/libcharset/lib/localcharset.c
+@@ -466,7 +466,7 @@ locale_charset (void)
+      But in GUI programs and for output sent to files and pipes, GetACP()
+      encoding is the best bet.  */
+   sprintf (buf, "CP%u", GetACP ());
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #elif defined OS2
+ 

--- a/mingw-w64-libiconv/PKGBUILD
+++ b/mingw-w64-libiconv/PKGBUILD
@@ -17,16 +17,19 @@ license=(partial:'GPL3' partial:'LGPL2')
 
 source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-compile-relocatable-in-gnulib.mingw.patch
-        0002-fix-cr-for-awk-in-configure.all.patch)
+        0002-fix-cr-for-awk-in-configure.all.patch
+        0003-locale_charset-use-utf8.patch)
 md5sums=('e34509b1623cec449dfeb73d7ce9c6c6'
          '8818b7fe31286f589d180713329eb893'
-         '9e955ee7135d39970a086451d4b87520')
+         '9e955ee7135d39970a086451d4b87520'
+         '58a5005c20b89cc81a711b9606042dc7')
 options=('!libtool' 'staticlibs')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-compile-relocatable-in-gnulib.mingw.patch
   patch -p1 -i ${srcdir}/0002-fix-cr-for-awk-in-configure.all.patch
+  patch -p1 -i ${srcdir}/0003-locale_charset-use-utf8.patch
 }
 
 build() {

--- a/mingw-w64-recode/13-locale_charset-use-utf8
+++ b/mingw-w64-recode/13-locale_charset-use-utf8
@@ -1,0 +1,13 @@
+diff --git a/src/localcharset.c "b/src/localcharset.c"
+index 936d93d..46620d8 100644
+--- a/src/localcharset.c
++++ b/src/localcharset.c
+@@ -241,7 +241,7 @@ locale_charset ()
+ 
+   /* Win32 has a function returning the locale's codepage as a number.  */
+   sprintf (buf, "CP%u", GetACP ());
+-  codeset = buf;
++  codeset = "UTF-8";
+ 
+ #endif
+ 

--- a/mingw-w64-recode/PKGBUILD
+++ b/mingw-w64-recode/PKGBUILD
@@ -24,6 +24,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/pinard/recode/tarball
         10-src-recodext-h-gcc-fix
         11-src-names-c-memory-leak
         12-src-names-c-format-string
+        13-locale_charset-use-utf8
         99-config-guess-config-sub
         'recode-3.6-as-if.patch'
         'recode-3.6-gettextfix.diff'
@@ -42,6 +43,7 @@ md5sums=('f82e9a6ede9119268c13493c9add2809'
          '1366feefb8681765b218f2da85f8398d'
          '485c5af523524f5381db4b29fb79e42b'
          '6588da3ef236bb2748d3fb37df7a70fd'
+         'd21b87001625f2279d244854c6210738'
          '9e15e2790c1728ae597432472e3392e2'
          'fca7484ba332c8ad59eb02334883cd92'
          'eb602e80a24b5448604bfebeacc55304'
@@ -64,6 +66,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/10-src-recodext-h-gcc-fix
   patch -Np1 -i ${srcdir}/11-src-names-c-memory-leak
   patch -Np1 -i ${srcdir}/12-src-names-c-format-string
+  patch -Np1 -i ${srcdir}/13-locale_charset-use-utf8
   patch -Np1 -i ${srcdir}/99-config-guess-config-sub
   patch -Np1 -i ${srcdir}/autotools.patch
   patch -Np1 -i ${srcdir}/mingw.patch

--- a/mingw-w64-recode/PKGBUILD
+++ b/mingw-w64-recode/PKGBUILD
@@ -10,7 +10,7 @@ url="http://recode.progiciels-bpi.ca/index.html"
 license=('GPL' 'LGPL')
 depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 options=('!strip' 'staticlibs')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "texinfo")
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/pinard/recode/tarball/v${pkgver}"
         01-no-usr-share-info-dir-gz
         02-src-libiconv-c-utf8


### PR DESCRIPTION
Referencing to https://github.com/git-for-windows/git/pull/83

gettext: always use UTF-8 on native Windows 
and also libiconv and recode
