### PR TITLE
nettle: Fix GMP_NUMB_BITS check in configure.ac

### DIFF
--- a/mingw-w64-nettle/0001-fix-GMP_NUMB_BITS-check.patch
+++ b/mingw-w64-nettle/0001-fix-GMP_NUMB_BITS-check.patch
@@ -1,0 +1,12 @@
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2015-04-08 01:00:08.000000000 +0600
++++ b/configure.ac	2015-04-09 18:44:40.857793700 +0600
+@@ -467,7 +467,7 @@
+ 	  dnl Note double square brackets, for extra m4 quoting.
+ 	  tmp_bits=`grep GMP_NUMB_BITS "$srcdir/$asm_dir/$tmp_h" \
+             | sed 's/^.*GMP_NUMB_BITS(\([[0-9]]*\)).*$/\1/'`
+-	  if test "$tmp_bits" && test "$tmp_bits" != '${GMP_NUMB_BITS}' ; then
++	  if test "$tmp_bits" && test "$tmp_bits" != "${GMP_NUMB_BITS}" ; then
+ 	     AC_MSG_WARN([skipping $tmp_h, because GMP_NUMB_BITS != $tmp_bits])
+ 	     continue
+ 	  fi

--- a/mingw-w64-nettle/PKGBUILD
+++ b/mingw-w64-nettle/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nettle
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A low-level cryptographic library (mingw-w64)"
 arch=('any')
 url="http://www.lysator.liu.se/~nisse/nettle"
@@ -11,8 +11,16 @@ license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gmp")
 options=('staticlibs' 'strip')
-source=("http://www.lysator.liu.se/~nisse/archive/nettle-$pkgver.tar.gz")
-md5sums=('075a3699cbab48ffa2ea6f9aad91e123')
+source=("http://www.lysator.liu.se/~nisse/archive/nettle-$pkgver.tar.gz"
+        "0001-fix-GMP_NUMB_BITS-check.patch")
+md5sums=('075a3699cbab48ffa2ea6f9aad91e123'
+         '650c6d9784de16b8e0bb016cde260f17')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}"/0001-fix-GMP_NUMB_BITS-check.patch
+  autoreconf -fiv
+}
 
 build() {
   mkdir -p "${srcdir}/${_realname}-${pkgver}-build-${CARCH}"


### PR DESCRIPTION
This patch enables ecc-224-modp.asm and ecc-521-modp.asm optimizations under win64