### PR TITLE
ocaml: remove the temporary patch during development

### DIFF
--- a/mingw-w64-ocaml/PKGBUILD
+++ b/mingw-w64-ocaml/PKGBUILD
@@ -18,8 +18,7 @@ source=("http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz"
         "0005-Install-libraries-to-lib-ocaml-instead-of-lib.patch"
         "0006-Configure-the-relative-paths-for-ocaml-libraries-on-.patch"
         "0007-Convert-to-windows-path-before-checking-stats.patch"
-        "0008-Use-the-standard-paths-as-default-in-ocamlbuild.patch"
-        "0009-Use-relative-paths-to-search-for-ld.conf.patch")
+        "0008-Use-the-standard-paths-as-default-in-ocamlbuild.patch")
 sha1sums=('6af8c67f2badece81d8e1d1ce70568a16e42313e'
           '75b14de1f4ea982ddbb86f49576aa0be10f9286a'
           'a780a6c94aaedcd0d19a7fbc26e09776b581a8af'
@@ -27,8 +26,7 @@ sha1sums=('6af8c67f2badece81d8e1d1ce70568a16e42313e'
           '17010515bd9715ed36300165643d8f3ad01288cf'
           '78b69527ce8a78fbb31f7b9f3e0e04bf3ffcc165'
           'cff96df7caef78097ac73a382e4ef50418a7583b'
-          '2924e4b417a6268513f4c5a9fc374a3c7ec11b07'
-          '921496361620301a6cb021bce418b59e403750c8')
+          '2924e4b417a6268513f4c5a9fc374a3c7ec11b07')
 install=ocaml-${CARCH}.install
 
 prepare() {


### PR DESCRIPTION
The 0009 patch is not necessary any more as the ld.conf path issue is now resolved by a post-install routine.

Signed-off-by: Junjie Mao <eternal.n08@gmail.com>