### PR TITLE
Make p11-kit use spawn instead of exec to call external helper programs

### DIFF
--- a/mingw-w64-ca-certificates/ca-certificates-i686.install
+++ b/mingw-w64-ca-certificates/ca-certificates-i686.install
@@ -12,8 +12,6 @@ post_install() {
   ${_mingw_prefix}/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
   ${_mingw_prefix}/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
 
-  # These files end up not being overwritten without a sleep
-  sleep 0.5
   mkdir -p ${_mingw_prefix}/ssl/certs
   cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/ssl/certs/ca-bundle.crt
   cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/ssl/cert.pem

--- a/mingw-w64-ca-certificates/ca-certificates-x86_64.install
+++ b/mingw-w64-ca-certificates/ca-certificates-x86_64.install
@@ -12,8 +12,6 @@ post_install() {
   ${_mingw_prefix}/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
   ${_mingw_prefix}/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
 
-  # These files end up not being overwritten without a sleep
-  sleep 0.5
   mkdir -p ${_mingw_prefix}/ssl/certs
   cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/ssl/certs/ca-bundle.crt
   cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/ssl/cert.pem

--- a/mingw-w64-p11-kit/0011-p11-kit-spawn-external.patch
+++ b/mingw-w64-p11-kit/0011-p11-kit-spawn-external.patch
@@ -1,0 +1,66 @@
+--- p11-kit-0.23.1/p11-kit/p11-kit.c.orig	2015-04-13 13:01:51.331355100 +0200
++++ p11-kit-0.23.1/p11-kit/p11-kit.c	2015-04-13 13:09:46.346179100 +0200
+@@ -72,6 +72,7 @@
+                char *argv[])
+ {
+ 	char **args;
++	int code;
+ 
+ 	args = calloc (argc + 2, sizeof (char *));
+ 	return_val_if_fail (args != NULL, 1);
+@@ -80,14 +81,18 @@
+ 	memcpy (args + 1, argv, sizeof (char *) * argc);
+ 	args[argc + 1] = NULL;
+ 
+-	execv (args[0], args);
+-
+-	/* At this point we have no command */
+-	p11_message_err (errno, "couldn't run trust tool");
++	code = _spawnv (_P_WAIT, args[0], args);
+ 
+ 	free (argv[0]);
+ 	free (args);
+-	return 2;
++
++	if (code) {
++		/* At this point we have no command */
++		p11_message_err (errno, "couldn't run trust tool");
++		return 2;
++	}
++
++	return 0;
+ }
+ 
+ int
+@@ -97,6 +102,7 @@
+ 	const char *private_dir;
+ 	char *filename;
+ 	char *path;
++	int code;
+ 
+ 	/* These are trust commands, send them to that tool */
+ 	if (strcmp (argv[0], "extract") == 0) {
+@@ -118,14 +124,18 @@
+ 	return_val_if_fail (path != NULL, 1);
+ 
+ 	argv[argc] = NULL;
+-	execv (path, argv);
+-
+-	/* At this point we have no command */
+-	p11_message ("'%s' is not a valid command. See 'p11-kit --help'", argv[0]);
++	code = _spawnv (_P_WAIT, path, argv);
+ 
+ 	free (filename);
+ 	free (path);
+-	return 2;
++
++	if (code) {
++		/* At this point we have no command */
++		p11_message ("'%s' is not a valid command. See 'p11-kit --help'", argv[0]);
++		return 2;
++	}
++
++	return 0;
+ }
+ 
+ int

--- a/mingw-w64-p11-kit/PKGBUILD
+++ b/mingw-w64-p11-kit/PKGBUILD
@@ -27,7 +27,8 @@ source=($url/releases/$_realname-$pkgver.tar.gz{,.sig}
         0007-mmap-CreateFile-with-FILE_SHARE_READ.patch
         0008-add-debugging-to-mmap.patch
         0009-add-debugging-to-path.patch
-        0010-fix-transport-test.patch)
+        0010-fix-transport-test.patch
+        0011-p11-kit-spawn-external.patch)
 md5sums=('96f073270c489c9a594e1c9413f42db8'
          'SKIP'
          '70330b415eb5167e5a530c13bb96c212'
@@ -39,7 +40,8 @@ md5sums=('96f073270c489c9a594e1c9413f42db8'
          '3a37950e2a7ab95a4e691c02ff0603ab'
          '0dcd0d7e10d5d898f32da8866580d640'
          '27793fc62cf1fbfe52964ba8099d2b44'
-         '8ecfeb942a3de9cb7355519c0eb62f79')
+         '8ecfeb942a3de9cb7355519c0eb62f79'
+         '3cd8e579c1163be32be3b5bcaf45e711')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -54,6 +56,7 @@ prepare() {
   # patch -p1 -i ${srcdir}/0007-add-debugging-to-mmap.patch
   # patch -p1 -i ${srcdir}/0008-add-debugging-to-path.patch
   patch -p1 -i ${srcdir}/0010-fix-transport-test.patch
+  patch -p1 -i ${srcdir}/0011-p11-kit-spawn-external.patch
 
   autoreconf -vfi
   gtkdocize


### PR DESCRIPTION
This fixes files not being written before p11-kit exits.