### PR TITLE
Licensing improvements for some packages

### DIFF
--- a/mingw-w64-jbigkit/PKGBUILD
+++ b/mingw-w64-jbigkit/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=jbigkit
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Data compression library/utilities for bi-level high-resolution images (mingw-w64)"
 arch=('any')
 url="http://www.cl.cam.ac.uk/~mgk25/jbigkit/"
-license=("GPL")
+license=(GPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
@@ -43,4 +44,5 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make prefix=${MINGW_PREFIX} DESTDIR="${pkgdir}" install
+  install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-libjpeg-turbo/PKGBUILD
+++ b/mingw-w64-libjpeg-turbo/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libjpeg-turbo
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="JPEG image codec with accelerated baseline compression and decompression (mingw-w64)"
 arch=('any')
 url="http://libjpeg-turbo.virtualgl.org"
-license=("GPL, custom")
+license=(custom:'BSD-like')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 groups=("${MINGW_PACKAGE_PREFIX}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-nasm" "${MINGW_PACKAGE_PREFIX}-gcc")
@@ -53,4 +54,11 @@ package() {
   make DESTDIR="$pkgdir" install
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
   cp "${srcdir}"/${_realname}-${pkgver}/{jinclude,transupp}.h ${pkgdir}${MINGW_PREFIX}/include/
+
+  # Licenses
+  # See http://www.libjpeg-turbo.org/About/License
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -Dm644 README            "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
+  install -Dm644 README-turbo.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README-turbo.txt"
+  install -Dm644 simd/jsimdext.inc "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/simd/jsimdext.inc"
 }

--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -1,13 +1,14 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libtiff
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.0.3
-pkgrel=4
+pkgrel=5
 pkgdesc="Library for manipulation of TIFF images (mingw-w64)"
 arch=('any')
 url="http://www.remotesensing.org/libtiff"
-license=("custom")
+license=(MIT)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
@@ -54,4 +55,9 @@ package() {
   #rm -rf "${pkgdir}${MINGW_PREFIX}/share"
   cp ${srcdir}/tiff-${pkgver}/libtiff/{tiffiop,tif_dir}.h ${pkgdir}${MINGW_PREFIX}/include/
   cp libtiff/tif_config.h ${pkgdir}${MINGW_PREFIX}/include/
+
+  # License
+  # See https://fedoraproject.org/wiki/Licensing:MIT#Hylafax_Variant
+  cd "${srcdir}/tiff-${pkgver}"
+  install -Dm644 COPYRIGHT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT"
 }

--- a/mingw-w64-wxwidgets/PKGBUILD
+++ b/mingw-w64-wxwidgets/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=wxWidgets
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.2
-pkgrel=5
+pkgrel=6
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
@@ -14,7 +15,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
-         "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib"
         )
@@ -41,6 +41,7 @@ build() {
     --target=${MINGW_CHOST} \
     --build=${MINGW_CHOST} \
     --with-msw \
+    --without-libtiff \
     --disable-mslu \
     --enable-shared \
     --enable-iniconf \
@@ -60,4 +61,13 @@ package() {
   make DESTDIR="${pkgdir}" install
 
   mv ${pkgdir}${MINGW_PREFIX}/lib/*.dll ${pkgdir}${MINGW_PREFIX}/bin
+
+  # License files
+  cd "${srcdir}/${_realname}-${pkgver}/docs"
+  install -Dm644 preamble.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/preamble.txt"
+  install -Dm644 licence.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licence.txt"
+  install -Dm644 licendoc.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/licendoc.txt"
+  install -Dm644 lgpl.txt     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/lgpl.txt"
+  install -Dm644 gpl.txt      "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/gpl.txt"
+  install -Dm644 xserver.txt  "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/xserver.txt"
 }

--- a/mingw-w64-xz/PKGBUILD
+++ b/mingw-w64-xz/PKGBUILD
@@ -1,13 +1,18 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=xz
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Library and command line tools for XZ and LZMA compressed files (mingw-w64)"
 arch=('any')
 url="http://tukaani.org/xz"
-license=("custom" "GPL" "LGPL")
+
+# TODO: check situation with getopt_long mentioned in COPYING for possible
+# removal of LGPL from this field
+license=(partial:'PublicDomain' partial:'LGPL2.1+' partial:'GPL2+')
+
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gettext")
 options=('staticlibs' 'strip')


### PR DESCRIPTION
* Improve license fields.
* Install missing license files.
* Build wxWidgets without libtiff to avoid GPL infection. A better fix though is reverting 1806f3e because that turns libtiff and thus wxWidgets into GPL2-only.