### PR TITLE
scite: Updated to v3.5.5 (fixes wrap issue)

### DIFF
--- a/mingw-w64-scite/PKGBUILD
+++ b/mingw-w64-scite/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=scite
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-defaults")
-pkgver=3.5.4
+pkgver=3.5.5
 pkgrel=1
 arch=('any')
 url='http://www.scintilla.org/SciTE.html'
@@ -15,7 +15,7 @@ source=("http://downloads.sourceforge.net/scintilla/${_realname}${pkgver//./}.tg
         "0001-Use-POSIX-tools-in-makefiles.patch"
         "0002-Prefix-library-names.patch"
         "0003-Use-FHS.patch")
-md5sums=('5438237551c50a9d57fce80dc23a4494'
+md5sums=('5c96c719fa01b27e987909502b671e25'
          'd4bd88fa3e173d26d9cacaef12b1d6f9'
          '2a9ec192f43f82d4b26b4a6667de350a'
          '17011da4ced7269d787433b599a1ae92')
@@ -31,7 +31,7 @@ prepare() {
 
 build() {
   cd "${srcdir}"/build-${CARCH}
-  
+
   GTK3=1 make -C scintilla/gtk
   make -C scintilla/win32
   # GTK3=1 make -C scite/gtk
@@ -74,7 +74,7 @@ package_mingw-w64-scite() {
 
 package_mingw-w64-scite-defaults() {
   pkgdesc='Default language files for the SciTE editor (mingw-w64)'
-  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
 
   cd "${srcdir}"/build-${CARCH}
 


### PR DESCRIPTION
I also changed a dependency of the split "slave" package to require the same version of the "master" package