### PR TITLE
Fix circular dependency between libiconv and gettext

### DIFF
--- a/mingw-w64-libiconv/PKGBUILD
+++ b/mingw-w64-libiconv/PKGBUILD
@@ -2,19 +2,13 @@
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libiconv
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}
+         ${MINGW_PACKAGE_PREFIX}-iconv)
 pkgver=1.14
-pkgrel=3
-pkgdesc='Libiconv is a conversion library'
+pkgrel=4
 groups=("${MINGW_PACKAGE_PREFIX}")
 arch=('any')
 url='http://www.gnu.org/software/libiconv/'
-
-# Some parts are GPL3, some parts are LGPL2, see README.
-# TODO: what is the license for the package as a whole? Is LGPL 2.0 compatible
-# with GPL3, so that GPL3 could be applied?
-license=(partial:'GPL3' partial:'LGPL2')
-
 source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-compile-relocatable-in-gnulib.mingw.patch
         0002-fix-cr-for-awk-in-configure.all.patch)
@@ -22,6 +16,7 @@ md5sums=('e34509b1623cec449dfeb73d7ce9c6c6'
          '8818b7fe31286f589d180713329eb893'
          '9e955ee7135d39970a086451d4b87520')
 options=('!libtool' 'staticlibs')
+makedepends=(${MINGW_PACKAGE_PREFIX}-gcc rsync)
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
@@ -30,7 +25,9 @@ prepare() {
 }
 
 build() {
-  cd $srcdir/${_realname}-${pkgver}
+  msg2 'Synchronizing build directory'
+  rsync --recursive --times "${srcdir}/${_realname}-${pkgver}"/* "${srcdir}/build-${CARCH}-${_realname}-${pkgver}"
+  cd "${srcdir}/build-${CARCH}-${_realname}-${pkgver}"
   ./configure --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -47,14 +44,21 @@ build() {
 }
 
 check() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}/build-${CARCH}-${_realname}-${pkgver}"
   make check
 }
 
-package() {
-  cd ${srcdir}/${_realname}-${pkgver}
+_package_libiconv() {
+  pkgdesc='Character encoding conversion library (mingw-w64)'
+  license=(LGPL2 documentation:'GPL3') # This is LGPL except for documentation, see README
+
+  cd "${srcdir}/build-${CARCH}-${_realname}-${pkgver}"
   make install DESTDIR="${pkgdir}"
-  rm -f ${pkgdir}${MINGW_PREFIX}/lib/charset.alias
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/bin/*.exe
+  rm -f  "${pkgdir}${MINGW_PREFIX}"/lib/charset.alias
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/share/locale
+  rm -f  "${pkgdir}${MINGW_PREFIX}"/share/doc/libiconv/*.1.*
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/share/man/man1
 
   # Licenses
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/README"                 "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/README"
@@ -62,3 +66,27 @@ package() {
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING.LIB"            "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.LIB"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/libcharset/COPYING.LIB" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/libcharset/COPYING.LIB"
 }
+
+_package_iconv() {
+  pkgdesc='Character encoding conversion utility (mingw-w64)'
+  depends=("${MINGW_PACKAGE_PREFIX}-libiconv=${pkgver}-${pkgrel}"
+           "${MINGW_PACKAGE_PREFIX}-gettext")
+  license=(GPL3)
+
+  cd "${srcdir}/build-${CARCH}-${_realname}-${pkgver}"
+  make install DESTDIR="${pkgdir}"
+  rm -f  "${pkgdir}${MINGW_PREFIX}"/bin/*.dll
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/include
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/lib
+  rm -f  "${pkgdir}${MINGW_PREFIX}"/share/doc/libiconv/*.3.*
+  rm -fr "${pkgdir}${MINGW_PREFIX}"/share/man/man3
+
+  # Licenses
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/README"  "${pkgdir}${MINGW_PREFIX}/share/licenses/iconv/README"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/iconv/COPYING"
+}
+
+package_mingw-w64-i686-iconv()      { _package_iconv;    }
+package_mingw-w64-i686-libiconv()   { _package_libiconv; }
+package_mingw-w64-x86_64-iconv()    { _package_iconv;    }
+package_mingw-w64-x86_64-libiconv() { _package_libiconv; }


### PR DESCRIPTION
There is a bug in MSYS2 where if someone wants to use the iconv program by installing libiconv, the program will fail without explanation when gettext is not installed. This is because gettext is not listed as dependency of libiconv, because libiconv is already a dependency for gettext, thus avoiding pacman warnings.

The circular dependency consists of gettext using libiconv for encoding conversion, and libiconv using gettext for translation of the iconv program. The libiconv package has been split into two separate packages to fix this:

* libiconv now contains only the library
* iconv is a new package containing the program