### PR TITLE
Include SSPI support in curl

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.42.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -77,6 +77,7 @@ build() {
     --without-random \
     --enable-static \
     --enable-shared \
+    --enable-sspi \
     "${_variant_config[@]}" \
     "${extra_config[@]}"
   make


### PR DESCRIPTION
SSPI support is necessary e.g. when accessing a TFS repository
and wants to use the credentials of the currently logged in user
via Windows Authentication (a sort of Kerberos):

git clone http://:@server/tfs/COLLECTION/TeamProject/_git/repo
or
git clone -c core.askpass=true http://server/tfs/COLLECTION/TeamProject/_git/repo

This fixes https://github.com/git-for-windows/git/issues/92

Signed-off-by: Ivo Bellin Salarin