### PR TITLE
libpatialite, spatialite-tools: rebuild with newer sqlite3

### DIFF
--- a/mingw-w64-libspatialite/PKGBUILD
+++ b/mingw-w64-libspatialite/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=libspatialite
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="SQLite extension to support spatial data types and operations (mingw-w64)"
 arch=('any')
 url="http://www.gaia-gis.it/fossil/libspatialite"

--- a/mingw-w64-spatialite-tools/PKGBUILD
+++ b/mingw-w64-spatialite-tools/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=spatialite-tools
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Set of CLI tools for spatialite (mingw-w64)'
 arch=('any')
 url='https://www.gaia-gis.it/fossil/spatialite-tools/index'


### PR DESCRIPTION
The current version of spatialite packages gives the following errors:
```
$ pacman -S mingw-w64-x86_64-spatialite-tools
....
$ spatialite
SQLite header and source version mismatch
2015-04-08 12:16:33 8a8ffc862e96f57aa698f93de10dee28e69f6e09
2014-10-17 11:24:17 e4ab094f8afce0817f4074e823fabe59fc29ebb4
```
I guess this is because sqlite3 was updated.
Simple rebuilding the packages with mingw-package helped. Should we increase the versions?

