### PR TITLE
GDAL: Add more libs to dependencies

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=gdal
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.11.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
 url="http://www.gdal.org/"
@@ -19,6 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
          "${MINGW_PACKAGE_PREFIX}-giflib"
          "${MINGW_PACKAGE_PREFIX}-hdf5"
          "${MINGW_PACKAGE_PREFIX}-jasper"
+         "${MINGW_PACKAGE_PREFIX}-json-c"
          "${MINGW_PACKAGE_PREFIX}-libfreexl"
          "${MINGW_PACKAGE_PREFIX}-libgeotiff"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
@@ -28,6 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-postgresql"

--- a/mingw-w64-libspatialite/PKGBUILD
+++ b/mingw-w64-libspatialite/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=libspatialite
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="SQLite extension to support spatial data types and operations (mingw-w64)"
 arch=('any')
 url="http://www.gaia-gis.it/fossil/libspatialite"

--- a/mingw-w64-spatialite-tools/PKGBUILD
+++ b/mingw-w64-spatialite-tools/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=spatialite-tools
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=4.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc='Set of CLI tools for spatialite (mingw-w64)'
 arch=('any')
 url='https://www.gaia-gis.it/fossil/spatialite-tools/index'


### PR DESCRIPTION
When I installed mingw-w64-x86_64-gdal package , 
```
gdalinfo --formats
```
was giving missing dll erros. I have added the missing ``json-c`` and ``openjpeg2`` to dependencies
(it is also feels better to rebuild gdal package with updated libspatialite from https://github.com/Alexpux/MINGW-packages/pull/601 )
