### PR TITLE
emacs: Update

### DIFF
--- a/mingw-w64-emacs-git/PKGBUILD
+++ b/mingw-w64-emacs-git/PKGBUILD
@@ -2,29 +2,27 @@
 
 _realname='emacs'
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r121216.18a78f8
+pkgver=r121276.5e7ed98
 pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="http://www.gnu.org/software/${_realname}/"
 license=('GPL3')
 arch=('any')
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-depends=(
-  "${MINGW_PACKAGE_PREFIX}-ctags"
-  "${MINGW_PACKAGE_PREFIX}-dbus"
-  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
-  "${MINGW_PACKAGE_PREFIX}-giflib"
-  "${MINGW_PACKAGE_PREFIX}-gnutls"
-  "${MINGW_PACKAGE_PREFIX}-imagemagick"
-  "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
-  "${MINGW_PACKAGE_PREFIX}-libpng"
-  "${MINGW_PACKAGE_PREFIX}-librsvg"
-  "${MINGW_PACKAGE_PREFIX}-libtiff"
-  "${MINGW_PACKAGE_PREFIX}-libxml2"
-  "${MINGW_PACKAGE_PREFIX}-xpm-nox"
-  "${MINGW_PACKAGE_PREFIX}-zlib"
-)
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+depends=("${MINGW_PACKAGE_PREFIX}-ctags"
+         "${MINGW_PACKAGE_PREFIX}-dbus"
+         "${MINGW_PACKAGE_PREFIX}-imagemagick"
+         "${MINGW_PACKAGE_PREFIX}-winpthreads")
+optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
+            "${MINGW_PACKAGE_PREFIX}-gnutls"
+            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+            "${MINGW_PACKAGE_PREFIX}-libpng"
+            "${MINGW_PACKAGE_PREFIX}-librsvg"
+            "${MINGW_PACKAGE_PREFIX}-libtiff"
+            "${MINGW_PACKAGE_PREFIX}-libxml2"
+            "${MINGW_PACKAGE_PREFIX}-xpm-nox"
+            "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "git")
@@ -32,11 +30,9 @@ options=('strip')
 source=("${_realname}"::"git://git.savannah.gnu.org/${_realname}.git"
         'image.c.diff'
         'lread.c.diff')
-sha256sums=(
-  'SKIP'
-  '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
-  'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f'
-)
+sha256sums=('SKIP'
+            '4571d45ec26fd556e73a70bb0ab0a2a8fa1efc5e3b3c5b472ab68bb7dc9bf52c'
+            'b9db1b7d939301d0fedf52db6ac055f7265ee5bc0c3c757e394700ca39577b7f')
 
 pkgver() {
   cd "${_realname}"
@@ -53,7 +49,7 @@ prepare() {
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd build-${MINGW_CHOST}
+  cd "build-${MINGW_CHOST}"
 
   local with_wide_int='no'
 
@@ -61,10 +57,8 @@ build() {
     with_wide_int='yes'
   fi
 
-  # NOTE:
-  # Do not add `-funroll-loops' to `CFLAGS'!
   CPPFLAGS="-DNDEBUG -isystem ${MINGW_PREFIX}/include"
-  CFLAGS="-pipe -O3 -fomit-frame-pointer"
+  CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
   LDFLAGS="-s -Wl,-s"
   "${srcdir}/${_realname}/configure" \
     --prefix="${MINGW_PREFIX}" \
@@ -85,4 +79,15 @@ package() {
   make DESTDIR="${pkgdir}" install
   rm -f "${pkgdir}${MINGW_PREFIX}/bin/ctags.exe"
   rm -f "${pkgdir}${MINGW_PREFIX}/share/man/man1/ctags.1.gz"
+
+  local dir="${pkgdir}${MINGW_PREFIX}/share/${_realname}"
+        dir="${dir}/$(ls -1 ${dir} | grep -E '([0-9]+\.[0-9]+)(\.[0-9]+)?')/src"
+
+  mkdir -p "${dir}"
+  cd "${srcdir}/${_realname}/src"
+  cp *.c *.h *.m "${dir}"
 }
+
+# TODO:
+# Patch `shell-file-name' default in the C source code similarly to
+# `source-directory'.

--- a/mingw-w64-emacs/PKGBUILD
+++ b/mingw-w64-emacs/PKGBUILD
@@ -1,33 +1,30 @@
 # Maintainer: Haroogan <Haroogan@gmail.com>
 
-_realname=emacs
+_realname='emacs'
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=24.5
-pkgrel='1'
-pkgdesc=\
-"The extensible, customizable, self-documenting, real-time display editor."
+pkgrel=1
+pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="http://www.gnu.org/software/${_realname}/"
 license=('GPL3')
 arch=('any')
-depends=(
-  "${MINGW_PACKAGE_PREFIX}-ctags"
-  "${MINGW_PACKAGE_PREFIX}-dbus"
-  "${MINGW_PACKAGE_PREFIX}-gcc-libs"
-  "${MINGW_PACKAGE_PREFIX}-giflib"
-  "${MINGW_PACKAGE_PREFIX}-gnutls"
-  "${MINGW_PACKAGE_PREFIX}-imagemagick"
-  "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
-  "${MINGW_PACKAGE_PREFIX}-libpng"
-  "${MINGW_PACKAGE_PREFIX}-librsvg"
-  "${MINGW_PACKAGE_PREFIX}-libtiff"
-  "${MINGW_PACKAGE_PREFIX}-libxml2"
-  "${MINGW_PACKAGE_PREFIX}-xpm-nox"
-  "${MINGW_PACKAGE_PREFIX}-zlib"
-)
+depends=("${MINGW_PACKAGE_PREFIX}-ctags"
+         "${MINGW_PACKAGE_PREFIX}-dbus"
+         "${MINGW_PACKAGE_PREFIX}-imagemagick"
+         "${MINGW_PACKAGE_PREFIX}-winpthreads")
+optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
+            "${MINGW_PACKAGE_PREFIX}-gnutls"
+            "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+            "${MINGW_PACKAGE_PREFIX}-libpng"
+            "${MINGW_PACKAGE_PREFIX}-librsvg"
+            "${MINGW_PACKAGE_PREFIX}-libtiff"
+            "${MINGW_PACKAGE_PREFIX}-libxml2"
+            "${MINGW_PACKAGE_PREFIX}-xpm-nox"
+            "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip')
-source=(http://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz{,.sig}
+source=("http://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"{,.sig}
         'image.c.diff'
         'lread.c.diff'
         'Makefile.in.diff')
@@ -48,7 +45,7 @@ prepare() {
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd build-${MINGW_CHOST}
+  cd "build-${MINGW_CHOST}"
 
   local with_wide_int='no'
 
@@ -56,10 +53,8 @@ build() {
     with_wide_int='yes'
   fi
 
-  # NOTE:
-  # Do not add `-funroll-loops' to `CFLAGS'!
   CPPFLAGS="-DNDEBUG -isystem ${MINGW_PREFIX}/include"
-  CFLAGS="-pipe -O3 -fomit-frame-pointer"
+  CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
   LDFLAGS="-s -Wl,-s"
   "${srcdir}/${_realname}-${pkgver}/configure" \
     --prefix="${MINGW_PREFIX}" \
@@ -80,4 +75,15 @@ package() {
   make DESTDIR="${pkgdir}" install
   rm -f "${pkgdir}${MINGW_PREFIX}/bin/ctags.exe"
   rm -f "${pkgdir}${MINGW_PREFIX}/share/man/man1/ctags.1.gz"
+
+  local dir="${pkgdir}${MINGW_PREFIX}/share/${_realname}"
+        dir="${dir}/$(ls -1 ${dir} | grep -E '([0-9]+\.[0-9]+)(\.[0-9]+)?')/src"
+
+  mkdir -p "${dir}"
+  cd "${srcdir}/${_realname}-${pkgver}/src"
+  cp *.c *.h *.m "${dir}"
 }
+
+# TODO:
+# Patch `shell-file-name' default in the C source code similarly to
+# `source-directory'.

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -7,9 +7,12 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-lib
 pkgver=5.0.0.4497.4254261
 pkgrel=1
 pkgdesc="MinGW-w64 winpthreads library"
-arch=('any')
 url="http://mingw-w64.sourceforge.net"
-license=(custom:'Permissive-like') # TODO: clarify
+# The main license of `winpthreads' is MIT, but parts of this library are
+# derived from the "POSIX Threads for Microsoft Windows" library, which is
+# licensed under BSD [1].
+license=('MIT' 'BSD')
+arch=('any')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-gcc"
@@ -125,3 +128,5 @@ package_mingw-w64-x86_64-winpthreads-git() {
 package_mingw-w64-x86_64-libwinpthread-git() {
   package_libwinpthread
 }
+
+# [1] http://locklessinc.com/articles/pthreads_on_windows/


### PR DESCRIPTION
-   Fixed dependencies;
-   Fixed problem with `-funroll-loops`;
-   Made source browsing available;
-   Fixed style inconsistencies;
-   Improved Windows POSIX Threads `PKGBUILD` a bit.