### PR TITLE
qt5: added patch to fix qnetwork bug qtbug-39874

### DIFF
--- a/mingw-w64-qt5/0046-qt-5.4.1-qnetwork-proxy-fix.patch
+++ b/mingw-w64-qt5/0046-qt-5.4.1-qnetwork-proxy-fix.patch
@@ -1,6 +1,29 @@
---- qnetworkproxy_win_old-8bdb9eab224a4341c54e9f93eca6ab4ecf6fce0b.cpp	2015-02-04 18:38:52.000000000 +0100
-+++ qnetworkproxy_win_new-67f9ca9f551a411274da4122a206f7ebeb96393f.cpp	2015-02-04 23:08:32.000000000 +0100
-@@ -130,10 +130,17 @@
+From dcedbce99a28a0a07c664ac264820412406a963e Mon Sep 17 00:00:00 2001
+From: Antonio Lotti <antonio.lotti@alice.it>
+Date: Wed, 17 Dec 2014 15:55:09 +0100
+Subject: Windows : fix call to LookupAccountNameW
+
+The call to LookupAccountNameW from advapi32 was rewritten following
+the example:
+http://msdn.microsoft.com/en-us/library/aa392742%28v=vs.85%29.aspx
+This prevents the generation of a garbage pointer when accessing
+QWindowsSystemProxy::init() for Qt compiled as 64bit library
+with MinGW-w64.
+
+Task-number: QTBUG-39874
+Task-number: QTBUG-38145
+Change-Id: I620b2fa64941f84838f9a386851480285336e8d1
+Reviewed-by: Friedemann Kleint <Friedemann.Kleint@theqtcompany.com>
+Reviewed-by: Richard J. Moore <rich@kde.org>
+---
+ src/network/kernel/qnetworkproxy_win.cpp | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/qtbase/src/network/kernel/qnetworkproxy_win.cpp b/qtbase/src/network/kernel/qnetworkproxy_win.cpp
+index da2c020..f2176d6 100644
+--- a/qtbase/src/network/kernel/qnetworkproxy_win.cpp
++++ b/qtbase/src/network/kernel/qnetworkproxy_win.cpp
+@@ -130,10 +130,17 @@ static bool currentProcessIsService()
          DWORD size = UNLEN;
          if (ptrGetUserName(userName, &size)) {
              SID_NAME_USE type = SidTypeUser;
@@ -22,3 +45,6 @@
                  return type != SidTypeUser; //returns true if the current user is not a user
          }
      }
+-- 
+cgit v0.11.0
+

--- a/mingw-w64-qt5/0046-qt-5.4.1-qnetwork-proxy-fix.patch
+++ b/mingw-w64-qt5/0046-qt-5.4.1-qnetwork-proxy-fix.patch
@@ -1,0 +1,24 @@
+--- qnetworkproxy_win_old-8bdb9eab224a4341c54e9f93eca6ab4ecf6fce0b.cpp	2015-02-04 18:38:52.000000000 +0100
++++ qnetworkproxy_win_new-67f9ca9f551a411274da4122a206f7ebeb96393f.cpp	2015-02-04 23:08:32.000000000 +0100
+@@ -130,10 +130,17 @@
+         DWORD size = UNLEN;
+         if (ptrGetUserName(userName, &size)) {
+             SID_NAME_USE type = SidTypeUser;
+-            DWORD dummy = MAX_PATH;
+-            wchar_t dummyStr[MAX_PATH] = L"";
+-            PSID psid = 0;
+-            if (ptrLookupAccountName(NULL, userName, &psid, &dummy, dummyStr, &dummy, &type))
++            DWORD sidSize = 0;
++            DWORD domainSize = 0;
++            // first call is to get the correct size
++            bool bRet = ptrLookupAccountName(NULL, userName, NULL, &sidSize, NULL, &domainSize, &type);
++            if (bRet == FALSE && ERROR_INSUFFICIENT_BUFFER != GetLastError())
++                return false;
++            QVarLengthArray<BYTE, 68> buff(sidSize);
++            QVarLengthArray<wchar_t, MAX_PATH> domainName(domainSize);
++            // second call to LookupAccountNameW actually gets the SID
++            // both the pointer to the buffer and the pointer to the domain name should not be NULL
++            if (ptrLookupAccountName(NULL, userName, buff.data(), &sidSize, domainName.data(), &domainSize, &type))
+                 return type != SidTypeUser; //returns true if the current user is not a user
+         }
+     }

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -77,7 +77,7 @@ _opengl_for_configure="${_opengl}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver_base=5.4.1
 pkgver=${_ver_base//-/}
-pkgrel=5
+pkgrel=6
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='http://qt-project.org/'
@@ -183,7 +183,7 @@ source=(#http://download.qt-project.org/development_releases/qt/${pkgver%.*}/${_
         0043-qt-5.4.1-static-use-qminimal-platform-plugin-for-qcollectiongenerator.patch
         0044-qt-5.4.1-Revert-Revert-fix-NTFS-mount-points.patch
         0045-qt-5.4.1-Emit-QMAKE_DEFAULT_LIBDIRS-and-INCDIRS-to-qconfig-pri.patch
-	0046-qt-5.4.1-qnetwork-proxy-fix.patch)
+        0046-qt-5.4.1-qnetwork-proxy-fix.patch)
 md5sums=('7afb5f9235d8d42b5b6e832442a32a5d'
          'a2fa66089b171ebb76a6e0bda2ef4ca8'
          'e3210b753ba04762de2ed4cb9c786bf1'
@@ -230,7 +230,7 @@ md5sums=('7afb5f9235d8d42b5b6e832442a32a5d'
          '51016015352313cdd749ae1ff3e14614'
          '9bc9c1177134d0f2fd782db3f394a318'
          '35ca99ccfe9fcd2ed2d8668023d885e2'
-	 'c4d4233f18c3c91b184cc16a53753306')
+         'f6fc1b3c5eec02a21c47fd77c941e4c7')
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -353,6 +353,8 @@ prepare() {
   popd > /dev/null
 
   patch -p1 -i ${srcdir}/0045-qt-5.4.1-Emit-QMAKE_DEFAULT_LIBDIRS-and-INCDIRS-to-qconfig-pri.patch
+
+  # Patch fixing bug https://bugreports.qt.io/browse/QTBUG-39874
   patch -p1 -i ${srcdir}/0046-qt-5.4.1-qnetwork-proxy-fix.patch
 
   # See: https://bugreports.qt-project.org/browse/QTBUG-37902

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -182,7 +182,8 @@ source=(#http://download.qt-project.org/development_releases/qt/${pkgver%.*}/${_
         0042-qt-5.4.0-win32-g++-enable-qtwebengine-build.patch
         0043-qt-5.4.1-static-use-qminimal-platform-plugin-for-qcollectiongenerator.patch
         0044-qt-5.4.1-Revert-Revert-fix-NTFS-mount-points.patch
-        0045-qt-5.4.1-Emit-QMAKE_DEFAULT_LIBDIRS-and-INCDIRS-to-qconfig-pri.patch)
+        0045-qt-5.4.1-Emit-QMAKE_DEFAULT_LIBDIRS-and-INCDIRS-to-qconfig-pri.patch
+	0046-qt-5.4.1-qnetwork-proxy-fix.patch)
 md5sums=('7afb5f9235d8d42b5b6e832442a32a5d'
          'a2fa66089b171ebb76a6e0bda2ef4ca8'
          'e3210b753ba04762de2ed4cb9c786bf1'
@@ -228,7 +229,8 @@ md5sums=('7afb5f9235d8d42b5b6e832442a32a5d'
          'd9e0f8a09b24757c274187469c7661d4'
          '51016015352313cdd749ae1ff3e14614'
          '9bc9c1177134d0f2fd782db3f394a318'
-         '35ca99ccfe9fcd2ed2d8668023d885e2')
+         '35ca99ccfe9fcd2ed2d8668023d885e2'
+	 'c4d4233f18c3c91b184cc16a53753306')
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -351,6 +353,7 @@ prepare() {
   popd > /dev/null
 
   patch -p1 -i ${srcdir}/0045-qt-5.4.1-Emit-QMAKE_DEFAULT_LIBDIRS-and-INCDIRS-to-qconfig-pri.patch
+  patch -p1 -i ${srcdir}/0046-qt-5.4.1-qnetwork-proxy-fix.patch
 
   # See: https://bugreports.qt-project.org/browse/QTBUG-37902
   # _ver_num=${_ver_base%%-*}


### PR DESCRIPTION
Should be integrated in 5.4.2, which is to be released soon. This means it's only a temporary fix.