### PR TITLE
curl: Update to 7.42.1

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -5,8 +5,8 @@ _variant=-openssl
 
 _realname=curl
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.42.0
-pkgrel=2
+pkgver=7.42.1
+pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -29,7 +29,7 @@ options=('staticlibs')
 source=("$url/download/${_realname}-$pkgver.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0002-curl-mingw-enable-static.patch")
-md5sums=('0a10174a0ea5105c46e92b51e1b311f8'
+md5sums=('296945012ce647b94083ed427c1877a8'
          'SKIP'
          '58520051c4ed77781d233c3fa40a5435'
          'eac9e212e619490966ae47004bec547b')


### PR DESCRIPTION
[Bugfixes][1]:

    CURLOPT_HEADEROPT: default to separate
    dist: include {src,lib}/checksrc.whitelist
    connectionexists: fix build without NTLM
    docs: distribute the CURLOPT_PINNEDPUBLICKEY man page, too
    curl -z: do not write empty file on unmet condition
    openssl: fix serial number output
    curl_easy_getinfo.3: document 'internals' in CURLINFO_TLS_SESSION
    sws: init http2 state properly
    curl.1: fix typo 

[1]: http://curl.haxx.se/changes.html#7_42_1