### PR TITLE
libsodium: bump to 1.0.2

### DIFF
--- a/mingw-w64-libsodium/PKGBUILD
+++ b/mingw-w64-libsodium/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=libsodium
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=1
 pkgdesc="P(ortable|ackageable) NaCl-based crypto library (mingw-w64)"
 arch=("any")
@@ -10,7 +10,7 @@ url="https://github.com/jedisct1/libsodium"
 license=('custom:ISC')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 source=("http://download.dnscrypt.org/${_realname}/releases/${_realname}-${pkgver}.tar.gz")
-md5sums=('9a221b49fba7281ceaaf5e278d0f4430')
+md5sums=('dc40eb23e293448c6fc908757738003f')
 
 build() {
   rm -rf "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
Didn't test the 2 packages in repo requiring this but there is no soname bump so should be good to go :)