### PR TITLE
curl: Fix netrc parsing on Windows

### DIFF
--- a/mingw-w64-curl/0003-curl-mingw-text-mode-for-netrc.patch
+++ b/mingw-w64-curl/0003-curl-mingw-text-mode-for-netrc.patch
@@ -1,0 +1,11 @@
+--- curl-7.42.1.orig/lib/netrc.c	2015-04-29 09:06:52.000000000 +0300
++++ curl-7.42.1/lib/netrc.c	2015-05-05 11:50:44.725023100 +0300
+@@ -109,7 +109,7 @@
+     netrc_alloc = TRUE;
+   }
+ 
+-  file = fopen(netrcfile, "r");
++  file = fopen(netrcfile, "rt");
+   if(netrc_alloc)
+     free(netrcfile);
+   if(file) {

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -28,11 +28,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs')
 source=("$url/download/${_realname}-$pkgver.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
-        "0002-curl-mingw-enable-static.patch")
+        "0002-curl-mingw-enable-static.patch"
+        "0003-curl-mingw-text-mode-for-netrc.patch")
 md5sums=('296945012ce647b94083ed427c1877a8'
          'SKIP'
          '58520051c4ed77781d233c3fa40a5435'
-         'eac9e212e619490966ae47004bec547b')
+         'eac9e212e619490966ae47004bec547b'
+         'c35c31a1c8ed28c75be93e5bf95c8c9e')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg
 
 prepare() {
@@ -40,6 +42,7 @@ prepare() {
   rm -f lib/pathtools.h lib/pathtools.c > /dev/null 2>&1 || true
   patch -p1 -i "${srcdir}/0001-curl-relocation.patch"
   patch -p1 -i "${srcdir}/0002-curl-mingw-enable-static.patch"
+  patch -p1 -i "${srcdir}/0003-curl-mingw-text-mode-for-netrc.patch"
   autoreconf -vfi
 }
 


### PR DESCRIPTION
Open it in text mode to avoid considering CR as part of the line