### PR TITLE
clang_svn: splitDebugName signature has changed

### DIFF
--- a/mingw-w64-clang-svn/0001-Add-Clang-MinGW-w64-driver.patch
+++ b/mingw-w64-clang-svn/0001-Add-Clang-MinGW-w64-driver.patch
@@ -342,7 +342,7 @@ index 7b661a7..35aea3b 100644
 +
 +  if (Args.hasArg(options::OPT_gsplit_dwarf))
 +    SplitDebugInfo(getToolChain(), C, *this, JA, Args, Output,
-+                   SplitDebugName(Args, Inputs));
++                   SplitDebugName(Args, Inputs[0]));
 +}
 +
 +void MinGW::Link::AddLibGCC(const ArgList &Args, ArgStringList &CmdArgs) const {


### PR DESCRIPTION
splitDebugName signature has changed recently.