### PR TITLE
armadillo: Fixes and refinements

### DIFF
--- a/mingw-w64-armadillo/0001-mingw-config-fix.patch
+++ b/mingw-w64-armadillo/0001-mingw-config-fix.patch
@@ -1,0 +1,23 @@
+diff -Naur a/include/armadillo_bits/config.hpp.cmake b/include/armadillo_bits/config.hpp.cmake
+--- a/include/armadillo_bits/config.hpp.cmake	2015-04-10 11:54:47.000000000 +0600
++++ b/include/armadillo_bits/config.hpp.cmake	2015-05-17 14:14:07.119929900 +0600
+@@ -6,7 +6,18 @@
+ // License, v. 2.0. If a copy of the MPL was not distributed with this
+ // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+-
++#if defined(_WIN64)
++  #if !defined(ARMA_BLAS_LONG) && !defined(ARMA_BLAS_LONG_LONG)
++    #define ARMA_BLAS_LONG_LONG
++  #endif
++  #if !defined(ARMA_64BIT_WORD)
++    #define ARMA_64BIT_WORD
++  #endif
++#elif defined(_WIN32)
++  #if !defined(ARMA_32BIT_WORD)
++    #define ARMA_32BIT_WORD
++  #endif
++#endif
+ 
+ #if !defined(ARMA_USE_LAPACK)
+ #cmakedefine ARMA_USE_LAPACK

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=armadillo
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.100.2
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ linear algebra library (mingw-w64)"
 arch=('any')
 url="http://arma.sourceforge.net/"
@@ -12,14 +12,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openblas")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
-source=(http://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.gz)
-md5sums=('fe57525a4fce94799d1556eb06339bbd')
+source=(http://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.gz
+        0001-mingw-config-fix.patch)
+md5sums=('fe57525a4fce94799d1556eb06339bbd'
+         '5ce663ba53e15ee85fcd7a0b01006672')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/0001-mingw-config-fix.patch"
+}
 
 build() {
   cd "$srcdir/${_realname}-${pkgver}"
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
-  
+
   #  PATH=${MINGW_PREFIX}/bin \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -23,9 +23,8 @@ prepare() {
 }
 
 build() {
-  cd "$srcdir/${_realname}-${pkgver}"
-  mkdir -p build-${MINGW_CHOST}
-  cd build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
 
   #  PATH=${MINGW_PREFIX}/bin \
   ${MINGW_PREFIX}/bin/cmake.exe \
@@ -33,10 +32,12 @@ build() {
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     -DLAPACK_NAMES=openblas \
-    ..
+    ../${_realname}-${pkgver}
+
+  make
 }
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${CARCH}"
   make install
 }
 

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -12,6 +12,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openblas")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
+install=${_realname}-${CARCH}.install
 source=(http://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.gz
         0001-mingw-config-fix.patch)
 md5sums=('fe57525a4fce94799d1556eb06339bbd'
@@ -36,8 +37,15 @@ build() {
 
   make
 }
+
 package() {
   cd "${srcdir}/build-${CARCH}"
   make install
-}
 
+  pushd "${pkgdir}${MINGW_PREFIX}" > /dev/null
+  local _INSTALL_PREFIX_WIN="$(cygpath -m "${pkgdir}${MINGW_PREFIX}")"
+  local _MINGW_PREFIX_WIN="$(cygpath -m "${MINGW_PREFIX}")"
+  sed -s -e "s|${_INSTALL_PREFIX_WIN}|${MINGW_PREFIX}|g" \
+    -e "s|${_MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" -i "share/Armadillo/CMake/"*.cmake
+  popd > /dev/null
+}

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -47,5 +47,10 @@ package() {
   local _MINGW_PREFIX_WIN="$(cygpath -m "${MINGW_PREFIX}")"
   sed -s -e "s|${_INSTALL_PREFIX_WIN}|${MINGW_PREFIX}|g" \
     -e "s|${_MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" -i "share/Armadillo/CMake/"*.cmake
+  install -d "share/doc/${_realname}-${pkgver}"
+  install -m644 "${srcdir}/${_realname}-${pkgver}/"*{.html,.png,.pdf,README.txt} \
+    "share/doc/${_realname}-${pkgver}/"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
+    "share/licenses/${_realname}/LICENSE.txt"
   popd > /dev/null
 }

--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -8,9 +8,10 @@ pkgdesc="C++ linear algebra library (mingw-w64)"
 arch=('any')
 url="http://arma.sourceforge.net/"
 license=(MPL2)
-depends=("${MINGW_PACKAGE_PREFIX}-openblas"
-         "${MINGW_PACKAGE_PREFIX}-lapack")
-
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-openblas")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
 source=(http://sourceforge.net/projects/arma/files/${_realname}-${pkgver}.tar.gz)
 md5sums=('fe57525a4fce94799d1556eb06339bbd')
 
@@ -24,6 +25,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DLAPACK_NAMES=openblas \
     ..
 }
 package() {

--- a/mingw-w64-armadillo/armadillo-i686.install
+++ b/mingw-w64-armadillo/armadillo-i686.install
@@ -1,0 +1,9 @@
+post_install() {
+  local _prefix="/mingw32"
+  local _prefix_win="$(cygpath -m "${_prefix}")"
+  sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/share/Armadillo/CMake/"*.cmake
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-armadillo/armadillo-x86_64.install
+++ b/mingw-w64-armadillo/armadillo-x86_64.install
@@ -1,0 +1,9 @@
+post_install() {
+  local _prefix="/mingw64"
+  local _prefix_win="$(cygpath -m "${_prefix}")"
+  sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/share/Armadillo/CMake/"*.cmake
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
List of changes

- use optimized openblas lapack implementation instead of the netlib lapack
- fix dependencies
- fix build directory
- call make in build()
- add patch to set appropriate default settings in config.hpp
- fix cmake scripts
- install docs and license file
