### PR TITLE
Add ragel as a tool

### DIFF
--- a/mingw-w64-ragel/PKGBUILD
+++ b/mingw-w64-ragel/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Ebrahim Byagowi <ebrahim@gnu.org>
+
+_realname=ragel
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=6.9
+pkgrel=1
+pkgdesc="Compiles finite state machines from regular languages into executable C, C++, Objective-C, or D code. (mingw-w64)"
+arch=('any')
+url="http://www.colm.net/open-source/ragel/"
+license=('GPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=("http://www.colm.net/files/${_realname}/${_realname}-$pkgver.tar.gz")
+md5sums=('0c3110d7f17f7af4d9cb774443898dc1')
+
+build() {
+  cd "$srcdir/${_realname}-$pkgver"
+
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST}
+  make
+}
+
+package() {
+  cd "$srcdir/${_realname}-$pkgver"
+
+  make DESTDIR="$pkgdir/" install
+  install -m0644 -D ragel.vim "$pkgdir"${MINGW_PREFIX}/share/vim/vimfiles/syntax/ragel.vim
+}


### PR DESCRIPTION
It is based on:
* https://github.com/KaOS-Community-Packages/ragel/blob/master/PKGBUILD
* https://github.com/johnbartholomew/pkgbuilds/blob/master/ragel/PKGBUILD

And it works well locally in order to compile a library I wanted to use this for.

First proposed as a msys2 package [here](https://github.com/Alexpux/MSYS2-packages/pull/254).