### PR TITLE
Prepare for upcoming 3.04 release of Tesseract-OCR

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -3,7 +3,7 @@
 
 _realname=tesseract-ocr
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.03.298e31465a44
+pkgver=3.04.rc1.master
 pkgrel=1
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
@@ -17,16 +17,12 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
         ${MINGW_PACKAGE_PREFIX}-pango
         ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')
-source=("https://tesseract-ocr.googlecode.com/archive/298e31465a445e54defedd076217ff24b1af3fc2.tar.gz"
-        "0001-Fix-broken_MSC_VER-checks.patch"
-        "0002-Use-intptr_t-for-pointer-cast-target.patch")
+source=("https://tesseract-ocr.googlecode.com/archive/master.tar.gz"
+)
 sha256sums=('SKIP'
-            '69e00058dd7c32c2c205dc1247b07edd43b3ba30faa4af67b646a8f7b58c6494'
-            '5a74ecf3d06f950064b7d570166629497940d491c85dda5b65defa66f65d47aa')
+)
 prepare() {
-  cd "$srcdir/${_realname}-298e31465a44"
-  patch -p1 -i "${srcdir}"/0001-Fix-broken_MSC_VER-checks.patch
-  patch -p1 -i "${srcdir}"/0002-Use-intptr_t-for-pointer-cast-target.patch
+  cd "$srcdir/${_realname}-master"
   ./autogen.sh
 }
 
@@ -39,7 +35,7 @@ build() {
     extra_config+=( --enable-debug )
   fi
 
-  ${srcdir}/${_realname}-298e31465a44/configure \
+  ${srcdir}/${_realname}-master/configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \


### PR DESCRIPTION
1. msys2 patches have already been applied in 3.04 rc1
2. change to use the current version from master branch
3. "We transferred code to https://github.com/tesseract-ocr/ and it looks like 3.04 release is very close. So this is the best time for testing and patching build/packaging system especially, it they want to have it in official release. Of course other patches are welcomed too."