### PR TITLE
jq: New package

### DIFF
--- a/mingw-w64-jq/PKGBUILD
+++ b/mingw-w64-jq/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Gore Liu <goreliu@126.com>
+
+_realname=jq
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.4
+pkgrel=1
+pkgdesc="Command-line JSON processor (mingw-w64)"
+arch=('any')
+url='http://stedolan.github.io/jq/'
+license=('MIT')
+makedepends=("autoconf" "automake" "bison" "flex" "python2")
+source=("http://stedolan.github.io/jq/download/source/${_realname}-${pkgver}.tar.gz")
+md5sums=('e3c75a4f805bb5342c9f4b3603fb248f')
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  [ -d "${srcdir}"/build-${CARCH} ] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
Name           : mingw-w64-x86_64-jq
Version        : 1.4-1
Description    : Command-line JSON processor (mingw-w64)
Architecture   : any
URL            : http://stedolan.github.io/jq/
Licenses       : MIT
