### PR TITLE
Fix separate debug symbols in drmingw-git

### DIFF
--- a/mingw-w64-drmingw-git/PKGBUILD
+++ b/mingw-w64-drmingw-git/PKGBUILD
@@ -3,7 +3,7 @@
 
 _realname=drmingw
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r401.3deab5f
+pkgver=r409.749fca8
 pkgrel=1
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')


### PR DESCRIPTION
Current Dr. MinGW packages do not work at all with separate debug symbols. This new version makes `.gnu_debuglink` work again in the git variant.