### PR TITLE
gegl-git fixes

### DIFF
--- a/mingw-w64-gegl-git/PKGBUILD
+++ b/mingw-w64-gegl-git/PKGBUILD
@@ -4,13 +4,14 @@ _realname=gegl
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r6521.06aea8e
+pkgver=r6592.8989a57
 pkgrel=1
 pkgdesc="Generic Graphics Library (mingw-w64)"
 arch=('any')
-url="http://gegl.org/gegl/"
+url="http://gegl.org/"
 license=("GPL-3.0+" "LGPL-3.0+")
 makedepends=("asciidoc"
+             "intltool"
              #"${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
@@ -28,6 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl-git"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-jasper"
+         "${MINGW_PACKAGE_PREFIX}-json-glib"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-librsvg"


### PR DESCRIPTION
* Added json-glib as a dependency to fix issue #656.
* Added intltool as a build dependency (it provides IT_PROG_INTLTOOL).
* Fixed the broken link to the project website.