### PR TITLE
Added win7appid package.

### DIFF
--- a/mingw-w64-win7appid/.gitignore
+++ b/mingw-w64-win7appid/.gitignore
@@ -1,0 +1,1 @@
+Win7AppId.cpp

--- a/mingw-w64-win7appid/LICENSE.txt
+++ b/mingw-w64-win7appid/LICENSE.txt
@@ -1,0 +1,16 @@
+The author of the Win7AppId project neglected to include a proper license with the project, but the website links to http://opensource.org/licenses/BSD-3-Clause which has this template:
+
+----
+
+Copyright (c) <YEAR>, <OWNER>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mingw-w64-win7appid/PKGBUILD
+++ b/mingw-w64-win7appid/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: David Grayson <davidegrayson@gmail.com>
+
+_realname=win7appid
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.1
+pkgrel=2
+pkgdesc='Windows 7 (and up) shortcut application id tool'
+arch=('any')
+url='https://code.google.com/p/win7appid'
+license=('custom')
+makedepends=(
+    "gzip"
+    "${MINGW_PACKAGE_PREFIX}-gcc"
+)
+depends=()
+options=('strip')
+source=(
+    "https://win7appid.googlecode.com/svn/trunk/Win7AppId.cpp"
+    "win7appid.1"
+    "LICENSE.txt"
+)
+
+sha256sums=(
+    'e6b5d9e5586d1a1e0c7911b951e00a964a80b94db21e74cdc327e523fecb9fa3'
+    'SKIP'
+    'SKIP'
+)
+
+prepare() {
+    gzip < win7appid.1 > win7appid.1.gz
+}
+
+build() {
+  mkdir -p "build-${MINGW_CHOST}"
+  cd "build-${MINGW_CHOST}"
+
+  g++ -O1 -municode -DWIN32_LEAN_AND_MEAN=1 -DUNICODE -D_UNICODE \
+    ../*.cpp -lole32 \
+    -o win7appid.exe
+}
+
+package() {
+  r="${pkgdir}${MINGW_PREFIX}"
+  mkdir -p "${r}/share/licenses/${_realname}" \
+    "${r}/share/man/man1" "${r}/bin"
+
+  install -m644 LICENSE.txt -t "${r}/share/licenses/${_realname}"
+  install -m644 win7appid.1.gz -t "${r}/share/man/man1"
+
+  cd "build-${MINGW_CHOST}"
+  install -m755 win7appid.exe -t "${r}/bin"
+}

--- a/mingw-w64-win7appid/win7appid.1
+++ b/mingw-w64-win7appid/win7appid.1
@@ -1,0 +1,39 @@
+.TH win7appid 1
+.SH NAME
+win7appid - Windows 7 (and up) shortcut application id tool
+.SH SYNOPSIS
+.B win7appid \fIshortcut\fP [\fInew_app_id\fP]
+.SH DESCRIPTION
+.P
+This is a fairly basic console application for setting the application id (System.AppUserModel.ID property) of a Windows 7 shortcut.
+.P
+In Windows 7, taskbar items are grouped by a string known as the application id or AppId. This can be set in the shortcut that launches a program, or by the application itself.  For more information, see:
+.P
+.nf
+.RS
+http://msdn.microsoft.com/en-us/library/dd378459%28VS.85%29.aspx
+.RE
+.fi
+.P
+This tool allows you to pin an application and then have another application's windows group under the same icon without modifying the applications themselves. It only works if you can launch both apps via a shortcut, child processes will have the default behaviour of having their own taskbar entry.
+.P
+If the \fInew_app_id\fP is omitted, it simply prints the current app id.
+.SH EXAMPLE
+.P
+I made the tool so I could pin a shortcut to start a Putty session with X forwarding, start gnome-terminal and have it's X window (running under Xming) group under the pinned icon.
+.P
+I issued the commands:
+.P
+.nf
+.RS
+Win7AppId xming.lnk putty-xming
+Win7AppId puttysession.lnk putty-xming
+.RE
+.fi
+.P
+And then put the xming shortcut in my Startup folder and pinned puttysession to the taskbar.
+.SH AUTHOR
+.nf
+David Roe (didroe)
+https://code.google.com/p/win7appid/
+.fi


### PR DESCRIPTION
win7appid is a very small, handy utility for setting the "App ID" of a shortcut file.  So I thought it might be nice to have a package for it.  I also converted the front page of the project's website into a man page!  

I use this tool on my pinned MSYS2 shortcuts in order to make my MSYS2 mintty windows get grouped under the pinned icon.  (I also have to [patch](https://gist.github.com/DavidEGrayson/30066232eb21c0c1492a) msys2/*.bat in order to set the same App ID on the mintty Windows.)