### PR TITLE
added current git repos for dlfcn / isl

### DIFF
--- a/mingw-w64-dlfcn-git/PKGBUILD
+++ b/mingw-w64-dlfcn-git/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Andreas Baumgaertner <andreas.baumgaertner@tisco.at>
+
+_realname=dlfcn
+
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=r66.e419539
+pkgrel=1
+pkgdesc="A wrapper for dlfcn to the Win32 API (mingw-w64)"
+arch=('any')
+url="http://code.google.com/p/dlfcn-win32"
+license=("LGPL")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+    "git")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+source=("${_realname}"::"git://github.com/dlfcn-win32/dlfcn-win32.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_realname"
+  printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+}
+
+build() {
+  cd "$srcdir/${_realname}"
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --libdir=${MINGW_PREFIX}/lib \
+    --incdir=${MINGW_PREFIX}/include \
+    --enable-shared
+   
+# --disable-stripping \   # dynamic libs can be stripped
+# --disable-msvc          # should be autodetected    
+
+  sed -i "s|libdl.dll |libdl-0.dll |g" Makefile
+  sed -i "s|libdl.dll$|libdl-0.dll|g" Makefile
+  sed -i "s|libdl.dll:|libdl-0.dll:|g" Makefile
+  make
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  make DESTDIR="$pkgdir" install
+}

--- a/mingw-w64-isl-git/PKGBUILD
+++ b/mingw-w64-isl-git/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Andreas Baumgaertner <andreas.baumgaertner@tisco.at>
+
+_realname=isl
+
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+pkgver=0.14.1
+pkgrel=1
+pkgdesc="Library for manipulating sets and relations of integer points bounded by linear constraints"
+arch=('any')
+url="http://freecode.com/projects/isl"
+groups=("${MINGW_PACKAGE_PREFIX}")
+#depends=("${MINGW_PACKAGE_PREFIX}-gmp")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gmp" 
+             "git")
+options=('staticlibs')
+license=('MIT')
+source=("${_realname}"::"git://repo.or.cz/isl.git#tag=isl-0.14.1"
+        "isl-0.14.1-no-undefined.patch")
+md5sums=('SKIP'
+         '1baeffd5df12e3e2c0feda4c636ff05a')
+
+prepare() {
+  cd "$srcdir/${_realname}"
+  patch -p1 -i ${srcdir}/isl-0.14.1-no-undefined.patch
+  
+  autoreconf -fi
+}
+
+build() {
+  cd "$srcdir/${_realname}"
+  ./configure --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --enable-static \
+    --disable-shared \
+    --with-gmp-prefix=${MINGW_PREFIX}
+  make
+}
+
+check() {
+  cd "$srcdir/${_realname}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-isl-git/isl-0.14.1-no-undefined.patch
+++ b/mingw-w64-isl-git/isl-0.14.1-no-undefined.patch
@@ -1,0 +1,11 @@
+--- isl/Makefile.am.orig	2015-06-08 05:05:45.466230600 +0200
++++ isl/Makefile.am	2015-06-08 05:06:28.808564400 +0200
+@@ -164,7 +164,7 @@
+ 	isl_vertices_private.h \
+ 	isl_vertices.c
+ libisl_la_LIBADD = @MP_LIBS@
+-libisl_la_LDFLAGS = -version-info @versioninfo@ \
++libisl_la_LDFLAGS = -version-info @versioninfo@ -no-undefined \
+ 	@MP_LDFLAGS@
+ 
+ isl_test_LDFLAGS = @MP_LDFLAGS@


### PR DESCRIPTION
Hi Alex,

small update for current git repos for 2 packages:
mingw-w64-dlfcn-git
mingw-w64-isl-git

for dlfcn head is used
for isl a version tag is specified

thx,
Andreas