### PR TITLE
x265: Install 10 bit-depth dll (libx265_main10.dll).

### DIFF
--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Yuta Nakai <nak5124@live.jp>
 
 _realname=x265
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7
-pkgrel=1
+pkgrel=2
 pkgdesc='Open Source H265/HEVC video encoder (mingw-w64)'
 arch=('any')
 license=('GPL')
@@ -17,24 +18,56 @@ md5sums=('d6020c277b05ab44f8222342aaa9c99f'
          'c1dc65fc3191d6bafdd3576235ade5ae')
 
 prepare() {
-  cd multicoreware-x265-*
-  patch -p1 -i ${srcdir}/install-shared-library.patch
+  cd "${srcdir}"/multicoreware-x265-*
+  patch -p1 -i "${srcdir}"/install-shared-library.patch
 }
 
 build() {
-  cd multicoreware-x265-*/build/msys
+  # Build 8 bit-depth lib and exe.
+  cd "${srcdir}"/multicoreware-x265-*/build/msys
+  if [ -d 8bit ]; then
+    rm -fr 8bit
+  fi
+  mkdir -p 8bit
+  cd 8bit
+
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
-    ../../source
+    ../../../source
+  make
+
+  # Build 10 bit-depth dll for x265_api_get.
+  if [ -d ../10bit ]; then
+    rm -fr ../10bit
+  fi
+  mkdir -p ../10bit
+  cd ../10bit
+
+  if [ "${CARCH}" = 'i686' ]; then
+    _ENABLE_ASM=OFF
+  else
+    _ENABLE_ASM=ON
+  fi
+
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "MSYS Makefiles" \
+    -DHIGH_BIT_DEPTH=ON \
+    -DENABLE_ASSEMBLY=$_ENABLE_ASM \
+    -DENABLE_CLI=OFF \
+    ../../../source
   make
 }
 
 package() {
-  cd multicoreware-x265-*/build/msys
+  cd "${srcdir}"/multicoreware-x265-*/build/msys/8bit
   make install
 
   local PREFIX_WIN=$(cygpath -am ${pkgdir}${MINGW_PREFIX})
   sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/x265.pc
+    -i "${pkgdir}"${MINGW_PREFIX}/lib/pkgconfig/x265.pc
+
+  # Install 10 bit-depth dll.
+  cd "${srcdir}"/multicoreware-x265-*/build/msys/10bit
+  install -m 755 libx265.dll "${pkgdir}"/${MINGW_PREFIX}/bin/libx265_main10.dll
 }


### PR DESCRIPTION
The dll is for applications which can use x265 multi-library interface.
e.g. x265.exe and ffmpeg.exe.