### PR TITLE
Some documentation fixes for Dr. MinGW

### DIFF
--- a/mingw-w64-drmingw-git/PKGBUILD
+++ b/mingw-w64-drmingw-git/PKGBUILD
@@ -4,12 +4,15 @@
 _realname=drmingw
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r450.bc67b75
-pkgrel=1
+pkgrel=2
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')
 license=(LGPL2.1)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc" "git")
+makedepends=(${MINGW_PACKAGE_PREFIX}-discount
+             ${MINGW_PACKAGE_PREFIX}-cmake
+             ${MINGW_PACKAGE_PREFIX}-gcc
+             git)
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 url=('https://github.com/jrfonseca/drmingw')
@@ -47,5 +50,13 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 install
 
-  install -Dm644 "${srcdir}/${_realname}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  # License files
+  cd "${pkgdir}${MINGW_PREFIX}/share"
+  mkdir -p licenses/${_realname}
+  mv doc/${_realname}/LICENSE* licenses/${_realname}
+
+  # Readme
+  cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  markdown README.md > README.html
+  rm README.md
 }

--- a/mingw-w64-drmingw/PKGBUILD
+++ b/mingw-w64-drmingw/PKGBUILD
@@ -4,12 +4,14 @@
 _realname=drmingw
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
 pkgver=0.7.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')
 license=(LGPL2)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=(${MINGW_PACKAGE_PREFIX}-discount
+             ${MINGW_PACKAGE_PREFIX}-cmake
+             ${MINGW_PACKAGE_PREFIX}-gcc)
 url=('https://github.com/jrfonseca/drmingw')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jrfonseca/drmingw/archive/${pkgver}.tar.gz"
         import-libs.patch
@@ -40,5 +42,13 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make -j1 install
 
-  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  # License files
+  cd "${pkgdir}${MINGW_PREFIX}/share"
+  mkdir -p licenses/${_realname}
+  mv doc/${_realname}/LICENSE* licenses/${_realname}
+
+  # Readme
+  cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  markdown README.md > README.html
+  rm README.md
 }


### PR DESCRIPTION
* Fix duplicated license installation.
* Convert markdown readme to HTML.