### PR TITLE
mpv: Update to 0.9.2

### DIFF
--- a/mingw-w64-mpv/0001-Revert-win32-fix-desktop-directory.patch
+++ b/mingw-w64-mpv/0001-Revert-win32-fix-desktop-directory.patch
@@ -1,0 +1,29 @@
+From 2739ea80b7137daf3f9a39fd3a2ddfd787a6b964 Mon Sep 17 00:00:00 2001
+From: James Ross-Gowan <rossymiles@gmail.com>
+Date: Wed, 24 Jun 2015 20:49:59 +1000
+Subject: [PATCH] Revert "win32: fix desktop directory"
+
+This reverts commit f56a7af9f696aab7f4095f282f22dcbe7c758c9e.
+
+This was incorrectly merged. There's no folder parameter in the version
+of the function on the release branch.
+---
+ osdep/path-win.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/osdep/path-win.c b/osdep/path-win.c
+index f22b8a3..26f7ffa 100644
+--- a/osdep/path-win.c
++++ b/osdep/path-win.c
+@@ -51,7 +51,7 @@ static char *mp_get_win_app_dir(void *talloc_ctx)
+ {
+     wchar_t w_appdir[MAX_PATH + 1] = {0};
+ 
+-    if (SHGetFolderPathW(NULL, folder|CSIDL_FLAG_CREATE, NULL,
++    if (SHGetFolderPathW(NULL, CSIDL_APPDATA|CSIDL_FLAG_CREATE, NULL,
+         SHGFP_TYPE_CURRENT, w_appdir) != S_OK)
+         return NULL;
+ 
+-- 
+2.4.4
+

--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -3,31 +3,33 @@
 
 _realname=mpv
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.0
+pkgver=0.9.2
 pkgrel=1
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="http://mpv.io"
 arch=('any')
 license=('GPL')
-depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg"
+depends=("${MINGW_PACKAGE_PREFIX}-enca"
+         "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
-         "${MINGW_PACKAGE_PREFIX}-libdvdread"
-         #"${MINGW_PACKAGE_PREFIX}-libcdio-paranoia"
-         "${MINGW_PACKAGE_PREFIX}-enca"
-         "${MINGW_PACKAGE_PREFIX}-libguess"
-         "${MINGW_PACKAGE_PREFIX}-mpg123"
-         "${MINGW_PACKAGE_PREFIX}-lua"
-         "${MINGW_PACKAGE_PREFIX}-libdvdnav"
-         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libcaca"
+         #"${MINGW_PACKAGE_PREFIX}-libcdio-paranoia"
+         "${MINGW_PACKAGE_PREFIX}-libdvdnav"
+         "${MINGW_PACKAGE_PREFIX}-libdvdread"
+         "${MINGW_PACKAGE_PREFIX}-libguess"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-lua51"
+         "${MINGW_PACKAGE_PREFIX}-rubberband"
          "winpty-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python3-docutils"
-             "python"
              "perl"
-             "pkg-config")
-source=(https://github.com/mpv-player/${_realname}/archive/v$pkgver.tar.gz)
-md5sums=('b3d02a0db096e77ce38c3946dd631e58')
+             "pkg-config"
+             "python")
+source=(https://github.com/mpv-player/${_realname}/archive/v$pkgver.tar.gz
+        0001-Revert-win32-fix-desktop-directory.patch)
+md5sums=('ed1384e703f7032e531731842e4da4f7'
+         '384699c849f1028b4abd57361f10d743')
 
 # strip doesn't work well with the mpv.com wrapper, so strip manually instead
 options=(!strip !emptydirs)
@@ -36,6 +38,7 @@ prepare() {
   cd ${_realname}-${pkgver}
   [ -x ./waf ] || /usr/bin/python3 ./bootstrap.py
   sed -i 's:bin/env python$:bin/env python3:' waf
+  patch -p1 -i "${srcdir}"/0001-Revert-win32-fix-desktop-directory.patch
 }
 
 build() {
@@ -52,18 +55,18 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --check-c-compiler=gcc \
     --enable-libmpv-shared \
-    --enable-libguess \
-    --enable-lua \
+    --disable-cdda \
+    --disable-ladspa \
+    --enable-caca \
+    --enable-dvdnav \
+    --enable-dvdread \
+    --enable-enca \
+    --enable-jpeg \
+    --enable-lcms2 \
     --enable-libass \
     --enable-libbluray \
-    --enable-dvdread \
-    --enable-dvdnav \
-    --disable-cdda \
-    --enable-enca \
-    --enable-mpg123 \
-    --enable-lcms2 \
-    --enable-caca \
-    --enable-jpeg \
+    --enable-libguess \
+    --enable-lua \
     --out="${srcdir}/build-${MINGW_CHOST}"
 
   /usr/bin/python3 ./waf build


### PR DESCRIPTION
This comes with a few changes:

- The Lua dependency has been fixed. mpv doesn't support Lua 5.3.
- librubberband is added as a dependency.
- libmpg123 has been removed (mpv no longer supports it.)
- LADSPA has been explicitly disabled. mpv auto-detects it, but it doesn't work on Windows yet because it relies on \<dlfcn.h>. af_ladspa is probably not important enough to add a dependency to dlfcn-win32 (it's disabled in the official builds as well.)
- A patch is included to fix a bad merge on mpv's release branch.