### PR TITLE
Fix winpty wrapper for mpv 0.9.x

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=mpv
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="http://mpv.io"
 arch=('any')
@@ -96,6 +96,7 @@ package() {
   mv "${pkgdir}${MINGW_PREFIX}/bin/mpv.exe" "${pkgdir}${MINGW_PREFIX}/bin/mpv_exe"
   _exename=mpv
   echo '#!/usr/bin/env bash' > "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
+  echo 'export _started_from_console=yes' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
   echo '/usr/bin/winpty "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"' >> "${pkgdir}${MINGW_PREFIX}/bin/${_exename}"
   mv "${pkgdir}${MINGW_PREFIX}/bin/mpv_exe" "${pkgdir}${MINGW_PREFIX}/bin/mpv.exe"
 }


### PR DESCRIPTION
I forgot this change, sorry. mpv 0.9.x uses an environment variable to determine whether it was started from the console wrapper (mpv.com.) The winpty wrapper also needs to set this for terminal input/output to work properly.