### PR TITLE
catch: Update to 1.2.0.

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -2,22 +2,21 @@
 
 _realname=catch
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.1
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
 url='https://github.com/philsquared/Catch'
 license=('custom')
 
-# The README says to get the latest version from the "develop" branch.
-_src="https://raw.githubusercontent.com/philsquared/Catch/develop"
+_src="https://raw.githubusercontent.com/philsquared/Catch/v${pkgver}"
 
 source=(
     "${_src}/single_include/catch.hpp"
     "${_src}/LICENSE_1_0.txt"
 )
 
-sha256sums=('d8d143fc91809792b961b62b1fcfc9c36023d8ca54173c337394e95c6b617095'
+sha256sums=('ccd4c1fec3cf0715961dcb86a60967d7bc91ae050e00c8f42d03698b3ff8f590'
             'c9bff75738922193e67fa726fa225535870d2aa1059f91452c411736284ad566')
 
 package() {


### PR DESCRIPTION
This pull request updates the Catch package to version 1.2.0.  As of today, Catch now uses semantic versioning and git tags, so I was able to improve the script to use the tag instead of using the "develop" branch.