### PR TITLE
tk: Move X11 headers to private folder

### DIFF
--- a/mingw-w64-tk/PKGBUILD
+++ b/mingw-w64-tk/PKGBUILD
@@ -74,6 +74,11 @@ package() {
   )
   chmod a-x "${pkgdir}${MINGW_PREFIX}/lib/"*/pkgIndex.tcl
 
+  #Move X11 headers to private folder
+  find "${pkgdir}${MINGW_PREFIX}/include" \
+    -type f -name "*.h" -exec sed -i "s/X11\//tk${pkgver%.*}\/X11\//g" {} \;
+  mv "${pkgdir}${MINGW_PREFIX}/include/X11" "${pkgdir}${MINGW_PREFIX}/include/tk${pkgver%.*}/"
+
   local _libver=${pkgver%.*}
   _libver=${_libver//./}
   sed -i \


### PR DESCRIPTION
Related issues: #677 
I could only find python that depends on tk. It seems to build fine with this change.

---

<strike>Since the libraries are already being built without dots in the version number
(e.g. tk86.dll) have the folders follow suit too. This is in agreement with
how Python searches for the tk includes.

e.g.:
/mingw**/include/tk8.6 --> /mingw**/include/tk86
/mingw**/include/tk.h --> /mingw**/include/tk86/tk.h
</strike>

By moving the X11 tk headers into its own folder, this avoids conflicts with any X11
headers that may already be present.
