### PR TITLE
Update Dr. MinGW to latest

### DIFF
--- a/mingw-w64-drmingw/PKGBUILD
+++ b/mingw-w64-drmingw/PKGBUILD
@@ -3,11 +3,11 @@
 
 _realname=drmingw
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
-pkgver=0.7.3
-pkgrel=4
+pkgver=0.7.4
+pkgrel=1
 pkgdesc="Just-in-Time (JIT) debugger (mingw-w64)"
 arch=('any')
-license=(LGPL2)
+license=(LGPL2.1)
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=(${MINGW_PACKAGE_PREFIX}-discount
              ${MINGW_PACKAGE_PREFIX}-cmake
@@ -17,13 +17,13 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/jrfonseca/drmingw/arc
         import-libs.patch
         install-files.patch)
 options=(!strip staticlibs)
-md5sums=('2a606a5dfb85e6092ae82acbd4612a7c'
+md5sums=('17a3df69abe4c2c46fc6aaabfb209e58'
          '95cf2d64efb65e035b96f58e9272798e'
-         '79edeee894e906bc3cce20f7f170de0c')
+         '5e8f6c0cf54d73b0232ae759ed950008')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i ${srcdir}/import-libs.patch
+  #patch -p1 -i ${srcdir}/import-libs.patch
   patch -p1 -i ${srcdir}/install-files.patch
 }
 

--- a/mingw-w64-drmingw/install-files.patch
+++ b/mingw-w64-drmingw/install-files.patch
@@ -1,6 +1,7 @@
---- drmingw/CMakeLists.txt.orig	2015-06-21 14:26:32.215200000 +0300
-+++ drmingw/CMakeLists.txt	2015-06-21 14:27:19.342800000 +0300
-@@ -120,7 +120,7 @@
+diff -aurN 000/CMakeLists.txt 001/CMakeLists.txt
+--- 000/CMakeLists.txt	2015-06-26 13:00:48.000000000 -0300
++++ 001/CMakeLists.txt	2015-06-30 12:07:28.121666600 -0300
+@@ -133,7 +133,7 @@
      FILES
          LICENSE.txt
          README.md
@@ -9,18 +10,20 @@
  )
  
  # cpack mistakenly detects Mingw-w64 as win32
---- drmingw/sample/CMakeLists.txt.orig	2015-06-21 14:27:55.165000000 +0300
-+++ drmingw/sample/CMakeLists.txt	2015-06-21 14:28:26.833000000 +0300
+diff -aurN 000/sample/CMakeLists.txt 001/sample/CMakeLists.txt
+--- 000/sample/CMakeLists.txt	2015-06-26 13:00:48.000000000 -0300
++++ 001/sample/CMakeLists.txt	2015-06-30 12:07:28.121666600 -0300
 @@ -6,5 +6,5 @@
-     exchndl2.cpp
- )
+ add_dependencies (sample exchndl_implib)
+ target_link_libraries (sample ${EXCHNDL_IMPLIB})
  
--install (FILES sample.cpp exchndl2.cpp DESTINATION sample)
+-install (FILES sample.cpp DESTINATION sample)
 -install (FILES sample.mak DESTINATION sample RENAME Makefile)
-+install (FILES sample.cpp exchndl2.cpp DESTINATION share/drmingw/sample)
++install (FILES sample.cpp DESTINATION share/drmingw/sample)
 +install (FILES sample.mak DESTINATION share/drmingw/sample RENAME Makefile)
---- drmingw/thirdparty/dwarf/CMakeLists.txt.orig	2015-06-21 14:33:35.812200000 +0300
-+++ drmingw/thirdparty/dwarf/CMakeLists.txt	2015-06-21 14:33:45.733800000 +0300
+diff -aurN 000/thirdparty/dwarf/CMakeLists.txt 001/thirdparty/dwarf/CMakeLists.txt
+--- 000/thirdparty/dwarf/CMakeLists.txt	2015-06-26 13:00:48.000000000 -0300
++++ 001/thirdparty/dwarf/CMakeLists.txt	2015-06-30 12:07:28.121666600 -0300
 @@ -38,6 +38,6 @@
  
  install (


### PR DESCRIPTION
This fixes import library for release-based flavor since 0.7.4 now provides the missing exchndl header.