### PR TITLE
Updated Openssl to Version 1.0.2d

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -2,10 +2,10 @@
 
 _realname=openssl
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_ver=1.0.2c
+_ver=1.0.2d
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=2
+pkgrel=1
 arch=('any')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -21,14 +21,14 @@ source=(http://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
         'openssl-1.0.1-x32.patch'
         'openssl-0.9.6-x509.patch'
         'openssl-1.0.1i-relocation.patch')
-md5sums=('8c8d81a9ae7005276e486702edbcd4b6'
+md5sums=('38dd619b2e77cbac69b99f52a053d25a'
          'SKIP'
-         '9e0abad8dd17079815d9e92345c5adcb'
-         '835a78dbe9c8690dbdd9190aaf5432e7'
-         '1d363d5e19c6eb4144b49f9daadefd5f'
-         '87610b76871d53d4b6f07374000dae87'
-         'cae4eea6db48a254653fd1903cfabd15'
-         'd8ed0865f35216a5e420e37d7a4e2515')
+         'dd616e53eba607f5ab46634f93d5c5a5'
+         'df46ea89a28b0bd18f13b9ab63d1ade3'
+         '7ea5aaac21cee0f89dfb58b03219caaa'
+         '7400927e547cd4c68d2af2fe0b322345'
+         '990d027cc82ff8b2acffead24073d43c'
+         '43e1787d8891f990e8fbe7dd4f6a258b')
 validpgpkeys=('8657ABB260F056B1E5190839D9C4D26D0E604491')
 
 prepare() {

--- a/mingw-w64-openssl/openssl-0.9.6-x509.patch
+++ b/mingw-w64-openssl/openssl-0.9.6-x509.patch
@@ -2,7 +2,7 @@ Do not treat duplicate certs as an error.
 
 --- openssl-0.9.6/crypto/x509/by_file.c	Wed Sep 27 15:09:05 2000
 +++ openssl-0.9.6/crypto/x509/by_file.c	Wed Sep 27 14:21:20 2000
-@@ -163,9 +163,12 @@
+@@ -152,9 +152,12 @@
                  }
              }
              i = X509_STORE_add_cert(ctx->store_ctx, x);
@@ -18,7 +18,7 @@ Do not treat duplicate certs as an error.
              X509_free(x);
              x = NULL;
          }
-@@ -179,8 +183,8 @@
+@@ -166,8 +169,8 @@
              goto err;
          }
          i = X509_STORE_add_cert(ctx->store_ctx, x);
@@ -31,7 +31,7 @@ Do not treat duplicate certs as an error.
          X509err(X509_F_X509_LOAD_CERT_FILE, X509_R_BAD_X509_FILETYPE);
 --- openssl-0.9.6/crypto/store/store.h	2009-08-12 00:57:20.000000000 +0200
 +++ openssl-0.9.6/crypto/store/store.h	2009-08-12 01:00:27.000000000 +0200
-@@ -70,6 +70,13 @@
+@@ -77,6 +77,13 @@
  extern "C" {
  #endif
  

--- a/mingw-w64-openssl/openssl-1.0.0a-ldflags.patch
+++ b/mingw-w64-openssl/openssl-1.0.0a-ldflags.patch
@@ -2,7 +2,7 @@ http://bugs.gentoo.org/327421
 
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -189,6 +189,7 @@
+@@ -216,6 +216,7 @@
  		MAKEDEPEND='$$$${TOP}/util/domd $$$${TOP} -MD $(MAKEDEPPROG)' \
  		DEPFLAG='-DOPENSSL_NO_DEPRECATED $(DEPFLAG)'	\
  		MAKEDEPPROG='$(MAKEDEPPROG)'			\

--- a/mingw-w64-openssl/openssl-1.0.0d-windres.patch
+++ b/mingw-w64-openssl/openssl-1.0.0d-windres.patch
@@ -12,7 +12,7 @@ retrieving revision 1.621.2.40
 diff -u -p -r1.621.2.40 Configure
 --- a/Configure	30 Nov 2010 22:19:26 -0000	1.621.2.40
 +++ b/Configure	4 Jul 2011 23:12:32 -0000
-@@ -1094,6 +1094,7 @@ my $shared_extension = $fields[$idx_shar
+@@ -1244,6 +1244,7 @@ my $shared_extension = $fields[$idx_shar
  my $ranlib = $ENV{'RANLIB'} || $fields[$idx_ranlib];
  my $ar = $ENV{'AR'} || "ar";
  my $arflags = $fields[$idx_arflags];
@@ -20,7 +20,7 @@ diff -u -p -r1.621.2.40 Configure
  my $multilib = $fields[$idx_multilib];
  
  # if $prefix/lib$multilib is not an existing directory, then
-@@ -1511,12 +1512,14 @@ while (<IN>)
+@@ -1706,12 +1707,14 @@ while (<IN>)
  		s/^AR=\s*/AR= \$\(CROSS_COMPILE\)/;
  		s/^NM=\s*/NM= \$\(CROSS_COMPILE\)/;
  		s/^RANLIB=\s*/RANLIB= \$\(CROSS_COMPILE\)/;
@@ -50,7 +50,7 @@ diff -u -p -r1.295.2.10 Makefile.org
  NM= nm
  PERL= perl
  TAR= tar
-@@ -180,6 +181,7 @@ BUILDENV=	PLATFORM='$(PLATFORM)' PROCESS
+@@ -207,6 +208,7 @@ BUILDENV=	PLATFORM='$(PLATFORM)' PROCESS
  		CC='$(CC)' CFLAG='$(CFLAG)' 			\
  		AS='$(CC)' ASFLAG='$(CFLAG) -c'			\
  		AR='$(AR)' NM='$(NM)' RANLIB='$(RANLIB)'	\

--- a/mingw-w64-openssl/openssl-1.0.1-x32.patch
+++ b/mingw-w64-openssl/openssl-1.0.1-x32.patch
@@ -12,7 +12,7 @@ Index: openssl-1.0.2a/Configure
 ===================================================================
 --- openssl-1.0.2a.orig/Configure
 +++ openssl-1.0.2a/Configure
-@@ -393,6 +393,7 @@ my %table=(
+@@ -217,6 +217,7 @@ my %table=(
  "debug-linux-generic32","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -g -Wall::-D_REENTRANT::-ldl:BN_LLONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
  "debug-linux-generic64","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DTERMIO -g -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR:${no_asm}:dlfcn:linux-shared:-fPIC::.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
  "debug-linux-x86_64","gcc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -m64 -DL_ENDIAN -g -Wall::-D_REENTRANT::-ldl:SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_UNROLL:${x86_64_asm}:elf:dlfcn:linux-shared:-fPIC:-m64:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):::64",
@@ -24,7 +24,7 @@ Index: openssl-1.0.2a/crypto/bn/asm/x86_64-gcc.c
 ===================================================================
 --- openssl-1.0.2a.orig/crypto/bn/asm/x86_64-gcc.c
 +++ openssl-1.0.2a/crypto/bn/asm/x86_64-gcc.c
-@@ -192,9 +192,9 @@ BN_ULONG bn_add_words (BN_ULONG *rp, con
+@@ -212,9 +212,9 @@ BN_ULONG bn_add_words (BN_ULONG *rp, con
      asm volatile ("       subq    %0,%0           \n" /* clear carry */
                    "       jmp     1f              \n"
                    ".p2align 4                     \n"
@@ -37,7 +37,7 @@ Index: openssl-1.0.2a/crypto/bn/asm/x86_64-gcc.c
                    "       lea     1(%2),%2        \n"
                    "       loop    1b              \n"
                    "       sbbq    %0,%0           \n":"=&r" (ret), "+c"(n),
-@@ -215,9 +215,9 @@ BN_ULONG bn_sub_words (BN_ULONG *rp, con
+@@ -238,9 +238,9 @@ BN_ULONG bn_sub_words (BN_ULONG *rp, con
      asm volatile ("       subq    %0,%0           \n" /* clear borrow */
                    "       jmp     1f              \n"
                    ".p2align 4                     \n"
@@ -54,7 +54,7 @@ Index: openssl-1.0.2a/crypto/bn/bn.h
 ===================================================================
 --- openssl-1.0.2a.orig/crypto/bn/bn.h
 +++ openssl-1.0.2a/crypto/bn/bn.h
-@@ -172,6 +172,13 @@ extern "C" {
+@@ -173,6 +173,13 @@ extern "C" {
  #  endif
  # endif
  

--- a/mingw-w64-openssl/openssl-1.0.1i-relocation.patch
+++ b/mingw-w64-openssl/openssl-1.0.1i-relocation.patch
@@ -1,7 +1,7 @@
 diff -Naur openssl-1.0.1i-orig/Configure openssl-1.0.1i/Configure
 --- openssl-1.0.1i-orig/Configure	2014-08-07 01:10:56.000000000 +0400
 +++ openssl-1.0.1i/Configure	2014-08-08 00:23:45.884200000 +0400
-@@ -1803,6 +1803,12 @@
+@@ -1900,6 +1900,12 @@
  		$foo =~ s/\\/\\\\/g;
  		print OUT "#define OPENSSLDIR \"$foo\"\n";
  		}
@@ -17,17 +17,17 @@ diff -Naur openssl-1.0.1i-orig/Configure openssl-1.0.1i/Configure
 diff -Naur openssl-1.0.1i-orig/crypto/engine/eng_list.c openssl-1.0.1i/crypto/engine/eng_list.c
 --- openssl-1.0.1i-orig/crypto/engine/eng_list.c	2014-07-22 23:41:23.000000000 +0400
 +++ openssl-1.0.1i/crypto/engine/eng_list.c	2014-08-08 00:32:40.141000000 +0400
-@@ -62,6 +62,7 @@
+@@ -63,6 +63,7 @@
   */
  
  #include "eng_int.h"
 +#include "pathtools.h"
  
- /* The linked-list of pointers to engine types. engine_list_head
-  * incorporates an implicit structural reference but engine_list_tail
-@@ -79,6 +80,24 @@
- /* This cleanup function is only needed internally. If it should be called, we
-  * register it with the "ENGINE_cleanup()" stack to be called during cleanup. */
+ /*
+  * The linked-list of pointers to engine types. engine_list_head incorporates
+@@ -84,6 +85,24 @@
+  * cleanup.
+  */
  
 +char * enginedir_relocation(const char *path)
 +{
@@ -48,9 +48,9 @@ diff -Naur openssl-1.0.1i-orig/crypto/engine/eng_list.c openssl-1.0.1i/crypto/en
 +}
 +
  static void engine_list_cleanup(void)
- 	{
- 	ENGINE *iterator = engine_list_head;
-@@ -401,8 +420,10 @@
+ {
+     ENGINE *iterator = engine_list_head;
+@@ -371,8 +390,10 @@
          if ((load_dir = getenv("OPENSSL_ENGINES")) == 0)
              load_dir = "SSLROOT:[ENGINES]";
  # else
@@ -66,7 +66,7 @@ diff -Naur openssl-1.0.1i-orig/crypto/engine/eng_list.c openssl-1.0.1i/crypto/en
 diff -Naur openssl-1.0.1i-orig/crypto/engine/Makefile openssl-1.0.1i/crypto/engine/Makefile
 --- openssl-1.0.1i-orig/crypto/engine/Makefile	2014-08-07 01:18:34.000000000 +0400
 +++ openssl-1.0.1i/crypto/engine/Makefile	2014-08-08 00:41:21.195800000 +0400
-@@ -207,7 +207,7 @@
+@@ -209,7 +209,7 @@
  eng_lib.o: ../../include/openssl/stack.h ../../include/openssl/symhacks.h
  eng_lib.o: ../../include/openssl/x509.h ../../include/openssl/x509_vfy.h
  eng_lib.o: ../cryptlib.h eng_int.h eng_lib.c
@@ -78,7 +78,7 @@ diff -Naur openssl-1.0.1i-orig/crypto/engine/Makefile openssl-1.0.1i/crypto/engi
 diff -Naur openssl-1.0.1i-orig/crypto/Makefile openssl-1.0.1i/crypto/Makefile
 --- openssl-1.0.1i-orig/crypto/Makefile	2014-08-07 01:18:30.000000000 +0400
 +++ openssl-1.0.1i/crypto/Makefile	2014-08-08 00:38:49.430000000 +0400
-@@ -34,9 +34,9 @@
+@@ -35,9 +35,9 @@
  
  LIB= $(TOP)/libcrypto.a
  SHARED_LIB= libcrypto$(SHLIB_EXT)
@@ -90,7 +90,7 @@ diff -Naur openssl-1.0.1i-orig/crypto/Makefile openssl-1.0.1i/crypto/Makefile
  	uid.o o_time.o o_str.o o_dir.o o_fips.o o_init.o fips_ers.o $(CPUID_OBJ)
  
  SRC= $(LIBSRC)
-@@ -213,6 +213,7 @@
+@@ -215,6 +215,7 @@
  o_str.o: o_str.c o_str.h
  o_time.o: ../include/openssl/e_os2.h ../include/openssl/opensslconf.h o_time.c
  o_time.o: o_time.h
@@ -101,7 +101,7 @@ diff -Naur openssl-1.0.1i-orig/crypto/Makefile openssl-1.0.1i/crypto/Makefile
 diff -Naur openssl-1.0.1i-orig/crypto/opensslconf.h openssl-1.0.1i/crypto/opensslconf.h
 --- openssl-1.0.1i-orig/crypto/opensslconf.h	2014-08-07 01:18:45.000000000 +0400
 +++ openssl-1.0.1i/crypto/opensslconf.h	2014-08-08 00:26:43.479000000 +0400
-@@ -86,6 +86,7 @@
+@@ -101,6 +101,7 @@
  
  #if !(defined(VMS) || defined(__VMS)) /* VMS uses logical names instead */
  #if defined(HEADER_CRYPTLIB_H) && !defined(OPENSSLDIR)
@@ -679,7 +679,7 @@ diff -urN old/pathtools.h new/pathtools.h
 diff -Naur openssl-1.0.1i-orig/crypto/x509/Makefile openssl-1.0.1i/crypto/x509/Makefile
 --- openssl-1.0.1i-orig/crypto/x509/Makefile	2014-08-07 01:18:39.000000000 +0400
 +++ openssl-1.0.1i/crypto/x509/Makefile	2014-08-08 00:39:56.382600000 +0400
-@@ -151,7 +151,7 @@
+@@ -153,7 +153,7 @@
  x509_d2.o: ../../include/openssl/stack.h ../../include/openssl/symhacks.h
  x509_d2.o: ../../include/openssl/x509.h ../../include/openssl/x509_vfy.h
  x509_d2.o: ../cryptlib.h x509_d2.c

--- a/mingw-w64-openssl/openssl-1.0.2a-parallel-build.patch
+++ b/mingw-w64-openssl/openssl-1.0.2a-parallel-build.patch
@@ -91,36 +91,31 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
  	ctags $(SRC)
 --- openssl-1.0.2a/Makefile.org
 +++ openssl-1.0.2a/Makefile.org
-@@ -274,17 +274,17 @@
- build_libs: build_crypto build_ssl build_engines
+@@ -281,17 +281,17 @@
+ build_libssl: build_ssl libssl.pc
  
  build_crypto:
 -	@dir=crypto; target=all; $(BUILD_ONE_CMD)
--build_ssl:
--	@dir=ssl; target=all; $(BUILD_ONE_CMD)
--build_engines:
--	@dir=engines; target=all; $(BUILD_ONE_CMD)
--build_apps:
--	@dir=apps; target=all; $(BUILD_ONE_CMD)
--build_tests:
--	@dir=test; target=all; $(BUILD_ONE_CMD)
--build_tools:
--	@dir=tools; target=all; $(BUILD_ONE_CMD)
 +	+@dir=crypto; target=all; $(BUILD_ONE_CMD)
-+build_ssl: build_crypto
+ build_ssl: build_crypto
+-	@dir=ssl; target=all; $(BUILD_ONE_CMD)
 +	+@dir=ssl; target=all; $(BUILD_ONE_CMD)
-+build_engines: build_crypto
+ build_engines: build_crypto
+-	@dir=engines; target=all; $(BUILD_ONE_CMD)
 +	+@dir=engines; target=all; $(BUILD_ONE_CMD)
-+build_apps: build_libs
+ build_apps: build_libs
+-	@dir=apps; target=all; $(BUILD_ONE_CMD)
 +	+@dir=apps; target=all; $(BUILD_ONE_CMD)
-+build_tests: build_libs
+ build_tests: build_libs
+-	@dir=test; target=all; $(BUILD_ONE_CMD)
 +	+@dir=test; target=all; $(BUILD_ONE_CMD)
-+build_tools: build_libs
+ build_tools: build_libs
+-	@dir=tools; target=all; $(BUILD_ONE_CMD)
 +	+@dir=tools; target=all; $(BUILD_ONE_CMD)
  
  all_testapps: build_libs build_testapps
  build_testapps:
-@@ -536,9 +536,9 @@
+@@ -530,9 +530,9 @@
  dist_pem_h:
  	(cd crypto/pem; $(MAKE) -e $(BUILDENV) pem.h; $(MAKE) clean)
  
@@ -132,7 +127,7 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
  	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR) \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines \
-@@ -547,12 +547,19 @@
+@@ -541,12 +541,19 @@
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/misc \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/certs \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/private
@@ -153,7 +148,7 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
  	@set -e; liblist="$(LIBS)"; for i in $$liblist ;\
  	do \
  		if [ -f "$$i" ]; then \
-@@ -636,12 +643,7 @@
+@@ -630,12 +640,7 @@
  		done; \
  	done
  
@@ -187,7 +182,7 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
  		fi; \
 --- openssl-1.0.2a/test/Makefile
 +++ openssl-1.0.2a/test/Makefile
-@@ -133,7 +133,7 @@
+@@ -134,7 +134,7 @@
  tags:
  	ctags $(SRC)
  
@@ -196,7 +191,7 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
  
  apps:
  	@(cd ..; $(MAKE) DIRS=apps all)
-@@ -402,121 +402,121 @@
+@@ -408,121 +408,121 @@
  		link_app.$${shlib_target}
  
  $(RSATEST)$(EXE_EXT): $(RSATEST).o $(DLIBCRYPTO)
@@ -355,9 +350,9 @@ http://rt.openssl.org/Ticket/Display.html?id=2084&user=guest&pass=guest
 -	@target=$(CONSTTIMETEST) $(BUILD_CMD)
 +	+@target=$(CONSTTIMETEST) $(BUILD_CMD)
  
- #$(AESTEST).o: $(AESTEST).c
- #	$(CC) -c $(CFLAGS) -DINTERMEDIATE_VALUE_KAT -DTRACE_KAT_MCT $(AESTEST).c
-@@ -529,7 +529,7 @@
+ $(VERIFYEXTRATEST)$(EXE_EXT): $(VERIFYEXTRATEST).o
+ 	@target=$(VERIFYEXTRATEST) $(BUILD_CMD)
+@@ -538,7 +538,7 @@
  #	fi
  
  dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)


### PR DESCRIPTION
Updated Openssl to Version 1.0.2d
This release is a fix of CVE-2015-1793

Changes: 
 * updated version number
 * fixed patches
 * updated md5 sums