### PR TITLE
aspell-es: New package

### DIFF
--- a/mingw-w64-aspell-es/001-unixy-dirs.patch
+++ b/mingw-w64-aspell-es/001-unixy-dirs.patch
@@ -1,0 +1,15 @@
+--- aspell6-en-7.1-0/configure.orig	2015-07-27 12:03:47.683663100 +0300
++++ aspell6-en-7.1-0/configure	2015-07-27 12:05:05.653865300 +0300
+@@ -73,10 +73,12 @@
+ 
+ echo $ECHO_N "Finding Dictionary file location ... $ECHO_C"
+ dictdir=`$ASPELL dump config dict-dir`
++dictdir=`cygpath -u $dictdir`
+ echo $dictdir
+ 
+ echo $ECHO_N "Finding Data file location ... $ECHO_C"
+ datadir=`$ASPELL dump config data-dir`
++datadir=`cygpath -u $datadir`
+ echo $datadir
+ 
+ echo "ASPELL = `which $ASPELL`" > Makefile

--- a/mingw-w64-aspell-es/PKGBUILD
+++ b/mingw-w64-aspell-es/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Oscar Fuentes <ofv@wanadoo.es>
+
+_realname=aspell-es
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+_pkgver=1.11-2
+pkgver=${_pkgver//-/.}
+pkgrel=1
+pkgdesc="Spanish dictionary for aspell (mingw-w64)"
+arch=('any')
+url="http://aspell.net/"
+license=('custom')
+depends=("${MINGW_PACKAGE_PREFIX}-aspell")
+source=(ftp://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-${_pkgver}.tar.bz2
+        001-unixy-dirs.patch)
+md5sums=('8406336a89c64e47e96f4153d0af70c4'
+         '59759a5f0047312a49f5817a83a8a2f9')
+sha1sums=('18acfa4bc08433e920bb015b158e43643e5125cf'
+          'a624663ef98117b62f45cab4ade44cce3105ef4d')
+
+prepare() {
+  cd "${srcdir}/aspell6-es-${_pkgver}"
+  patch -p1 -i ${srcdir}/001-unixy-dirs.patch
+}
+
+build() {
+  cd "${srcdir}/aspell6-es-${_pkgver}"
+  ./configure
+  sed -i 's/C\:\\msys64\\/\//' Makefile
+  make
+}
+
+package() {
+  cd "${srcdir}/aspell6-es-${_pkgver}"
+  make DESTDIR="${pkgdir}" install
+
+  install -D -m644 Copyright "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
The generated pkg name contain the full upstream version (1.11-2). (See `pkgver` assignment). This differs from what Alexey did on `aspell-en`, but IMO it is more correct to include the full upstream version on the generated pkg file name.