### PR TITLE
libgit2: add -mincoming-stack-boundary=2 for i686

### DIFF
--- a/mingw-w64-libgit2/PKGBUILD
+++ b/mingw-w64-libgit2/PKGBUILD
@@ -29,6 +29,12 @@ build() {
   mkdir -p ${srcdir}/build-${MINGW_CHOST}
   cd ${srcdir}/build-${MINGW_CHOST}
 
+  if [[ $CARCH == i686 ]]; then
+    local _conf="-DCMAKE_C_FLAGS=-mincoming-stack-boundary=2"
+  else
+    local _conf=""
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
@@ -36,6 +42,7 @@ build() {
     -DPKG_CONFIG_WITHOUT_PREFIX=ON \
     -DTHREADSAFE=ON \
     -DWINHTTP=OFF \
+    ${_conf} \
     ../${_realname}-${pkgver}
 
   make


### PR DESCRIPTION
Without this flag, the following example program was segfaulting when linked against a release build of libgit2:

```
#include "git2.h"
void main() {
    git_repository* repo_ptr = NULL;
    char* repo_url = "https://github.com/JuliaLang/Example.jl";
    char* repo_path = "Example.Bare";
    git_clone_options clone_opts = GIT_CLONE_OPTIONS_INIT;
    clone_opts.bare = 1;
    git_libgit2_init();
    git_clone(&repo_ptr, repo_url, repo_path, &clone_opts);
    git_libgit2_shutdown();
}
```

Built as `gcc -L/mingw32/bin -lgit2 clonetest.c -o clonetest.exe`
