### PR TITLE
xz-git: Fix git repository URL.

### DIFF
--- a/mingw-w64-xz-git/PKGBUILD
+++ b/mingw-w64-xz-git/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gettext")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('staticlibs' 'strip')
-source=("git+http://tukaani.org/xz.git")
+source=("git+http://git.tukaani.org/xz.git")
 sha256sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
My fault, I didn't test git repository URL since I used --noextract in Travis CI. Sorry for my mistake.