### PR TITLE
 Build wxwidgets while replacing msw/winundef.h 

### DIFF
--- a/mingw-w64-libharu/01-Fix cast from pointer to uintptr_t.patch
+++ b/mingw-w64-libharu/01-Fix cast from pointer to uintptr_t.patch
@@ -1,0 +1,11 @@
+--- a/src/hpdf_image_ccitt.c
++++ b/src/hpdf_image_ccitt.c
+@@ -78,7 +78,7 @@
+ 
+ #define	Fax3State(tif)		(&(tif)->tif_data->b)
+ #define	EncoderState(tif)	((tif)->tif_data)
+-#define	isAligned(p,t)	((((unsigned long)(p)) & (sizeof (t)-1)) == 0)
++#define	isAligned(p,t)	((((uintptr_t)(p)) & (sizeof (t)-1)) == 0)
+ 
+ /* NB: the uint32 casts are to silence certain ANSI-C compilers */
+ #define TIFFhowmany(x, y) ((((uint32)(x))+(((uint32)(y))-1))/((uint32)(y)))

--- a/mingw-w64-libharu/PKGBUILD
+++ b/mingw-w64-libharu/PKGBUILD
@@ -1,0 +1,62 @@
+# Contributor: Greg Jung <gvjung@gmail.com>
+
+_realname=libharu
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+distname=RELEASE_2_3_0
+pkgver=2.3.0
+pkgrel=0
+pkgdesc="A C-library for producing PDF files"
+arch=('any')
+license=('custom:zlib/libpng')
+url="http://www.libharu.org/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+#             "${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-libpng")            
+options=('strip' 'staticlibs')
+#
+source=("https://github.com/libharu/libharu/archive/RELEASE_2_3_0.zip"
+        "01-Fix cast from pointer to uintptr_t.patch")
+md5sums=('f0423cdf911fcb4f78a2e69c725070f9'
+         '5704fbddd011235a32dc7185822932ac')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${distname}
+  pwd
+  patch -p1 -i ${srcdir}"/01-Fix cast from pointer to uintptr_t.patch"
+  cp -p CMakeLists.txt ./CMakeLists.txt.orig
+  cat CMakeLists.txt.orig | sed 's/set(LIBHPDF_MINOR 2)/set(LIBHPDF_MINOR 3)/' >  CMakeLists.txt
+  cp -p src/CMakeLists.txt ./src-CMakeLists.txt.orig
+  cat ./src-CMakeLists.txt.orig | sed 's/HPDF_DLL_MAKE)/HPDF_DLL_MAKE_CDECL)/' > src/CMakeLists.txt
+}
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=ON \
+    -DDEVPAK=ON \
+    ../${_realname}-${distname}
+
+  make
+}
+
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/doc/libharu
+  cd ${pkgdir}${MINGW_PREFIX}
+  mv README share/doc/libharu/
+  mv CHANGES share/doc/libharu/
+  mv libharu.DevPackage share/doc/libharu/
+  mv INSTALL share/doc/libharu/
+  pushd ${pkgdir}${MINGW_PREFIX}/lib >/dev/null
+  rm libpng*.dll.a libz*.dll.a
+  popd >/dev/null
+
+}

--- a/mingw-w64-plplot-5.11.0/PKGBUILD
+++ b/mingw-w64-plplot-5.11.0/PKGBUILD
@@ -1,0 +1,85 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# modified: Greg Jung. Disable qt, java, ada
+_realname=plplot
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=5.11.0
+pkgrel=2
+arch=('any')
+pkgdesc="Scientific plotting software (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
+         "${MINGW_PACKAGE_PREFIX}-qhull"
+         "${MINGW_PACKAGE_PREFIX}-shapelib"
+         "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+        )
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+license=('LGPL')
+url="http://plplot.sourceforge.net"
+source=(http://downloads.sourceforge.net/sourceforge/plplot/${_realname}-${pkgver}.tar.gz
+	fix_cairo_togit.patch
+        fix_wingcc_togit.patch
+        find-gd.patch)
+sha1sums=('215c60b86ae1381813e5c837ea6afa6d7708127d'
+          '27ac87e2945f83ac651fd6b8246b17b44bca8680'
+          '07c7de553e8e08c19c51e5f353dd3a64873a577c'
+          '7800cad653ebcedf596a01e545116f6ffd04f0f9')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/find-gd.patch
+  patch -p1 -i ${srcdir}/fix_cairo_togit.patch
+}
+
+build() {
+  # cmake's FindSWIG doesn't work properly on MSYS,
+  # so we provide SWIG here
+ # SWIG_DIR_U=`${MINGW_PREFIX}/bin/swig -swiglib`
+ # SWIG_DIR=`cygpath -m ${SWIG_DIR_U}`
+# more stuff we shouldn't need:
+#     -DCMAKE_Fortran_COMPILER=${MINGW_PREFIX}/bin/gfortran.exe \
+#     -DSWIG_EXECUTABLE="${SWIG_EXECUTABLE}" \
+#    -DSWIG_DIR="${SWIG_DIR}" \
+#    -DQHULL_INCLUDE_DIR=${MINGW_PREFIX}/include \
+
+  # cmake may be confused if there is a Windows installation
+  # of the official Python MSI. Please do the Python-enabled
+  # build only, if no official Python is installed.
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DDEFAULT_NO_CAIRO_DEVICES=ON \
+    -DWITH_FREETYPE=OFF \
+    -DWITH_CSA=OFF \
+    -DENABLE_lua=OFF \
+    -DENABLE_python=OFF \
+    -DENABLE_DYNDRIVERS=OFF \
+    -DENABLE_ada=OFF \
+    -DENABLE_java=OFF \
+    -DENABLE_qt=OFF \
+    -DENABLE_itcl=OFF \
+    -DENABLE_itk=OFF \
+    -DENABLE_tcl=OFF \
+    -DENABLE_tk=OFF \
+    ../${_realname}-${pkgver}
+
+  make V=1
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
+  cp -pf ${srcdir}/${_realname}-${pkgver}/Copyright \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  cp -pf ${srcdir}/${_realname}-${pkgver}/COPYING* \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+}

--- a/mingw-w64-plplot-5.11.0/find-gd.patch
+++ b/mingw-w64-plplot-5.11.0/find-gd.patch
@@ -1,0 +1,20 @@
+--- plplot/cmake/modules/FindGD.cmake.orig	2014-04-06 11:52:17.031600000 +0400
++++ plplot/cmake/modules/FindGD.cmake	2014-04-06 11:52:53.208000000 +0400
+@@ -14,7 +14,7 @@
+ /usr/include
+ )
+ 
+-if(WIN32_AND_NOT_CYGWIN)
++if(WIN32_AND_NOT_CYGWIN AND NOT MINGW)
+   set(GD_NAMES ${GD_NAMES} bgd)
+ else(WIN32_AND_NOT_CYGWIN)
+   set(GD_NAMES ${GD_NAMES} gd)
+@@ -33,7 +33,7 @@
+ endif(GD_LIBRARY AND GD_INCLUDE_DIR)
+ 
+ if(GD_FOUND)
+-  if(WIN32_AND_NOT_CYGWIN)
++  if(WIN32_AND_NOT_CYGWIN AND NOT MINGW)
+     set(GD_SUPPORTS_PNG ON)
+     set(GD_SUPPORTS_JPEG ON)
+     set(GD_SUPPORTS_GIF ON)

--- a/mingw-w64-plplot-5.11.0/fix_cairo_togit.patch
+++ b/mingw-w64-plplot-5.11.0/fix_cairo_togit.patch
@@ -1,0 +1,30 @@
+--- a/drivers/cairo.c	2015-04-12 03:08:04.000000000 -0700
++++ b/drivers/cairo.c	2015-07-31 15:44:35.115653100 -0700
+@@ -43,6 +43,7 @@
+ // Driver-dependent includes
+ #if defined ( PLD_wincairo )
+ #include <windows.h>
++#include <cairo-win32.h>
+ #endif
+ #if defined ( PLD_xcairo )
+ #include <cairo-xlib.h>
+@@ -3276,8 +3277,8 @@
+     }
+     else
+     {
+-        pls = (PLStream *) GetWindowLong( hwnd, GWL_USERDATA ); // Try to get the address to pls for this window
+-        if ( pls )                                              // If we got it, then we will initialise this windows plplot private data area
++        pls = (PLStream *) GetWindowLongPtr( hwnd, GWLP_USERDATA ); // Try to get the address to pls for this window
++        if ( pls )                                                  // If we got it, then we will initialise this windows plplot private data area
+         {
+             dev = (PLCairo *) pls->dev;
+         }
+@@ -3483,7 +3484,7 @@
+ // process this window
+ //
+ 
+-    SetWindowLong( aStream->hwnd, GWL_USERDATA, (long) pls );
++    SetWindowLongPtr( aStream->hwnd, GWLP_USERDATA, (LONG_PTR) pls );
+     aStream->SCRN_hdc = aStream->hdc = GetDC( aStream->hwnd );
+ 
+ //

--- a/mingw-w64-plplot-5.11.0/fix_wingcc_togit.patch
+++ b/mingw-w64-plplot-5.11.0/fix_wingcc_togit.patch
@@ -1,0 +1,343 @@
+--- a/drivers/wingcc.c	2015-04-12 03:08:04.000000000 -0700
++++ b/drivers/wingcc.c	2015-08-06 00:47:00.057728900 -0700
+@@ -31,10 +31,6 @@
+ #include <winnt.h>
+ #define _T( a )    __TEXT( a )
+ #endif
+-#ifdef _WIN64
+-#define GWL_USERDATA    GWLP_USERDATA
+-#define GCL_HCURSOR     GCLP_HCURSOR
+-#endif
+ 
+ #include "plplotP.h"
+ #include "drivers.h"
+@@ -84,7 +80,7 @@
+     PLINT        PRNT_width;
+     PLINT        PRNT_height;
+ 
+-    PLGraphicsIn gin;
++//    PLGraphicsIn gin;
+ 
+     char         FT_smooth_text;
+ //
+@@ -125,14 +121,15 @@
+ 
+ void plD_dispatch_init_wingcc( PLDispatchTable *pdt );
+ 
+-void plD_init_wingcc( PLStream * );
+-void plD_line_wingcc( PLStream *, short, short, short, short );
+-void plD_polyline_wingcc( PLStream *, short *, short *, PLINT );
+-void plD_eop_wingcc( PLStream * );
+-void plD_bop_wingcc( PLStream * );
+-void plD_tidy_wingcc( PLStream * );
+-void plD_state_wingcc( PLStream *, PLINT );
+-void plD_esc_wingcc( PLStream *, PLINT, void * );
++static void plD_init_wingcc( PLStream * );
++static void plD_line_wingcc( PLStream *, short, short, short, short );
++static void plD_polyline_wingcc( PLStream *, short *, short *, PLINT );
++static void plD_eop_wingcc( PLStream * );
++static void plD_bop_wingcc( PLStream * );
++static void plD_tidy_wingcc( PLStream * );
++static void plD_wait_wingcc( PLStream * );
++static void plD_state_wingcc( PLStream *, PLINT );
++static void plD_esc_wingcc( PLStream *, PLINT, void * );
+ 
+ #ifdef PL_HAVE_FREETYPE
+ 
+@@ -196,17 +193,17 @@
+ 
+ #define CrossHairCursor()    do {                                   \
+         dev->cursor = LoadCursor( NULL, IDC_CROSS );                \
+-        SetClassLong( dev->hwnd, GCL_HCURSOR, (long) dev->cursor ); \
++        SetClassLongPtr( dev->hwnd, GCLP_HCURSOR, (LONG_PTR) dev->cursor ); \
+         SetCursor( dev->cursor ); } while ( 0 )
+ 
+ #define NormalCursor()       do {                                          \
+         dev->cursor = LoadCursor( NULL, IDC_ARROW );                       \
+-        SetClassLongPtr( dev->hwnd, GCL_HCURSOR, (LONG_PTR) dev->cursor ); \
++        SetClassLongPtr( dev->hwnd, GCLP_HCURSOR, (LONG_PTR) dev->cursor ); \
+         SetCursor( dev->cursor ); } while ( 0 )
+ 
+ #define BusyCursor()         do {                                          \
+         dev->cursor = LoadCursor( NULL, IDC_WAIT );                        \
+-        SetClassLongPtr( dev->hwnd, GCL_HCURSOR, (LONG_PTR) dev->cursor ); \
++        SetClassLongPtr( dev->hwnd, GCLP_HCURSOR, (LONG_PTR) dev->cursor ); \
+         SetCursor( dev->cursor ); } while ( 0 )
+ 
+ #define PopupPrint       0x08A1
+@@ -230,6 +227,7 @@
+     pdt->pl_tidy     = (plD_tidy_fp) plD_tidy_wingcc;
+     pdt->pl_state    = (plD_state_fp) plD_state_wingcc;
+     pdt->pl_esc      = (plD_esc_fp) plD_esc_wingcc;
++    pdt->pl_wait     = (plD_wait_fp) plD_wait_wingcc;
+ }
+ 
+ static TCHAR* szWndClass = _T( "PlplotWin" );
+@@ -262,11 +260,8 @@
+     }
+     else
+     {
+-#ifndef _WIN64
+-#undef GetWindowLongPtr
+-#define GetWindowLongPtr    GetWindowLong
+-#endif
+-        pls = (PLStream *) GetWindowLongPtr( hwnd, GWL_USERDATA ); // Try to get the address to pls for this window
++
++        pls = (PLStream *) GetWindowLongPtr( hwnd, GWLP_USERDATA ); // Try to get the address to pls for this window
+         if ( pls )                                                 // If we got it, then we will initialise this windows plplot private data area
+         {
+             dev = (wingcc_Dev *) pls->dev;
+@@ -408,7 +403,7 @@
+ // Initialize device (terminal).
+ //--------------------------------------------------------------------------
+ 
+-void
++static void
+ plD_init_wingcc( PLStream *pls )
+ {
+     wingcc_Dev *dev;
+@@ -433,7 +428,6 @@
+         { "text",   DRV_INT, &freetype,    "Use driver text (FreeType)"            },
+         { "smooth", DRV_INT, &smooth_text, "Turn text smoothing on (1) or off (0)" },
+         { "save",   DRV_INT, &save_reg,    "Save defaults to registary"            },
+-
+ #endif
+         { NULL,     DRV_INT, NULL,         NULL                                    }
+     };
+@@ -591,11 +585,8 @@
+ // process this window
+ //
+ 
+-#ifdef _WIN64
+-    SetWindowLongPtr( dev->hwnd, GWL_USERDATA, (LONG_PTR) pls );
+-#else
+-    SetWindowLong( dev->hwnd, GWL_USERDATA, (LONG) pls );
+-#endif
++
++    SetWindowLongPtr( dev->hwnd, GWLP_USERDATA, (LONG_PTR) pls );
+ 
+     dev->SCRN_hdc = dev->hdc = GetDC( dev->hwnd );
+ 
+@@ -630,7 +621,7 @@
+     // sort of thing).
+     //
+     ShowWindow( dev->hwnd, SW_SHOWDEFAULT );
+-    SetForegroundWindow( dev->hwnd );
++    BringWindowToTop( dev->hwnd );
+ 
+     //
+     // Set up the DPI etc...
+@@ -693,7 +684,7 @@
+ // Draw a line in the current color from (x1,y1) to (x2,y2).
+ //--------------------------------------------------------------------------
+ 
+-void
++static void
+ plD_line_wingcc( PLStream *pls, short x1a, short y1a, short x2a, short y2a )
+ {
+     wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
+@@ -725,7 +716,7 @@
+ // Draw a polyline in the current color.
+ //--------------------------------------------------------------------------
+ 
+-void
++static void
+ plD_polyline_wingcc( PLStream *pls, short *xa, short *ya, PLINT npts )
+ {
+     wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
+@@ -824,7 +815,7 @@
+ 
+ 
+ 
+-void
++static void
+ plD_eop_wingcc( PLStream *pls )
+ {
+     wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
+@@ -835,73 +826,14 @@
+ 
+     NormalCursor();
+ 
+-    if ( !pls->nopause )
+-    {
+-        dev->waiting = 1;
+-        while ( GetMessage( &dev->msg, NULL, 0, 0 ) )
+-        {
+-            TranslateMessage( &dev->msg );
+-            switch ( (int) dev->msg.message )
+-            {
+-            case WM_CONTEXTMENU:
+-            case WM_RBUTTONDOWN:
+-                TrackPopupMenu( dev->PopupMenu, TPM_CENTERALIGN | TPM_RIGHTBUTTON, LOWORD( dev->msg.lParam ),
+-                    HIWORD( dev->msg.lParam ), 0, dev->hwnd, NULL );
+-                break;
+-
+-            case WM_CHAR:
+-                if ( ( (TCHAR) ( dev->msg.wParam ) == 32 ) ||
+-                     ( (TCHAR) ( dev->msg.wParam ) == 13 ) )
+-                {
+-                    dev->waiting = 0;
+-                }
+-                else if ( ( (TCHAR) ( dev->msg.wParam ) == 27 ) ||
+-                          ( (TCHAR) ( dev->msg.wParam ) == 'q' ) ||
+-                          ( (TCHAR) ( dev->msg.wParam ) == 'Q' ) )
+-                {
+-                    dev->waiting = 0;
+-                    PostQuitMessage( 0 );
+-                }
+-                break;
+-
+-            case WM_LBUTTONDBLCLK:
+-                Debug( "WM_LBUTTONDBLCLK\t" );
+-                dev->waiting = 0;
+-                break;
+-
+-            case WM_COMMAND:
+-                switch ( LOWORD( dev->msg.wParam ) )
+-                {
+-                case PopupPrint:
+-                    Debug( "PopupPrint" );
+-                    PrintPage( pls );
+-                    break;
+-                case PopupNextPage:
+-                    Debug( "PopupNextPage" );
+-                    dev->waiting = 0;
+-                    break;
+-                case PopupQuit:
+-                    Debug( "PopupQuit" );
+-                    dev->waiting = 0;
+-                    PostQuitMessage( 0 );
+-                    break;
+-                }
+-                break;
++    if ( !pls->nopause ) plD_wait_wingcc( pls);
+ 
+-            default:
+-                DispatchMessage( &dev->msg );
+-                break;
+-            }
+-            if ( dev->waiting == 0 )
+-                break;
+-        }
+-    }
+ }
+ 
+ //--------------------------------------------------------------------------
+ //  Beginning of the new page
+ //--------------------------------------------------------------------------
+-void
++static void
+ plD_bop_wingcc( PLStream *pls )
+ {
+     wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
+@@ -922,7 +854,7 @@
+     plD_state_wingcc( pls, PLSTATE_COLOR0 );
+ }
+ 
+-void
++static void
+ plD_tidy_wingcc( PLStream *pls )
+ {
+     wingcc_Dev *dev = NULL;
+@@ -952,21 +884,84 @@
+             ReleaseDC( dev->hwnd, dev->hdc );
+         if ( dev->bitmap != NULL )
+             DeleteObject( dev->bitmap );
+-
++	if(IsWindow(dev->hwnd)) DestroyWindow(dev->hwnd);
+         free_mem( pls->dev );
+     }
+ }
+ 
++static void
++plD_wait_wingcc( PLStream * pls )
++{
++    wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
++
++    Debug( "Wait for user input\n" );
++
++    dev->waiting = 1;
++    while ( dev->waiting == 1 && GetMessage( &dev->msg, NULL, 0, 0 ) )
++    {
++        TranslateMessage( &dev->msg );
++        switch ( (int) dev->msg.message )
++        {
++        case WM_RBUTTONDOWN:
++        case WM_CONTEXTMENU:
++            TrackPopupMenu( dev->PopupMenu, TPM_CENTERALIGN | TPM_RIGHTBUTTON, LOWORD( dev->msg.lParam ),
++                HIWORD( dev->msg.lParam ), 0, dev->hwnd, NULL );
++            break;
++
++        case WM_CHAR:
++            if ( ( (TCHAR) ( dev->msg.wParam ) == 32 ) ||
++                 ( (TCHAR) ( dev->msg.wParam ) == 13 ) )
++            {
++                dev->waiting = 0;
++            }
++            else if ( ( (TCHAR) ( dev->msg.wParam ) == 27 ) ||
++                      ( (TCHAR) ( dev->msg.wParam ) == 'q' ) ||
++                      ( (TCHAR) ( dev->msg.wParam ) == 'Q' ) )
++            {
++                dev->waiting = 0;
++                PostQuitMessage( 0 );
++            }
++            break;
++
++        case WM_LBUTTONDBLCLK:
++            Debug( "WM_LBUTTONDBLCLK\t" );
++            dev->waiting = 0;
++            break;
++
++        case WM_COMMAND:
++            switch ( LOWORD( dev->msg.wParam ) )
++            {
++            case PopupPrint:
++                Debug( "PopupPrint" );
++                PrintPage( pls );
++                break;
++            case PopupNextPage:
++                Debug( "PopupNextPage" );
++                dev->waiting = 0;
++                break;
++            case PopupQuit:
++                Debug( "PopupQuit" );
++                dev->waiting = 0;
++                PostQuitMessage( 0 );
++                break;
++            }
++            break;
+ 
++        default:
++            DispatchMessage( &dev->msg );
++            break;
++        }
++    }
++}
+ 
+ 
+ //--------------------------------------------------------------------------
+-// plD_state_png()
++// plD_state_wingcc()
+ //
+ // Handle change in PLStream state (color, pen width, fill attribute, etc).
+ //--------------------------------------------------------------------------
+ 
+-void
++static void
+ plD_state_wingcc( PLStream *pls, PLINT op )
+ {
+     wingcc_Dev *dev = (wingcc_Dev *) pls->dev;
+@@ -1061,11 +1056,11 @@
+ // Handle PLplot escapes
+ //--------------------------------------------------------------------------
+ 
+-void
++static void
+ plD_esc_wingcc( PLStream *pls, PLINT op, void *ptr )
+ {
+     wingcc_Dev   *dev = (wingcc_Dev *) pls->dev;
+-    PLGraphicsIn *gin = &( dev->gin );
++//    PLGraphicsIn *gin = &( dev->gin );
+ 
+ 
+     switch ( op )

--- a/mingw-w64-wxwidgets/PKGBUILD
+++ b/mingw-w64-wxwidgets/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 # Contributor: Zach Bacon <11doctorwhocanada@gmail.com>
+# Contributor: Greg Jung <gvjung@gmail.com>
 
 _realname=wxWidgets
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -22,10 +23,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-python2")
 options=('strip' 'staticlibs' 'buildflags')
 source=(http://downloads.sourceforge.net/wxwindows/wxWidgets-${pkgver}.tar.bz2
+	"winundef.h.modified"
         "wxWidgets-3.0.0-gcc-codelight.patch"
         "wxWidgets-3.0.2-msw-dc-orientation-fix.patch"
         "wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch")
 sha1sums=('6461eab4428c0a8b9e41781b8787510484dea800'
+          'f5ab76a4b077b3dc6b8cfd211cbc98941910d787'
           '05a3471dcf735d86defe0df00dcb8e9ff0698290'
           '99999865476ce03bb75e8244806f3585fe9e71e2'
           '62dcd59adde91925e5c51422e192c035978cdedd')
@@ -35,6 +38,16 @@ prepare() {
   patch -p1 -i ${srcdir}/wxWidgets-3.0.0-gcc-codelight.patch
   patch -p1 -i ${srcdir}/wxWidgets-3.0.2-msw-dc-orientation-fix.patch
   patch -p1 -i ${srcdir}/wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch
+#
+# 2015/08/02 Greg Jung:
+# winundef.h will cause trouble if UNICODE is not pre-defined before including windows.h
+# This is an uneccessary condition.
+# My attempt to get it into WX: https://groups.google.com/forum/#!topic/wx-dev/MTYzgOqLdfU
+#
+  cp -p ${srcdir}/${_realname}-${pkgver}/include/wx/msw/winundef.h \
+	${srcdir}/${_realname}-${pkgver}/include/wx/msw/winundef.h.original
+  cp -p ${srcdir}/winundef.h.modified ${srcdir}/${_realname}-${pkgver}/include/wx/msw/winundef.h.modified
+  cp -p ${srcdir}/winundef.h.modified ${srcdir}/${_realname}-${pkgver}/include/wx/msw/winundef.h
 }
 
 build() {

--- a/mingw-w64-wxwidgets/winundef.h.modified
+++ b/mingw-w64-wxwidgets/winundef.h.modified
@@ -1,0 +1,551 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        winundef.h
+// Purpose:     undefine the common symbols #define'd by <windows.h>
+// Author:      Vadim Zeitlin
+// Modified by:
+// Created:     16.05.99
+// Copyright:   (c) wxWidgets team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+/* THIS SHOULD NOT BE USED since you might include it once e.g. in window.h,
+ * then again _AFTER_ you've included windows.h, in which case it won't work
+ * a 2nd time -- JACS
+#ifndef _WX_WINUNDEF_H_
+#define _WX_WINUNDEF_H_
+ */
+// ----------------------------------------------------------------------------
+// 2015-08-01 Greg Jung: explicitly call out LPCWSTR and other "W" types
+//  in the inline function declarations, in the _UNICODE case, avoiding a silly
+//  commpilation error in c++;  a user may be using a unicode-enabled wx library
+//  without creating the TCHAR=WCHAR typedefs by simply including <windows.h>
+//  without setting UNICODE.
+//
+// ----------------------------------------------------------------------------
+// windows.h #defines the following identifiers which are also used in wxWin so
+// we replace these symbols with the corresponding inline functions and
+// undefine the macro.
+//
+// This looks quite ugly here but allows us to write clear (and correct!) code
+// elsewhere because the functions, unlike the macros, respect the scope.
+// ----------------------------------------------------------------------------
+
+// CreateDialog
+
+#if defined(CreateDialog) || defined(CreateFont) || defined(CreateWindow) || \
+    defined(LoadMenu) || defined(FindText) || defined(GetCharWidth) || \
+    defined(FindWindow) || defined(PlaySound)  || defined(GetClassName) || \
+    defined(GetClassInfo) || defined(LoadAccelerators) || defined(DrawText)
+
+#if defined(CreateDialog)
+    #undef CreateDialog
+
+        #ifdef _UNICODE
+    inline HWND CreateDialog(HINSTANCE hInstance,
+                             LPCWSTR pTemplate,
+                             HWND hwndParent,
+                             DLGPROC pDlgProc)
+    {
+            return CreateDialogW(hInstance, pTemplate, hwndParent, pDlgProc);
+    }
+        #else
+    inline HWND CreateDialog(HINSTANCE hInstance,
+                             LPCTSTR pTemplate,
+                             HWND hwndParent,
+                             DLGPROC pDlgProc)
+    {
+            return CreateDialogA(hInstance, pTemplate, hwndParent, pDlgProc);
+    }
+#endif
+#endif
+
+// CreateFont
+
+#ifdef CreateFont
+    #undef CreateFont
+
+        #ifdef _UNICODE
+    inline HFONT CreateFont(int height,
+                            int width,
+                            int escapement,
+                            int orientation,
+                            int weight,
+                            DWORD italic,
+                            DWORD underline,
+                            DWORD strikeout,
+                            DWORD charset,
+                            DWORD outprecision,
+                            DWORD clipprecision,
+                            DWORD quality,
+                            DWORD family,
+                            LPCWSTR facename)
+    {
+            return CreateFontW(height, width, escapement, orientation,
+                               weight, italic, underline, strikeout, charset,
+                               outprecision, clipprecision, quality,
+                               family, facename);
+	        }
+
+        #else
+    inline HFONT CreateFont(int height,
+                            int width,
+                            int escapement,
+                            int orientation,
+                            int weight,
+                            DWORD italic,
+                            DWORD underline,
+                            DWORD strikeout,
+                            DWORD charset,
+                            DWORD outprecision,
+                            DWORD clipprecision,
+                            DWORD quality,
+                            DWORD family,
+                            LPCTSTR facename)
+   {
+            return CreateFontA(height, width, escapement, orientation,
+                               weight, italic, underline, strikeout, charset,
+                               outprecision, clipprecision, quality,
+                               family, facename);
+    }
+        #endif
+#endif // CreateFont
+
+// CreateWindow
+
+#if defined(CreateWindow)
+    #undef CreateWindow
+
+        #ifdef _UNICODE
+    inline HWND CreateWindow(LPCWSTR lpClassName,
+                             LPCWSTR lpWndClass,
+                             DWORD dwStyle,
+                             int x, int y, int w, int h,
+                             HWND hWndParent,
+                             HMENU hMenu,
+                             HINSTANCE hInstance,
+                             LPVOID lpParam)
+    {
+            return CreateWindowW(lpClassName, lpWndClass, dwStyle, x, y, w, h,
+                                 hWndParent, hMenu, hInstance, lpParam);
+    }
+        #else
+    inline HWND CreateWindow(LPCTSTR lpClassName,
+                             LPCTSTR lpWndClass,
+                             DWORD dwStyle,
+                             int x, int y, int w, int h,
+                             HWND hWndParent,
+                             HMENU hMenu,
+                             HINSTANCE hInstance,
+                             LPVOID lpParam)
+    {
+            return CreateWindowA(lpClassName, lpWndClass, dwStyle, x, y, w, h,
+                                 hWndParent, hMenu, hInstance, lpParam);
+    }
+#endif
+#endif
+
+// LoadMenu
+
+#ifdef LoadMenu
+    #undef LoadMenu
+
+        #ifdef _UNICODE
+    inline HMENU LoadMenu(HINSTANCE instance, LPCWSTR name)
+    {
+            return LoadMenuW(instance, name);
+    }
+        #else
+    inline HMENU LoadMenu(HINSTANCE instance, LPCTSTR name)
+    {
+            return LoadMenuA(instance, name);
+    }
+#endif
+#endif
+
+// FindText
+
+#ifdef FindText
+    #undef FindText
+
+        #ifdef _UNICODE
+    inline HWND APIENTRY FindText(LPFINDREPLACEW lpfindreplace)
+    {
+            return FindTextW(lpfindreplace);
+    }
+        #else
+    inline HWND APIENTRY FindText(LPFINDREPLACE lpfindreplace)
+    {
+            return FindTextA(lpfindreplace);
+    }
+#endif
+#endif
+
+// GetCharWidth
+
+#ifdef GetCharWidth
+   #undef GetCharWidth
+   inline BOOL  GetCharWidth(HDC dc, UINT first, UINT last, LPINT buffer)
+   {
+   #ifdef _UNICODE
+      return GetCharWidthW(dc, first, last, buffer);
+   #else
+      return GetCharWidthA(dc, first, last, buffer);
+   #endif
+   }
+#endif
+
+// FindWindow
+
+#ifdef FindWindow
+   #undef FindWindow
+   #ifdef _UNICODE
+   inline HWND FindWindow(LPCWSTR classname, LPCWSTR windowname)
+   {
+      return FindWindowW(classname, windowname);
+   }
+   #else
+   inline HWND FindWindow(LPCTSTR classname, LPCTSTR windowname)
+   {
+      return FindWindowA(classname, windowname);
+   }
+   #endif
+#endif
+
+// PlaySound
+
+#ifdef PlaySound
+   #undef PlaySound
+   #ifdef _UNICODE
+   inline BOOL PlaySound(LPCWSTR pszSound, HMODULE hMod, DWORD fdwSound)
+   {
+      return PlaySoundW(pszSound, hMod, fdwSound);
+   }
+   #else
+   inline BOOL PlaySound(LPCSTR pszSound, HMODULE hMod, DWORD fdwSound)
+   {
+      return PlaySoundA(pszSound, hMod, fdwSound);
+   }
+   #endif
+#endif
+
+// GetClassName
+
+#ifdef GetClassName
+   #undef GetClassName
+   #ifdef _UNICODE
+   inline int GetClassName(HWND h, LPWSTR classname, int maxcount)
+   {
+      return GetClassNameW(h, classname, maxcount);
+   }
+   #else
+   inline int GetClassName(HWND h, LPSTR classname, int maxcount)
+   {
+      return GetClassNameA(h, classname, maxcount);
+   }
+   #endif
+#endif
+
+// GetClassInfo
+
+#ifdef GetClassInfo
+   #undef GetClassInfo
+   #ifdef _UNICODE
+   inline BOOL GetClassInfo(HINSTANCE h, LPCWSTR name, LPWNDCLASSW winclass)
+   {
+      return GetClassInfoW(h, name, winclass);
+   }
+   #else
+   inline BOOL GetClassInfo(HINSTANCE h, LPCTSTR name, LPWNDCLASSA winclass)
+   {
+      return GetClassInfoA(h, name, winclass);
+   }
+   #endif
+#endif
+
+// LoadAccelerators
+
+#ifdef LoadAccelerators
+   #undef LoadAccelerators
+   #ifdef _UNICODE
+   inline HACCEL LoadAccelerators(HINSTANCE h, LPCWSTR name)
+   {
+      return LoadAcceleratorsW(h, name);
+   }
+   #else
+   inline HACCEL LoadAccelerators(HINSTANCE h, LPCTSTR name)
+   {
+      return LoadAcceleratorsA(h, name);
+   }
+   #endif
+#endif
+
+// DrawText
+
+#ifdef DrawText
+   #undef DrawText
+   #ifdef _UNICODE
+   inline int DrawText(HDC h, LPCWSTR str, int count, LPRECT rect, UINT format)
+   {
+      return DrawTextW(h, str, count, rect, format);
+   }
+   #else
+   inline int DrawText(HDC h, LPCTSTR str, int count, LPRECT rect, UINT format)
+   {
+      return DrawTextA(h, str, count, rect, format);
+   }
+   #endif
+#endif
+
+#endif
+
+/*
+  When this file is included, sometimes the wxCHECK_W32API_VERSION macro
+  is undefined. With for example CodeWarrior this gives problems with
+  the following code:
+  #if 0 && wxCHECK_W32API_VERSION( 0, 5 )
+  Because CodeWarrior does macro expansion before test evaluation.
+  We define wxCHECK_W32API_VERSION here if it's undefined.
+*/
+#if !defined(__GNUG__) && !defined(wxCHECK_W32API_VERSION)
+    #define wxCHECK_W32API_VERSION(maj, min) (0)
+#endif
+#if defined(StartDoc) || defined(GetObject) || \
+    defined(GetMessage) || defined(LoadIcon) || defined(LoadBitmap) || \
+    defined(LoadLibrary) || defined(FindResource)
+
+// StartDoc
+
+#ifdef StartDoc
+   #undef StartDoc
+   #if defined( __GNUG__ ) && !wxCHECK_W32API_VERSION( 0, 5 )
+      #define DOCINFOW DOCINFO
+      #define DOCINFOA DOCINFO
+   #endif
+   #ifdef _UNICODE
+   inline int StartDoc(HDC h, CONST DOCINFOW* info)
+   {
+      return StartDocW(h, (DOCINFOW*) info);
+   }
+   #else
+   inline int StartDoc(HDC h, CONST DOCINFOA* info)
+   {
+      return StartDocA(h, (DOCINFOA*) info);
+   }
+   #endif
+#endif
+
+// GetObject
+
+#ifdef GetObject
+   #undef GetObject
+   inline int GetObject(HGDIOBJ h, int i, LPVOID buffer)
+   {
+   #ifdef _UNICODE
+      return GetObjectW(h, i, buffer);
+   #else
+      return GetObjectA(h, i, buffer);
+   #endif
+   }
+#endif
+
+// GetMessage
+
+#ifdef GetMessage
+   #undef GetMessage
+   inline int GetMessage(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax)
+   {
+   #ifdef _UNICODE
+      return GetMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+   #else
+      return GetMessageA(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+   #endif
+   }
+#endif
+
+// LoadIcon
+#ifdef LoadIcon
+    #undef LoadIcon
+        #ifdef _UNICODE
+    inline HICON LoadIcon(HINSTANCE hInstance, LPCWSTR lpIconName)
+    {
+            return LoadIconW(hInstance, lpIconName);
+    }
+        #else // ANSI
+    inline HICON LoadIcon(HINSTANCE hInstance, LPCTSTR lpIconName)
+    {
+            return LoadIconA(hInstance, lpIconName);
+    }
+        #endif // Unicode/ANSI
+#endif // LoadIcon
+
+// LoadBitmap
+#ifdef LoadBitmap
+    #undef LoadBitmap
+        #ifdef _UNICODE
+    inline HBITMAP LoadBitmap(HINSTANCE hInstance, LPCWSTR lpBitmapName)
+    {
+            return LoadBitmapW(hInstance, lpBitmapName);
+    }
+        #else // ANSI
+    inline HBITMAP LoadBitmap(HINSTANCE hInstance, LPCTSTR lpBitmapName)
+    {
+            return LoadBitmapA(hInstance, lpBitmapName);
+    }
+        #endif // Unicode/ANSI
+#endif // LoadBitmap
+
+// LoadLibrary
+
+#ifdef LoadLibrary
+    #undef LoadLibrary
+    #ifdef _UNICODE
+    inline HINSTANCE LoadLibrary(LPCWSTR lpLibFileName)
+    {
+        return LoadLibraryW(lpLibFileName);
+    }
+    #else
+    inline HINSTANCE LoadLibrary(LPCTSTR lpLibFileName)
+    {
+        return LoadLibraryA(lpLibFileName);
+    }
+    #endif
+#endif
+
+// FindResource
+#ifdef FindResource
+    #undef FindResource
+    #ifdef _UNICODE
+    inline HRSRC FindResource(HMODULE hModule, LPCWSTR lpName, LPCWSTR lpType)
+    {
+        return FindResourceW(hModule, lpName, lpType);
+    }
+    #else
+    inline HRSRC FindResource(HMODULE hModule, LPCTSTR lpName, LPCTSTR lpType)
+    {
+        return FindResourceA(hModule, lpName, lpType);
+    }
+    #endif
+#endif
+
+#endif
+
+// IsMaximized
+
+#ifdef IsMaximized
+    #undef IsMaximized
+    inline BOOL IsMaximized(HWND WXUNUSED_IN_WINCE(hwnd))
+    {
+#ifdef __WXWINCE__
+        return FALSE;
+#else
+        return IsZoomed(hwnd);
+#endif
+    }
+#endif
+
+// GetFirstChild
+
+#ifdef GetFirstChild
+    #undef GetFirstChild
+    inline HWND GetFirstChild(HWND WXUNUSED_IN_WINCE(hwnd))
+    {
+#ifdef __WXWINCE__
+        return 0;
+#else
+        return GetTopWindow(hwnd);
+#endif
+    }
+#endif
+
+// GetFirstSibling
+
+#ifdef GetFirstSibling
+    #undef GetFirstSibling
+    inline HWND GetFirstSibling(HWND hwnd)
+    {
+        return GetWindow(hwnd,GW_HWNDFIRST);
+    }
+#endif
+
+// GetLastSibling
+
+#ifdef GetLastSibling
+    #undef GetLastSibling
+    inline HWND GetLastSibling(HWND hwnd)
+    {
+        return GetWindow(hwnd,GW_HWNDLAST);
+    }
+#endif
+
+// GetPrevSibling
+
+#ifdef GetPrevSibling
+    #undef GetPrevSibling
+    inline HWND GetPrevSibling(HWND hwnd)
+    {
+        return GetWindow(hwnd,GW_HWNDPREV);
+    }
+#endif
+
+// GetNextSibling
+
+#ifdef GetNextSibling
+    #undef GetNextSibling
+    inline HWND GetNextSibling(HWND hwnd)
+    {
+        return GetWindow(hwnd,GW_HWNDNEXT);
+    }
+#endif
+
+// For WINE
+
+#if defined(GetWindowStyle)
+  #undef GetWindowStyle
+#endif
+
+// For ming and cygwin
+
+// GetFirstChild
+#ifdef GetFirstChild
+   #undef GetFirstChild
+   inline HWND GetFirstChild(HWND h)
+   {
+      return GetTopWindow(h);
+   }
+#endif
+
+
+// GetNextSibling
+#ifdef GetNextSibling
+   #undef GetNextSibling
+   inline HWND GetNextSibling(HWND h)
+   {
+     return GetWindow(h, GW_HWNDNEXT);
+   }
+#endif
+
+
+#ifdef Yield
+    #undef Yield
+#endif
+
+
+#if defined(__WXWINCE__) && defined(DrawIcon) //#ifdef DrawIcon
+    #undef DrawIcon
+    inline BOOL DrawIcon(HDC hdc, int x, int y, HICON hicon)
+    {
+        return DrawIconEx(hdc,x,y,hicon,0,0,0,NULL, DI_NORMAL) ;
+    }
+#endif
+
+
+// GetWindowProc
+//ifdef GetWindowProc
+//   #undef GetWindowProc
+//endif
+//ifdef GetNextChild
+//    #undef GetNextChild
+//endif
+
+// #endif // _WX_WINUNDEF_H_
+


### PR DESCRIPTION
mingw-w64-wxwidgets
A modified wx/msw/winundef.h.modified replaces the winundef.h coming in. Modifying winundef.h in this way has it do exactly what it did before but stops compiler errors due to TCHAR=WCHAR not being set up correctly, via UNICODE macro,  before <wx/> headers are included: LPCWSTR is used instead of LPCTSTR in the _UNICODE case. Attempts to replace this in wx are being made. https://groups.google.com/forum/#!topic/wx-dev/MTYzgOqLdfU

mingw-w64-plplot-5.11.0:
Many of the options afforded in the plplot package are turned off and the drivers remaining are 
built into the libplplot library.  With wingcc and wxwidgets, C++, F95 bindings (no ada, java, python).
The above modified wx installation allows the plplot build to proceed smoothly through the wxWidgets portion (apart from the warnings).  plplot still had trouble with python (v 5.11.0: fewer problems for 5.11.1 but I was unable to identify  a patch to fix it).  SWIG should be taken from mingw64 installation - no special defines are needed.  
