### PR TITLE
ffmpeg: Use libdcadec

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ffmpeg
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.7.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 url="http://ffmpeg.org/"
@@ -12,6 +12,7 @@ options=('staticlibs' 'strip')
 depends=(
         "${MINGW_PACKAGE_PREFIX}-bzip2"
         "${MINGW_PACKAGE_PREFIX}-celt"
+        "${MINGW_PACKAGE_PREFIX}-dcadec-git"
         "${MINGW_PACKAGE_PREFIX}-fontconfig"
         "${MINGW_PACKAGE_PREFIX}-gnutls"
         "${MINGW_PACKAGE_PREFIX}-gsm"
@@ -69,6 +70,7 @@ build() {
     --enable-libbluray \
     --enable-libcaca \
     --enable-libcelt \
+    --enable-libdcadec \
     --enable-libfreetype \
     --enable-libgsm \
     --enable-libmodplug \


### PR DESCRIPTION
This enables lossless DTS-HD MA decoding in FFmpeg. mpv in particular will prefer libdcadec over FFmpeg's internal DTS decoder when it's available.