### PR TITLE
Update 0007-Windows-New-feature-to-allow-overriding-lmsvcrt.patch

### DIFF
--- a/mingw-w64-gcc-git/0007-Windows-New-feature-to-allow-overriding-lmsvcrt.patch
+++ b/mingw-w64-gcc-git/0007-Windows-New-feature-to-allow-overriding-lmsvcrt.patch
@@ -32,7 +32,7 @@ index eef90fb..47e12e7 100644
 @@ -140,7 +140,7 @@ along with GCC; see the file COPYING3.  If not see
  #define REAL_LIBGCC_SPEC \
    "%{mthreads:-lmingwthrd} -lmingw32 \
-    " SHARED_LIBGCC_SPEC " \
+    "SHARED_LIBGCC_SPEC" \
 -   -lmoldname -lmingwex -lmsvcrt"
 +   -lmoldname -lmingwex %{!mcrtdll=*:-lmsvcrt} %{mcrtdll=*:-l%*}"
  

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc-git")
 pkgver=r140393.28c4d97
-_realpkgver=5.2.0
+_realpkgver=5.2.1
 pkgrel=1
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
@@ -34,7 +34,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 #checkdepends=('dejagnu')
 optdepends=()
 options=('staticlibs' '!emptydirs' '!strip' 'debug')
-source=("git://gcc.gnu.org/git/gcc.git"
+source=("git://gcc.gnu.org/git/gcc.git#branch=gcc-5-branch"
         "0001-Relocate-libintl.patch"
         "0002-PR54314-Include-_ZTC-in-libstdc-exports-deprecated.patch"
         "0003-PR52300-Avoid-__weakref__-on-__MINGW32__-deprecated.patch"


### PR DESCRIPTION
Correct spacing around SHARED_LIBGCC_SPEC which prevents 0007-Windows-New-feature-to-allow-overriding-lsmvcrt.patch from applying.