### PR TITLE
universal-ctags-git: New package

### DIFF
--- a/mingw-w64-universal-ctags-git/PKGBUILD
+++ b/mingw-w64-universal-ctags-git/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Oscar Fuentes <ofv@wanadoo.es>
+
+_realname=ctags
+pkgname="${MINGW_PACKAGE_PREFIX}-universal-${_realname}-git"
+pkgver=r2541.7812e7d
+pkgrel=1
+pkgdesc="A maintained Ctags implementation (mingw-w64)"
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+url="https://github.com/universal-ctags/ctags"
+license=("GPL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libiconv")
+options=('staticlibs' 'strip')
+source=("git+https://github.com/universal-ctags/ctags.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd ${srcdir}/${_realname}
+  autoreconf -fiv
+  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  CFLAGS="-U__USE_MINGW_ANSI_STDIO" \
+    ../${_realname}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-etags \
+    --disable-external-sort \
+    --enable-iconv
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make prefix="${pkgdir}/${MINGW_PREFIX}" install
+}


### PR DESCRIPTION
The Exuberant Ctags project is unmaintained, for all practical purposes. Universal Ctags is its continuation.