### PR TITLE
Fontconfig doesn't pass in a library directory when checking for libiconv

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -50,6 +50,7 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-iconv \
+    --with-libiconv=${MINGW_PREFIX} \
     --disable-docs \
     --with-arch=${CARCH} \
     --with-cache-dir=/var/cache/${_realname} \


### PR DESCRIPTION
Fontconfig isn't passing in a prefix-based library path when attempting to check for libiconv causing detection to fail.  Configuring it with --with-libiconv corrects this.