### PR TITLE
Disable rpath in libidn to keep -R flags out of pkg-config.

### DIFF
--- a/mingw-w64-libidn/PKGBUILD
+++ b/mingw-w64-libidn/PKGBUILD
@@ -38,6 +38,7 @@ build() {
     --target=${MINGW_CHOST} \
     --disable-csharp \
     --disable-java \
+    --disable-rpath \
     --enable-threads=win32
 
   make


### PR DESCRIPTION
Passing --disable-rpath prevents -R/mingw{32,64}/lib from showing up in libidn's pkg-config file.