### PR TITLE
Add the mingw-w64-connect package

### DIFF
--- a/mingw-w64-connect/PKGBUILD
+++ b/mingw-w64-connect/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=connect
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.104
+tag='fd6f352325d4'
+pkgrel=1
+pkgdesc="Make socket connection using SOCKS4/5 and HTTP tunnel (mingw-w64)"
+arch=('any')
+license=('GPL2+')
+url="https://bitbucket.org/gotoh/connect/overview"
+options=('strip')
+source=("https://bitbucket.org/gotoh/${_realname}/get/${pkgver}.tar.bz2")
+sha1sums=('bc65ff2833142ae6bd49d469224bc2111f30e078')
+
+build() {
+  cd "${srcdir}/gotoh-${_realname}-${tag}"
+
+  test -x ver || printf '#!/bin/sh\n\necho Windows\n' > ver
+
+  PATH=.:$PATH make -j1 rebuild
+}
+
+package() {
+  cd "${srcdir}/gotoh-${_realname}-${tag}"
+
+  install -d "${pkgdir}${MINGW_PREFIX}/bin/"
+  install connect.exe "${pkgdir}${MINGW_PREFIX}/bin/"
+
+  install -d "${pkgdir}${MINGW_PREFIX}/share/doc/connect/"
+  install doc/manual.html "${pkgdir}${MINGW_PREFIX}/share/doc/connect/"
+  install doc/manual.txt "${pkgdir}${MINGW_PREFIX}/share/doc/connect/"
+}


### PR DESCRIPTION
The connect.exe helper is a very useful helper when trying to connect to
SSH through a SOCKS or HTTP proxy.

It comes in particularly handy when users are stuck behind restrictive
firewalls. If even one HTTP proxy is accessible that allows to connect to
port 22 of the desired outside machine, `connect.exe` can be used in
conjunction with the `ProxyCommand` directive in `$HOME/.ssh/config` to
allow regular ssh and scp connections. Example:

-- snippet of $HOME/.ssh/config --
Host github.com
User git
ProxyCommand connect -H proxy.local.net:8080 %h %p
-- end snippet

If a SOCKS proxy is available, the same directive works when `-H` is
replaced with the `-S` option.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>