### PR TITLE
Add groff dependency in clang

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -18,7 +18,7 @@ license=("custom:University of Illinois/NCSA Open Source License")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-python3-sphinx"
-             "python2" "tar")
+             "python2" "tar" "groff")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=(http://llvm.org/releases/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -56,7 +56,7 @@ sha256sums=('f60dc158bfda6822de167e87275848969f0558b3134892ff54fced87e4667b94'
             '0804146b32138d55c611336cc81e1783c29a8fab0fe62f248ba1ad7acc711c4d'
             '13a95a61e9c1c44c18a69947734e07515332a549446394f48b86b52511d221de')
 
-validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D')
+validpgpkeys=('11E521D646982372EB577A1F8F0871F202119294')
 noextract=(cfe-${pkgver}.src.tar.xz
            libcxx-${pkgver}.src.tar.xz
            lldb-${pkgver}.src.tar.xz


### PR DESCRIPTION
Without groff build failed
```
llvm[2]: Installing MAN Clang Tools Documentation
groff -Tps -man /MINGW-packages/mingw-w64-clang/src/build-x86_64-w64-mingw32/tools/clang/docs/tools/clang.1 > /MINGW-packages/mingw-w64-clang/src/build-x86_64-w64-mingw32/tools/clang/docs/tools/clang.ps
/bin/sh: groff: command not found
Makefile:76: recipe for target '/MINGW-packages/mingw-w64-clang/src/build-x86_64-w64-mingw32/tools/clang/docs/tools/clang.ps' failed
```