### PR TITLE
universal-ctags-git: New package

### DIFF
--- a/mingw-w64-universal-ctags-git/PKGBUILD
+++ b/mingw-w64-universal-ctags-git/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Oscar Fuentes <ofv@wanadoo.es>
+
+_realname=ctags
+pkgname="${MINGW_PACKAGE_PREFIX}-universal-${_realname}-git"
+pkgver=r2611.44688c7
+pkgrel=1
+pkgdesc="A maintained Ctags implementation (mingw-w64)"
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+url="https://github.com/universal-ctags/ctags"
+license=("GPL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libiconv")
+options=('staticlibs' 'strip')
+source=("git+https://github.com/universal-ctags/ctags.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${_realname}"
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd ${srcdir}/${_realname}
+  autoreconf -fiv
+  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  ../${_realname}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-etags \
+    --disable-external-sort \
+    --enable-iconv
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make prefix="${pkgdir}/${MINGW_PREFIX}" install
+}


### PR DESCRIPTION
This is a maintained fork of Exuberant Ctags, which is already present as a MinGW-package.

As Exuberant Ctags is virtually unmaintained for several years, and Universal Ctags includes lots of fixes and new features over Exuberant Ctags, I suggest to build and provide a binary package.