### PR TITLE
German and French aspell dictionary packages

### DIFF
--- a/mingw-w64-aspell-de/001-unixy-dirs.patch
+++ b/mingw-w64-aspell-de/001-unixy-dirs.patch
@@ -1,0 +1,15 @@
+--- aspell6-de-20030222-1/configure.orig	2015-08-21 17:45:17.008196500 +0200
++++ aspell6-de-20030222-1/configure	2015-08-21 17:46:06.620617000 +0200
+@@ -73,10 +73,12 @@ if test x = "x$PREZIP"
+ 
+ echo $ECHO_N "Finding Dictionary file location ... $ECHO_C"
+ dictdir=`$ASPELL dump config dict-dir`
++dictdir=`cygpath -u $dictdir`
+ echo $dictdir
+ 
+ echo $ECHO_N "Finding Data file location ... $ECHO_C"
+ datadir=`$ASPELL dump config data-dir`
++datadir=`cygpath -u $datadir`
+ echo $datadir
+ 
+ echo "ASPELL = `which $ASPELL`" > Makefile

--- a/mingw-w64-aspell-de/PKGBUILD
+++ b/mingw-w64-aspell-de/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=aspell-de
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=20030222
+pkgrel=1
+pkgdesc="German dictionary for aspell (mingw-w64)"
+arch=('any')
+url="http://aspell.net/"
+license=('custom')
+depends=("${MINGW_PACKAGE_PREFIX}-aspell")
+source=(ftp://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-${pkgver}-1.tar.bz2
+        001-unixy-dirs.patch)
+md5sums=('5950c5c8a36fc93d4d7616591bace6a6'
+         '71e32e4d2c2eeb14f3f358bb13dab1e1')
+sha1sums=('a06b1153404f6d1f9bd8aa03d596c14093e561c7'
+          'ffdb6ab423aa5772a411ec7c997d2472f72e8448')
+
+prepare() {
+  cd "${srcdir}/aspell6-de-${pkgver}-1"
+  patch -p1 -i ${srcdir}/001-unixy-dirs.patch
+}
+
+build() {
+  cd "${srcdir}/aspell6-de-${pkgver}-1"
+  ./configure
+  sed -i 's/C\:\\msys64\\/\//' Makefile
+  make
+}
+
+package() {
+  cd "${srcdir}/aspell6-de-${pkgver}-1"
+  make DESTDIR="${pkgdir}" install
+
+  install -D -m644 Copyright "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}

--- a/mingw-w64-aspell-fr/001-unixy-dirs.patch
+++ b/mingw-w64-aspell-fr/001-unixy-dirs.patch
@@ -1,0 +1,15 @@
+--- aspell-fr-0.50-3/configure.orig	2015-08-24 15:25:37.040164200 +0200
++++ aspell-fr-0.50-3/configure	2015-08-24 15:26:51.598072800 +0200
+@@ -69,10 +69,12 @@ if test x = "x$WORD_LIST_COMPRESS"
+ 
+ echo $ECHO_N "Finding Dictionary file location ... $ECHO_C"
+ dictdir=`$ASPELL dump config dict-dir`
++dictdir=`cygpath -u $dictdir`
+ echo $dictdir
+ 
+ echo $ECHO_N "Finding Data file location ... $ECHO_C"
+ datadir=`$ASPELL dump config data-dir`
++datadir=`cygpath -u $datadir`
+ echo $datadir
+ 
+ echo "ASPELL = $ASPELL" > Makefile

--- a/mingw-w64-aspell-fr/PKGBUILD
+++ b/mingw-w64-aspell-fr/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=aspell-fr
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.50
+pkgrel=1
+pkgdesc="French dictionary for aspell (mingw-w64)"
+arch=('any')
+url="http://aspell.net/"
+license=('custom')
+depends=("${MINGW_PACKAGE_PREFIX}-aspell")
+source=(ftp://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-${pkgver}-3.tar.bz2
+        001-unixy-dirs.patch)
+md5sums=('53a2d05c4e8f7fabd3cefe24db977be7'
+         '2bdec16a2dc204a49378609f90fb436f')
+sha1sums=('4712f81069eb20763aaf855f73b2819f4805f132'
+          'f386c73e7bb57563850e980d723f2711608fd7ea')
+
+prepare() {
+  cd "${srcdir}/aspell-fr-${pkgver}-3"
+  patch -p1 -i ${srcdir}/001-unixy-dirs.patch
+}
+
+build() {
+  cd "${srcdir}/aspell-fr-${pkgver}-3"
+  ./configure
+  sed -i 's/C\:\\msys64\\/\//' Makefile
+  make
+}
+
+package() {
+  cd "${srcdir}/aspell-fr-${pkgver}-3"
+  make DESTDIR="${pkgdir}" install
+
+  install -D -m644 Copyright "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
The packages for the German and French aspell dictionaries proposed in this pull request were created by adjusting the PKGBUILD script and associated patch of the English aspell dictionary package. The packages build, install, and uninstall fine on an up-to-date MSYS2 installation using the MinGW-W64 toolchains for i686 and x86_64 on Windows 7. The dictionaries have been tested using the aspell integration in Emacs flyspell-mode.