### PR TITLE
Add the msmtp package

### DIFF
--- a/mingw-w64-msmtp/0001-include-winsock2.patch
+++ b/mingw-w64-msmtp/0001-include-winsock2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/msmtp.c b/src/msmtp.c
+index 3c21d2e..fc1d408 100644
+--- a/src/msmtp.c
++++ b/src/msmtp.c
+@@ -78,6 +78,8 @@ extern int optind;
+ 
+ /* Default file names. */
+ #ifdef W32_NATIVE
++#include <winsock2.h>
++
+ #define SYSCONFFILE     "msmtprc.txt"
+ #define USERCONFFILE    "msmtprc.txt"
+ #define SYSNETRCFILE    "netrc.txt"

--- a/mingw-w64-msmtp/0002-dont-redefine-winver-constant.patch
+++ b/mingw-w64-msmtp/0002-dont-redefine-winver-constant.patch
@@ -1,0 +1,30 @@
+diff --git a/src/net.c b/src/net.c
+index 8793180..706bb51 100644
+--- a/src/net.c
++++ b/src/net.c
+@@ -44,7 +44,9 @@
+ #endif
+ #ifdef W32_NATIVE
+ # define WIN32_LEAN_AND_MEAN    /* do not include more than necessary */
+-# define _WIN32_WINNT 0x0502    /* Windows XP SP2 or later */
++# ifndef _WIN32_WINNT
++#  define _WIN32_WINNT 0x0502    /* Windows XP SP2 or later */
++# endif
+ # include <winsock2.h>
+ # include <ws2tcpip.h>
+ #endif
+diff --git a/src/tools.c b/src/tools.c
+index 8c9efe1..6a8be58 100644
+--- a/src/tools.c
++++ b/src/tools.c
+@@ -35,7 +35,9 @@
+ #include <unistd.h>
+ #ifdef W32_NATIVE
+ # define WIN32_LEAN_AND_MEAN    /* do not include more than necessary */
+-# define _WIN32_WINNT 0x0502    /* Windows XP SP2 or later */
++# ifndef _WIN32_WINNT
++#  define _WIN32_WINNT 0x0502    /* Windows XP SP2 or later */
++# endif
+ # include <windows.h>
+ # include <io.h>
+ # include <conio.h>

--- a/mingw-w64-msmtp/PKGBUILD
+++ b/mingw-w64-msmtp/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
+
+_realname=msmtp
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.6.2
+tag=msmtp-${pkgver}
+pkgrel=1
+pkgdesc="An SMTP client (mingw-w64)"
+arch=('any')
+license=('GPL2+')
+url="http://msmtp.sourceforge.net/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gettext"
+  "${MINGW_PACKAGE_PREFIX}-gnutls"
+  "${MINGW_PACKAGE_PREFIX}-libffi"
+  "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
+options=('strip')
+source=("git://git.code.sf.net/p/msmtp/code#tag=${tag}"
+  '0001-include-winsock2.patch'
+  '0002-dont-redefine-winver-constant.patch')
+sha1sums=('SKIP'
+  'dbca2cf777e5c591f021168c83cb128f703153fe'
+  '295758aa2ad31540a4c0adde725d568210c2b356')
+
+prepare () {
+  cd ${srcdir}/code
+
+  patch -p1 -i "${srcdir}/0001-include-winsock2.patch"
+  patch -p1 -i "${srcdir}/0002-dont-redefine-winver-constant.patch"
+  autoreconf -i
+  ./configure --prefix=${MINGW_PREFIX}
+  sed -i 's/-R\/mingw..\/lib//' src/Makefile
+  touch src/*.c
+}
+
+build() {
+  cd ${srcdir}/code
+
+  make
+}
+
+package() {
+  cd ${srcdir}/code
+
+    make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
This package provides a minimal SMTP client for use in the command-line and in shell scripts. We used to ship this with Git for Windows 1.x and the plan is to ship it with 2.x again, providing support for sending patches as mails directly via SMTP.

This was lightly tested by sending two (unencrypted) mails. (Successfully, of course.)