### PR TITLE
Added mingw-w64-glbinding-git package

### DIFF
--- a/mingw-w64-glbinding-git/PKGBUILD
+++ b/mingw-w64-glbinding-git/PKGBUILD
@@ -1,0 +1,91 @@
+# Maintainer: Nazar Mishturak <nazar m x at gmail dot com>
+
+
+_realname=glbinding
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+pkgver=v1.1.0.r33.gfa8559d
+pkgrel=1
+arch=('any')
+url='https://github.com/cginternals/glbinding'
+pkgdesc='A C++ binding for the OpenGL API, generated using the gl.xml specification. (mingw-w64)'
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
+license=('MIT')
+options=('strip' 'staticlibs' 'docs')
+source=("${_realname}"::'git+https://github.com/cginternals/glbinding.git')
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  git describe --long --tags | sed -r 's/([^-]*-g)/r\1/;s/-/./g'
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+
+  local BUILD_TYPE="Release"
+  if check_option "debug" "y"; then
+    BUILD_TYPE="Debug"
+  fi
+  
+  # Build static libs
+  [[ -d ${srcdir}/static-${MINGW_CHOST} ]] && rm -rf ${srcdir}/static-${MINGW_CHOST}
+  mkdir -p ${srcdir}/static-${MINGW_CHOST}
+  cd ${srcdir}/static-${MINGW_CHOST}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_C_COMPILER=${MINGW_CHOST}-gcc \
+    -DCMAKE_CXX_COMPILER=${MINGW_CHOST}-g++ \
+    -DOPTION_BUILD_EXAMPLES=OFF \
+    -DOPTION_BUILD_TESTS=OFF \
+    -DOPTION_BUILD_TOOLS=OFF \
+    -DOPTION_BUILD_STATIC=ON \
+    ../${_realname}
+  make
+
+  # Build shared libs
+  [[ -d ${srcdir}/shared-${MINGW_CHOST} ]] && rm -rf ${srcdir}/shared-${MINGW_CHOST}
+  mkdir -p ${srcdir}/shared-${MINGW_CHOST}
+  cd ${srcdir}/shared-${MINGW_CHOST}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_C_COMPILER=${MINGW_CHOST}-gcc \
+    -DCMAKE_CXX_COMPILER=${MINGW_CHOST}-g++ \
+    -DOPTION_BUILD_EXAMPLES=OFF \
+    -DOPTION_BUILD_TESTS=OFF \
+    -DOPTION_BUILD_TOOLS=OFF \
+    -DOPTION_BUILD_STATIC=OFF \
+    ../${_realname}
+  make
+  
+}
+
+package () {
+  cd "${srcdir}/static-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+  
+  cd "${srcdir}/shared-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+
+  # Some things need to be moved
+  cd "${pkgdir}${MINGW_PREFIX}"
+
+  mkdir -p "lib/cmake/${_realname}"
+  mv -f "${_realname}-config.cmake" "lib/cmake/${_realname}/"
+  
+  mkdir -p "share/doc/${_realname}"
+  mv -f "AUTHORS" "share/doc/${_realname}/"
+  mv -f "gl.revision" "share/doc/${_realname}/"
+  mv -f "revision" "share/doc/${_realname}/"
+  mkdir -p "share/licenses/${_realname}"
+  mv -f "LICENSE" "share/licenses/${_realname}/"
+}


### PR DESCRIPTION
glbinding project is on GitHub, so I made a -git package. I don't know if `pkgver()` looks ok. This package requires no patch (issue fixed upstream).