### PR TITLE
Do not hard-code DOS paths in libintl-8.dll

### DIFF
--- a/mingw-w64-gettext/121-keep-posix-path.patch
+++ b/mingw-w64-gettext/121-keep-posix-path.patch
@@ -1,0 +1,37 @@
+From c9b8cf86ba8a24f1e0a45de53a295166672cf219 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Thu, 10 Sep 2015 13:09:15 +0200
+Subject: [PATCH] Prevent absolute DOS path from being hard-coded
+
+When passing absolute POSIX-style paths to the MinGW compiler, they are
+mangled into Windows-style paths, including the DOS drive, making the
+paths highly specific to the developer who happened to build the package.
+
+This is obviously not what we want, so prefix the absolute POSIX path with
+a space to convince the MSys2 runtime *not* to mangle the aliaspath.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ gettext-runtime/intl/Makefile.in | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/gettext-runtime/intl/Makefile.in b/gettext-runtime/intl/Makefile.in
+index 49751a2..b801220 100644
+--- a/gettext-runtime/intl/Makefile.in
++++ b/gettext-runtime/intl/Makefile.in
+@@ -98,9 +98,9 @@ am__v_lt_0 = --silent
+ 
+ # -DBUILDING_LIBINTL: Change expansion of LIBINTL_DLL_EXPORTED macro.
+ # -DBUILDING_DLL: Change expansion of RELOCATABLE_DLL_EXPORTED macro.
+-DEFS = -DLOCALEDIR=\"$(localedir)\" -DLOCALE_ALIAS_PATH=\"$(aliaspath)\" \
+--DLIBDIR=\"$(libdir)\" -DBUILDING_LIBINTL -DBUILDING_DLL -DIN_LIBINTL \
+--DENABLE_RELOCATABLE=1 -DIN_LIBRARY -DINSTALLDIR=\"$(libdir)\" -DNO_XMALLOC \
++DEFS = -DLOCALEDIR=\ \"$(localedir)\" -DLOCALE_ALIAS_PATH=\ \"$(aliaspath)\" \
++-DLIBDIR=\ \"$(libdir)\" -DBUILDING_LIBINTL -DBUILDING_DLL -DIN_LIBINTL \
++-DENABLE_RELOCATABLE=1 -DIN_LIBRARY -DINSTALLDIR=\ \"$(libdir)\" -DNO_XMALLOC \
+ -Dset_relocation_prefix=libintl_set_relocation_prefix \
+ -Drelocate=libintl_relocate \
+ -DDEPENDS_ON_LIBICONV=1 @DEFS@
+-- 
+2.5.1+unc.5.gc15a74e.dirty
+

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -25,7 +25,8 @@ source=("http://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"{
         05-always-use-libintl-vsnprintf.mingw.patch
         06-dont-include-ctype-after-gnulibs-wctype.mingw.patch
         07-fix-asprintf-conflict.mingw.patch
-        08-vs-compatible.patch)
+        08-vs-compatible.patch
+        121-keep-posix-path.patch)
 md5sums=('2b2ab90f6405a414bbe30cf6655f3e28'
          'SKIP'
          '397d7d6d4abd15a70edb3c9f2bab4cd2'
@@ -34,7 +35,8 @@ md5sums=('2b2ab90f6405a414bbe30cf6655f3e28'
          '27852a388b8cf38188dc392c244230ff'
          'f69747f43f279b8a81286cfe5916b82f'
          '3ebccf730ec3377b068027eb2283afb2'
-         'f5b611172ae58f1e4589a8d0c1d53414')
+         'f5b611172ae58f1e4589a8d0c1d53414'
+         'cc773909f10b1cbb626caafa822c73cf')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -50,6 +52,7 @@ prepare() {
   patch -p0 -i ${srcdir}/07-fix-asprintf-conflict.mingw.patch
   patch -p0 -i ${srcdir}/08-vs-compatible.patch
   #patch -p1 -i ${srcdir}/120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
+  patch -p1 -i ${srcdir}/121-keep-posix-path.patch
 
   # libtoolize --automake --copy --force
   #WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib


### PR DESCRIPTION
The `libintl-8.dll` file from mingw-w64-x86_64-gettext 0.19.5.1-1 has
the path `D:/develop/msys64/mingw64/share/locale` hard-coded. As a
consequence, programs that link to libintl-8.dll may try to open said
directory. In many setups, `D:\` actually refers to a CD/DVD drive which
means that the user may see this nasty error message:

	There is no disk in the drive. Please insert a disk into drive D:

Let's not do that, but instead hard-code the *POSIX* path into that
`.dll` file, i.e. `/mingw64/share/locale`.

This fixes https://github.com/git-for-windows/git/issues/329

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>