### PR TITLE
glbinding: Fix the package URL, install the documentation

### DIFF
--- a/mingw-w64-glbinding/PKGBUILD
+++ b/mingw-w64-glbinding/PKGBUILD
@@ -5,7 +5,7 @@ _realname=glbinding
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://github.com/cginternals/glbinding'
 pkgdesc='A C++ binding for the OpenGL API, generated using the gl.xml specification (mingw-w64)'
@@ -17,7 +17,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2")
 license=('MIT')
 options=('strip' 'staticlibs' 'docs')
-source=(${_realname}-${pkgver}.tar.gz::'https://github.com/cginternals/glbinding/archive/v${pkgver}.tar.gz'
+
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/cginternals/glbinding/archive/v${pkgver}.tar.gz"
         'werror-conversion.patch'
         'mingw-unix-layout.patch')
 md5sums=('fe6517dc1aa5f81d56ee060073da0f44'
@@ -71,11 +72,13 @@ build() {
     -DCMAKE_CXX_COMPILER=${MINGW_CHOST}-g++ \
     -DOPTION_BUILD_EXAMPLES=OFF \
     -DOPTION_BUILD_TESTS=OFF \
-    -DOPTION_BUILD_TOOLS=ON \
+    -DOPTION_BUILD_TOOLS=OFF \
     -DOPTION_BUILD_STATIC=OFF \
     ../${_realname}-${pkgver}
   make
   
+  # Build the docs once
+  make docs
 }
 
 package () {
@@ -84,4 +87,5 @@ package () {
   
   cd "${srcdir}/shared-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
+  make DESTDIR=${pkgdir} docs-doxygen
 }

--- a/mingw-w64-glbinding/PKGBUILD
+++ b/mingw-w64-glbinding/PKGBUILD
@@ -87,5 +87,7 @@ package () {
   
   cd "${srcdir}/shared-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
-  make DESTDIR=${pkgdir} docs-doxygen
+  
+  mkdir -p ${pkgdir}/usr/share/doc/${_realname}/
+  cp -R docs/doxygen/html ${pkgdir}/usr/share/doc/${_realname}/
 }

--- a/mingw-w64-glbinding/PKGBUILD
+++ b/mingw-w64-glbinding/PKGBUILD
@@ -12,9 +12,7 @@ pkgdesc='A C++ binding for the OpenGL API, generated using the gl.xml specificat
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-doxygen"
-             "${MINGW_PACKAGE_PREFIX}-glfw"
-             "${MINGW_PACKAGE_PREFIX}-python2")
+	     "${MINGW_PACKAGE_PREFIX}-doxygen")
 license=('MIT')
 options=('strip' 'staticlibs' 'docs')
 


### PR DESCRIPTION
Package had single quotes in source URL so `${pkgver}` wasn't expanded in the string. Also I fixed documentation installation.