### PR TITLE
Add the Antiword Package

### DIFF
--- a/mingw-w64-antiword/PKGBUILD
+++ b/mingw-w64-antiword/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Matthias Aßhauer <mha1993@live.de>
+
+_realname=antiword
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.37
+pkgrel=1
+pkgdesc="Convert MS Word 2.0-2003 documents to plain text or PostScript. (mingw-w64)"
+arch=('any')
+license=('GPL3+')
+url="http://www.winfield.demon.nl/"
+options=('strip')
+source=("http://www.winfield.demon.nl/linux/${_realname}-${pkgver}.tar.gz")
+md5sums=('F868E2A269EDCBC06BF77E89A55898D1')
+provides=("${_realname}")
+noextract=("${_realname}-${pkgver}.tar.gz")
+
+prepare(){
+  tar xzf "${_realname}-${pkgver}.tar.gz" ||  tar xzf "${_realname}-${pkgver}.tar.gz"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  make -f Makefile.Linux ${_realname}
+}
+
+package() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -D -m755 ${_realname}.exe ${pkgdir}${MINGW_PREFIX}/bin/${_realname}.exe
+  install -D -m755 Resources/8859-1.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-1.txt
+  install -D -m755 Resources/8859-2.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-2.txt
+  install -D -m755 Resources/8859-3.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-3.txt
+  install -D -m755 Resources/8859-4.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-4.txt
+  install -D -m755 Resources/8859-5.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-5.txt
+  install -D -m755 Resources/8859-6.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-6.txt
+  install -D -m755 Resources/8859-7.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-7.txt
+  install -D -m755 Resources/8859-8.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-8.txt
+  install -D -m755 Resources/8859-9.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-9.txt
+  install -D -m755 Resources/8859-10.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-10.txt
+  install -D -m755 Resources/8859-11.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-11.txt
+  install -D -m755 Resources/8859-13.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-13.txt
+  install -D -m755 Resources/8859-14.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-14.txt
+  install -D -m755 Resources/8859-15.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-15.txt
+  install -D -m755 Resources/8859-16.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/8859-16.txt
+  install -D -m755 Resources/cp437.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp437.txt
+  install -D -m755 Resources/cp850.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp850.txt
+  install -D -m755 Resources/cp852.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp852.txt
+  install -D -m755 Resources/cp862.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp862.txt
+  install -D -m755 Resources/cp864.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp864.txt
+  install -D -m755 Resources/cp866.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp866.txt
+  install -D -m755 Resources/cp1250.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp1250.txt
+  install -D -m755 Resources/cp1251.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp1251.txt
+  install -D -m755 Resources/cp1252.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/cp1252.txt
+  install -D -m755 Resources/koi8-r.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/koi8-r.txt
+  install -D -m755 Resources/koi8-u.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/koi8-u.txt
+  install -D -m755 Resources/MacCyrillic.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/MacCyrillic.txt
+  install -D -m755 Resources/MacRoman.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/MacRoman.txt
+  install -D -m755 Resources/roman.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/roman.txt
+  install -D -m755 Resources/UTF-8.txt ${pkgdir}${MINGW_PREFIX}/share/${_realname}/UTF-8.txt
+  install -D -m755 Resources/fontnames ${pkgdir}${MINGW_PREFIX}/share/${_realname}/fontnames
+}


### PR DESCRIPTION
[Antiword](http://www.winfield.demon.nl/) is a free MS Word reader for Linux and RISC OS. There are ports to FreeBSD, BeOS, OS/2, Mac OS X, Amiga, VMS, NetWare, Plan9, EPOC, Zaurus PDA, MorphOS, Tru64/OSF, Minix, Solaris and DOS. Antiword converts the binary files from Word 2, 6, 7, 97, 2000, 2002 and 2003 to plain text and to PostScript. It simplifies comparison between two Word documents.
`makepkg-mingw -s` has slight trouble building this package, because `bsdtar` doesn't handle symlinks properly. This results in `makepkg-mingw -s` reproducible failing on the first try to build Antiword and succeeding on the second run. I could introduce a [workaroundby using GNU `tar`](https://bbs.archlinux.org/viewtopic.php?id=70030) if you think that's better.