### PR TITLE
Add the mbedtls package.

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Nazar Mishturak <nazar m x at gmail dot com>
+
+_realname=mbedtls
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.1.0
+pkgrel=1
+arch=('any')
+url='https://tls.mbed.org/'
+pkgdesc='mbed TLS is an open source and commercial SSL library licensed by ARM Limited. (mingw-w64)'
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-doxygen")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-perl")
+license=('Apache License 2.0')
+options=('strip' 'staticlibs' 'docs')
+source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${pkgver}-apache.tgz"
+        'symlink-test.patch')
+sha1sums=('13fcb4858145e972f8abaedf029ceb5c8461408e'
+          '72e420d5676007a168a82210dba960bea4e29190')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/symlink-test.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  local BUILD_TYPE="Release"
+  if check_option "debug" "y"; then
+    BUILD_TYPE="Debug"
+  fi
+  
+  # Build static libs
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_C_COMPILER=${MINGW_CHOST}-gcc \
+    -DENABLE_TESTING=ON \
+    -DENABLE_PROGRAMS=OFF \
+    -DENABLE_ZLIB_SUPPORT=ON \
+    -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
+    -DUSE_STATIC_MBEDTLS_LIBRARY=ON \
+    ../${_realname}-${pkgver}
+  make
+  # Generate the documentation
+  make apidoc
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  cp -p library/*.dll tests/ # Tests are dynamically linked
+  make test
+}
+
+package () {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+  # Install the documentation
+  cd "${srcdir}/${_realname}-${pkgver}"
+  mkdir -p "${pkgdir}/usr/share/doc/${_realname}"
+  cp -Rp apidoc "${pkgdir}/usr/share/doc/${_realname}/html"
+}

--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -17,13 +17,16 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-perl")
 license=('Apache License 2.0')
 options=('strip' 'staticlibs' 'docs')
 source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${pkgver}-apache.tgz"
-        'symlink-test.patch')
+        'symlink-test.patch'
+        'dll-location.patch')
 sha1sums=('13fcb4858145e972f8abaedf029ceb5c8461408e'
-          '72e420d5676007a168a82210dba960bea4e29190')
+          '72e420d5676007a168a82210dba960bea4e29190'
+          'e905d99cacf3b3d91872e8736ff03ef950b32a34')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/symlink-test.patch"
+  patch -p1 -i "${srcdir}/dll-location.patch"
 }
 
 build() {
@@ -65,8 +68,9 @@ check() {
 package () {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
+  
   # Install the documentation
   cd "${srcdir}/${_realname}-${pkgver}"
-  mkdir -p "${pkgdir}/usr/share/doc/${_realname}"
-  cp -Rp apidoc "${pkgdir}/usr/share/doc/${_realname}/html"
+  mkdir -p "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}"
+  cp -Rp apidoc "${pkgdir}/${MINGW_PREFIX}/share/doc/${_realname}/html"
 }

--- a/mingw-w64-mbedtls/dll-location.patch
+++ b/mingw-w64-mbedtls/dll-location.patch
@@ -1,0 +1,24 @@
+--- mbedtls-2.1.0/library/CMakeLists.txt.orig	2015-09-04 15:38:26.000000000 +0300
++++ mbedtls-2.1.0/library/CMakeLists.txt	2015-09-14 17:32:04.783122700 +0300
+@@ -132,7 +132,9 @@
+     target_link_libraries(${mbedtls_static_target} ${libs} ${mbedx509_static_target})
+ 
+     install(TARGETS ${mbedtls_static_target} ${mbedx509_static_target} ${mbedcrypto_static_target}
+-            DESTINATION ${LIB_INSTALL_DIR}
++            RUNTIME DESTINATION "bin"
++            LIBRARY DESTINATION "lib"
++            ARCHIVE DESTINATION "lib"
+             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+ endif(USE_STATIC_MBEDTLS_LIBRARY)
+ 
+@@ -150,7 +152,9 @@
+     target_link_libraries(mbedtls ${libs} mbedx509)
+ 
+     install(TARGETS mbedtls mbedx509 mbedcrypto
+-            DESTINATION ${LIB_INSTALL_DIR}
++            RUNTIME DESTINATION "bin"
++            LIBRARY DESTINATION "lib"
++            ARCHIVE DESTINATION "lib"
+             PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+ endif(USE_SHARED_MBEDTLS_LIBRARY)
+ 

--- a/mingw-w64-mbedtls/symlink-test.patch
+++ b/mingw-w64-mbedtls/symlink-test.patch
@@ -1,0 +1,11 @@
+--- mbedtls-2.1.0/tests/CMakeLists.txt.orig	2015-09-04 15:38:26.000000000 +0300
++++ mbedtls-2.1.0/tests/CMakeLists.txt	2015-09-13 21:45:47.677244800 +0300
+@@ -101,7 +101,7 @@
+     file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/data_files" target)
+ 
+     if (NOT EXISTS ${link})
+-        if (CMAKE_HOST_UNIX)
++        if (CMAKE_HOST_UNIX OR MSYS)
+             set(command ln -s ${target} ${link})
+         else()
+             set(command cmd.exe /c mklink /d ${link} ${target})


### PR DESCRIPTION
mbed TLS is an open source and commercial SSL library licensed by ARM
Limited.

There are 2 versions of this library: GPLv2 licensed and Apache 2.0. I packaged the Apache 2.0 one because it is their main license. This package builds static and shared libraries. Upstream doesn't provide `Config.cmake` file, should I try to create one?. Also I am not sure if I put the documentation in correct place.