### PR TITLE
curl: enable IPv6 support

### DIFF
--- a/mingw-w64-curl/0003-curl-detect-ipv6-on-windows.patch
+++ b/mingw-w64-curl/0003-curl-detect-ipv6-on-windows.patch
@@ -1,0 +1,71 @@
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Thu, 17 Sep 2015 20:03:34 +0200
+Subject: [PATCH] Auto-detect IPv6 support even on Windows
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ configure.ac         | 11 ++++++++++-
+ m4/curl-functions.m4 | 10 ++++++++++
+ 2 files changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index be2634a..9ff200d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1081,7 +1081,11 @@ AC_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
+ 
+   AC_TRY_RUN([ /* is AF_INET6 available? */
+ #include <sys/types.h>
++#ifdef HAVE_WINSOCK2_H
++#include <winsock2.h>
++#else
+ #include <sys/socket.h>
++#endif
+ #include <stdlib.h> /* for exit() */
+ main()
+ {
+@@ -1108,7 +1112,12 @@ if test "$ipv6" = yes; then
+   AC_MSG_CHECKING([if struct sockaddr_in6 has sin6_scope_id member])
+   AC_TRY_COMPILE([
+ #include <sys/types.h>
+-#include <netinet/in.h>] ,
++#ifdef HAVE_WINSOCK2_H
++#include <winsock2.h>
++#include <ws2tcpip.h>
++#else
++#include <netinet/in.h>
++#endif] ,
+   struct sockaddr_in6 s; s.sin6_scope_id = 0; , have_sin6_scope_id=yes)
+   if test "$have_sin6_scope_id" = yes; then
+     AC_MSG_RESULT([yes])
+diff --git a/m4/curl-functions.m4 b/m4/curl-functions.m4
+index 0d65421..9f04661 100644
+--- a/m4/curl-functions.m4
++++ b/m4/curl-functions.m4
+@@ -44,6 +44,10 @@ curl_includes_arpa_inet="\
+ #ifdef HAVE_ARPA_INET_H
+ #  include <arpa/inet.h>
+ #endif
++#ifdef HAVE_WINSOCK2_H
++#include <winsock2.h>
++#include <ws2tcpip.h>
++#endif
+ /* includes end */"
+   AC_CHECK_HEADERS(
+     sys/types.h sys/socket.h netinet/in.h arpa/inet.h,
+@@ -2098,6 +2102,12 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
+         struct addrinfo *ai = 0;
+         int error;
+ 
++        #ifdef HAVE_WINSOCK2_H
++        WSADATA wsa;
++        if (WSAStartup(MAKEWORD(2,2), &wsa))
++                exit(2);
++        #endif
++
+         memset(&hints, 0, sizeof(hints));
+         hints.ai_flags = AI_NUMERICHOST;
+         hints.ai_family = AF_UNSPEC;
+-- 
+2.5.2.windows.2
+

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.44.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -29,11 +29,13 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs')
 source=("$url/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
-        "0002-curl-mingw-enable-static.patch")
+        "0002-curl-mingw-enable-static.patch"
+        "0003-curl-detect-ipv6-on-windows.patch")
 md5sums=('6b952ca00e5473b16a11f05f06aa8dae'
          'SKIP'
          '58520051c4ed77781d233c3fa40a5435'
-         'eac9e212e619490966ae47004bec547b')
+         'eac9e212e619490966ae47004bec547b'
+         'f1c5b8648af0dfab7bde4d68a6b65f25')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg
 
 prepare() {
@@ -41,6 +43,7 @@ prepare() {
   rm -f lib/pathtools.h lib/pathtools.c > /dev/null 2>&1 || true
   patch -p1 -i "${srcdir}/0001-curl-relocation.patch"
   patch -p1 -i "${srcdir}/0002-curl-mingw-enable-static.patch"
+  patch -p1 -i "${srcdir}/0003-curl-detect-ipv6-on-windows.patch"
   autoreconf -vfi
 }
 


### PR DESCRIPTION
The support is already there, of course, it was just not auto-detected
correctly.

This fixes https://github.com/git-for-windows/git/issues/370

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>