### PR TITLE
Nuitka: update to 0.5.14.3, fix #788

### DIFF
--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -57,10 +57,6 @@ package_python2-nuitka() {
     sed -e "s|...\python|python2|g" \
         -e "s|${filename}|${filename}2|g" \
         -i "${pkgdir}${MINGW_PREFIX}"/bin/${filename}.bat
-
-    sed -e "s|...\python|python2|g" \
-        -e "s|${filename}|${filename}2|g" \
-        -i "${pkgdir}${MINGW_PREFIX}"/bin/${filename}
     mv "${pkgdir}${MINGW_PREFIX}"/bin/${filename} "${pkgdir}${MINGW_PREFIX}"/bin/${filename}2
     mv "${pkgdir}${MINGW_PREFIX}"/bin/${filename}.bat "${pkgdir}${MINGW_PREFIX}"/bin/${filename}2.bat
   done

--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=nuitka
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.5.13
+pkgver=0.5.14.3
 pkgrel=1
 pkgdesc="Python to native compiler (mingw-w64)"
 arch=('any')
@@ -11,7 +11,7 @@ url="http://www.nuitka.net/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 source=("http://nuitka.net/releases/Nuitka-${pkgver}.tar.gz")
 noextract=(Nuitka-$pkgver.tar.gz)
-md5sums=('e231f92edc2766c72c5a357f7d917223')
+md5sums=('17f448e0421c0112d54bdee5777d2e97')
 
 prepare() {
   [[ -d $srcdir/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
There's a new upstream version [available](http://nuitka.net/pages/download.html): 0.5.14.3. Could mingw-w64-python-nuitka be updated please?

Branch contains a fix for #788 that gets it running on my system, but it's otherwise untested.

(I'll assume setuptools alone should be responsible for the `#!` line.)