### PR TITLE
mbedtls: Update to version 2.1.1

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.1.0
+pkgver=2.1.1
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
@@ -19,7 +19,7 @@ options=('strip' 'staticlibs' 'docs')
 source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${pkgver}-apache.tgz"
         'symlink-test.patch'
         'dll-location.patch')
-sha1sums=('13fcb4858145e972f8abaedf029ceb5c8461408e'
+sha1sums=('f4348b730a8731f5ed2bacb458ffa053798cc5ff'
           '72e420d5676007a168a82210dba960bea4e29190'
           'e905d99cacf3b3d91872e8736ff03ef950b32a34')
 


### PR DESCRIPTION
A bugfix release, patch notes [here](https://tls.mbed.org/tech-updates/releases/mbedtls-2.1.1-and-1.3.13-and-polarssl-1.2.16-released).