### PR TITLE
Added mingw-w64-usbview.

### DIFF
--- a/mingw-w64-usbview/01-strsafe-after-tchar.patch
+++ b/mingw-w64-usbview/01-strsafe-after-tchar.patch
@@ -1,0 +1,20 @@
+diff --binary -u -r C++/uvcview.h C++fix/uvcview.h
+--- C++/uvcview.h	2014-04-04 18:10:36.000000000 -0700
++++ C++fix/uvcview.h	2015-04-22 20:42:54.355211400 -0700
+@@ -34,7 +34,6 @@
+ #include <usbioctl.h>
+ #include <usbiodef.h>
+ #include <intsafe.h>
+-#include <strsafe.h>
+ #include <specstrings.h>
+ #include <usb.h>
+ #include <usbuser.h>
+@@ -50,6 +49,7 @@
+ #include <winioctl.h>
+ #include <devpkey.h>
+ #include <math.h>
++#include <strsafe.h>
+ 
+ // This is mostly a private USB Audio descriptor header
+ #include "usbdesc.h"
+

--- a/mingw-w64-usbview/02-sal.patch
+++ b/mingw-w64-usbview/02-sal.patch
@@ -1,0 +1,10 @@
+--- orig/uvcview.h	2015-08-28 11:07:16.380217500 -0400
++++ new/uvcview.h	2015-08-28 11:07:28.123146100 -0400
+@@ -50,6 +50,7 @@
+ #include <devpkey.h>
+ #include <math.h>
+ #include <strsafe.h>
++#include <sal.h>
+ 
+ // This is mostly a private USB Audio descriptor header
+ #include "usbdesc.h"

--- a/mingw-w64-usbview/03-resource-fix.patch
+++ b/mingw-w64-usbview/03-resource-fix.patch
@@ -1,0 +1,22 @@
+Only in C++fix: out.so
+diff -u -r C++/uvcview.rc C++fix/uvcview.rc
+--- C++/uvcview.rc	2015-04-23 08:52:46.193018500 -0700
++++ C++fix/uvcview.rc	2015-04-23 08:53:32.858881400 -0700
+@@ -84,7 +84,7 @@
+     BEGIN
+         MENUITEM "&Refresh\tF5",        ID_REFRESH
+         MENUITEM SEPARATOR
+-        MENUITEM "Save Current &View ..."        ID_SAVE
++        MENUITEM "Save Current &View ...",  ID_SAVE
+         MENUITEM "Save As (&txt) ...",      ID_SAVEALL
+         MENUITEM "Save As (&xml) ...\tF2",  ID_SAVEXML
+         MENUITEM SEPARATOR
+@@ -130,7 +130,7 @@
+ BEGIN
+     IDS_STANDARD_FONT           "Courier"
+     IDS_STANDARD_FONT_HEIGHT    "\13"
+-    IDS_STANDARD_FONT_WIDTH     "\8"
++    IDS_STANDARD_FONT_WIDTH     "\08"
+ END
+ 
+ STRINGTABLE DISCARDABLE

--- a/mingw-w64-usbview/PKGBUILD
+++ b/mingw-w64-usbview/PKGBUILD
@@ -1,0 +1,79 @@
+# Maintainer: David Grayson <davidegrayson@gmail.com>
+
+# Note: We currently build an older version of usbview from a ZIP file
+# that was on a page that Microsoft has since unpublished.  We are not
+# yet able to build the version of usbview from github because
+# mingw-w64 is missing some new structs/typedefs.
+#
+# https://github.com/Microsoft/Windows-driver-samples/tree/master/usb/usbview
+
+_realname=usbview
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1.20140402
+pkgrel=1
+pkgdesc='GUI for browsing all USB controllers and connected USB devices on your computer (mingw-w64)'
+arch=('any')
+url='https://web.archive.org/web/20140824072648/http://code.msdn.microsoft.com/windowshardware/USBView-sample-application-e3241039'
+license=('custom')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  'patch'
+)
+depends=()
+options=('strip')
+source=(
+  "https://code.msdn.microsoft.com/windowshardware/USBView-sample-application-e3241039/file/51333/38/USBView%20sample%20application.zip"
+  'my_xmlhelper.c'
+  '01-strsafe-after-tchar.patch'
+  '02-sal.patch'
+  '03-resource-fix.patch'
+)
+
+sha256sums=('fd07e8b20f9cff7efd8c01bf2b9cc9ac39ba85c76e56287b80d8abf38ec92287'
+            'b3d551683be0398bca58e67bf7c91b22d88283e10292c9cda5ab367921511ebf'
+            'dd0dade894b612cc0d30b0cbe1c47647de3697c9feeff65b866c32b01430154e'
+            'b6959253bde6fd85af82cdd74c0993d0e9c82871f95cb507811b1fd8528cd301'
+            '2be3167e95f8d5d8abf91e43a49fac4593b8264df5c20478f476bdbe1bae89a3')
+
+prepare() {
+  cd "${srcdir}/C++"
+
+  # dos2unix -q *.c *.h *.rc
+
+  # strsafe.h must be after tchar.h in mingw-w64
+  patch -p1 -i "../01-strsafe-after-tchar.patch"
+
+  # Include sal.h in some places it is needed.
+  patch -p1 -i "../02-sal.patch"
+
+  # We exclude the XML stuff because it requires Visual C++ (.NET).
+  rm usbschema.hpp xmlhelper.cpp
+  cp "../my_xmlhelper.c" .
+
+  # Fix some syntax errors that windres complains about
+  patch -p1 -i "../03-resource-fix.patch"
+}
+
+build() {
+  cd "${srcdir}"
+  mkdir -p "build-${MINGW_CHOST}"
+  cd "build-${MINGW_CHOST}"
+
+  windres ../C++/uvcview.rc rc.so
+
+  gcc -mwindows --std=c99 ${CFLAGS} ${LDFLAGS} \
+    -DNTDDI_VERSION=0x06020000 -D_WIN32_WINNT=0x0602 \
+    -DSTRSAFE_NO_DEPRECATE \
+    ../C++/*.c rc.so \
+    -lcomctl32 -lcomdlg32 -lsetupapi -lshell32 -lshlwapi -lole32 -lgdi32 \
+    -o usbview.exe
+}
+
+package() {
+  cd "${srcdir}"
+  install -Dm644 license.rtf "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/license.rtf"
+  cd "build-${MINGW_CHOST}"
+  mkdir "${pkgdir}${MINGW_PREFIX}/bin"
+  install -Dm755 usbview.exe "${pkgdir}${MINGW_PREFIX}/bin"
+}

--- a/mingw-w64-usbview/my_xmlhelper.c
+++ b/mingw-w64-usbview/my_xmlhelper.c
@@ -1,0 +1,48 @@
+#include "xmlhelper.h"
+
+EXTERN_C HRESULT InitXmlHelper()
+{
+    return 0;
+}
+
+EXTERN_C HRESULT ReleaseXmlWriter()
+{
+    return 0;
+}
+
+EXTERN_C HRESULT SaveXml(LPTSTR szfileName, DWORD dwCreationDisposition)
+{
+    MessageBox(NULL,
+        "Sorry, XML saving is not supported in this build.",
+        "XML not supported",
+        MB_OK | MB_ICONEXCLAMATION);
+    return 0;
+}
+
+EXTERN_C HRESULT XmlAddHostController(
+    PSTR hcName,
+    PUSBHOSTCONTROLLERINFO hcInfo
+    )
+{
+    return 0;
+}
+
+EXTERN_C HRESULT XmlAddRootHub(PSTR rhName, PUSBROOTHUBINFO rhInfo)
+{
+    return 0;
+}
+
+EXTERN_C HRESULT XmlAddExternalHub(PSTR ehName, PUSBEXTERNALHUBINFO ehInfo)
+{
+    return 0;
+}
+
+EXTERN_C HRESULT XmlAddUsbDevice(PSTR devName, PUSBDEVICEINFO deviceInfo)
+{
+    return 0;
+}
+
+EXTERN_C VOID XmlNotifyEndOfNodeList(PVOID pContext)
+{
+    return 0;
+}


### PR DESCRIPTION
This pull request adds a package for usbview, a sample GUI application from Microsoft that shows interesting information about connected USB controllers and devices.

Three caveats:

* It uses an older ZIP file from Microsoft's website because the [latest one on github](https://github.com/Microsoft/Windows-driver-samples/tree/master/usb/usbview) cannot yet be compiled with mingw-w64 because of some missing structs/typedefs.  I will probably submit patches to mingw-w64 so we can eventually compile it.
* It compiles with warnings because of macro redefinitions and arrays that are assumed to have one element.
* xmlhelper.cpp uses .NET, so this package replaces it with a dummy file that just shows an error message.  This build will not be able to save data as an XML file.

If either of these reasons make you not want to merge this in, I would understand.