### PR TITLE
usbview: Make sure mingw-w64's usb.h takes precedence over libusb-com…

### DIFF
--- a/mingw-w64-usbview/PKGBUILD
+++ b/mingw-w64-usbview/PKGBUILD
@@ -57,12 +57,16 @@ prepare() {
 
 build() {
   cd "${srcdir}"
-  mkdir -p "build-${MINGW_CHOST}"
+  mkdir -p "build-${MINGW_CHOST}/include"
   cd "build-${MINGW_CHOST}"
+
+  # Make sure mingw-w64's usb.h takes precedence over libusb-compat's.
+  cp ${MINGW_PREFIX}/${MINGW_CHOST}/include/usb.h include
 
   windres ../C++/uvcview.rc rc.so
 
   gcc -mwindows --std=c99 ${CFLAGS} ${LDFLAGS} \
+    -Iinclude \
     -DNTDDI_VERSION=0x06020000 -D_WIN32_WINNT=0x0602 \
     -DSTRSAFE_NO_DEPRECATE \
     ../C++/*.c rc.so \


### PR DESCRIPTION
This fixes the problem we discussed in #797.