### PR TITLE
mbedtls: Enable SSE2 and threading support via pthread.

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -4,12 +4,11 @@ _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.1.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://tls.mbed.org/'
 pkgdesc='mbed TLS is an open source and commercial SSL library licensed by ARM Limited. (mingw-w64)'
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen")
@@ -18,15 +17,18 @@ license=('Apache License 2.0')
 options=('strip' 'staticlibs' 'docs')
 source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${pkgver}-apache.tgz"
         'symlink-test.patch'
-        'dll-location.patch')
+        'dll-location.patch'
+        'enable-features.patch')
 sha1sums=('f4348b730a8731f5ed2bacb458ffa053798cc5ff'
           '72e420d5676007a168a82210dba960bea4e29190'
-          'e905d99cacf3b3d91872e8736ff03ef950b32a34')
+          'e905d99cacf3b3d91872e8736ff03ef950b32a34'
+          '9ce57bb1e9dd0298454b48faa0f1b5317d245cdb')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/symlink-test.patch"
   patch -p1 -i "${srcdir}/dll-location.patch"
+  patch -p1 -i "${srcdir}/enable-features.patch"
 }
 
 build() {
@@ -50,7 +52,6 @@ build() {
     -DCMAKE_C_COMPILER=${MINGW_CHOST}-gcc \
     -DENABLE_TESTING=ON \
     -DENABLE_PROGRAMS=OFF \
-    -DENABLE_ZLIB_SUPPORT=ON \
     -DUSE_SHARED_MBEDTLS_LIBRARY=ON \
     -DUSE_STATIC_MBEDTLS_LIBRARY=ON \
     ../${_realname}-${pkgver}

--- a/mingw-w64-mbedtls/enable-features.patch
+++ b/mingw-w64-mbedtls/enable-features.patch
@@ -1,0 +1,47 @@
+--- mbedtls-2.1.1/include/mbedtls/config.h.orig	2015-09-26 18:53:50.950970200 +0300
++++ mbedtls-2.1.1/include/mbedtls/config.h	2015-09-26 19:01:45.088633900 +0300
+@@ -63,7 +63,7 @@
+  *
+  * Uncomment if the CPU supports SSE2 (IA-32 specific).
+  */
+-//#define MBEDTLS_HAVE_SSE2
++#define MBEDTLS_HAVE_SSE2
+ 
+ /**
+  * \def MBEDTLS_HAVE_TIME
+@@ -170,7 +170,7 @@
+  *
+  * Uncomment to get warnings on using deprecated functions.
+  */
+-//#define MBEDTLS_DEPRECATED_WARNING
++#define MBEDTLS_DEPRECATED_WARNING
+ 
+ /**
+  * \def MBEDTLS_DEPRECATED_REMOVED
+@@ -721,7 +721,7 @@
+  * Disable if you run into name conflicts and want to really remove the
+  * mbedtls_strerror()
+  */
+-#define MBEDTLS_ERROR_STRERROR_DUMMY
++//#define MBEDTLS_ERROR_STRERROR_DUMMY
+ 
+ /**
+  * \def MBEDTLS_GENPRIME
+@@ -1215,7 +1215,7 @@
+  *
+  * Uncomment this to enable pthread mutexes.
+  */
+-//#define MBEDTLS_THREADING_PTHREAD
++#define MBEDTLS_THREADING_PTHREAD
+ 
+ /**
+  * \def MBEDTLS_VERSION_FEATURES
+@@ -2208,7 +2208,7 @@
+  *
+  * Enable this layer to allow use of mutexes within mbed TLS
+  */
+-//#define MBEDTLS_THREADING_C
++#define MBEDTLS_THREADING_C
+ 
+ /**
+  * \def MBEDTLS_TIMING_C


### PR DESCRIPTION
Also disable zlib support because it is not used, because TLS compression is
unsafe (CRIME). Remove dummy error reporting function.

Is SSE2 common enough to keep it enabled (on both i686 and x86_64)? If not I can move it into a separate patch.