### PR TITLE
curl: fix NTLM proxy when reusing connection

### DIFF
--- a/mingw-w64-curl/0004-NTLM-Reset-auth-done-when-using-a-fresh-connection.patch
+++ b/mingw-w64-curl/0004-NTLM-Reset-auth-done-when-using-a-fresh-connection.patch
@@ -1,0 +1,33 @@
+From f65e07ca5930a27a54fe96e99e838f6c85c5356b Mon Sep 17 00:00:00 2001
+From: Isaac Boukris <iboukris@gmail.com>
+Date: Wed, 16 Sep 2015 03:52:36 +0300
+Subject: [PATCH] NTLM: Reset auth-done when using a fresh connection
+
+With NTLM a new connection will always require authentication.
+Fixes #435
+---
+ lib/url.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/url.c b/lib/url.c
+index dccd710..f056b16 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -5839,12 +5839,14 @@ static CURLcode create_conn(struct SessionHandle *data,
+        data->state.authhost.done) {
+       infof(data, "NTLM picked AND auth done set, clear picked!\n");
+       data->state.authhost.picked = CURLAUTH_NONE;
++      data->state.authhost.done = FALSE;
+     }
+ 
+     if((data->state.authproxy.picked & (CURLAUTH_NTLM | CURLAUTH_NTLM_WB)) &&
+        data->state.authproxy.done) {
+       infof(data, "NTLM-proxy picked AND auth done set, clear picked!\n");
+       data->state.authproxy.picked = CURLAUTH_NONE;
++      data->state.authproxy.done = FALSE;
+     }
+ #endif
+   }
+-- 
+2.5.3.windows.1.2.gcb92cc1
+

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.44.0
-pkgrel=2
+pkgrel=3
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -30,12 +30,14 @@ options=('staticlibs')
 source=("$url/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0002-curl-mingw-enable-static.patch"
-        "0003-curl-detect-ipv6-on-windows.patch")
+        "0003-curl-detect-ipv6-on-windows.patch"
+        "0004-NTLM-Reset-auth-done-when-using-a-fresh-connection.patch")
 md5sums=('6b952ca00e5473b16a11f05f06aa8dae'
          'SKIP'
          '58520051c4ed77781d233c3fa40a5435'
          'eac9e212e619490966ae47004bec547b'
-         'f1c5b8648af0dfab7bde4d68a6b65f25')
+         'f1c5b8648af0dfab7bde4d68a6b65f25'
+         '1e42a032267f66041a117df4dcd1cf1f')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg
 
 prepare() {
@@ -44,6 +46,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-curl-relocation.patch"
   patch -p1 -i "${srcdir}/0002-curl-mingw-enable-static.patch"
   patch -p1 -i "${srcdir}/0003-curl-detect-ipv6-on-windows.patch"
+  patch -p1 -i "${srcdir}/0004-NTLM-Reset-auth-done-when-using-a-fresh-connection.patch"
   autoreconf -vfi
 }
 


### PR DESCRIPTION
Under certain circumstances, an NTLM proxy connection will be reused.
If that is the case, the state of the authentication needs to be
handled properly.

There is a bug in cURL 7.44.0 that has been fixed in cURL's `master`
already (https://github.com/bagder/curl/commit/f65e07ca5) and this
patch backports it.

This fixes https://github.com/git-for-windows/git/issues/373

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>