### PR TITLE
libass: Update to 0.13.0

### DIFF
--- a/mingw-w64-libass/PKGBUILD
+++ b/mingw-w64-libass/PKGBUILD
@@ -1,8 +1,9 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=libass
+pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.12.3
+pkgver=0.13.0
 pkgrel=1
 pkgdesc="A portable library for SSA/ASS subtitles rendering (mingw-w64)"
 arch=('any')
@@ -11,19 +12,13 @@ license=('ISC')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-yasm"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-enca"
-         "${MINGW_PACKAGE_PREFIX}-fribidi"
+depends=("${MINGW_PACKAGE_PREFIX}-fribidi"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-harfbuzz")
 options=('strip' 'staticlibs')
-source=("${_realname}-${pkgver}.tar.gz"::https://github.com/libass/${_realname}/archive/${pkgver}.tar.gz)
-md5sums=('1b53e739ab389335ce46fd626777ec61')
-
-prepare() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-  ./autogen.sh
-}
+source=(https://github.com/libass/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz)
+md5sums=('8e6a506b4e5a637764183083421dc827')
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
@@ -38,7 +33,6 @@ build() {
     --enable-static \
     --enable-harfbuzz \
     --enable-fontconfig \
-    --enable-enca \
     --enable-asm
   make
 }


### PR DESCRIPTION
This adds DirectWrite font selection, so fontconfig is now only needed for Windows XP. Also, the enca dependency was dropped and the PKGBUILD was changed to use the release tarball (Arch did this as well.)