### PR TITLE
gtk3: fix bad patch reapply that breaks toarray.pl

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -42,7 +42,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0013-fix-mingw-w64-fstat-call.mingw.patch
   patch -Np1 -i "${srcdir}"/060-fix-tests.patch
 
-  echo "" > gdk/broadway/toarray.pl
+  rm -f gdk/broadway/toarray.pl
   patch -p1 -i ${srcdir}/0056-missing-file-toarray-pl.patch
 
   autoreconf -i


### PR DESCRIPTION
Repeatedly re-running prepare() was causing /usr/bin/patch to brokenly
append 0056-missing-file-toarray-pl.patch's "+" lines to toarray.pl every
time, with a mangled "#!" line half-way through the resultant mess.
Surprisingly, this line noise is invalid Perl syntax.

The broken "#!" line problem was seemingly caused by a lack of the "-n"
flag to echo, but for some reason the redirection itself was not blanking
the file at all. There's some weird underlying bug here, but the workaround
is to remove the previously created file on each prepare().