### PR TITLE
mbedtls: Update to 2.1.2

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.1.1
-pkgrel=2
+pkgver=2.1.2
+pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
 pkgdesc='mbed TLS is an open source and commercial SSL library licensed by ARM Limited. (mingw-w64)'
@@ -19,7 +19,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha1sums=('f4348b730a8731f5ed2bacb458ffa053798cc5ff'
+sha1sums=('c99dfeaa27489f0e74e704e69a181f6ceb3db2a7'
           '72e420d5676007a168a82210dba960bea4e29190'
           'e905d99cacf3b3d91872e8736ff03ef950b32a34'
           '9ce57bb1e9dd0298454b48faa0f1b5317d245cdb')


### PR DESCRIPTION
8 security patches, 1 bugfix
Changelog: https://tls.mbed.org/tech-updates/releases/mbedtls-2.1.2-and-1.3.14-and-polarssl-1.2.17-released

Should I use SHA-256 checksums? I don't know if I SHA-1 is good enough, since `gnutls` and `openssl` package both use PGP key. Upstream doesn't PGP sign their relases.