### PR TITLE
gdk-pixbuf2: enable relocations

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.32.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -51,6 +51,7 @@ build() {
     --enable-static \
     --enable-shared \
     --enable-introspection \
+    --enable-relocations \
     --with-included-loaders
   make
 }


### PR DESCRIPTION
OS-specific auto-detections for this were dropped upstream,
so a configure-time enable flag is needed now.
Without this, the SVG module cannot be loaded correctly at runtime.

Closes Alexpux/MINGW-packages#818.