### PR TITLE
build curl with winssl instead of openssl

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
-_variant=-openssl
-#_variant=-winssl
+#_variant=-openssl
+_variant=-winssl
 #_variant=-gnutls
 
 _realname=curl


### PR DESCRIPTION
The native way on windows is to use the windows certificate store. The main reason here is for corporate networks with active directory it's easy to ship a company root ca. Meaning this root ca is not in the default openssl ca-bundle. 
We disused some aspects of it already here: https://github.com/git-for-windows/git/issues/301

Also I tested a few things with a curl with winssl, which worked flaw less for me. 

**Pro**

* it's native
* it's more like how you expect that it works
* easier for company's 
* (no impact on existing users since not a large number of users use this) _not so sure about that_

**con**

* it's a regression
* it breaks the ca-bundle
* already tried with [msygit]( https://groups.google.com/forum/#!topic/msysgit/VqWArHFoeYU ) and reversed 


My personal standpoint is here to accept the regression since the behavior change is only notable for power users (major git hosting will work regardless github, bitbucket). The disclaimer here is that I use it in a corporate environment, where we have our own root ca.