### PR TITLE
New package: confuse

### DIFF
--- a/mingw-w64-confuse/PKGBUILD
+++ b/mingw-w64-confuse/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: David Grayson <davidegrayson@gmail.com>
+
+_realname=confuse
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.8
+pkgrel=1
+pkgdesc='Library for parsing configuration files (mingw-w64)'
+arch=('any')
+url="https://github.com/martinh/libconfuse"
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gettext")
+options=('staticlibs' 'strip')
+source=(
+  "https://github.com/martinh/libconfuse/releases/download/v${pkgver}/confuse-${pkgver}.tar.xz"
+)
+
+sha256sums=('2a8102bfa3ccc846c14d94a81b0abfb4f5e855809f89ff3722aca1a9f314ea0d')
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  "../${_realname}-${pkgver}/configure" \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --enable-static \
+    --enable-shared \
+    --disable-examples
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  # Note that the license also gets installed in share/doc/confuse along with
+  # other documentation.
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
Thanks to some recent pull requests of mine, this library can be compiled and tested totally fine on MSYS2.  I'm interested in adding an MSYS2 package for it because it is an optional dependency of libftdi, which is an optional dependency of avrdude.

I'm not sure why, but the arch package name is [confuse](https://www.archlinux.org/packages/community/x86_64/confuse/) instead of "libconfuse", so I copied their naming.
