### PR TITLE
gdk-pixbuf2: introspection patch

### DIFF
--- a/mingw-w64-gdk-pixbuf2/0002-gdk-pixbuf-introspection.patch
+++ b/mingw-w64-gdk-pixbuf2/0002-gdk-pixbuf-introspection.patch
@@ -1,119 +1,26 @@
-header files pached for introspection workaround
-
---- gdk-pixbuf/gdk-pixbuf-animation.h	Thu Mar 06 11:36:45 2014
-+++ gdk-pixbuf/gdk-pixbuf-animation.h	Wed May 28 10:48:29 2014
-@@ -62,12 +62,6 @@
- 
- GType               gdk_pixbuf_animation_get_type        (void) G_GNUC_CONST;
- 
--#ifndef __GTK_DOC_IGNORE__
--#ifdef G_OS_WIN32
--#define gdk_pixbuf_animation_new_from_file gdk_pixbuf_animation_new_from_file_utf8
--#endif
--#endif
--
- GdkPixbufAnimation *gdk_pixbuf_animation_new_from_file   (const char         *filename,
-                                                           GError            **error);
- GdkPixbufAnimation *gdk_pixbuf_animation_new_from_stream (GInputStream       *stream,
-@@ -81,6 +75,16 @@
-                                                           GError            **error);
- GdkPixbufAnimation *gdk_pixbuf_animation_new_from_resource(const char        *resource_path,
-                                                           GError            **error);
-+
-+#ifndef __GTK_DOC_IGNORE__
-+#ifdef G_OS_WIN32
-+#define gdk_pixbuf_animation_new_from_file gdk_pixbuf_animation_new_from_file_utf8
-+
-+GdkPixbufAnimation *gdk_pixbuf_animation_new_from_file_utf8   (const char         *filename,
-+                                                          GError            **error);
-+
-+#endif
-+#endif
- 
- #ifndef GDK_PIXBUF_DISABLE_DEPRECATED
- G_DEPRECATED_FOR(g_object_ref)
---- gdk-pixbuf/gdk-pixbuf-core.h	Sat Mar 15 04:09:46 2014
-+++ gdk-pixbuf/gdk-pixbuf-core.h	Wed May 28 10:48:29 2014
-@@ -261,15 +261,6 @@
- 
- /* Simple loading */
- 
--#ifndef __GTK_DOC_IGNORE__
--#ifdef G_OS_WIN32
--/* DLL ABI stability hack. */
--#define gdk_pixbuf_new_from_file gdk_pixbuf_new_from_file_utf8
--#define gdk_pixbuf_new_from_file_at_size gdk_pixbuf_new_from_file_at_size_utf8
--#define gdk_pixbuf_new_from_file_at_scale gdk_pixbuf_new_from_file_at_scale_utf8
--#endif
--#endif
--
- GdkPixbuf *gdk_pixbuf_new_from_file (const char *filename,
-                                      GError    **error);
- GdkPixbuf *gdk_pixbuf_new_from_file_at_size (const char *filename,
-@@ -303,28 +294,64 @@
- 					 gboolean      copy_pixels,
- 					 GError      **error);
- #endif
-+
-+#ifndef __GTK_DOC_IGNORE__
-+#ifdef G_OS_WIN32
-+/* DLL ABI stability hack. */
-+#define gdk_pixbuf_new_from_file gdk_pixbuf_new_from_file_utf8
-+#define gdk_pixbuf_new_from_file_at_size gdk_pixbuf_new_from_file_at_size_utf8
-+#define gdk_pixbuf_new_from_file_at_scale gdk_pixbuf_new_from_file_at_scale_utf8
-+
-+GdkPixbuf *gdk_pixbuf_new_from_file_utf8 (const char *filename,
-+                                     GError    **error);
-+GdkPixbuf *gdk_pixbuf_new_from_file_at_size_utf8 (const char *filename,
-+					     int         width, 
-+					     int         height,
-+					     GError    **error);
-+GdkPixbuf *gdk_pixbuf_new_from_file_at_scale_utf8 (const char *filename,
-+					      int         width, 
-+					      int         height,
-+					      gboolean    preserve_aspect_ratio,
-+					      GError    **error);
-+
-+#endif
-+#endif
-+
- 
- /* Mutations */
- void       gdk_pixbuf_fill              (GdkPixbuf    *pixbuf,
-                                          guint32       pixel);
- 
- /* Saving */
- 
-+gboolean gdk_pixbuf_save           (GdkPixbuf  *pixbuf, 
-+                                    const char *filename, 
-+                                    const char *type, 
-+                                    GError    **error,
-+                                    ...) G_GNUC_NULL_TERMINATED;
-+
-+gboolean gdk_pixbuf_savev          (GdkPixbuf  *pixbuf, 
-+                                    const char *filename, 
-+                                    const char *type,
-+                                    char      **option_keys,
-+                                    char      **option_values,
-+                                    GError    **error);
-+
- #ifndef __GTK_DOC_IGNORE__
- #ifdef G_OS_WIN32
- /* DLL ABI stability hack. */
- #define gdk_pixbuf_save gdk_pixbuf_save_utf8
- #define gdk_pixbuf_savev gdk_pixbuf_savev_utf8
- #endif
- #endif
- 
--gboolean gdk_pixbuf_save           (GdkPixbuf  *pixbuf, 
-+gboolean gdk_pixbuf_save_utf8      (GdkPixbuf  *pixbuf, 
-                                     const char *filename, 
-                                     const char *type, 
+Index: gdk-pixbuf-2.31.1/gdk-pixbuf/gdk-pixbuf-core.h
+===================================================================
+--- gdk-pixbuf-2.31.1/gdk-pixbuf/gdk-pixbuf-core.h
++++ gdk-pixbuf-2.31.1/gdk-pixbuf/gdk-pixbuf-core.h
+@@ -333,6 +333,21 @@ gboolean gdk_pixbuf_save           (GdkP
                                      GError    **error,
                                      ...) G_GNUC_NULL_TERMINATED;
  
--gboolean gdk_pixbuf_savev          (GdkPixbuf  *pixbuf, 
-+gboolean gdk_pixbuf_savev_utf8     (GdkPixbuf  *pixbuf, 
++/**
++ * gdk_pixbuf_savev_utf8:
++ * @pixbuf: a #GdkPixbuf.
++ * @filename: name of file to save.
++ * @type: name of file format.
++ * @option_keys: (array zero-terminated=1): name of options to set, %NULL-terminated
++ * @option_values: (array zero-terminated=1): values for named options
++ * @error: (allow-none): return location for error, or %NULL
++ *
++ * Saves pixbuf to a file in @type, which is currently "jpeg", "png", "tiff", "ico" or "bmp".
++ * If @error is set, %FALSE will be returned.
++ * See gdk_pixbuf_save () for more details.
++ *
++ * Return value: whether an error was set
++ **/
+ gboolean gdk_pixbuf_savev          (GdkPixbuf  *pixbuf, 
                                      const char *filename, 
                                      const char *type,
-                                     char      **option_keys,

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.32.1
-pkgrel=2
+pkgrel=3
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -26,12 +26,12 @@ source=("http://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${
         0002-gdk-pixbuf-introspection.patch)
 sha256sums=('4432b74f25538c7d6bcb3ca51adabdd666168955f25812a2568dc9637697f3bc'
             'e8d278e30c44e973e14e3c61e8ab195621d6a9a402e0da557db4616955ca4543'
-            'c22ce6c4de87c9f6e8b18452a728e4677fac18d2b51d6e536db27160c368f0c6')
+            'dd496d66f0a6b369410fb4039e116ac7d6c2808c97998932a1f8f70b58f88ce2')
 
 prepare() {
   cd ${srcdir}/gdk-pixbuf-${pkgver}
   patch -p1 -i ${srcdir}/0001-Use-a-regex-to-properly-export-the-symbols.patch
-  patch -p0 -i ${srcdir}/0002-gdk-pixbuf-introspection.patch
+  patch -p1 -i ${srcdir}/0002-gdk-pixbuf-introspection.patch
 
   autoreconf -fi
 }
@@ -58,6 +58,11 @@ build() {
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
+  
+  #get rid of "_utf8" sufix in function names
+  sed -i 's/\(<constructor\|method name="\)\(.*\)\(_utf8"\)/\1\2"/' gdk-pixbuf/GdkPixbuf-2.0.gir
+  g-ir-compiler gdk-pixbuf/GdkPixbuf-2.0.gir > gdk-pixbuf/GdkPixbuf-2.0.typelib
+
   make DESTDIR="${pkgdir}" install
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gdk-pixbuf-2.0/2.10.0/loaders
   install -Dm644 "${srcdir}/gdk-pixbuf-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"


### PR DESCRIPTION
This fix utf8 support functions in typelib, without that pixbuf2 can only work with paths which have ascii characters