### PR TITLE
gtk3: backport fixes for notebook tab-drag crashes

### DIFF
--- a/mingw-w64-gtk3/0080-backport-notebook-tab-drag-fixes.patch
+++ b/mingw-w64-gtk3/0080-backport-notebook-tab-drag-fixes.patch
@@ -1,0 +1,41 @@
+diff --git a/gdk/win32/gdkdevice-virtual.c b/gdk/win32/gdkdevice-virtual.c
+index 2ed341f..b947800 100644
+--- a/gdk/win32/gdkdevice-virtual.c
++++ b/gdk/win32/gdkdevice-virtual.c
+@@ -266,10 +266,9 @@ gdk_device_virtual_grab (GdkDevice    *device,
+ 	{
+ 	  if (GetCursor () == GDK_WIN32_CURSOR (_gdk_win32_grab_cursor)->hcursor)
+ 	    SetCursor (NULL);
+-	  g_clear_object (&_gdk_win32_grab_cursor);
+ 	}
+ 
+-      _gdk_win32_grab_cursor = cursor;
++      g_set_object (&_gdk_win32_grab_cursor, cursor);
+ 
+       if (_gdk_win32_grab_cursor != NULL)
+ 	SetCursor (GDK_WIN32_CURSOR (_gdk_win32_grab_cursor)->hcursor);
+@@ -303,9 +302,8 @@ gdk_device_virtual_ungrab (GdkDevice *device,
+ 	{
+ 	  if (GetCursor () == GDK_WIN32_CURSOR (_gdk_win32_grab_cursor)->hcursor)
+ 	    SetCursor (NULL);
+-	  g_clear_object (&_gdk_win32_grab_cursor);
+ 	}
+-      _gdk_win32_grab_cursor = NULL;
++      g_clear_object (&_gdk_win32_grab_cursor);
+ 
+       ReleaseCapture ();
+     }
+diff --git a/gdk/x11/gdkwindow-x11.c b/gdk/x11/gdkwindow-x11.c
+index d08cee0..2ae8105 100644
+--- a/gdk/x11/gdkwindow-x11.c
++++ b/gdk/x11/gdkwindow-x11.c
+@@ -4933,8 +4933,7 @@ finish_drag (MoveResizeData *mv_resize)
+ {
+   gdk_window_destroy (mv_resize->moveresize_emulation_window);
+   mv_resize->moveresize_emulation_window = NULL;
+-  g_object_unref (mv_resize->moveresize_window);
+-  mv_resize->moveresize_window = NULL;
++  g_clear_object (&mv_resize->moveresize_window);
+   g_clear_pointer (&mv_resize->moveresize_pending_event, g_free);
+ }
+ 

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.18.2
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -30,10 +30,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('strip' '!debug' 'staticlibs')
 source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
         0013-fix-mingw-w64-fstat-call.mingw.patch
-        0056-missing-file-toarray-pl.patch)
+        0056-missing-file-toarray-pl.patch
+        0080-backport-notebook-tab-drag-fixes.patch
+)
 md5sums=('230fd78e42419d35ff790784b457e5f2'
          '21789d52c1debcab59f8b6a99232de68'
-         'f25cb2486d761b60e04036947552bf82')
+         'f25cb2486d761b60e04036947552bf82'
+         '8d86218ed960cd86c8b04c987f7038e9'
+)
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
@@ -41,6 +45,8 @@ prepare() {
 
   rm -f gdk/broadway/toarray.pl
   patch -p1 -i ${srcdir}/0056-missing-file-toarray-pl.patch
+
+  patch -Np1 -i ${srcdir}/0080-backport-notebook-tab-drag-fixes.patch
 
   autoreconf -i
 }


### PR DESCRIPTION
Fix some crashes seen when dragging tabs out of a notebook widget.
On the win32 backend, the second or later attempt to drag a tab out of
a GtkNotebook supporting reordering of tabs would segfault.

https://bugzilla.gnome.org/show_bug.cgi?id=756160

This commit backports the upstream fixes below onto GTK 3.18.2.
These will hopefully be incorporated into the release after 3.18.2,
so this commit can be reverted when MINGW-packages builds GTK >= 3.18.3.

1. 00b39e4a82401f407a2df2e2e35a18ede88b41ea
   "W32: Add missing reference taking in gdk_device_virtual_grab()"
2. c8604923598aad745a65ec16eb79113c97649345
   "Clean up handling of _gdk_win32_grab_cursor".
3. 25483304cdc967c374a435200416affb573583f8
   "Minor cleanup. Replace a unref-and-unset combination with g_clear_object."