### PR TITLE
python-setuptools: Update to 18.4.

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 _py3_base=3.5
 _py2_base=2.7
-pkgver=18.3.2
+pkgver=18.4
 pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ source=(http://pypi.python.org/packages/source/s/setuptools/${_realname}-${pkgve
         '0002-Allow-usr-bin-env-in-script.patch'
         '0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch'
         '0004-dont-execute-msvc.patch')
-sha1sums=('7a0c0f378dcb6ffcb863ccd9503a647ff4ad3ae9'
+sha1sums=('ab7964759591adb3c894bd08a086233e15550df1'
           'a26b8313592899ff6e5c18e5a4d489b7d8a6e021'
           '3f475c0510ecaa1ee86412197cb3624ebfba7105'
           '101db3f8acbd116c81ee170adea2b1453ccc709a'


### PR DESCRIPTION
Disclaimer:  I don't fully understand how python-setuptools works and I am having some weird issues where pip thinks that version 18.3.2 is installed, even though I installed my 18.4 package.  However, this pull request only changes a version number and a checksum, and I think it will help out users who try to install pips using the `-U` option, e.g. `pip install -U cryptography`.  I was discussing this problem here:

https://github.com/ARMmbed/yotta_windows_installer/issues/13#issuecomment-149430588