### PR TITLE
Boost 1.59: fix uuid header seed_rng.h MinGW build error.

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.59.0
 _boostver=${pkgver//./_}
-pkgrel=1
+pkgrel=2
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 url="http://www.boost.org/"
@@ -35,6 +35,7 @@ source=(http://downloads.sourceforge.net/sourceforge/boost/boost_${_boostver}.ta
         boost-1.59.0-log.patch
         boost-1.59.0-mingw-serialization.patch
         boost-1.59.0-mingw-context.patch
+        boost-1.59.0-mingw-uuid-seed-rng-header.patch
         boost-include-intrin-h-on-mingw-w64.patch
         using-mingw-w64-python.patch
         msys2-mingw-folders-bootstrap.patch)
@@ -55,15 +56,16 @@ md5sums=('6aa9a5c6a4ca1016edd0ed1178e3cb87'
          '1453e99bb24028e7b299df3ee70b5846'
          'db4ed93452debd15b2cd165c438f9911'
          '349127a0f1bcddfc189c56219bf39853'
+         '8eb226e08b529cdfc9b849d29b11cb14'
          '7f2942e46b6aa6eec02bdde157b8b132'
          'c2aac61b370b321552b5240b9ee7248e'
          '29ffd4b1636e31678fa8e1afa77305eb')
 
 prepare() {
   cd "${srcdir}/boost_${_boostver}"
-  
+
   patch -p1 -i ${srcdir}/boost-1.54.0-bootstrap.patch
-  
+
   # https://svn.boost.org/trac/boost/ticket/6150
   patch -p1 -i ${srcdir}/boost-1.50.0-fix-non-utf8-files.patch
 
@@ -104,18 +106,20 @@ prepare() {
 
   # https://svn.boost.org/trac/boost/ticket/7262
   patch -p0 -i ${srcdir}/boost-1.59.0-mingw-context.patch
-  
+
   # Fix FTBFS on recent mingw-w64 and also use intrinsics based
   # versions of the Interlocked symbols which are better optimized
   patch -p0 -i ${srcdir}/boost-include-intrin-h-on-mingw-w64.patch
-  
+
   # https://github.com/boostorg/serialization/pull/19
   patch -p1 -i ${srcdir}/boost-1.59.0-mingw-serialization.patch
 
   # Use out own build Python
   patch -p1 -i ${srcdir}/using-mingw-w64-python.patch
-  
+
   patch -p1 -i ${srcdir}/msys2-mingw-folders-bootstrap.patch
+
+  patch -p1 -i ${srcdir}/boost-1.59.0-mingw-uuid-seed-rng-header.patch
 }
 
 build() {
@@ -123,9 +127,9 @@ build() {
 
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   lndir "${srcdir}/boost_${_boostver}" "${srcdir}/build-${MINGW_CHOST}"
-  
+
   cd "${srcdir}/build-${MINGW_CHOST}"
-  
+
   echo "using python : 2.7 : ${PREFIX_DEPS}/bin/python2.exe : ${PREFIX_DEPS}/include/python2.7 ;" >> ./tools/build/src/user-config.jam
   echo "using python : 3.5 : ${PREFIX_DEPS}/bin/python3.exe : ${PREFIX_DEPS}/include/python3.5m : ${PREFIX_DEPS}/lib/python3.5/config-3.5m ;" >> ./tools/build/src/user-config.jam
   #echo "using gcc : : ${PREFIX_DEPS}/bin/g++.exe : <rc>${PREFIX_DEPS}/bin/windres.exe ;" >> ./tools/build/src/user-config.jam

--- a/mingw-w64-boost/boost-1.59.0-mingw-uuid-seed-rng-header.patch
+++ b/mingw-w64-boost/boost-1.59.0-mingw-uuid-seed-rng-header.patch
@@ -1,0 +1,18 @@
+--- a/boost/uuid/seed_rng.hpp	Fri May 15 12:55:19 2015
++++ b/boost/uuid/seed_rng.hpp	Tue Oct 20 09:03:44 2015
+@@ -40,11 +40,14 @@
+ #if defined(_MSC_VER)
+ #   pragma warning(push) // Save warning settings.
+ #   pragma warning(disable : 4996) // Disable deprecated std::fopen
++#   pragma comment(lib, "advapi32.lib")
++#endif
++
++#if defined(BOOST_WINDOWS)
+ #   include <boost/detail/winapi/crypt.hpp> // for CryptAcquireContextA, CryptGenRandom, CryptReleaseContext
+ #   include <boost/detail/winapi/timers.hpp>
+ #   include <boost/detail/winapi/process.hpp>
+ #   include <boost/detail/winapi/thread.hpp>
+-#   pragma comment(lib, "advapi32.lib")
+ #else 
+ #   include <sys/time.h>  // for gettimeofday
+ #   include <sys/types.h> // for pid_t


### PR DESCRIPTION
* Add winapi headers when building on windows not just MSVC.  See
  https://github.com/boostorg/uuid/pull/6 for more information.
* Fixes issue #836.
