### PR TITLE
gtk3: backport an upsteam GI syntax fix

### DIFF
--- a/mingw-w64-gtk3/0090-backport-fix-introspection-syntax.patch
+++ b/mingw-w64-gtk3/0090-backport-fix-introspection-syntax.patch
@@ -1,0 +1,24 @@
+From f703ea65995f4c8bd5c7e1c554a36d5ca835067d Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Thu, 22 Oct 2015 11:50:49 -0400
+Subject: win32: Fix introspection syntax
+
+---
+ gdk/win32/gdkdisplay-win32.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk/win32/gdkdisplay-win32.c b/gdk/win32/gdkdisplay-win32.c
+index a98841a..0a47970 100644
+--- a/gdk/win32/gdkdisplay-win32.c
++++ b/gdk/win32/gdkdisplay-win32.c
+@@ -29,7 +29,7 @@
+ /**
+  * gdk_win32_display_set_cursor_theme:
+  * @display: (type GdkWin32Display): a #GdkDisplay
+- * @name: (allow-none) the name of the cursor theme to use, or %NULL to unset
++ * @name: (allow-none): the name of the cursor theme to use, or %NULL to unset
+  *         a previously set value
+  * @size: the cursor size to use, or 0 to keep the previous size
+  *
+-- 
+cgit v0.11.2

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.18.2
-pkgrel=2
+pkgrel=3
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -32,11 +32,13 @@ source=("http://ftp.gnome.org/pub/gnome/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}
         0013-fix-mingw-w64-fstat-call.mingw.patch
         0056-missing-file-toarray-pl.patch
         0080-backport-notebook-tab-drag-fixes.patch
+        0090-backport-fix-introspection-syntax.patch
 )
 md5sums=('230fd78e42419d35ff790784b457e5f2'
          '21789d52c1debcab59f8b6a99232de68'
          'f25cb2486d761b60e04036947552bf82'
          '8d86218ed960cd86c8b04c987f7038e9'
+         '664ce09ba116bda6207ff2ef898392fa'
 )
 
 prepare() {
@@ -47,6 +49,8 @@ prepare() {
   patch -p1 -i ${srcdir}/0056-missing-file-toarray-pl.patch
 
   patch -Np1 -i ${srcdir}/0080-backport-notebook-tab-drag-fixes.patch
+
+  patch -Np1 -i ${srcdir}/0090-backport-fix-introspection-syntax.patch
 
   autoreconf -i
 }


### PR DESCRIPTION
Backport upstream's fix for a syntax error (missing colon) in the annotations.

https://git.gnome.org/browse/gtk+/commit/?id=f703ea65995f4c8bd5c7e1c554a36d5ca835067d

This doesn't address Alexpux/MINGW-packages#845, but it's probably worth having in our builds.