### PR TITLE
SDL*_mixer: help ./configure find shared libraries for dynamic loading

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -18,13 +18,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-fluidsynth")
 options=('staticlibs' 'strip')
 noextract=(${_realname}-${pkgver}.tar.gz)
-source=("$url/release/${_realname}-${pkgver}.tar.gz")
-md5sums=('65f6d80df073a1fb3bb537fbda031b50')
+source=("$url/release/${_realname}-${pkgver}.tar.gz"
+        SDL2_mixer-find_lib.mingw.patch)
+md5sums=('65f6d80df073a1fb3bb537fbda031b50'
+         'c891fc5d73238c85ff42cfe31213da7b')
 
 prepare() {
   [[ -d ${srcdir}/${_realname}-${pkgver} ]] || tar -xzvf ${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
 
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -Np1 -i ${srcdir}/SDL2_mixer-find_lib.mingw.patch
 
   sed -i "s|/etc/timidity|/etc/timidity++|g" timidity/config.h
   sed -i "s|/etc/timidity++.cfg|/etc/timidity++/timidity.cfg|g" timidity/config.h

--- a/mingw-w64-SDL2_mixer/SDL2_mixer-find_lib.mingw.patch
+++ b/mingw-w64-SDL2_mixer/SDL2_mixer-find_lib.mingw.patch
@@ -1,0 +1,101 @@
+diff --git a/configure b/configure
+index 878381b..be39a38 100755
+--- a/configure
++++ b/configure
+@@ -11143,13 +11143,14 @@ find_lib()
+     gcc_bin_path=`$CC -print-search-dirs 2>/dev/null | fgrep programs: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`
+     gcc_lib_path=`$CC -print-search-dirs 2>/dev/null | fgrep libraries: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`
+     env_lib_path=`echo $LIBS $LDFLAGS $* | sed 's/-L[ ]*//g'`
++    env_path=`echo $PATH | sed 's/:/ /g'`
+     if test "$cross_compiling" = yes; then
+         host_lib_path=""
+     else
+         host_lib_path="/usr/$base_libdir /usr/local/$base_libdir"
+     fi
+-    for path in $gcc_bin_path $gcc_lib_path $env_lib_path $host_lib_path; do
+-        lib=`ls -- $path/$1 2>/dev/null | sed -e '/\.so\..*\./d' -e 's,.*/,,' | sort | tail -1`
++    for path in $gcc_bin_path $gcc_lib_path $env_lib_path $env_path $host_lib_path; do
++        lib=`ls -- $path/$1 2>/dev/null | sort | sed 's/.*\/\(.*\)/\1/; q'`
+         if test x$lib != x; then
+             echo $lib
+             return
+@@ -11938,7 +11939,7 @@ fi
+             *-*-darwin*)
+                 modplug_lib=`find_lib libmodplug.dylib`
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 modplug_lib=`find_lib "libmodplug*.dll"`
+                 ;;
+             *)
+@@ -12070,7 +12071,7 @@ fi
+             *-*-darwin*)
+                 mikmod_lib=`find_lib libmikmod.dylib`
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 mikmod_lib=`find_lib "libmikmod*.dll"`
+                 ;;
+             *)
+@@ -12132,7 +12133,7 @@ fi
+             *mingw32ce*)
+                 use_music_midi_native=no
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 use_music_midi_native=yes
+                 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lwinmm"
+                 ;;
+@@ -12221,8 +12222,11 @@ fi
+                 *-*-darwin*)
+                     fluidsynth_lib=`find_lib libfluidsynth.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     fluidsynth_lib=`find_lib "fluidsynth*.dll"`
++                    if test x$fluidsynth_lib = x; then
++                        fluidsynth_lib=`find_lib "libfluidsynth*.dll"`
++                    fi
+                     ;;
+                 *)
+                     fluidsynth_lib=`find_lib "libfluidsynth[0-9]*.so.*"`
+@@ -12331,8 +12335,11 @@ fi
+                 *-*-darwin*)
+                     ogg_lib=`find_lib libvorbisidec.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=`find_lib "vorbisidec*.dll"`
++                    if test x$ogg_lib = x; then
++                        ogg_lib=`find_lib "libvorbisidec*.dll"`
++                    fi
+                     ;;
+                 *)
+                     ogg_lib=`find_lib "libvorbisidec[0-9]*.so.*"`
+@@ -12409,7 +12416,7 @@ fi
+                 *-*-darwin*)
+                     ogg_lib=`find_lib libvorbisfile.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=`find_lib "libvorbisfile*.dll"`
+                     ;;
+                 *)
+@@ -12545,7 +12552,7 @@ fi
+                 *-*-darwin*)
+                     flac_lib=`find_lib libFLAC.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     flac_lib=`find_lib "libFLAC-*.dll"`
+                     ;;
+                 *)
+@@ -12841,7 +12848,7 @@ rm -f core conftest.err conftest.$ac_objext \
+             *-*-darwin*)
+                 smpeg_lib=`find_lib libsmpeg2.dylib`
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 smpeg_lib=`find_lib "smpeg2*.dll"`
+                 ;;
+             *)

--- a/mingw-w64-SDL_mixer/PKGBUILD
+++ b/mingw-w64-SDL_mixer/PKGBUILD
@@ -22,12 +22,14 @@ source=(http://www.libsdl.org/projects/SDL_mixer/release/${_realname}-${pkgver}.
         mikmod1.patch
         mikmod2.patch
         fluidsynth-volume.patch
-        double-free-crash.patch)
+        double-free-crash.patch
+        SDL_mixer-find_lib.mingw.patch)
 md5sums=('e03ff73d77a55e3572ad0217131dc4a1'
          'c335d4ff1fe86950d1fc730745c9c96d'
          'd13d98fef8ec51167a370fa7976a7a7f'
          'eceb06e3a8b31fee300d7f33478401d4'
-         'b38c1b23751ca95631badeb9327d085e')
+         'b38c1b23751ca95631badeb9327d085e'
+         'a116f6c880aae14d2a1657447bdbd81e')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -40,6 +42,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/mikmod2.patch
   patch -Np1 -i ${srcdir}/fluidsynth-volume.patch
   patch -Np1 -i ${srcdir}/double-free-crash.patch
+  patch -Np1 -i ${srcdir}/SDL_mixer-find_lib.mingw.patch
 
   #sed -e "/CONFIG_FILE_ETC/s|/etc/timidity.cfg|/etc/timidity++/timidity.cfg|" \
   #    -e "/DEFAULT_PATH/s|/etc/timidity|/etc/timidity++|" \

--- a/mingw-w64-SDL_mixer/SDL_mixer-find_lib.mingw.patch
+++ b/mingw-w64-SDL_mixer/SDL_mixer-find_lib.mingw.patch
@@ -1,0 +1,90 @@
+diff --git a/configure b/configure
+index e7c8c97..f6b9ad1 100755
+--- a/configure
++++ b/configure
+@@ -11850,12 +11850,13 @@ find_lib()
+     gcc_bin_path=`$CC -print-search-dirs 2>/dev/null | fgrep programs: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`
+     gcc_lib_path=`$CC -print-search-dirs 2>/dev/null | fgrep libraries: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`
+     env_lib_path=`echo $LIBS $LDFLAGS $* | sed 's/-L[ ]*//g'`
++    env_path=`echo $PATH | sed 's/:/ /g'`
+     if test "$cross_compiling" = yes; then
+         host_lib_path=""
+     else
+         host_lib_path="/usr/$base_libdir /usr/local/$base_libdir"
+     fi
+-    for path in $gcc_bin_path $gcc_lib_path $env_lib_path $host_lib_path; do
++    for path in $gcc_bin_path $gcc_lib_path $env_lib_path $env_path $host_lib_path; do
+         lib=`ls -- $path/$1 2>/dev/null | sort | sed 's/.*\/\(.*\)/\1/; q'`
+         if test x$lib != x; then
+             echo $lib
+@@ -12727,7 +12728,7 @@ fi
+             *-*-darwin*)
+                 mikmod_lib=`find_lib libmikmod.dylib`
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 mikmod_lib=`find_lib "libmikmod*.dll"`
+                 ;;
+             *)
+@@ -12916,7 +12917,7 @@ fi
+             *mingw32ce*)
+                 use_music_native_midi=no
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 use_music_native_midi=yes
+                 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lwinmm"
+                 ;;
+@@ -13159,8 +13160,11 @@ fi
+                         fluidsynth_lib=`find_lib libfluidsynth.[0-9]*`
+                     fi
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     fluidsynth_lib=`find_lib "fluidsynth*.dll"`
++                    if test x$fluidsynth_lib = x; then
++                        fluidsynth_lib=`find_lib "libfluidsynth*.dll"`
++                    fi
+                     ;;
+                 *)
+                     fluidsynth_lib=`find_lib "libfluidsynth.so.[0-9]"`
+@@ -13415,8 +13419,11 @@ fi
+                         ogg_lib=`find_lib libvorbisidec.[0-9]*`
+                     fi
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=`find_lib "vorbisidec*.dll"`
++                    if test x$ogg_lib = x; then
++                        ogg_lib=`find_lib "libvorbisidec*.dll"`
++                    fi
+                     ;;
+                 *)
+                     ogg_lib=`find_lib "libvorbisidec.so.[0-9]"`
+@@ -13640,7 +13647,7 @@ fi
+                 *-*-darwin*)
+                     ogg_lib=`find_lib libvorbisfile.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=`find_lib "libvorbisfile*.dll"`
+                     ;;
+                 *)
+@@ -14073,7 +14080,7 @@ fi
+                 *-*-darwin*)
+                     flac_lib=`find_lib libFLAC.dylib`
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     flac_lib=`find_lib "libFLAC*.dll"`
+                     ;;
+                 *)
+@@ -14649,7 +14656,7 @@ rm -f core conftest.err conftest.$ac_objext conftest_ipa8_conftest.oo \
+             *-*-darwin*)
+                 smpeg_lib=`find_lib libsmpeg.dylib`
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 smpeg_lib=`find_lib "smpeg*.dll"`
+                 ;;
+             *)


### PR DESCRIPTION
This avoids hard dependencies against the libraries providing the
music backends (with the exception of libmad). Instead, if the
libraries are found in the search path, they are loaded as plug-ins at
run-time.

Fixes https://github.com/Alexpux/MINGW-packages/issues/865

First, the ./configure script did check only for $host being
*-mingw32*, so it skipped the relevant parts for $host=*-mingw64*.

Then, the ./configure script did check for the wrong library names for
both libfluidsynth*.dll and ibvorbisidec*.dll.

Finally, the find_lib() function in the ./configure script searched
for the shared libraries in the wrong directories. Fixed this by
adding $PATH to the search paths.