### PR TITLE
SDL*_mixer: build against libmad instead of smpeg

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libmodplug"
-         "${MINGW_PACKAGE_PREFIX}-smpeg2"
+         "${MINGW_PACKAGE_PREFIX}-libmad"
          "${MINGW_PACKAGE_PREFIX}-flac"
          "${MINGW_PACKAGE_PREFIX}-fluidsynth")
 options=('staticlibs' 'strip')
@@ -39,7 +39,10 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static
+    --enable-static \
+    --enable-music-mp3 \
+    --disable-music-mp3-smpeg \
+    --enable-music-mp3-mad-gpl
 
   make
 }

--- a/mingw-w64-SDL_mixer/PKGBUILD
+++ b/mingw-w64-SDL_mixer/PKGBUILD
@@ -12,7 +12,7 @@ license=('custom')
 depends=("${MINGW_PACKAGE_PREFIX}-SDL"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libmikmod"
-         "${MINGW_PACKAGE_PREFIX}-smpeg"
+         "${MINGW_PACKAGE_PREFIX}-libmad"
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -56,7 +56,9 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static
+    --enable-static \
+    --disable-music-mp3 \
+    --enable-music-mp3-mad-gpl
 
   make
 }


### PR DESCRIPTION
Build the SDL*_mixer libraries against libmad instead of smpeg for
MP3 playback. The libmad backend is much more popular and the smpeg
backend reportedly caused issues for e.g. Doom Retro:
bradharding/doomretro@fda2fe3 .

Fixes https://github.com/Alexpux/MINGW-packages/issues/863

NB: The libmad library is licensed under the GPL, so linking against
this dependency will effectively turn the whole SDL*_mixer libraries
GPL licensed.

NB2: Should we ever have to autoreconf the source tree, we might want
to add the dependency on *-smpeg back (though unused) for the mere
presence of the macros in the smpeg.m4 file.