### PR TITLE
glib2: update to version 2.46.2

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.46.1
+pkgver=2.46.2
 pkgrel=1
 url="http://www.gtk.org/"
 arch=('any')
@@ -28,7 +28,7 @@ source=("http://ftp.gnome.org/pub/GNOME/sources/glib/${pkgver%.*}/glib-${pkgver}
         0027-no_sys_if_nametoindex.patch
         0028-inode_directory.patch
         0029-grand.all.patch)
-md5sums=('c90e93ceb45100ffc1d40ec5d2ca3248'
+md5sums=('7f815d6e46df68e070cb421ed7f1139e'
          '10cf1e482b6a1367d79648466f2cf23c'
          '27e8188e764eed3b3d565e5fc5746654'
          'b3cf766d5e717010a7534c61e53f3204'


### PR DESCRIPTION
This also fixes a segfault with 32bit applications.