### PR TITLE
mbedtls: Updated to 2.2.0

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.1.2
+pkgver=2.2.0
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
@@ -19,10 +19,10 @@ source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha1sums=('c99dfeaa27489f0e74e704e69a181f6ceb3db2a7'
-          '72e420d5676007a168a82210dba960bea4e29190'
-          'e905d99cacf3b3d91872e8736ff03ef950b32a34'
-          '9ce57bb1e9dd0298454b48faa0f1b5317d245cdb')
+sha256sums=('3c6d3487ab056da94450cf907afc84f026aff7880182baffe137c98e3d00fb55'
+            '5c5382ff266e5cc293f31a46e1f10782c765c5cc1476dfc21d5c4ad405f647a0'
+            '89eb82f9e9fb456d0595035925d2d512aa2ca9b9e283b9c51d5524bfc8dbf996'
+            '1be88267b045a8728fe4dde663faf328ad788eeefcb43915beeb364b4d2dd2e8')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -39,7 +39,6 @@ build() {
     BUILD_TYPE="Debug"
   fi
   
-  # Build static libs
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST}
   cd ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
64bit builds ok, but I am having trouble building `mingw32` build, but it seems that its a local problem:
```
-- Check for working C compiler: G:/msys64/mingw32/bin/i686-w64-mingw32-gcc.exe -- broken
CMake Error at G:/msys64/mingw32/share/cmake-3.3/Modules/CMakeTestCCompiler.cmake:61 (message):
  The C compiler "G:/msys64/mingw32/bin/i686-w64-mingw32-gcc.exe" is not able
  to compile a simple test program.

  It fails with the following output:

   Change Dir: D:/MINGW-packages/mingw-w64-mbedtls/src/build-i686-w64-mingw32/CMakeFiles/CMakeTmp

  

  Run Build Command:"G:/msys64/usr/bin/make.exe" "cmTC_cfdd6/fast"

  /usr/bin/make -f CMakeFiles/cmTC_cfdd6.dir/build.make
  CMakeFiles/cmTC_cfdd6.dir/build

        0 [main] make 7444 G:\msys64\usr\bin\make.exe: *** fatal error in forked process - fork: can't reserve memory for parent stack 0x600000 - 0x800000, (child has 0x400000 - 0x600000), Win32 error 487
      326 [main] make 7444 cygwin_exception::open_stackdumpfile: Dumping stack trace to make.exe.stackdump
        0 [main] make 7672 fork: child -1 - forked process 7444 died unexpectedly, retry 0, exit code 0x100, errno 11

  make: fork: Resource temporarily unavailable
```
Tried rebooting, didn't help. I have 64bit MSYS.