### PR TITLE
Add packages for pycparser and cffi Python modules.

### DIFF
--- a/mingw-w64-python-cffi/001-compile-and-setup-fixes.patch
+++ b/mingw-w64-python-cffi/001-compile-and-setup-fixes.patch
@@ -1,0 +1,23 @@
+diff -r 0c0093754b62 c/misc_win32.h
+--- a/c/misc_win32.h	Tue Nov 17 10:36:39 2015 +0100
++++ b/c/misc_win32.h	Wed Nov 18 10:34:34 2015 +0100
+@@ -238,4 +238,3 @@
+ /************************************************************/
+ /* obscure */
+ 
+-#define ffi_prep_closure(a,b,c,d)  ffi_prep_closure_loc(a,b,c,d,a)
+diff -r 0c0093754b62 setup.py
+--- a/setup.py	Tue Nov 17 10:36:39 2015 +0100
++++ b/setup.py	Wed Nov 18 10:34:34 2015 +0100
+@@ -86,10 +86,7 @@
+         os.environ.get('PKG_CONFIG_PATH', '') + ':' + pkgconfig)
+ 
+ 
+-if sys.platform == 'win32':
+-    COMPILE_LIBFFI = 'c/libffi_msvc'    # from the CPython distribution
+-else:
+-    COMPILE_LIBFFI = None
++COMPILE_LIBFFI = None
+ 
+ if COMPILE_LIBFFI:
+     assert os.path.isdir(COMPILE_LIBFFI), "directory not found!"

--- a/mingw-w64-python-cffi/PKGBUILD
+++ b/mingw-w64-python-cffi/PKGBUILD
@@ -1,0 +1,65 @@
+# Contributor: Frederic Wang <fred.wang@free.fr>
+
+_realname=cffi
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.3.0
+pkgrel=1
+pkgdesc='C Foreign Function Interface for Python (mingw-w64)'
+arch=('any')
+url='http://cffi.readthedocs.org/en/latest/'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-pycparser"
+             "${MINGW_PACKAGE_PREFIX}-python3-pycparser")
+source=("https://pypi.python.org/packages/source/c/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('9daa53aff0b5cf64c85c10eab7ce6776880d0ee71b78cedeae196ae82b6734e9')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 < "${startdir}"/001-compile-and-setup-fixes.patch
+  cd "${srcdir}"
+  cp -r ${_realname}-${pkgver} python2-build
+  cp -r ${_realname}-${pkgver} python3-build
+}
+
+package_python3-cffi() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd ${srcdir}/python3-build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-cffi() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd ${srcdir}/python2-build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-cffi() {
+  package_python2-cffi
+}
+
+package_mingw-w64-i686-python3-cffi() {
+  package_python3-cffi
+}
+
+package_mingw-w64-x86_64-python2-cffi() {
+  package_python2-cffi
+}
+
+package_mingw-w64-x86_64-python3-cffi() {
+  package_python3-cffi
+}

--- a/mingw-w64-python-pycparser/PKGBUILD
+++ b/mingw-w64-python-pycparser/PKGBUILD
@@ -1,0 +1,59 @@
+# Contributor: Frederic Wang <fred.wang@free.fr>
+
+_realname=pycparser
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=2.14
+pkgrel=1
+pkgdesc='Complete parser of the C language, written in pure Python (mingw-w64)'
+arch=('any')
+url='https://github.com/eliben/pycparser'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2")
+source=("https://pypi.python.org/packages/source/p/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73')
+
+prepare() {
+  cd "${srcdir}"
+  cp -r ${_realname}-${pkgver} python2-build
+  cp -r ${_realname}-${pkgver} python3-build
+}
+
+package_python3-pycparser() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd ${srcdir}/python3-build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-pycparser() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd ${srcdir}/python2-build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-pycparser() {
+  package_python2-pycparser
+}
+
+package_mingw-w64-i686-python3-pycparser() {
+  package_python3-pycparser
+}
+
+package_mingw-w64-x86_64-python2-pycparser() {
+  package_python2-pycparser
+}
+
+package_mingw-w64-x86_64-python3-pycparser() {
+  package_python3-pycparser
+}


### PR DESCRIPTION
In my attempt to run buildbot with MSYS2, I found that there is a plan to replace pywin32 with cffi:

https://twistedmatrix.com/trac/ticket/7477

As a consequence, I've prepared some PKGBUILD for cffi and (its dependency) pycparser ; even if I'll continue to explore the pywin32 way. I have not really tested these Python packages, but at least the cffi demo for Windows seems to work (copying some text into the clipboard).

cffi needed a small patch to use the libffi, but the ifdef / sys.platform definitions on http://sourceforge.net/p/msys2/wiki/Contributing%20to%20MSYS2/ do not seem to help distinguishing with the case where MSVC.