### PR TITLE
Add packages for zope.event and zope.interface Python modules #893

### DIFF
--- a/mingw-w64-python-zope.event/PKGBUILD
+++ b/mingw-w64-python-zope.event/PKGBUILD
@@ -1,0 +1,57 @@
+# Contributor: Frederic Wang <fred.wang@free.fr>
+
+_realname=zope.event
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=4.1.0
+pkgrel=1
+pkgdesc='Very basic event publishing system (mingw-w64)'
+url='http://pypi.python.org/pypi/zope.event'
+license=('ZPL 2.1')
+arch=('any')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+source=("https://pypi.python.org/packages/source/z/${_realname}/${_realname}-${pkgver}.tar.gz")
+md5sums=('82abb495b6eb2ad196a1a94948674ec0')
+
+prepare() {
+  cd ${srcdir}
+  cp -r ${_realname}-${pkgver} build-python2
+  cp -r ${_realname}-${pkgver} build-python3
+}
+
+package_python3-zope.event() {
+  cd ${srcdir}/build-python3
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-zope.event() {
+  cd ${srcdir}/build-python2
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-zope.event() {
+  package_python2-zope.event
+}
+
+package_mingw-w64-i686-python3-zope.event() {
+  package_python3-zope.event
+}
+
+package_mingw-w64-x86_64-python2-zope.event() {
+  package_python2-zope.event
+}
+
+package_mingw-w64-x86_64-python3-zope.event() {
+  package_python3-zope.event
+}

--- a/mingw-w64-python-zope.interface/PKGBUILD
+++ b/mingw-w64-python-zope.interface/PKGBUILD
@@ -1,0 +1,57 @@
+# Contributor: Frederic Wang <fred.wang@free.fr>
+
+_realname=zope.interface
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=4.1.3
+pkgrel=1
+pkgdesc='Interfaces for Python (mingw-w64)'
+url=' https://github.com/zopefoundation/zope.interface'
+license=('ZPL 2.1')
+arch=('any')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+source=("https://pypi.python.org/packages/source/z/${_realname}/${_realname}-${pkgver}.tar.gz")
+md5sums=('9ae3d24c0c7415deb249dd1a132f0f79')
+
+prepare() {
+  cd ${srcdir}
+  cp -r ${_realname}-${pkgver} build-python2
+  cp -r ${_realname}-${pkgver} build-python3
+}
+
+package_python3-zope.interface() {
+  cd ${srcdir}/build-python3
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-zope.interface() {
+  cd ${srcdir}/build-python2
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-zope.interface() {
+  package_python2-zope.interface
+}
+
+package_mingw-w64-i686-python3-zope.interface() {
+  package_python3-zope.interface
+}
+
+package_mingw-w64-x86_64-python2-zope.interface() {
+  package_python2-zope.interface
+}
+
+package_mingw-w64-x86_64-python3-zope.interface() {
+  package_python3-zope.interface
+}


### PR DESCRIPTION
zope.interface is required for python.twisted (and I used zope.event to run the tests)