### PR TITLE
clang: Removed -DLLVM_ENABLE_THREADS=0 as it is causing segmentation fault w…

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -14,7 +14,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          )
 pkgver=3.7.0
-pkgrel=7
+pkgrel=8
 pkgdesc="LC language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="http://llvm.org"
@@ -79,7 +79,7 @@ sha256sums=('ab45895f9dcdad1e140a3a79fd709f64b05ad7364e308c0e582c5b02e9cc3153'
             '8f35b80eca6c18df020b176eee4eb95901c31e3e640848a6d606983aca15a3af'
             '962b4de1afa781ee171f71211518c58f6a3531d7fcca5ec458e39703b0fb9af7'
             'f7bc109b07b5256a068dbe55097c24b46307aea442bec884d8ba455dc3ad18fd'
-            'e0f4127df5857af667a9e40e2a7a13877352b89c99f3213b491215bf7bd03565'
+            '59e7afa5e74d186ad596c9a7625d6022fde0679faea9d1fd516fe0a622dbc01a'
             '47fbe90718742d1a3c0aee919b159241e616738447de3505a48a9f5886e5db96'
             '421befbe54123066544f53876c7eb6013ac6684744d8173fb0a3fa9be16d68c7'
             '96a6fcd81b8d5134b4273a2e413cd268430022533f1bfb44ed73503ee0ae7e87'
@@ -191,7 +191,6 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_TARGETS_TO_BUILD="ARM;CppBackend;X86" \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
-    -DLLVM_ENABLE_THREADS=0 \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python2.exe \
     -DLLVM_ENABLE_FFI=ON \
     -DLLVM_ENABLE_SPHINX=ON \


### PR DESCRIPTION
…hen performing multithreaded libclang parsing, and fixed a sha256sum.