### PR TITLE
c-ares: Added validpgpkeys.  Fixes #888.

### DIFF
--- a/mingw-w64-c-ares/PKGBUILD
+++ b/mingw-w64-c-ares/PKGBUILD
@@ -12,6 +12,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=(strip staticlibs)
 source=("http://c-ares.haxx.se/download/${_realname}-${pkgver}.tar.gz"{,.asc}
         0001-Use-RPM-compiler-options.patch)
+validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')
 sha1sums=('e44e6575d5af99cb3a38461486e1ee8b49810eb5'
           'SKIP'
           '7e1c721c5f4efd49db998209eaa9b80bea1a9819')


### PR DESCRIPTION
Adding this `validpgpkeys` entry allows makepkg to successfully verify all the source files.  I did *not* securely verify that this is the right key to use because the c-ares project doesn't make it easy to do so.

By the way, I got the full fingerprint by running:

~~~~
gpg --recv-keys 78E11C6B279D5C91
gpg --list-keys --fingerprint 78E11C6B279D5C91
~~~~