### PR TITLE
We use gtk2 for windows, so we need a buildin ime for windows

### DIFF
--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -83,7 +83,8 @@ build() {
     --enable-static \
     --enable-shared \
     --enable-introspection \
-    --disable-glibtest
+    --disable-glibtest \
+    --with-included-immodules=ime
 
   make
 }


### PR DESCRIPTION
Native input method interface is necessary for other language.
And If you use Windows 8 or later without this module, gtk2 will crash when system input method was set Chinese, Japanese or others. 