### PR TITLE
We use gtk2 for windows, so we need a buildin ime for windows

### DIFF
--- a/mingw-w64-gdl2/001-pixbuf.patch
+++ b/mingw-w64-gdl2/001-pixbuf.patch
@@ -1,0 +1,370 @@
+diff -rup gdl-2.31.2/gdl/gdl-dock-bar.c gdl-2.31.2-ricky/gdl/gdl-dock-bar.c
+--- gdl-2.31.2/gdl/gdl-dock-bar.c	2010-05-02 20:03:06.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-bar.c	2013-07-01 15:25:01.795260400 +0800
+@@ -269,6 +269,7 @@ gdl_dock_bar_add_item (GdlDockBar  *dock
+     GtkWidget *button;
+     gchar *stock_id;
+     gchar *name;
++	GdkPixbuf *pixbuf_icon;
+     GtkWidget *image, *box, *label;
+ 
+     g_return_if_fail (GDL_IS_DOCK_BAR (dockbar));
+@@ -293,6 +294,8 @@ gdl_dock_bar_add_item (GdlDockBar  *dock
+         box = gtk_vbox_new (FALSE, 0);
+     
+     g_object_get (item, "stock-id", &stock_id, "long-name", &name, NULL);
++	g_object_get (item, "stock-id", &stock_id, "pixbuf-icon", &pixbuf_icon,
++					"long-name", &name, NULL);
+ 
+     if (dockbar->_priv->dockbar_style == GDL_DOCK_BAR_TEXT ||
+         dockbar->_priv->dockbar_style == GDL_DOCK_BAR_BOTH) {
+@@ -311,7 +314,9 @@ gdl_dock_bar_add_item (GdlDockBar  *dock
+             image = gtk_image_new_from_stock (stock_id,
+                                               GTK_ICON_SIZE_SMALL_TOOLBAR);
+             g_free (stock_id);
+-        } else {
++        } else if(pixbuf_icon){
++			image = gtk_image_new_from_pixbuf (pixbuf_icon);
++		}else {
+             image = gtk_image_new_from_stock (GTK_STOCK_NEW,
+                                               GTK_ICON_SIZE_SMALL_TOOLBAR);
+         }
+diff -rup gdl-2.31.2/gdl/gdl-dock-item.c gdl-2.31.2-ricky/gdl/gdl-dock-item.c
+--- gdl-2.31.2/gdl/gdl-dock-item.c	2010-05-03 03:53:28.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-item.c	2013-07-02 09:33:19.280291200 +0800
+@@ -177,6 +177,7 @@ struct _GdlDockItemPrivate {
+     gboolean  intern_tab_label;
+     guint     notify_label;
+     guint     notify_stock_id;
++	guint     notify_pixbuf_icon;
+ 
+     gint       preferred_width;
+     gint       preferred_height;
+@@ -444,11 +445,21 @@ on_stock_id_changed (GObject* item,
+                       gpointer user_data)
+ {
+     gchar* stock_id;
+-    g_object_get (item, "stock_id", &stock_id, NULL);
++    g_object_get (item, "stock-id", &stock_id, NULL);
+     gtk_image_set_from_stock (GTK_IMAGE (user_data), stock_id, GTK_ICON_SIZE_MENU);
+     g_free(stock_id);
+ }
+ 
++static void
++on_pixbuf_icon_changed (GObject* item,
++                      GParamSpec* spec,
++                      gpointer user_data)
++{
++    GdkPixbuf* pixbuf_icon;
++    g_object_get (item, "pixbuf-icon", &pixbuf_icon, NULL);
++	gtk_image_set_from_pixbuf(GTK_IMAGE (user_data), pixbuf_icon);
++}
++
+ static GObject *
+ gdl_dock_item_constructor (GType                  type,
+                            guint                  n_construct_properties,
+@@ -469,6 +480,7 @@ gdl_dock_item_constructor (GType
+         GtkWidget *icon;
+         gchar* long_name;
+         gchar* stock_id;
++		GdkPixbuf *pixbuf_icon;
+ 
+         if (GDL_DOCK_ITEM_HAS_GRIP (item)) {
+             item->_priv->grip_shown = TRUE;
+@@ -481,6 +493,8 @@ gdl_dock_item_constructor (GType
+         }
+ 
+         g_object_get (g_object, "long-name", &long_name, "stock-id", &stock_id, NULL);
++		g_object_get (g_object, "long-name", &long_name, "stock-id", &stock_id,
++					"pixbuf-icon", &pixbuf_icon,NULL);
+ 
+         hbox = gtk_hbox_new (FALSE, 5);    
+         label = gtk_label_new (long_name);
+@@ -488,6 +502,9 @@ gdl_dock_item_constructor (GType
+         if (stock_id)
+             gtk_image_set_from_stock (GTK_IMAGE (icon), stock_id, 
+                                       GTK_ICON_SIZE_MENU);
++		else if(pixbuf_icon)
++			gtk_image_set_from_pixbuf (GTK_IMAGE (icon), pixbuf_icon);
++
+         gtk_box_pack_start (GTK_BOX (hbox), icon, FALSE, FALSE, 0);
+         gtk_box_pack_start (GTK_BOX (hbox), label, FALSE, FALSE, 0);
+ 
+@@ -497,6 +514,9 @@ gdl_dock_item_constructor (GType
+         item->_priv->notify_stock_id = 
+             g_signal_connect (item, "notify::stock-id", G_CALLBACK (on_stock_id_changed),
+                               icon);
++		item->_priv->notify_pixbuf_icon = 
++            g_signal_connect (item, "notify::pixbuf-icon", G_CALLBACK (on_pixbuf_icon_changed),
++                              icon);
+         
+         gtk_widget_show_all (hbox);
+         
+@@ -1722,6 +1742,28 @@ gdl_dock_item_new_with_stock (const gcha
+     return GTK_WIDGET (item);
+ }
+ 
++GtkWidget *
++gdl_dock_item_new_with_pixbuf_icon (const gchar         *name,
++                                    const gchar         *long_name,
++                                    const GdkPixbuf     *pixbuf_icon,
++                                    GdlDockItemBehavior  behavior)
++{
++    GdlDockItem *item;
++
++    item = GDL_DOCK_ITEM (g_object_new (GDL_TYPE_DOCK_ITEM, 
++                                        "name", name, 
++                                        "long-name", long_name,
++                                        "pixbuf-icon", pixbuf_icon,
++                                        "behavior", behavior,
++                                        NULL));
++
++    GDL_DOCK_OBJECT_UNSET_FLAGS (item, GDL_DOCK_AUTOMATIC);
++    gdl_dock_item_set_tablabel (item, gtk_label_new (long_name));
++
++    return GTK_WIDGET (item);
++}
++
++
+ /* convenient function (and to preserve source compat) */
+ /**
+  * gdl_dock_item_dock_to:
+@@ -1842,6 +1884,7 @@ gdl_dock_item_set_tablabel (GdlDockItem
+         item->_priv->intern_tab_label = FALSE;
+         g_signal_handler_disconnect (item, item->_priv->notify_label);        
+         g_signal_handler_disconnect (item, item->_priv->notify_stock_id);
++		g_signal_handler_disconnect (item, item->_priv->notify_pixbuf_icon);
+     }
+     
+     if (item->_priv->tab_label) {
+diff -rup gdl-2.31.2/gdl/gdl-dock-item.h gdl-2.31.2-ricky/gdl/gdl-dock-item.h
+--- gdl-2.31.2/gdl/gdl-dock-item.h	2010-04-11 21:26:30.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-item.h	2013-07-01 15:30:01.489563500 +0800
+@@ -142,6 +142,12 @@ GtkWidget     *gdl_dock_item_new_with_st
+                                                 const gchar         *stock_id,
+                                                 GdlDockItemBehavior  behavior);
+ 
++GtkWidget     *gdl_dock_item_new_with_pixbuf_icon (const gchar         *name,
++                                                   const gchar         *long_name,
++                                                   const GdkPixbuf     *pixbuf_icon,
++                                                   GdlDockItemBehavior  behavior);
++
++
+ GType          gdl_dock_item_get_type          (void);
+ 
+ void           gdl_dock_item_dock_to           (GdlDockItem      *item,
+diff -rup gdl-2.31.2/gdl/gdl-dock-item-grip.c gdl-2.31.2-ricky/gdl/gdl-dock-item-grip.c
+--- gdl-2.31.2/gdl/gdl-dock-item-grip.c	2010-05-02 20:03:06.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-item-grip.c	2013-07-01 15:27:55.387563500 +0800
+@@ -69,10 +69,12 @@ gdl_dock_item_create_label_widget(GdlDoc
+     GtkLabel *label;
+     gchar *stock_id = NULL;
+     gchar *title = NULL;
++	GdkPixbuf *pixbuf;
+   
+     label_box = (GtkHBox*)gtk_hbox_new (FALSE, 0);
+     
+     g_object_get (G_OBJECT (grip->item), "stock-id", &stock_id, NULL);
++	g_object_get (G_OBJECT (grip->item), "pixbuf-icon", &pixbuf, NULL);
+     if(stock_id) {   
+         image = GTK_IMAGE(gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_MENU));
+         
+@@ -81,6 +83,12 @@ gdl_dock_item_create_label_widget(GdlDoc
+             
+         g_free (stock_id);
+     }
++	else if(pixbuf){
++		image = GTK_IMAGE(gtk_image_new_from_pixbuf (pixbuf));
++		
++		gtk_widget_show (GTK_WIDGET(image));
++		gtk_box_pack_start(GTK_BOX(label_box), GTK_WIDGET(image), FALSE, TRUE, 0);
++	}
+         
+     g_object_get (G_OBJECT (grip->item), "long-name", &title, NULL);
+     if (title) {
+diff -rup gdl-2.31.2/gdl/gdl-dock-notebook.c gdl-2.31.2-ricky/gdl/gdl-dock-notebook.c
+--- gdl-2.31.2/gdl/gdl-dock-notebook.c	2010-04-24 19:42:49.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-notebook.c	2013-07-02 11:56:58.058942800 +0800
+@@ -388,11 +388,12 @@ gdl_dock_notebook_dock (GdlDockObject
+             GdlDockItem *item = GDL_DOCK_ITEM (object);
+             GdlDockItem *requestor_item = GDL_DOCK_ITEM (requestor);
+             gchar       *long_name, *stock_id;
++			GdkPixbuf   *pixbuf_icon;
+             GtkWidget   *label;
+             gint         position = -1;
+             
+             g_object_get (requestor_item, "long-name", &long_name,
+-                          "stock-id", &stock_id, NULL);
++                          "stock-id", &stock_id, "pixbuf-icon", &pixbuf_icon, NULL);
+             label = gdl_dock_item_get_tablabel (requestor_item);
+             if (!label) {
+                 label = gtk_label_new (long_name);
+@@ -412,7 +413,7 @@ gdl_dock_notebook_dock (GdlDockObject
+             position = gdl_switcher_insert_page (GDL_SWITCHER (item->child), 
+                                                  GTK_WIDGET (requestor), label,
+                                                  long_name, long_name,
+-                                                 stock_id, position);
++                                                 stock_id, pixbuf_icon, position);
+             
+             GDL_DOCK_OBJECT_SET_FLAGS (requestor, GDL_DOCK_ATTACHED);
+             
+diff -rup gdl-2.31.2/gdl/gdl-dock-object.c gdl-2.31.2-ricky/gdl/gdl-dock-object.c
+--- gdl-2.31.2/gdl/gdl-dock-object.c	2010-05-02 20:03:06.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-object.c	2013-07-01 16:37:45.281565200 +0800
+@@ -81,6 +81,7 @@ enum {
+     PROP_NAME,
+     PROP_LONG_NAME,
+     PROP_STOCK_ID,
++	PROP_PIXBUF_ICON,
+     PROP_MASTER,
+     PROP_EXPORT_PROPERTIES
+ };
+@@ -137,6 +138,12 @@ gdl_dock_object_class_init (GdlDockObjec
+                              G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+ 
+     g_object_class_install_property (
++        g_object_class, PROP_PIXBUF_ICON,
++        g_param_spec_pointer ("pixbuf-icon", _("Pixbuf Icon"),
++                              _("Pixbuf icon for the dock object"),
++                              G_PARAM_READWRITE));
++
++    g_object_class_install_property (
+         g_object_class, PROP_MASTER,
+         g_param_spec_object ("master", _("Dock master"),
+                              _("Dock master this dock object is bound to"),
+@@ -213,6 +220,9 @@ gdl_dock_object_set_property  (GObject
+         g_free (object->stock_id);
+         object->stock_id = g_value_dup_string (value);
+         break;
++    case PROP_PIXBUF_ICON:
++        object->pixbuf_icon = g_value_get_pointer (value);
++        break;
+     case PROP_MASTER:
+         if (g_value_get_object (value)) 
+             gdl_dock_object_bind (object, g_value_get_object (value));
+@@ -243,6 +253,9 @@ gdl_dock_object_get_property  (GObject
+     case PROP_STOCK_ID:
+         g_value_set_string (value, object->stock_id);
+         break;
++    case PROP_PIXBUF_ICON:
++        g_value_set_pointer (value, object->pixbuf_icon);
++        break;
+     case PROP_MASTER:
+         g_value_set_object (value, object->master);
+         break;
+diff -rup gdl-2.31.2/gdl/gdl-dock-object.h gdl-2.31.2-ricky/gdl/gdl-dock-object.h
+--- gdl-2.31.2/gdl/gdl-dock-object.h	2010-04-11 21:26:30.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-dock-object.h	2013-07-01 15:50:02.935563500 +0800
+@@ -88,6 +88,7 @@ struct _GdlDockObject {
+     gchar              *name;
+     gchar              *long_name;
+     gchar              *stock_id;
++	GdkPixbuf          *pixbuf_icon;
+     
+     gboolean            reduce_pending;
+ };
+diff -rup gdl-2.31.2/gdl/gdl-switcher.c gdl-2.31.2-ricky/gdl/gdl-switcher.c
+--- gdl-2.31.2/gdl/gdl-switcher.c	2010-05-02 20:09:27.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-switcher.c	2013-07-02 09:18:28.271970500 +0800
+@@ -51,6 +51,7 @@ static void gdl_switcher_add_button  (Gd
+                                       const gchar *label,
+                                       const gchar *tooltips,
+                                       const gchar *stock_id,
++									  const GdkPixbuf *pixbuf_icon,
+                                       gint switcher_id,
+                                       GtkWidget *page);
+ /* static void gdl_switcher_remove_button (GdlSwitcher *switcher, gint switcher_id); */
+@@ -125,6 +126,18 @@ gdl_switcher_stock_id_changed (GObject*
+     g_free (id);
+ }
+ 
++static void
++gdl_switcher_pixbuf_icon_changed (GObject* object,
++                               GParamSpec* spec,
++                               gpointer user_data)
++{
++    Button* button = user_data;
++	GdkPixbuf* pixbuf_icon;
++
++    g_object_get (object, "pixbuf-icon", &pixbuf_icon, NULL);
++    gtk_image_set_from_pixbuf (GTK_IMAGE(button->icon),pixbuf_icon);
++}
++
+ 
+ static Button *
+ button_new (GtkWidget *button_widget, GtkWidget *label, GtkWidget *icon,
+@@ -144,6 +157,8 @@ button_new (GtkWidget *button_widget, Gt
+                       button);
+     g_signal_connect (page, "notify::stock-id", G_CALLBACK (gdl_switcher_stock_id_changed), 
+                       button);
++	g_signal_connect (page, "notify::pixbuf-icon", G_CALLBACK (gdl_switcher_pixbuf_icon_changed), 
++                      button);
+     
+     g_object_ref (button_widget);
+     g_object_ref (label);
+@@ -670,8 +685,8 @@ gdl_switcher_page_added_cb (GtkNotebook
+  
+     switcher_id = gdl_switcher_get_page_id (page);
+     
+-    gdl_switcher_add_button (GDL_SWITCHER (switcher), NULL, NULL, NULL,
+-                             switcher_id, page);
++	gdl_switcher_add_button (GDL_SWITCHER (switcher), NULL, NULL, NULL, NULL,
++                              switcher_id, page);
+     gdl_switcher_select_button (GDL_SWITCHER (switcher), switcher_id);
+ }
+ 
+@@ -781,6 +796,7 @@ gdl_switcher_new (void)
+ void
+ gdl_switcher_add_button (GdlSwitcher *switcher, const gchar *label,
+                          const gchar *tooltips, const gchar *stock_id,
++						 const GdkPixbuf *pixbuf_icon,
+                          gint switcher_id, GtkWidget* page)
+ {
+     GtkWidget *event_box;
+@@ -803,8 +819,15 @@ gdl_switcher_add_button (GdlSwitcher *sw
+     gtk_container_add (GTK_CONTAINER (button_widget), hbox);
+     gtk_widget_show (hbox);
+ 
+-    icon_widget = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_MENU);
+-    gtk_widget_show (icon_widget);
++    if (stock_id) {
++        icon_widget = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_MENU);
++    } else if (pixbuf_icon) {
++        icon_widget = gtk_image_new_from_pixbuf (pixbuf_icon);
++    } else {
++        icon_widget = gtk_image_new_from_stock (GTK_STOCK_NEW, GTK_ICON_SIZE_MENU);
++    }
++
++	gtk_widget_show (icon_widget);
+     
+     if (!label) {
+         gchar *text = g_strdup_printf ("Item %d", switcher_id);
+@@ -881,7 +904,7 @@ gint
+ gdl_switcher_insert_page (GdlSwitcher *switcher, GtkWidget *page,
+                           GtkWidget *tab_widget, const gchar *label,
+                           const gchar *tooltips, const gchar *stock_id,
+-                          gint position)
++                          const GdkPixbuf *pixbuf_icon, gint position)
+ {
+     gint ret_position;
+     gint switcher_id;
+@@ -894,7 +917,7 @@ gdl_switcher_insert_page (GdlSwitcher *s
+         gtk_widget_show (tab_widget);
+     }
+     switcher_id = gdl_switcher_get_page_id (page);
+-    gdl_switcher_add_button (switcher, label, tooltips, stock_id, switcher_id, page);
++	gdl_switcher_add_button (switcher, label, tooltips, stock_id, pixbuf_icon, switcher_id, page);
+     
+     ret_position = gtk_notebook_insert_page (GTK_NOTEBOOK (switcher), page,
+                                              tab_widget, position);
+diff -rup gdl-2.31.2/gdl/gdl-switcher.h gdl-2.31.2-ricky/gdl/gdl-switcher.h
+--- gdl-2.31.2/gdl/gdl-switcher.h	2010-04-11 21:26:30.000000000 +0800
++++ gdl-2.31.2-ricky/gdl/gdl-switcher.h	2013-07-01 15:43:38.083563500 +0800
+@@ -60,6 +60,7 @@ gint       gdl_switcher_insert_page  (Gd
+                                       const gchar *label,
+                                       const gchar *tooltips,
+                                       const gchar *stock_id,
++									  const GdkPixbuf *pixbuf_icon,
+                                       gint position);
+ G_END_DECLS
+ 

--- a/mingw-w64-gdl2/PKGBUILD
+++ b/mingw-w64-gdl2/PKGBUILD
@@ -1,0 +1,53 @@
+# $Id$
+# Maintainer: Ricky Wu <rickleaf.wu@gmail.com>
+
+_realname=gdl2
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=2.31.2
+pkgrel=1
+pkgdesc="GNOME Docking Library (mingw-w64)"
+arch=('any')
+license=('LGPL 2')
+url="http://www.gnome.org/"
+depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
+         "${MINGW_PACKAGE_PREFIX}-libxml2")
+makedepends=("intltool"
+             "gtk-doc")
+options=('strip' 'staticlibs')
+source=(http://ftp.gnome.org/pub/GNOME/sources/${_realname:0:3}/${pkgver:0:4}/${_realname:0:3}-${pkgver}.tar.gz
+        001-pixbuf.patch)
+sha256sums=('34cbe104f5df9a20ea26aa8acca2b6d1a73035448aa854162c598e90f4e6ff80'
+            'ba2f1eed43f926df573ec299b973929499e1da78c0f15157a4ec4ae40057afa1')
+
+prepare() {
+  cd "${srcdir}"/${_realname:0:3}-${pkgver}
+
+  patch -b -V simple -p1 -i ${srcdir}/001-pixbuf.patch
+
+  autoreconf -f -i
+}
+
+build() {
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  mkdir -p docs/reference/html
+  cp -rf ../${_realname:0:3}-${pkgver}/docs/reference/html/* docs/reference/html
+
+  ../${_realname:0:3}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --libexecdir=${MINGW_PREFIX}/lib \
+    --enable-introspection=no
+  make
+}
+
+package() {
+  cd "$srcdir/build-${MINGW_CHOST}"
+  make DESTDIR=$pkgdir install
+
+  install -Dm644 "${srcdir}/${_realname:0:3}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-gdlmm2/000-C11.patch
+++ b/mingw-w64-gdlmm2/000-C11.patch
@@ -1,0 +1,28 @@
+diff -rup gdlmm-2.30.0-org/gdl/gdlmm/Makefile.am gdlmm-2.30.0/gdl/gdlmm/Makefile.am
+--- gdlmm-2.30.0-org/gdl/gdlmm/Makefile.am	2010-04-26 04:21:18.000000000 +0800
++++ gdlmm-2.30.0/gdl/gdlmm/Makefile.am	2015-10-22 22:06:15.021489400 +0800
+@@ -23,8 +23,8 @@ include $(top_srcdir)/build/compile-bind
+ 
+ local_cppflags = $(binding_includes) $(binding_cppflags) -DGDLMM_BUILD=1
+ 
+-AM_CPPFLAGS = $(local_cppflags) $(GTHREAD_CFLAGS) $(GDLMM_CFLAGS)
+-AM_CXXFLAGS = $(GDLMM_WXXFLAGS)
++AM_CPPFLAGS = $(local_cppflags) $(GTHREAD_CFLAGS) $(GDLMM_CFLAGS) -std=c++11
++AM_CXXFLAGS = $(GDLMM_WXXFLAGS) -std=c++11
+ 
+ libgdlmm_@GDLMM_API_VERSION@_la_SOURCES = $(binding_sources)
+ libgdlmm_@GDLMM_API_VERSION@_la_LDFLAGS = -no-undefined -version-info $(GDLMM_SO_VERSION)
+diff -rup gdlmm-2.30.0-org/gdl/gdlmm/Makefile.in gdlmm-2.30.0/gdl/gdlmm/Makefile.in
+--- gdlmm-2.30.0-org/gdl/gdlmm/Makefile.in	2010-04-26 04:32:22.000000000 +0800
++++ gdlmm-2.30.0/gdl/gdlmm/Makefile.in	2015-10-22 22:06:07.821479300 +0800
+@@ -300,8 +300,8 @@ binding_private_HEADERS = $(files_built_
+ binding_built_sources = $(files_built_cc) $(files_built_h) $(files_built_ph)
+ MAINTAINERCLEANFILES = $(binding_built_sources) $(addprefix $(srcdir)/,$(binding_built_sources))
+ local_cppflags = $(binding_includes) $(binding_cppflags) -DGDLMM_BUILD=1
+-AM_CPPFLAGS = $(local_cppflags) $(GTHREAD_CFLAGS) $(GDLMM_CFLAGS)
+-AM_CXXFLAGS = $(GDLMM_WXXFLAGS)
++AM_CPPFLAGS = $(local_cppflags) $(GTHREAD_CFLAGS) $(GDLMM_CFLAGS) -std=c++11
++AM_CXXFLAGS = $(GDLMM_WXXFLAGS) -std=c++11
+ libgdlmm_@GDLMM_API_VERSION@_la_SOURCES = $(binding_sources)
+ libgdlmm_@GDLMM_API_VERSION@_la_LDFLAGS = -no-undefined -version-info $(GDLMM_SO_VERSION)
+ libgdlmm_@GDLMM_API_VERSION@_la_LIBADD = $(GDLMM_LIBS)

--- a/mingw-w64-gdlmm2/PKGBUILD
+++ b/mingw-w64-gdlmm2/PKGBUILD
@@ -1,0 +1,53 @@
+# $Id$
+# Maintainer: Ricky Wu <rickleaf.wu@gmail.com>
+
+_realname=gdlmm2
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+pkgver=2.30.0
+pkgrel=1
+pkgdesc="GNOME Docking Library (mingw-w64)"
+arch=('any')
+license=('LGPL 2')
+url="http://www.gnome.org/"
+depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
+         "${MINGW_PACKAGE_PREFIX}-libxml2")
+makedepends=("intltool"
+             "gtk-doc")
+options=('strip' 'staticlibs')
+source=(http://ftp.gnome.org/pub/GNOME/sources/${_realname:0:5}/${pkgver:0:4}/${_realname:0:5}-${pkgver}.tar.gz
+		000-C11.patch
+        )
+sha256sums=('34cbe104f5df9a20ea26aa8acca2b6d1a73035448aa854162c598e90f4e6ff80'
+            'ba2f1eed43f926df573ec299b973929499e1da78c0f15157a4ec4ae40057afa1')
+
+prepare() {
+  cd "${srcdir}"/${_realname:0:5}-${pkgver}
+  
+  patch -b -V simple -p1 -i ${srcdir}/000-C11.patch
+}
+
+build() {
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  mkdir -p docs/reference/html
+  #cp -rf ../${_realname:0:5}-${pkgver}/docs/reference/html/* docs/reference/html
+
+  ../${_realname:0:5}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --libexecdir=${MINGW_PREFIX}/lib \
+    --enable-static \
+    --enable-shared
+  make
+}
+
+package() {
+  cd "$srcdir/build-${MINGW_CHOST}"
+  make DESTDIR=$pkgdir install
+
+  install -Dm644 "${srcdir}/${_realname:0:5}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -83,7 +83,8 @@ build() {
     --enable-static \
     --enable-shared \
     --enable-introspection \
-    --disable-glibtest
+    --disable-glibtest \
+    --with-included-immodules=ime
 
   make
 }


### PR DESCRIPTION
1. Native input method interface is necessary for other language.
And If you use Windows 8 or later without this module, gtk2 will crash when system input method was set Chinese, Japanese or others.
2 . I add gdl library for gtk+ 2.0