### PR TITLE
Added libftdi and avrdude.

### DIFF
--- a/mingw-w64-avrdude/01-libtool.patch
+++ b/mingw-w64-avrdude/01-libtool.patch
@@ -1,0 +1,20 @@
+--- avrdude-6.2-orig/configure.ac
++++ avrdude-6.2/configure.ac
+@@ -34,7 +34,7 @@
+ AC_CONFIG_HEADERS(ac_cfg.h)
+ AC_CONFIG_MACRO_DIR([m4])
+ 
+-LT_INIT()
++LT_INIT([win32-dll])
+ 
+ # Checks for programs.
+ AC_PROG_CC
+--- avrdude-6.2-orig/Makefile.am
++++ avrdude-6.2/Makefile.am
+@@ -178,5 +178,5 @@
+ libavrdude_la_SOURCES = $(libavrdude_a_SOURCES)
+-libavrdude_la_LDFLAGS = -version-info 1:0
++libavrdude_la_LDFLAGS = -no-undefined -version-info 1:0
+ 
+ include_HEADERS = libavrdude.h
+ 

--- a/mingw-w64-avrdude/02-ddk-headers.patch
+++ b/mingw-w64-avrdude/02-ddk-headers.patch
@@ -1,0 +1,63 @@
+--- avrdude-6.2-orig/configure.ac
++++ avrdude-6.2/configure.ac
+@@ -185,6 +185,8 @@
+ AC_CHECK_HEADERS([fcntl.h sys/ioctl.h sys/time.h termios.h unistd.h])
+ AC_CHECK_HEADERS([ddk/hidsdi.h],,,[#include <windows.h>
+ #include <setupapi.h>])
++AC_CHECK_HEADERS([hidsdi.h],,,[#include <windows.h>
++#include <setupapi.h>])
+ 
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+@@ -202,9 +204,12 @@
+ case $target in
+         *-*-mingw32* | *-*-cygwin* | *-*-windows*)
+ 		LIBHID="-lhid -lsetupapi"
+-		if test $ac_cv_header_ddk_hidsdi_h = yes
++		if test x$ac_cv_header_ddk_hidsdi_h = xyes
+ 		then
+ 			HIDINCLUDE="#include <ddk/hidsdi.h>"
++		elif test x$ac_cv_header_hidsdi_h = xyes
++		then
++			HIDINCLUDE="#include <hidsdi.h>"
+ 		else
+ 			HIDINCLUDE="#include \"my_ddk_hidsdi.h\""
+ 		fi
+--- avrdude-6.2-orig/pickit2.c
++++ avrdude-6.2/pickit2.c
+@@ -60,6 +60,8 @@
+ #include <windows.h>
+ #if defined(HAVE_DDK_HIDSDI_H)
+ #  include <ddk/hidsdi.h>
++#elif defined(HAVE_HIDSDI_H)
++#  include <hidsdi.h>
+ #else
+ #  include "my_ddk_hidsdi.h"
+ #endif
+--- avrdude-6.2-orig/ser_avrdoper.c
++++ avrdude-6.2/ser_avrdoper.c
+@@ -71,10 +71,13 @@
+ 
+ #if defined(HAVE_DDK_HIDSDI_H)
+ #  include <ddk/hidsdi.h>
++#  include <ddk/hidpi.h>
++#elif defined (HAVE_HIDSDI_H)
++#  include <hidsdi.h>
++#  include <hidpi.h>
+ #else
+ #  include "my_ddk_hidsdi.h"
+ #endif
+-#include <ddk/hidpi.h>
+ 
+ #ifdef USB_DEBUG
+ #define DEBUG_PRINT(arg)    printf arg
+--- avrdude-6.2-orig/Makefile.am
++++ avrdude-6.2/Makefile.am
+@@ -138,7 +138,6 @@
+ 	linuxgpio.h \
+ 	linux_ppdev.h \
+ 	lists.c \
+-	my_ddk_hidsdi.h \
+ 	par.c \
+ 	par.h \
+ 	pgm.c \

--- a/mingw-w64-avrdude/03-handle-printing.patch
+++ b/mingw-w64-avrdude/03-handle-printing.patch
@@ -1,0 +1,24 @@
+--- avrdude-6.2-orig/serbb_win32.c
++++ avrdude-6.2/serbb_win32.c
+@@ -308,8 +308,8 @@
+                         progname, port);
+                 return -1;
+ 	}
+-        avrdude_message(MSG_DEBUG, "%s: ser_open(): opened comm port \"%s\", handle 0x%x\n",
+-                        progname, port, (int)hComPort);
++        avrdude_message(MSG_DEBUG, "%s: ser_open(): opened comm port \"%s\", handle 0x%p\n",
++                        progname, port, hComPort);
+ 
+         pgm->fd.pfd = (void *)hComPort;
+ 
+@@ -326,8 +326,8 @@
+ 		pgm->setpin(pgm, PIN_AVR_RESET, 1);
+ 		CloseHandle (hComPort);
+ 	}
+-        avrdude_message(MSG_DEBUG, "%s: ser_close(): closed comm port handle 0x%x\n",
+-                                progname, (int)hComPort);
++        avrdude_message(MSG_DEBUG, "%s: ser_close(): closed comm port handle 0x%p\n",
++                                progname, hComPort);
+ 
+ 	hComPort = INVALID_HANDLE_VALUE;
+ }

--- a/mingw-w64-avrdude/04-no-giveio.patch
+++ b/mingw-w64-avrdude/04-no-giveio.patch
@@ -1,0 +1,15 @@
+--- avrdude-6.2-orig/windows/Makefile.am
++++ avrdude-6.2/windows/Makefile.am
+@@ -24,11 +24,7 @@
+ # This Makefile will only be used on windows based systems.
+ #
+ 
+-local_install_list = \
+-	giveio.sys \
+-	install_giveio.bat \
+-	remove_giveio.bat \
+-	status_giveio.bat
++local_install_list =
+ 
+ EXTRA_DIST   = \
+ 	giveio.c \

--- a/mingw-w64-avrdude/PKGBUILD
+++ b/mingw-w64-avrdude/PKGBUILD
@@ -1,0 +1,102 @@
+# Maintainer: David Grayson <davidegrayson@gmail.com>
+
+_realname=avrdude
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=6.2
+pkgrel=1
+pkgdesc='Software for programming Atmel AVR Microcontrollers (mingw-w64)'
+arch=('any')
+url="http://www.nongnu.org/avrdude/"
+license=('GPL')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "grep"
+  "bison"
+  "flex"
+)
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-libftdi"
+  "${MINGW_PACKAGE_PREFIX}-libusb"
+  "${MINGW_PACKAGE_PREFIX}-libelf"
+)
+options=('staticlibs' 'strip')
+source=(
+  "http://download.savannah.gnu.org/releases/avrdude/avrdude-${pkgver}.tar.gz"
+  '01-libtool.patch'
+  '02-ddk-headers.patch'
+  '03-handle-printing.patch'
+  '04-no-giveio.patch'
+)
+
+sha256sums=('e65f833493b7d63a4436c7056694a0f04ae5b437b72cc084e32c58bc543b0f91'
+            '3a5c041f97e8fcd6706b08ae24fe21337fd1df13319479e2d49c3f82529ba054'
+            '7b52523834e492281347bc92a064ca924dc5d09e2d653e7076c5a966d03f7768'
+            '159fb7d3253931c00a019c43f343f533d4e67c3a9859b7bcdb51878b8dc26451'
+            'c52f01656cfece50da9513170549fa5f0c8240544e10e77f67eea7a3ad8d1b50')
+
+prepare()
+{
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  # Delete binaries.
+  rm windows/giveio.sys
+
+  # Let's use mingw-w64's hidsdi.h instead of AVRDUDE's.
+  rm my_ddk_hidsdi.h
+
+  # Fixes a warning from libtool.  However, a DLL still does not generated.
+  patch -p1 -i ../01-libtool.patch
+
+  # Look for headers like hidsdi.h and hidpi.h at the top level,
+  # (do not assume they are inside the "ddk" directory).
+  patch -p1 -i ../02-ddk-headers.patch
+
+  # Proper printing of 64-bit HANDLE pointers.  The upstream code results
+  # in a compiler warning on x86_64 and wouldn't print the whole pointer.
+  patch -p1 -i ../03-handle-printing.patch
+
+  # Don't install giveio.sys or the batch scripts associated with it since it is
+  # a precompiled binary and unlikely to work on modern versions of Windows
+  # anyway due to driver signing requirements.
+  patch -p1 -i ../04-no-giveio.patch
+
+  ./bootstrap
+}
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  "../${_realname}-${pkgver}/configure" \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}"
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  cd "${pkgdir}${MINGW_PREFIX}"
+
+  # Remove loaddrv.exe because we aren't distributing any drivers one could use
+  # with it and driver signing requirements in modern versions of Windows mean
+  # it is unlikely to work (it only claims to support Windows NT/2000/XP).
+  # Also, with a generic name like loaddrv, it could cause a name collision.
+  rm bin/loaddrv.exe
+
+  # As we can see from confwin.c, AVRDUDE searches for avrdude.conf
+  # using the PATH; it does not find it in /etc.
+  mv etc/avrdude.conf bin
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+  install -D COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-libftdi/PKGBUILD
+++ b/mingw-w64-libftdi/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: David Grayson <davidegrayson@gmail.com>
+
+_realname=libftdi
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.2
+pkgrel=1
+pkgdesc='Library to talk to FTDI chips, with Python 2 bindings (mingw-w64)'
+arch=('any')
+url="https://www.intra2net.com/en/developer/libftdi/"
+license=('LGPL', 'GPL')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc"
+  "${MINGW_PACKAGE_PREFIX}-cmake"
+  "${MINGW_PACKAGE_PREFIX}-boost"
+  "${MINGW_PACKAGE_PREFIX}-swig"
+  "${MINGW_PACKAGE_PREFIX}-python2"
+)
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-libusb"
+  "${MINGW_PACKAGE_PREFIX}-confuse"
+  "${MINGW_PACKAGE_PREFIX}-gettext"
+  "${MINGW_PACKAGE_PREFIX}-libiconv"
+)
+options=('staticlibs' 'strip')
+source=(
+  "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-${pkgver}.tar.bz2"
+)
+
+sha256sums=('a6ea795c829219015eb372b03008351cee3fb39f684bff3bf8a4620b558488d6')
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DEXAMPLES=Off \
+    -DPYTHON_BINDINGS=On \
+    "../${_realname}1-${pkgver}/"
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  PATH=$PATH:"${srcdir}/build-${MINGW_CHOST}/src" make check
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}/${_realname}1-${pkgver}"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  cp COPYING* "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+
+  sed -i "s;$(cygpath -m /);/;" \
+      "${pkgdir}${MINGW_PREFIX}/lib/cmake/${_realname}1"/*.cmake
+}


### PR DESCRIPTION
This pull request adds AVRDUDE, a utility that is very popular in the maker community because it allows you to upload programs to AVR microcontrollers using a wide variety of hardware programmers or bootloaders.  It is used inside the Arduino IDE.

This pull request also adds libftdi, because it is an (optional) dependency of AVRDUDE.

I listed libconfuse as a run-time dependency of libftdi because libftdi seems to be finding  C:/msys64/mingw32/lib/libconfuse.dll.a during its build configuration but I am not totally sure about that, because the compiled DLLs do not seem to depend on libconfuse.dll.