### PR TITLE
Issue #923, CMake 3.4.1, cotire

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: CMake Qt GUI")
-options=('staticlibs' '!strip' 'debug')
+options=('staticlibs') # '!strip' 'debug'
 source=("http://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
         "disable-response-files-for-msys.patch"
         "dont-install-bundle.patch"

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.2
-pkgrel=3
+pkgver=3.4.1
+pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="http://www.cmake.org/"
@@ -26,10 +26,10 @@ source=("http://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
         "qt5-static-plugin-support.patch"
         "pkg-config-without-prefix.patch"
         "do-not-generate-import-library-for-executables.patch")
-md5sums=('5febbd11bcaac854a27eebaf4a124be2'
+md5sums=('73acda0d33be9b2729af99893d99a012'
          '3b0eb07bb98ea9b8e8482e4936971013'
-         'fb33ace70ba863159b2c7964a9661e1e'
-         '1800f99cdae3abe0ae96b6bf7fa873df'
+         '3e70d2e8a616402163d52ac512059c68'
+         'b2eb8c3d2036adfa3d48a40980a241cb'
          'a55c5c6231fc953bad5600c3bb49667b'
          '3105d5c805111cd4db89a4c743ed18fe')
 
@@ -62,5 +62,4 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   ./bin/cmake.exe -DCMAKE_INSTALL_PREFIX:PATH=${pkgdir}${MINGW_PREFIX} -P cmake_install.cmake
-  rm "${pkgdir}${MINGW_PREFIX}/cmake.org.html"
 }

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="http://www.cmake.org/"
@@ -29,7 +29,7 @@ source=("http://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz"
 md5sums=('5febbd11bcaac854a27eebaf4a124be2'
          '3b0eb07bb98ea9b8e8482e4936971013'
          'fb33ace70ba863159b2c7964a9661e1e'
-         '6461b89ff7d1ca0c4022801dff8475a7'
+         '1800f99cdae3abe0ae96b6bf7fa873df'
          'a55c5c6231fc953bad5600c3bb49667b'
          '3105d5c805111cd4db89a4c743ed18fe')
 

--- a/mingw-w64-cmake/dont-install-bundle.patch
+++ b/mingw-w64-cmake/dont-install-bundle.patch
@@ -1,11 +1,11 @@
---- cmake-2.8.12.2/Source/QtDialog/CMakeLists.txt.orig	2014-04-24 10:45:16.178600000 +0400
-+++ cmake-2.8.12.2/Source/QtDialog/CMakeLists.txt	2014-04-24 10:45:23.198600000 +0400
-@@ -140,7 +140,7 @@
-                 WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin)")
+--- cmake-3.4.1/Source/QtDialog/CMakeLists.txt.orig	2015-12-07 15:53:12.279129300 +0100
++++ cmake-3.4.1/Source/QtDialog/CMakeLists.txt	2015-12-07 15:56:52.484583000 +0100
+@@ -207,7 +207,7 @@
+   " ${COMPONENT})
  endif()
  
--if(APPLE OR WIN32)
-+if(APPLE OR WIN32 AND NOT MINGW)
+-if(CMake_INSTALL_DEPENDENCIES AND (APPLE OR WIN32))
++if(CMake_INSTALL_DEPENDENCIES AND (APPLE OR WIN32) AND NOT MINGW)
    # install rules for including 3rd party libs such as Qt
    # if a system Qt is used (e.g. installed in /usr/lib/), it will not be included in the installation
    set(fixup_exe "\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/cmake-gui${CMAKE_EXECUTABLE_SUFFIX}")

--- a/mingw-w64-cmake/qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/qt5-static-plugin-support.patch
@@ -22,14 +22,6 @@ diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQt
  #include "cmQtAutoGenerators.h"
  
  
-@@ -193,6 +194,7 @@
- 
-     target->AddSource(mocCppFile);
-     }
-+
-   // create a custom target for running generators at buildtime:
-   std::string autogenTargetName = getAutogenTargetName(target);
- 
 @@ -230,7 +232,13 @@
      {
      toolNames.push_back("rcc");

--- a/mingw-w64-cmake/qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/qt5-static-plugin-support.patch
@@ -1,28 +1,28 @@
-diff -urN cmake-3.1.0.orig/Source/cmGlobalGenerator.cxx cmake-3.1.0/Source/cmGlobalGenerator.cxx
---- cmake-3.1.0.orig/Source/cmGlobalGenerator.cxx	2015-01-03 16:49:13.831653600 +0000
-+++ cmake-3.1.0/Source/cmGlobalGenerator.cxx	2015-01-03 15:44:34.928951000 +0000
-@@ -1392,7 +1392,8 @@
+diff -Naur cmake-3.4.1.orig/Source/cmGlobalGenerator.cxx cmake-3.4.1/Source/cmGlobalGenerator.cxx
+--- cmake-3.4.1.orig/Source/cmGlobalGenerator.cxx	2015-12-02 16:43:21.000000000 +0100
++++ cmake-3.4.1/Source/cmGlobalGenerator.cxx	2015-12-07 22:43:50.804803400 +0100
+@@ -1432,7 +1432,8 @@
+         }
+       if((!ti->second.GetPropertyAsBool("AUTOMOC")
+             && !ti->second.GetPropertyAsBool("AUTOUIC")
+-            && !ti->second.GetPropertyAsBool("AUTORCC"))
++            && !ti->second.GetPropertyAsBool("AUTORCC")
++            && !ti->second.GetPropertyAsBool("AUTOSTATICPLUGINS"))
+           || ti->second.IsImported())
          {
-         if((target.GetPropertyAsBool("AUTOMOC")
-               || target.GetPropertyAsBool("AUTOUIC")
--              || target.GetPropertyAsBool("AUTORCC"))
-+              || target.GetPropertyAsBool("AUTORCC")
-+              || target.GetPropertyAsBool("AUTOSTATICPLUGINS"))
-             && !target.IsImported())
-           {
-           cmQtAutoGenerators autogen;
-diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQtAutoGenerators.cxx
---- cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx	2015-01-03 16:49:13.862853600 +0000
-+++ cmake-3.1.0/Source/cmQtAutoGenerators.cxx	2015-01-03 17:03:44.895400500 +0000
-@@ -31,6 +31,7 @@
- #include <unistd.h>
- #endif
+         continue;
+diff -Naur cmake-3.4.1.orig/Source/cmQtAutoGeneratorInitializer.cxx cmake-3.4.1/Source/cmQtAutoGeneratorInitializer.cxx
+--- cmake-3.4.1.orig/Source/cmQtAutoGeneratorInitializer.cxx	2015-12-02 16:43:22.000000000 +0100
++++ cmake-3.4.1/Source/cmQtAutoGeneratorInitializer.cxx	2015-12-08 01:16:20.424623700 +0100
+@@ -13,6 +13,7 @@
  
-+#include <cmGeneratedFileStream.h>
- #include "cmQtAutoGenerators.h"
+ #include "cmQtAutoGeneratorInitializer.h"
  
- 
-@@ -230,7 +232,13 @@
++#include "cmGeneratedFileStream.h"
+ #include "cmLocalGenerator.h"
+ #include "cmMakefile.h"
+ #include "cmSourceFile.h"
+@@ -255,7 +256,13 @@
      {
      toolNames.push_back("rcc");
      }
@@ -30,14 +30,14 @@ diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQt
 +  /* AUTOSTATICPLUGINS .cpp files are created at cmake execution time,
 +   * and not at build time, so in that case it is possible to get here
 +   * with no toolNames. */
-+  if (!toolNames.size())
++  if (toolNames.empty())
 +    {
-+    return true;
++    return;
 +    }
    std::string tools = toolNames[0];
    toolNames.erase(toolNames.begin());
    while (toolNames.size() > 1)
-@@ -393,7 +401,9 @@
+@@ -477,7 +484,9 @@
  
    if (target->GetPropertyAsBool("AUTOMOC")
        || target->GetPropertyAsBool("AUTOUIC")
@@ -46,20 +46,19 @@ diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQt
 +      || (    target->GetPropertyAsBool("AUTOSTATICPLUGINS")
 +           && target->GetType() == cmTarget::EXECUTABLE))
      {
-     this->SetupSourceFiles(target);
-     }
-@@ -554,6 +564,57 @@
+     cmQtAutoGeneratorInitializer::SetupSourceFiles(target, skipMoc,
+                                          mocSources, mocHeaders, skipUic);
+@@ -649,6 +658,56 @@
      {
      const_cast<cmTarget*>(target)->AddSource(*fileIt);
      }
-+
 +  /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake, macro(_populate_Core_plugin_properties ..), we'd have:
 +   * set_property(TARGET PROPERTY AUTOSTATICPLUGINS True) // Not currently need as defaults to "ON"
 +   * set_property(TARGET Qt5::Core APPEND PROPERTY STATIC_PLUGINS ${Plugin})
 +   */
 +  if (target->GetPropertyAsBool("AUTOSTATICPLUGINS"))
 +    {
-+    std::vector<cmTarget const*> libTargets = target->GetLinkImplementationClosure("");
++    std::vector<cmTarget const*> libTargets = gtgt->GetLinkImplementationClosure("");
 +    std::vector<cmTarget const*>::const_iterator li;
 +    std::vector<std::string> staticPlugins;
 +    for (li = libTargets.begin(); li != libTargets.end(); ++li)
@@ -105,11 +104,11 @@ diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQt
 +    }
  }
  
- void cmQtAutoGenerators::SetupAutoMocTarget(cmTarget const* target,
-diff -urN cmake-3.1.0.orig/Source/cmTarget.cxx cmake-3.1.0/Source/cmTarget.cxx
---- cmake-3.1.0.orig/Source/cmTarget.cxx	2015-01-03 16:49:13.862853600 +0000
-+++ cmake-3.1.0/Source/cmTarget.cxx	2015-01-03 15:44:35.006951100 +0000
-@@ -342,6 +342,7 @@
+ void cmQtAutoGeneratorInitializer::SetupAutoMocTarget(cmTarget const* target,
+diff -Naur cmake-3.4.1.orig/Source/cmTarget.cxx cmake-3.4.1/Source/cmTarget.cxx
+--- cmake-3.4.1.orig/Source/cmTarget.cxx	2015-12-02 16:43:22.000000000 +0100
++++ cmake-3.4.1/Source/cmTarget.cxx	2015-12-07 22:38:57.046997600 +0100
+@@ -229,6 +229,7 @@
      this->SetPropertyDefault("AUTOMOC", 0);
      this->SetPropertyDefault("AUTOUIC", 0);
      this->SetPropertyDefault("AUTORCC", 0);
@@ -117,7 +116,7 @@ diff -urN cmake-3.1.0.orig/Source/cmTarget.cxx cmake-3.1.0/Source/cmTarget.cxx
      this->SetPropertyDefault("AUTOMOC_MOC_OPTIONS", 0);
      this->SetPropertyDefault("AUTOUIC_OPTIONS", 0);
      this->SetPropertyDefault("AUTORCC_OPTIONS", 0);
-@@ -1727,6 +1728,7 @@
+@@ -1564,6 +1565,7 @@
      builtIns.insert("IMPORTED");
      builtIns.insert("NAME");
      builtIns.insert("TYPE");

--- a/mingw-w64-cmake/qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/qt5-static-plugin-support.patch
@@ -22,15 +22,6 @@ diff -urN cmake-3.1.0.orig/Source/cmQtAutoGenerators.cxx cmake-3.1.0/Source/cmQt
  #include "cmQtAutoGenerators.h"
  
  
-@@ -151,7 +152,7 @@
- static std::string getAutogenTargetName(cmTarget const* target)
- {
-   std::string autogenTargetName = target->GetName();
--  autogenTargetName += "_automoc";
-+  autogenTargetName += "_autogen";
-   return autogenTargetName;
- }
- 
 @@ -193,6 +194,7 @@
  
      target->AddSource(mocCppFile);

--- a/mingw-w64-cotire/PKGBUILD
+++ b/mingw-w64-cotire/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="$MINGW_PACKAGE_PREFIX-$_realname"
 pkgver=1.7.6
 pkgrel=1
-pkgdesc='CMake module to speed up builds. Cotire (compile time reducer) is a CMake module that speeds up the build process of CMake based build systems by fully automating techniques as precompiled header usage and single compilation unit builds for C and C++'
+pkgdesc='CMake module to speed up builds (automated PCH, unity builds). (mingw-w64)'
 arch=(any)
 license=('custom')
 conflicts=("$MINGW_PACKAGE_PREFIX-cmake<3.4" "$MINGW_PACKAGE_PREFIX-cmake>=3.5") # the Modules dir changes every major release

--- a/mingw-w64-cotire/PKGBUILD
+++ b/mingw-w64-cotire/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Norbert Pfeiler <norbert.pfeiler+aur ät gmail.com>
 
 _realname=cotire
+pkgbase=mingw-w64-${_realname}
 pkgname="$MINGW_PACKAGE_PREFIX-$_realname"
 pkgver=1.7.6
 pkgrel=1

--- a/mingw-w64-cotire/PKGBUILD
+++ b/mingw-w64-cotire/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Norbert Pfeiler <norbert.pfeiler+aur ät gmail.com>
+
+_realname=cotire
+pkgname="$MINGW_PACKAGE_PREFIX-$_realname"
+pkgver=1.7.6
+pkgrel=1
+pkgdesc='CMake module to speed up builds. Cotire (compile time reducer) is a CMake module that speeds up the build process of CMake based build systems by fully automating techniques as precompiled header usage and single compilation unit builds for C and C++'
+arch=(any)
+license=('custom')
+conflicts=("$MINGW_PACKAGE_PREFIX-cmake<3.4" "$MINGW_PACKAGE_PREFIX-cmake>=3.5") # the Modules dir changes every major release
+url='https://github.com/sakra/cotire'
+source=("https://github.com/sakra/cotire/archive/$_realname-$pkgver.tar.gz")
+md5sums=('9f33cfa81d99686af98e73331adc0ed7')
+
+package() {
+  cd "$_realname-$_realname-$pkgver"
+
+  modules_dir="$pkgdir$MINGW_PREFIX/share/cmake-3.4/Modules/"
+  mkdir -p $modules_dir
+  cp CMake/cotire.cmake $modules_dir
+
+  license_dir="$pkgdir$MINGW_PREFIX/share/licenses/cotire/"
+  mkdir -p $license_dir
+  cp license $license_dir
+}


### PR DESCRIPTION
I tested `automoc`, `autorcc` and `autostaticplugins`, i have nothing to test `autouic` with though, but it should work nonetheless. 

CMake 3.4 split off `cmQtAutoGeneratorInitializer.cxx` from `cmQtAutoGenerators.cxx` and `GetLinkImplementationClosure` moved from `cmTarget` to `cmGeneratorTarget`. 
The hunk with most of the implementation actually applied without error, but at the wrong position in the source. 

The path in cotire’s packaging has to be changed with every major CMake release. (CMake only searches in the module directory of the current version)