### PR TITLE
gitg: update to version 3.19.1

### DIFF
--- a/mingw-w64-gitg/PKGBUILD
+++ b/mingw-w64-gitg/PKGBUILD
@@ -2,18 +2,18 @@
 
 _realname=gitg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.3.3
+pkgver=3.19.1
 pkgrel=1
 arch=('any')
 pkgdesc="git repository viewer for GTK+/GNOME (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-gtksourceview3"
+depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
+         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
          "${MINGW_PACKAGE_PREFIX}-libpeas"
          "${MINGW_PACKAGE_PREFIX}-enchant"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-python3-gobject"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
-         "${MINGW_PACKAGE_PREFIX}-libgit2-glib"
-         "${MINGW_PACKAGE_PREFIX}-webkit2gtk3")
+         "${MINGW_PACKAGE_PREFIX}-libgit2-glib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vala"
@@ -25,7 +25,7 @@ options=('strip' 'staticlibs')
 license=("GPL2+")
 url="https://wiki.gnome.org/Apps/Gitg"
 source=(http://ftp.gnome.org/pub/gnome/sources/${_realname}/${pkgver:0:4}/${_realname}-$pkgver.tar.xz)
-sha256sums=('a206574d5d3542223c79693d0954fa87d4ba95f13074bb9598e83c91df8f9a16')
+sha256sums=('fb31c8a23c93829afb518eaa81560508208a366e006593b0dba9d2f874017457')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
Now that gitg does not depend on webkit we should be able
to build it without problems