### PR TITLE
gitg: add missing deps

### DIFF
--- a/mingw-w64-gitg/PKGBUILD
+++ b/mingw-w64-gitg/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=gitg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.19.1
+pkgver=3.19.2
 pkgrel=1
 arch=('any')
 pkgdesc="git repository viewer for GTK+/GNOME (mingw-w64)"
@@ -13,10 +13,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-iso-codes"
          "${MINGW_PACKAGE_PREFIX}-python3-gobject"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
+         "${MINGW_PACKAGE_PREFIX}-libsoup"
+         "${MINGW_PACKAGE_PREFIX}-libsecret"
+         "${MINGW_PACKAGE_PREFIX}-gtkspell3"
          "${MINGW_PACKAGE_PREFIX}-libgit2-glib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-vala"
+             "${MINGW_PACKAGE_PREFIX}-libgee"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "intltool"
              "itstool"
@@ -24,11 +28,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('strip' 'staticlibs')
 license=("GPL2+")
 url="https://wiki.gnome.org/Apps/Gitg"
+install=${_realname}-${CARCH}.install
 source=(http://ftp.gnome.org/pub/gnome/sources/${_realname}/${pkgver:0:4}/${_realname}-$pkgver.tar.xz)
-sha256sums=('fb31c8a23c93829afb518eaa81560508208a366e006593b0dba9d2f874017457')
+sha256sums=('52968be7d3dffaf20d14b25ca68773bf8ce73b32c5c8d3eac63cea0721c7a709')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
   #autopoint --force
   #AUTOPOINT='intltoolize --automake --copy' autoreconf -f -i
 }
@@ -50,4 +56,6 @@ build() {
 package() {
   cd "$srcdir/build-${MINGW_CHOST}"
   make DESTDIR=$pkgdir install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-gitg/gitg-i686.install
+++ b/mingw-w64-gitg/gitg-i686.install
@@ -1,0 +1,12 @@
+post_install() {
+    mingw32/bin/glib-compile-schemas /mingw32/share/glib-2.0/schemas
+    mingw32/bin/gtk-update-icon-cache-3.0.exe /mingw32/share/icons/hicolor
+}
+
+post_upgrade() {
+    post_install $1
+}
+
+post_remove() {
+    post_install $1
+}

--- a/mingw-w64-gitg/gitg-x86_64.install
+++ b/mingw-w64-gitg/gitg-x86_64.install
@@ -1,0 +1,12 @@
+post_install() {
+    mingw64/bin/glib-compile-schemas /mingw64/share/glib-2.0/schemas
+    mingw64/bin/gtk-update-icon-cache-3.0.exe /mingw64/share/icons/hicolor
+}
+
+post_upgrade() {
+    post_install $1
+}
+
+post_remove() {
+    post_install $1
+}


### PR DESCRIPTION
See that it will still not build due to the gio-unix dep.
This will be fixed by patch later on.