### PR TITLE
jucipp-git: working PKGBUILD

### DIFF
--- a/mingw-w64-jucipp-git/PKGBUILD
+++ b/mingw-w64-jucipp-git/PKGBUILD
@@ -3,9 +3,9 @@
 _realname=jucipp
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-provides="${MINGW_PACKAGE_PREFIX}-${_realname}"
-replaces="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1022.4eedbca
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1157.6205b2b
 pkgrel=1
 pkgdesc="A lightweight platform independent C++-IDE with support for C++11 and C++14 (mingw-w64)"
 arch=('any')
@@ -20,10 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-aspell-en")
 options=('strip' 'staticlibs')
-source=("${_realname}"::"git+https://github.com/cppit/jucipp.git"
-        "libclangmm"::"git+https://github.com/cppit/libclangmm.git")
-md5sums=('SKIP'
-         'SKIP')
+source=("${_realname}"::"git+https://github.com/cppit/jucipp.git")
+md5sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}"/${_realname}
@@ -33,7 +31,6 @@ pkgver() {
 prepare() {
   cd "${srcdir}"/${_realname}
   git submodule init
-  git config submodule.libclangmm.url "${srcdir}"/libclangmm
   git submodule update
 }
 


### PR DESCRIPTION
* provides/replaces are now arrays
* removed unnessessary libclangmm download (this happens in prepare() through submodule init and update)
* updated pkgver

Not sure if pkgrel should be set to 2 though, so I leave this up to you. 