### PR TITLE
mingw-w64-headers-git: Rename usb.h to usb-windows.h

### DIFF
--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 pkgdesc="MinGW-w64 headers for Windows"
-pkgver=5.0.0.4598.fc005cd
+pkgver=5.0.0.4601.5e2e73b
 pkgrel=1
 arch=('any')
 url="http://mingw-w64.sourceforge.net"
@@ -60,14 +60,29 @@ build() {
     --enable-idl --without-widl
 }
 
+rename_header() {
+  local oldname=$1
+  local newname=$2
+  msg "Renaming ${oldname} to ${newname}"
+  mv ${oldname} ${newname}
+  sed -i \
+    -e "s/^#include\s*<${oldname}>/#include <${newname}>/" \
+    -e "s/^#include\s*\"${oldname}\"/#include \"${newname}\"/" \
+    `grep -Flr ${oldname}`
+}
+
 package() {
   msg "Installing ${MINGW_CHOST} headers"
   cd ${srcdir}/headers-${MINGW_CHOST}
   make DESTDIR=${pkgdir} install
 
-  rm ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include/pthread_signal.h
-  rm ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include/pthread_time.h
-  rm ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include/pthread_unistd.h
+  cd ${pkgdir}${MINGW_PREFIX}/${MINGW_CHOST}/include
+  rm pthread_signal.h
+  rm pthread_time.h
+  rm pthread_unistd.h
+
+  # Avoid a conflict with libusb-compat's usb.h
+  rename_header usb.h usb-windows.h
 
   msg "Installing MinGW-w64 licenses"
   install -Dm644 ${srcdir}/mingw-w64/mingw-w64-headers/ddk/readme.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/ddk-readme.txt


### PR DESCRIPTION
I have thought about the usb.h name conflict some more (with help from @DanGrayson) and I think this pull request is the right way to solve it.  Here are my previous attempts to fix it, for reference:

* https://sourceforge.net/p/mingw-w64/mailman/message/34590803/
* https://github.com/Alexpux/MINGW-packages/pull/946

Recap:  Microsoft and mingw-w64 both provide a file named `usb.h` which defines some Microsoft USB stuff.  In MSYS2, we install the mingw-w64 implementation in `/mingw64/x86_64-w64-mingw32/include/usb.h`.  The library/package libusb-compat also provides a file named `usb.h`, which is installed in `/mingw64/include/usb.h`.  Because of the way the GCC search paths are ordered, the compiler will always prefer to use the libusb-compat version of usb.h if it is installed.  This means that if libusb-compat is installed, it is very hard to compile native Windows software like [usbview](https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-usbview-git) that need to use the Microsoft-style usb.h.

MSYS2 is trying to combine two worlds of software: native Windows software that uses Microsoft APIs, and cross-platform software from the Linux world that uses more standard APIs.  There are bound to be conflicts like this because Microsoft adds headers without caring about what exists in the Linux world, and vice versa.

When a user writes `#include <usb.h>` in a program, MSYS2 has no way to tell what they mean.  So we either have to inconvenience the group of users who are trying to use the libusb-compat usb.h, or we have to inconvenience the group of users who are trying to use the Microsoft-style usb.h.

Which group should we inconvenience?  I think we should inconvenience the users who want to use the Microsoft-style usb.h, because one of the main points of MSYS2 is to allow us to compile open-source software from the Linux world on Windows.  This attitude is consistent with the ordering of the include search paths in MSYS2's gcc: `/mingw64/include` comes before `/mingw64/x86_64-w64-mingw32/include`, which means the cross-platform software takes precedence.

Right now, we are severely inconveniencing the users who want to use the Microsoft-style usb.h: they have to copy mingw-w64 header files around and/or manually edit them if they want their code to compile.  This includes people who are not directly using usb.h: anyone using usbdi.h, winsubio.h, or winusb.h is also affected.

I propose that we inconvenience these users less by renaming the mingw-w64 header from usb.h to usb-windows.h.  Native Windows programs referring to usb.h will have to be patched to refer to usb-windows.h or some header like usbdi.h that includes usb.h.  Native Windows programs that use usbdi.h, winusbio.h, or winusb.h, will work properly without any patches.

I am not sending this as a patch to the mingw-w64 project because you can see from my previous [attempt](https://sourceforge.net/p/mingw-w64/mailman/message/34590803/) that it is unlikely that they would want to rename one of their header files.  From the mingw-w64 perspective, usb.h is a Microsoft-style USB header.  MSYS2 is the project that enables users to use either the Microsoft-style usb.h or the libusb-compat usb.h, so MSYS2 is the project that should probably be cleaning up the namespace collision.

This pull request renames the mingw-w64 usb.h to usb-windows.h.  I think it's best to rename usb.h instead of making a copy or alias for it: that way "usb.h" on MSYS2 means one and only thing: it always means libusb-compat's header.  If my pull request didn't remove the mingw-w64 usb.h, then it is possible that someone would write software including usb.h, and it would only compile correctly when the libusb-compat package is not installed.  That would be a surprising/annoying experience for them, I think.  It would be better if they encounter a compiler error immediately rather than encountering a compiler error later when libusb-compat is installed, or (worse) having their colleague report to them that their software does not compile because their colleague happens to have libusb-compat installed.

I hope my understanding of the MSYS2 and mingw-w64 projects is correct, and I hope I have been able to draw the right conclusions from this understanding.  Please let me know if I overlooked something.  Thanks!