### PR TITLE
avrdude fixes

### DIFF
--- a/mingw-w64-avrdude/PKGBUILD
+++ b/mingw-w64-avrdude/PKGBUILD
@@ -4,7 +4,7 @@ _realname=avrdude
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=6.2
-pkgrel=1
+pkgrel=2
 pkgdesc='Software for programming Atmel AVR Microcontrollers (mingw-w64)'
 arch=('any')
 url="http://www.nongnu.org/avrdude/"
@@ -15,6 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "flex")
 depends=("${MINGW_PACKAGE_PREFIX}-libftdi"
          "${MINGW_PACKAGE_PREFIX}-libusb"
+         "${MINGW_PACKAGE_PREFIX}-libusb-compat"
          "${MINGW_PACKAGE_PREFIX}-libelf")
 options=('staticlibs' 'strip')
 source=(#http://download.savannah.gnu.org/releases/avrdude/avrdude-${pkgver}.tar.gz{,.sig}
@@ -24,6 +25,8 @@ source=(#http://download.savannah.gnu.org/releases/avrdude/avrdude-${pkgver}.tar
         '03-handle-printing.patch'
         '04-no-giveio.patch')
 
+validpgpkeys=('EF497ABE47ED91B3FC3D7EA54D902FF7723BDEE9'
+              '5E84F980C3CAFD4BB5841070F48CA81B69A85873')
 sha256sums=('e65f833493b7d63a4436c7056694a0f04ae5b437b72cc084e32c58bc543b0f91'
             'SKIP'
             '3a5c041f97e8fcd6706b08ae24fe21337fd1df13319479e2d49c3f82529ba054'


### PR DESCRIPTION
- Added validpgpkeys
- Added a dependency on libusb-compat because there is code in AVRDUDE that uses it and cannot use libusb-1.0 (fixes #947).