### PR TITLE
Update to cego version 2.28.2

### DIFF
--- a/mingw-w64-cego/PKGBUILD
+++ b/mingw-w64-cego/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cego
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.28.1
+pkgver=2.28.2
 pkgrel=1
 pkgdesc="Cego database system (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ source=("http://www.lemke-it.com/${_realname}-${pkgver}.tar.gz")
 depends=("${MINGW_PACKAGE_PREFIX}-lfcbase")
 depends=("${MINGW_PACKAGE_PREFIX}-lfcxml")
 
-sha256sums=("7e69361a3837af839b25918c223235203dca42a0eb78a6dbc58bd86278adbcc3")
+sha256sums=("7df255e79a28f71a292d88874f3df789031187c2141d995b07bea8d6f8d6a6c3")
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
Fix in CegoTableManager::deleteDataTable ( renamed to deleteDataTableEntry )
Since we allow now parallel updates, the method must check if the target tuple has already been touched by another transaction. Otherwise, invalid double entries could occur in case of concurrent updates on the same tuple. 
If a concurrent transaction is detected, the method returns false. This return value is used by the updateTuple method to decide, if the subsequent insert operation must be performed.