### PR TITLE
mpv: Update to 0.14.0

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -4,13 +4,14 @@
 _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.11.0
+pkgver=0.14.0
 pkgrel=1
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="http://mpv.io"
 arch=('any')
-license=('GPL')
-depends=("${MINGW_PACKAGE_PREFIX}-enca"
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-angleproject-git"
+         "${MINGW_PACKAGE_PREFIX}-enca"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
@@ -30,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "pkg-config"
              "python")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mpv-player/${_realname}/archive/v${pkgver}.tar.gz)
-md5sums=('988bec97a4057beecc2f6a8a2c18e342')
+md5sums=('9f78599b52d9e603f2481d36746ddd0c')
 
 # strip doesn't work well with the mpv.com wrapper, so strip manually instead
 options=(!strip !emptydirs)
@@ -59,7 +60,9 @@ build() {
     --enable-caca \
     --enable-dvdnav \
     --enable-dvdread \
+    --enable-egl-angle \
     --enable-enca \
+    --enable-gpl3 \
     --enable-jpeg \
     --enable-lcms2 \
     --enable-libarchive \


### PR DESCRIPTION
This might require the latest ANGLE update (the binaries don't seem to be in repo.msys2.org yet.)

As for the build error in #810, I think it's just a race condition. Hopefully it won't happen again. If it does, I hate to say it, but I think the solution is just to run the build again.