### PR TITLE
Create PKGBUILD for enet 1.3.13 (http://enet.bespin.org/)

### DIFF
--- a/mingw-w64-enet/PKGBUILD
+++ b/mingw-w64-enet/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=enet
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.3.13
+pkgrel=1
+pkgdesc="Reliable UDP networking library (mingw-w64)"
+url="http://enet.bespin.org/"
+arch=('any')
+license=('custom')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=('staticlibs' 'strip')
+source=("http://enet.bespin.org/download/enet-${pkgver}.tar.gz")
+md5sums=('b83b9a7791417b6b6f5c68231f6e218b')
+
+prepare() {
+  cd "${srcdir}/enet-${pkgver}"
+}
+
+build() {
+  cd "${srcdir}/enet-${pkgver}"
+  gcc -shared ${CFLAGS} \
+    -Wl,--out-implib,libenet.dll.a \
+    -DENET_DLL\
+    -Iinclude \
+    *.c \
+    -lws2_32 -lwinmm \
+    -o enet.dll 
+}
+
+package() {
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,lib,include}
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/${_realname}
+  cd "${srcdir}/enet-${pkgver}"
+  install -m644 enet.dll "${pkgdir}${MINGW_PREFIX}/bin/"
+  install -m644 libenet.dll.a "${pkgdir}${MINGW_PREFIX}/lib/"
+  install -m644 include/enet/*.h "${pkgdir}${MINGW_PREFIX}/include/${_realname}/"
+}

--- a/mingw-w64-enet/PKGBUILD
+++ b/mingw-w64-enet/PKGBUILD
@@ -1,6 +1,7 @@
-# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: qme5400 <qme5400@gmail.com>
 
 _realname=enet
+pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.13
 pkgrel=1


### PR DESCRIPTION
Please review new PKGBUILD: Nothing to do in "prepare()". No need to run "./configure".