### PR TITLE
cURL: Get relocatable base from .dll instead of .exe

### DIFF
--- a/mingw-w64-curl/0004-cURL-Get-relocatable-base-from-dll.patch
+++ b/mingw-w64-curl/0004-cURL-Get-relocatable-base-from-dll.patch
@@ -1,0 +1,121 @@
+From 6ae2e927271b441e759e4c7a6d41dc4cbcd7a929 Mon Sep 17 00:00:00 2001
+From: Johannes Schindelin <johannes.schindelin@gmx.de>
+Date: Sat, 9 Jan 2016 12:35:03 +0000
+Subject: [PATCH] cURL: Get relocatable base from .dll instead of .exe
+
+Currently, cURL uses the path to the current executable to figure out
+where the certificates are. This works as long as all executables are in
+/mingw64/bin/ (or /mingw32/bin/).
+
+However, the entire point of having a DLL with a linkable .dll.a is to
+be able to use it in executables that other people build. For example,
+if an .exe lives in %HOME%\bin, the path used by our libcurl to look up
+the certificates is all wrong.
+
+Same problem with Git for Windows: its executables are hidden away from
+the user, in the /mingw64/libexec/git-core/ directory. So the path to
+the certificates is all wrong again.
+
+So let's just use the path to the *cURL library* instead of the path to
+the current .exe. This requires Win32 API available in Windows XP & 2003
+and later, well within the Windows versions supported by Cygwin (and
+therefore MSys2).
+
+Reported by David Ebbo.
+
+Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>
+---
+ lib/pathtools.c | 36 +++++++++++++++++++++++++++++++++++-
+ lib/pathtools.h |  4 ++++
+ lib/url.c       |  6 +++---
+ 3 files changed, 42 insertions(+), 4 deletions(-)
+
+diff --git a/lib/pathtools.c b/lib/pathtools.c
+index 81ffa7e..c66df92 100644
+--- a/lib/pathtools.c
++++ b/lib/pathtools.c
+@@ -26,7 +26,7 @@
+ #define IMPLEMENT_SYS_GET_EXECUTABLE_PATH
+ 
+ #if defined(IMPLEMENT_SYS_GET_EXECUTABLE_PATH)
+-#if defined(__linux__) || defined(__CYGWIN__) || defined(__MSYS__)
++#if defined(__linux__)
+ /* Nothing needed, unistd.h is enough. */
+ #elif defined(__APPLE__)
+ #include <mach-o/dyld.h>
+@@ -332,6 +332,40 @@ get_executable_path(char const * argv0, char * result, ssize_t max_size)
+   return result_size;
+ }
+ 
++#if defined(_WIN32)
++int
++get_dll_path(char * result, unsigned long max_size)
++{
++  HMODULE handle;
++  char * p;
++  int ret;
++
++  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
++      GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
++      (LPCSTR) &get_dll_path, &handle))
++    {
++      return -1;
++    }
++
++  ret = GetModuleFileNameA(handle, result, max_size);
++  if (ret == 0 || ret == (int)max_size)
++    {
++      return -1;
++    }
++
++  /* Early conversion to unix slashes instead of more changes
++     everywhere else .. */
++  result[ret] = '\0';
++  p = result - 1;
++  while ((p = strchr (p + 1, '\\')) != NULL)
++    {
++      *p = '/';
++    }
++
++  return ret;
++}
++#endif
++
+ char const *
+ strip_n_prefix_folders(char const * path, size_t n)
+ {
+diff --git a/lib/pathtools.h b/lib/pathtools.h
+index a8a2928..d4ff40f 100644
+--- a/lib/pathtools.h
++++ b/lib/pathtools.h
+@@ -28,6 +28,10 @@ void sanitise_path(char * path);
+    if IMPLEMENT_SYS_GET_EXECUTABLE_PATH is defined, otherwise uses argv0. */
+ int get_executable_path(char const * argv0, char * result, ssize_t max_size);
+ 
++#if defined(_WIN32)
++int get_dll_path(char * result, unsigned long max_size);
++#endif
++
+ /* Where possible, in-place removes occourances of '.' and 'path/..' */
+ void simplify_path(char * path);
+ 
+diff --git a/lib/url.c b/lib/url.c
+index 460137f..8e74a64 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -599,9 +599,9 @@ CURLcode Curl_init_userdefined(struct UserDefined *set)
+ #if defined(__MINGW32__)
+   const size_t path_max = PATH_MAX;
+   char relocated[path_max];
+-  get_executable_path(NULL, &relocated, path_max);
+-  strip_n_suffix_folders(&relocated, 1);
+-  strncat(&relocated, "/", path_max);
++  get_dll_path(relocated, path_max);
++  strip_n_suffix_folders(relocated, 1);
++  strncat(relocated, "/", path_max);
+   char * relative = get_relative_path(CURL_BINDIR, CURL_CA_BUNDLE);
+   strncat(relocated, relative, path_max);
+   simplify_path(relocated);
+-- 
+2.6.4.windows.1
+

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.46.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="http://curl.haxx.se"
@@ -30,12 +30,14 @@ options=('staticlibs')
 source=("$url/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0002-curl-mingw-enable-static.patch"
-        "0003-curl-detect-ipv6-on-windows.patch")
+        "0003-curl-detect-ipv6-on-windows.patch"
+        "0004-cURL-Get-relocatable-base-from-dll.patch")
 md5sums=('9979f989a2a9930d10f1b3deeabc2148'
          'SKIP'
          '58520051c4ed77781d233c3fa40a5435'
          'eac9e212e619490966ae47004bec547b'
-         'f1c5b8648af0dfab7bde4d68a6b65f25')
+         'f1c5b8648af0dfab7bde4d68a6b65f25'
+         '3d235171a1a0a091ca7508024e689b87')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg
 
 prepare() {
@@ -44,6 +46,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0001-curl-relocation.patch"
   patch -p1 -i "${srcdir}/0002-curl-mingw-enable-static.patch"
   patch -p1 -i "${srcdir}/0003-curl-detect-ipv6-on-windows.patch"
+  patch -p1 -i "${srcdir}/0004-cURL-Get-relocatable-base-from-dll.patch"
   autoreconf -vfi
 }
 


### PR DESCRIPTION
Currently, cURL uses the path to the current executable to figure out
where the certificates are. This works as long as all executables are in
/mingw64/bin/ (or /mingw32/bin/).

However, the entire point of having a DLL with a linkable .dll.a is to
be able to use it in executables that other people build. For example,
if an .exe lives in %HOME%\bin, the path used by our libcurl to look up
the certificates is all wrong.

Same problem with Git for Windows: its executables are hidden away from
the user, in the /mingw64/libexec/git-core/ directory. So the path to
the certificates is all wrong again.

So let's just use the path to the *cURL library* instead of the path to
the current .exe. This requires Win32 API available in Windows XP & 2003
and later, well within the Windows versions supported by Cygwin (and
therefore MSys2).

Reported by David Ebbo.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>