### PR TITLE
pkg-config: Fixed tests.  This fixes issue #982.

### DIFF
--- a/mingw-w64-pkg-config/0001-fix-double-slash-in-test.patch
+++ b/mingw-w64-pkg-config/0001-fix-double-slash-in-test.patch
@@ -1,0 +1,11 @@
+--- pkg-config-0.29-orig/check/check-sysroot
++++ pkg-config-0.29/check/check-sysroot
+@@ -9,7 +9,7 @@
+ # MSYS mangles / paths to its own root in windows format. This probably
+ # means sysroot doesn't work there, but match what pkg-config passes
+ # back anyway.
+-[ "$OSTYPE" = msys ] && root=$(cd / && pwd -W) || root=
++[ "$OSTYPE" = msys ] && root=$(cd / && pwd -W) && root=${root%/} || root=
+ 
+ RESULT=""
+ run_test --cflags simple

--- a/mingw-w64-pkg-config/PKGBUILD
+++ b/mingw-w64-pkg-config/PKGBUILD
@@ -14,6 +14,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-pkgconf")
 replaces=("${MINGW_PACKAGE_PREFIX}-pkgconf")
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 source=(http://pkgconfig.freedesktop.org/releases/${_realname}-${pkgver}.tar.gz
+        0001-fix-double-slash-in-test.patch
         0010-expand-paths.mingw.patch
         0011-platform-dependent-separator-and-adjustable-prefix.mingw.patch
         1001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
@@ -23,6 +24,7 @@ source=(http://pkgconfig.freedesktop.org/releases/${_realname}-${pkgver}.tar.gz
         1024-return-actually-written-data-in-printf.all.patch
         1030-fix-stat.all.patch)
 md5sums=('77f27dce7ef88d0634d0d6f90e03a77f'
+         '2dcdec472db1a40b977dc0ec22a76710'
          'cb65caa60584d471aa6f76b181790ee1'
          'd6b6acdb90f93c35378f53e34e7cd6fa'
          '10cf1e482b6a1367d79648466f2cf23c'
@@ -34,9 +36,12 @@ md5sums=('77f27dce7ef88d0634d0d6f90e03a77f'
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/0001-fix-double-slash-in-test.patch
   patch -p1 -i ${srcdir}/0010-expand-paths.mingw.patch
   patch -p1 -i ${srcdir}/0011-platform-dependent-separator-and-adjustable-prefix.mingw.patch
-  
+
+  sed -i check/simple.pc -e "s,prefix=/usr,prefix=${MINGW_PREFIX},"
+
   cd glib
 
   patch -Np1 -i "${srcdir}/1001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch"


### PR DESCRIPTION
There were some minor issues preventing the tests for pkg-config from passing.  Nothing was wrong with the actual program, so there is no need to rebuild the package.