### PR TITLE
Updated SQLite to 3.10.0

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Brisingr Aerowing <ztgreve@live.com>
 
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_amalgamationver=3090200
-pkgver=3.9.2.0
+_amalgamationver=3100000
+pkgver=3.10.0.0
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -17,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=("http://www.sqlite.org/2015/sqlite-autoconf-${_amalgamationver}.tar.gz"
         LICENSE)
-sha1sums=('dae1ae5297fece9671ae0c434a7ecd0cda09c76a'
+sha1sums=('7be6e6869d0d2d9fe3df71b5c65f065dd2325f58'
           'e2aa07adae13aed713860b74165d3325a18c6792')
 options=('!strip' 'staticlibs' '!buildflags')
 
@@ -30,7 +31,9 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --build=${MINGW_CHOST} \
-    --enable-threadsafe
+    --enable-threadsafe \
+    --disable-editline \
+    --enable-readline
 
   make
 }


### PR DESCRIPTION
SQLite updated to 3.10.0. The --disable-editline --enable-readline flags are needed to get SQLite to use readline as editline is now the default, likely due to licensing.