### PR TITLE
Update libmongoose

### DIFF
--- a/mingw-w64-libmongoose-git/Makefile
+++ b/mingw-w64-libmongoose-git/Makefile
@@ -56,7 +56,6 @@ install: $(SHARED_LIB)
 	install -Dm644 mongoose.h $(DESTDIR)$(PREFIX)/include/mongoose.h
 	install -dm755 $(DESTDIR)$(DOCDIR)
 	cp -a examples $(DESTDIR)$(DOCDIR)
-	cp -a docs/* $(DESTDIR)$(DOCDIR)/
 	
 test:
 	$(MAKE) -C test/

--- a/mingw-w64-libmongoose-git/PKGBUILD
+++ b/mingw-w64-libmongoose-git/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=libmongoose
+pkgbase="mingw-w64-${_realname}-git"
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
 provides=(${MINGW_PACKAGE_PREFIX}-${_realname})
 conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname})
-pkgver=r1793.41b405d
-pkgrel=3
+pkgver=r1938.81d977c
+pkgrel=1
 url="https://github.com/cesanta/mongoose"
 pkgdesc='Embedded web server for C/C++ (mingw-w64)'
 license=('GPL2')
@@ -17,7 +18,7 @@ source=(${_realname}::"git+https://github.com/cesanta/mongoose"
         Makefile)
 sha1sums=('SKIP'
           '92c82813e7c1b277a0078c0e67addc7e159aec81'
-          '94385286bcb7e3639d03ba283dc43111062c4a23')
+          '344bfa94b2a032dcf47adbaaa190100445fa0181')
 
 pkgver() {
   cd "${srcdir}/${_realname}"

--- a/mingw-w64-libmongoose/Makefile
+++ b/mingw-w64-libmongoose/Makefile
@@ -1,0 +1,66 @@
+SONAME_MAJOR=5
+SONAME_MINOR=6
+LIBNAME=libmongoose
+
+SHARED_LIB=$(LIBNAME)-$(SONAME_MAJOR).dll
+STATIC_LIB=$(LIBNAME).a
+IMPORT_LIB=$(LIBNAME).dll.a
+
+ifndef CC
+  CC=gcc
+endif
+
+ifndef AR
+  AR=ar
+endif
+
+ifndef PREFIX
+  PREFIX=/usr/local
+endif
+
+ifndef BINDIR
+  BINDIR=$(PREFIX)/bin
+endif
+
+ifndef LIBDIR
+  LIBDIR=$(PREFIX)/lib
+endif
+
+ifndef DOCDIR
+  DOCDIR=$(PREFIX)/share/$(LIBNAME)/doc
+endif
+
+CPPFLAGS+= #-DNS_ENABLE_SSL -DNS_ENABLE_IPV6
+CFLAGS+=-c -Wall
+LDFLAGS+=-shared -Wl,--out-implib,$(IMPORT_LIB) -lws2_32 #-lssl
+
+SRCS=mongoose.c
+OBJS=mongoose.o
+INCLUDE=.
+
+all: $(STATIC_LIB) $(SHARED_LIB)
+
+$(SHARED_LIB): $(OBJS)
+	$(CC) $(OBJS) $(LDFLAGS) -o $(SHARED_LIB)
+
+$(STATIC_LIB): $(OBJS)
+	$(AR) rcs $(STATIC_LIB) $(OBJS)
+
+$(OBJS): $(SRCS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -I$(INCLUDE) $(SRCS) -o $(OBJS)
+
+install: $(SHARED_LIB)
+	install -Dm655 $(SHARED_LIB) $(DESTDIR)$(BINDIR)/$(SHARED_LIB)
+	install -Dm644 $(STATIC_LIB) $(DESTDIR)$(LIBDIR)/$(STATIC_LIB)
+	install -Dm644 $(IMPORT_LIB) $(DESTDIR)$(LIBDIR)/$(IMPORT_LIB)
+	install -Dm644 mongoose.h $(DESTDIR)$(PREFIX)/include/mongoose.h
+	install -dm755 $(DESTDIR)$(DOCDIR)
+	cp -a examples $(DESTDIR)$(DOCDIR)
+
+test:
+	$(MAKE) -C test/
+clean:
+	rm -f $(OBJS) $(SHARED_LIB) $(STATIC_LIB)
+	$(MAKE) -C test/ clean
+
+.PHONY: clean test all

--- a/mingw-w64-libmongoose/PKGBUILD
+++ b/mingw-w64-libmongoose/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+
+_realname=libmongoose
+pkgbase="mingw-w64-${_realname}"
+pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname})
+pkgver=6.2
+pkgrel=1
+url="https://github.com/cesanta/mongoose"
+pkgdesc='Embedded web server for C/C++ (mingw-w64)'
+license=('GPL2')
+arch=('any')
+depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs)
+makedepends=(${MINGW_PACKAGE_PREFIX}-gcc)
+source=(${_realname}-${pkgver}.tar.gz::"https://github.com/cesanta/mongoose/archive/${pkgver}.tar.gz"
+        mongoose.pc
+        Makefile)
+sha1sums=('6aee69d07a1b674de9b11c3cab6a878f0d43b727'
+          '92c82813e7c1b277a0078c0e67addc7e159aec81'
+          '344bfa94b2a032dcf47adbaaa190100445fa0181')
+
+prepare() {
+  cp Makefile mongoose-${pkgver}/
+  cp mongoose.pc mongoose-${pkgver}/
+}
+
+build() {
+  cd "${srcdir}/mongoose-${pkgver}"
+  make PREFIX=${MINGW_PREFIX} CC=gcc AR=ar -j1
+}
+
+package() {
+  cd "${srcdir}/mongoose-${pkgver}"
+  make PREFIX=${MINGW_PREFIX} DESTDIR=${pkgdir} install
+  install -D -m644 mongoose.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/mongoose.pc"
+  install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+  sed -e "s|@@PREFIX@@|${MINGW_PREFIX}|g" \
+      -e "s|@@VERSION@@|5.6|g" \
+      -i "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/mongoose.pc"
+}

--- a/mingw-w64-libmongoose/mongoose.pc
+++ b/mingw-w64-libmongoose/mongoose.pc
@@ -1,0 +1,11 @@
+prefix=@@PREFIX@@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+ 
+Name: mongoose
+Description: embedded library, to start a web server in few lines of code
+Version: @@VERSION@@
+Requires: libssl
+Libs: -L${libdir} -lmongoose
+Cflags: -I${includedir} -pthread


### PR DESCRIPTION
A release-based version has been added as well. It needs `MSYS=winsymlinks` for building, see [this issue](https://github.com/Alexpux/MSYS2-packages/issues/140).