### PR TITLE
Update URL for oniguruma

### DIFF
--- a/mingw-w64-oniguruma/PKGBUILD
+++ b/mingw-w64-oniguruma/PKGBUILD
@@ -8,9 +8,9 @@ pkgrel=1
 pkgdesc="A regular expressions library (mingw-w64)"
 arch=('any')
 license=('BSD')
-url="http://www.geocities.jp/kosako3/oniguruma"
+url="https://github.com/kkos/oniguruma"
 options=('staticlibs')
-source=("http://www.geocities.jp/kosako3/${_fullname}/archive/${_realname}-${pkgver}.tar.gz"
+source=("https://github.com/kkos/${_fullname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-no-undefined.patch
         002-autoconf.patch)
 md5sums=('d08f10ea5c94919780e6b7bed1ef9830'


### PR DESCRIPTION
The URL seems to have been switched to https://github.com/kkos/oniguruma