### PR TITLE
mingw-w64-gcc: Add cc.exe

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
 pkgver=5.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="http://gcc.gnu.org"
@@ -126,7 +126,7 @@ prepare() {
   patch -p1 -i ${srcdir}/230-build-more-gnattools.mingw.patch
 
   patch -p1 -i ${srcdir}/240-prettify-linking-no-undefined.mingw.patch
-  
+
   patch -p1 -i ${srcdir}/310-gcc-make-xmmintrin-header-cplusplus-compatible.patch
 
   if [ "${CARCH}" = "i686" ]; then
@@ -274,6 +274,7 @@ package_mingw-w64-gcc() {
   cd ${srcdir}${MINGW_PREFIX}
   cp bin/cpp.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/gcc.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/
+  cp bin/gcc.exe                                        ${pkgdir}${MINGW_PREFIX}/bin/cc.exe
   cp bin/gcc-ar.exe                                     ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/gcc-nm.exe                                     ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/gcc-ranlib.exe                                 ${pkgdir}${MINGW_PREFIX}/bin/


### PR DESCRIPTION
This has been reported as a problem several times, that `cc` in mingw64 shell points to `/usr/bin/cc` or nothing (depending on whether the user installed the `gcc` package).