### PR TITLE
Add drone build script.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,14 @@
+build:
+  image: fracting/msys32
+  shell: msys32
+  commands:
+    - drone/build.sh
+
+notify:
+  irc:
+    prefix: build
+    nick: MINGW-packages
+    channel: msys2
+    server:
+      host: irc.oftc.net
+      port: 6667

--- a/drone/build.sh
+++ b/drone/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# fetch first changed file, assume at most one package touched per commit
+TOUCHED=`git show --pretty="format:" --name-only | grep . | head -1`
+PKGDIR=`dirname $TOUCHED`
+if [ "$PKGDIR" = "." ]
+then
+    echo Nothing to test
+else
+    pushd $PKGDIR > /dev/null
+    makepkg-mingw -f -s --noconfirm --skippgpcheck --noprogressbar
+    popd > /dev/null
+fi


### PR DESCRIPTION
Similar to https://github.com/Alexpux/MSYS2-packages/pull/431, this patch add build script for MINGW packages, using mingw32 compilers.

mingw64 will be added once some strange Wine64 bugs are fixed (like https://bugs.wine-staging.com/show_bug.cgi?id=623)

Currently the server has only one CPU core, running on AWS. In the coming days I'll start to upgrade the server with more cores.