### PR TITLE
libbotan: Updated to 1.11.28

### DIFF
--- a/mingw-w64-libbotan/PKGBUILD
+++ b/mingw-w64-libbotan/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libbotan
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.11.26
+pkgver=1.11.28
 pkgrel=1
 arch=('any')
 url='http://botan.randombit.net/'
@@ -23,12 +23,14 @@ options=('strip' 'staticlibs' 'docs')
 source=(http://botan.randombit.net/releases/Botan-${pkgver}.tgz{,.asc}
         'boost-link.patch'
         'winsock-link.patch'
-        'disable-mkgmtime.patch')
-sha1sums=('8d3258696fe5c2b1557b11f82f3c623af39e46c1'
+        'disable-mkgmtime.patch'
+        'remove-GetTickCount64.patch')
+sha1sums=('44e61467353cb937c1e7663fe3ca8413f8d688b9'
           'SKIP'
           '407e623b46ef1b288b90195d9acadb34611b088b'
           '867667533df37c6b88b267c0e95b979d8115dea7'
-          '57289f42ad28111d5a5a05eab58ac5887d7e1f84')
+          '57289f42ad28111d5a5a05eab58ac5887d7e1f84'
+          'b7cbf11c255852603bca31649c01e682b8ee51f4')
 validpgpkeys=('621DAF6411E1851C4CF9A2E16211EBF1EFBADFBC')
 
 prepare() {
@@ -36,6 +38,7 @@ prepare() {
   patch -p1 -i "${srcdir}/boost-link.patch"
   patch -p1 -i "${srcdir}/winsock-link.patch"
   patch -p1 -i "${srcdir}/disable-mkgmtime.patch"
+  patch -p1 -i "${srcdir}/remove-GetTickCount64.patch"
 }
 
 build() {

--- a/mingw-w64-libbotan/remove-GetTickCount64.patch
+++ b/mingw-w64-libbotan/remove-GetTickCount64.patch
@@ -1,0 +1,10 @@
+--- Botan-1.11.28/src/lib/entropy/win32_stats/es_win32.cpp.orig	2016-02-06 17:05:24.361838900 +0200
++++ Botan-1.11.28/src/lib/entropy/win32_stats/es_win32.cpp	2016-02-06 17:05:27.910173600 +0200
+@@ -20,7 +20,6 @@
+    First query a bunch of basic statistical stuff, though
+    don't count it for much in terms of contributed entropy.
+    */
+-   accum.add(GetTickCount64(), BOTAN_ENTROPY_ESTIMATE_SYSTEM_DATA);
+    accum.add(GetMessagePos(), BOTAN_ENTROPY_ESTIMATE_SYSTEM_DATA);
+    accum.add(GetMessageTime(), BOTAN_ENTROPY_ESTIMATE_SYSTEM_DATA);
+    accum.add(GetInputState(), BOTAN_ENTROPY_ESTIMATE_SYSTEM_DATA);


### PR DESCRIPTION
Is this patch okay? Making `_WIN32_WINNT` equal to `0x0600` breaks complitability with < Windows Vista.