### PR TITLE
mingw-w64-gitg: This is a dummy patch to test the build system.

### DIFF
--- a/mingw-w64-gitg/PKGBUILD
+++ b/mingw-w64-gitg/PKGBUILD
@@ -68,3 +68,4 @@ package() {
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }
+# dummy.


### PR DESCRIPTION
Hopefully the CI scripts works fine with pull request... Good luck to me...

BTW, the package fail to build here:

http://wine-ci.org/fracting/MINGW-packages/12/1

```
CC       gitg/gitg_gitg-gitg-application.o
../gitg-3.19.6/gitg/gitg-application.c:128:2: error: unknown type name 'GtkShortcutsWindow'
  GtkShortcutsWindow* d_shortcuts;
  ^
gitg-application.c: In function 'gitg_application_on_shortcuts_activated':
gitg-application.c:1411:2: error: unknown type name 'GtkShortcutsWindow'
gitg-application.c:1413:2: error: unknown type name 'GtkShortcutsWindow'
gitg-application.c:1426:3: error: unknown type name 'GtkShortcutsWindow'
/home/nacho/checkout/gnome/gitg/gitg/gitg-application.vala:284:38: error: 'GTK_TYPE_SHORTCUTS_WINDOW' undeclared (first use in this function)
/home/nacho/checkout/gnome/gitg/gitg/gitg-application.vala:284:38: note: each undeclared identifier is reported only once for each function it appears in
/home/nacho/checkout/gnome/gitg/gitg/gitg-application.vala:284:30: error: 'GtkShortcutsWindow' undeclared (first use in this function)
/home/nacho/checkout/gnome/gitg/gitg/gitg-application.vala:284:49: error: expected expression before ')' token
gitg-application.c:1444:23: error: '_tmp5_' undeclared (first use in this function)
Makefile:3459: recipe for target 'gitg/gitg_gitg-gitg-application.o' failed
```

I'll retest on Windows, wait me for some minutes.