### PR TITLE
Tcllib fix md5

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,4 +17,5 @@ notify:
 matrix:
   runtest:
     - false
-    - true # allow failures
+# Temprorary disable matrix build to workaround irc plugin bug on wine-ci.org, see https://github.com/drone/drone/issues/1459
+#    - true # allow failures

--- a/mingw-w64-tcllib/PKGBUILD
+++ b/mingw-w64-tcllib/PKGBUILD
@@ -12,7 +12,7 @@ url="http://core.tcl.tk/tcllib/"
 license=('bsd')
 depends=("${MINGW_PACKAGE_PREFIX}-tcl")
 source=(https://github.com/tcltk/tcllib/archive/tcllib_${pkgver/./_}.tar.gz)
-md5sums=('fdeb9efd3a9da6361ef2451f2e5dc6b1')
+md5sums=('08dac86021c30c0a85c0a159f085143c')
 
 package(){
   cd ${srcdir}/tcllib-tcllib_${pkgver/./_}


### PR DESCRIPTION
https://github.com/Alexpux/MINGW-packages/pull/1045 doesn't build on CI server, see:

http://wine-ci.org/Alexpux/MINGW-packages/12

I manually verified on Windows in order to confirm it is not a CI server bug.

However, there is a CI server bug which reports fake success for matrix build at irc (and only at irc), I think this fake report is very misleading, so I temporary disable matrix build, will re-enable after fix irc notify.

