### PR TITLE
osgearth: add debug package (osgearth is now a split package...)

### DIFF
--- a/mingw-w64-openscenegraph/PKGBUILD
+++ b/mingw-w64-openscenegraph/PKGBUILD
@@ -6,38 +6,37 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_real
 _pkgver=3.5.1
 pkgver=${_pkgver//-/}
 pkgrel=1
-pkgdesc="Open source high performance 3D graphics toolkit (mingw-w64)"
 arch=('any')
 url="http://www.openscenegraph.org/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-boost"
-         "${MINGW_PACKAGE_PREFIX}-collada-dom-svn"
-         "${MINGW_PACKAGE_PREFIX}-curl"
-         "${MINGW_PACKAGE_PREFIX}-ffmpeg"
-         "${MINGW_PACKAGE_PREFIX}-fltk"
-         "${MINGW_PACKAGE_PREFIX}-freetype"
-         "${MINGW_PACKAGE_PREFIX}-gdal"
-         "${MINGW_PACKAGE_PREFIX}-giflib"
-         "${MINGW_PACKAGE_PREFIX}-gstreamer"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
-         "${MINGW_PACKAGE_PREFIX}-gtkglext"
-         "${MINGW_PACKAGE_PREFIX}-jasper"
-         "${MINGW_PACKAGE_PREFIX}-libjpeg"
-         "${MINGW_PACKAGE_PREFIX}-libpng"
-         "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-lua"
-         "${MINGW_PACKAGE_PREFIX}-SDL"
-         "${MINGW_PACKAGE_PREFIX}-SDL2"
-         "${MINGW_PACKAGE_PREFIX}-poppler"
-         "${MINGW_PACKAGE_PREFIX}-python3"
-         "${MINGW_PACKAGE_PREFIX}-qt5"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+             "${MINGW_PACKAGE_PREFIX}-boost"
+             "${MINGW_PACKAGE_PREFIX}-collada-dom-svn"
+             "${MINGW_PACKAGE_PREFIX}-curl"
+             "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+             "${MINGW_PACKAGE_PREFIX}-fltk"
+             "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-gdal"
+             "${MINGW_PACKAGE_PREFIX}-giflib"
+             "${MINGW_PACKAGE_PREFIX}-gstreamer"
+             "${MINGW_PACKAGE_PREFIX}-gtk2"
+             "${MINGW_PACKAGE_PREFIX}-gtkglext"
+             "${MINGW_PACKAGE_PREFIX}-jasper"
+             "${MINGW_PACKAGE_PREFIX}-libjpeg"
+             "${MINGW_PACKAGE_PREFIX}-libpng"
+             "${MINGW_PACKAGE_PREFIX}-libtiff"
+             "${MINGW_PACKAGE_PREFIX}-libxml2"
+             "${MINGW_PACKAGE_PREFIX}-lua"
+             "${MINGW_PACKAGE_PREFIX}-SDL"
+             "${MINGW_PACKAGE_PREFIX}-SDL2"
+             "${MINGW_PACKAGE_PREFIX}-poppler"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-qt5"
+             "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+             "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=(http://trac.openscenegraph.org/downloads/developer_releases/${_realname}-${_pkgver}.zip
         find-collada.patch
@@ -94,9 +93,35 @@ build() {
 }
 
 package_release() {
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+           "${MINGW_PACKAGE_PREFIX}-boost"
+           "${MINGW_PACKAGE_PREFIX}-collada-dom-svn"
+           "${MINGW_PACKAGE_PREFIX}-curl"
+           "${MINGW_PACKAGE_PREFIX}-ffmpeg"
+           "${MINGW_PACKAGE_PREFIX}-fltk"
+           "${MINGW_PACKAGE_PREFIX}-freetype"
+           "${MINGW_PACKAGE_PREFIX}-gdal"
+           "${MINGW_PACKAGE_PREFIX}-giflib"
+           "${MINGW_PACKAGE_PREFIX}-gstreamer"
+           "${MINGW_PACKAGE_PREFIX}-gtk2"
+           "${MINGW_PACKAGE_PREFIX}-gtkglext"
+           "${MINGW_PACKAGE_PREFIX}-jasper"
+           "${MINGW_PACKAGE_PREFIX}-libjpeg"
+           "${MINGW_PACKAGE_PREFIX}-libpng"
+           "${MINGW_PACKAGE_PREFIX}-libtiff"
+           "${MINGW_PACKAGE_PREFIX}-libxml2"
+           "${MINGW_PACKAGE_PREFIX}-lua"
+           "${MINGW_PACKAGE_PREFIX}-SDL"
+           "${MINGW_PACKAGE_PREFIX}-SDL2"
+           "${MINGW_PACKAGE_PREFIX}-poppler"
+           "${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-qt5"
+           "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+           "${MINGW_PACKAGE_PREFIX}-zlib")
+  pkgdesc="Open source high performance 3D graphics toolkit (mingw-w64)"
+
   cd Release-${MINGW_CHOST}
   make DESTDIR=${pkgdir} -j1 install
-
 }
 
 package_debug() {

--- a/mingw-w64-osgearth/0004-Fixed-debug-library-names.patch
+++ b/mingw-w64-osgearth/0004-Fixed-debug-library-names.patch
@@ -1,0 +1,49 @@
+From d828be245582c19f9d1c8fedcac4510e05a1c277 Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Mon, 1 Feb 2016 23:34:02 +0100
+Subject: [PATCH] Fixed debug library names
+
+Plugins and extensions libraries did not have debug postfix.
+---
+ CMakeModules/OsgEarthMacroUtils.cmake | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeModules/OsgEarthMacroUtils.cmake b/CMakeModules/OsgEarthMacroUtils.cmake
+index 492e916..83b7af8 100644
+--- a/CMakeModules/OsgEarthMacroUtils.cmake
++++ b/CMakeModules/OsgEarthMacroUtils.cmake
+@@ -222,12 +222,12 @@ MACRO(SETUP_PLUGIN PLUGIN_NAME)
+         ADD_LIBRARY(${TARGET_TARGETNAME} STATIC ${TARGET_SRC} ${TARGET_H} ${TARGET_GLSL} ${TARGET_IN})
+     ENDIF(DYNAMIC_OSGEARTH)
+ 
+-    #not sure if needed, but for plugins only msvc need the d suffix
+-    IF(NOT MSVC)
++    # not sure if needed, but for plugins only win32 needs the d suffix
++    IF(NOT WIN32)
+       IF(NOT UNIX)
+            SET_TARGET_PROPERTIES(${TARGET_TARGETNAME} PROPERTIES DEBUG_POSTFIX "")
+       ENDIF(NOT UNIX)
+-    ENDIF(NOT MSVC)
++    ENDIF(NOT WIN32)
+     SET_TARGET_PROPERTIES(${TARGET_TARGETNAME} PROPERTIES PROJECT_LABEL "${TARGET_LABEL}")
+ 
+     SETUP_LINK_LIBRARIES()
+@@ -294,12 +294,12 @@ MACRO(SETUP_EXTENSION PLUGIN_NAME)
+         ADD_LIBRARY(${TARGET_TARGETNAME} STATIC ${TARGET_SRC} ${TARGET_H} ${TARGET_GLSL} ${TARGET_IN})
+     ENDIF(DYNAMIC_OSGEARTH)
+ 
+-    #not sure if needed, but for plugins only msvc need the d suffix
+-    IF(NOT MSVC)
++    # not sure if needed, but for extensions only win32 needs the d suffix
++    IF(NOT WIN32)
+       IF(NOT UNIX)
+            SET_TARGET_PROPERTIES(${TARGET_TARGETNAME} PROPERTIES DEBUG_POSTFIX "")
+       ENDIF(NOT UNIX)
+-    ENDIF(NOT MSVC)
++    ENDIF(NOT WIN32)
+     SET_TARGET_PROPERTIES(${TARGET_TARGETNAME} PROPERTIES PROJECT_LABEL "${TARGET_LABEL}")
+ 
+     SETUP_LINK_LIBRARIES()
+-- 
+2.7.0
+

--- a/mingw-w64-osgearth/0005-Fixed-crash-due-to-probable-GCC-5.3.0-optimizer-bug.patch
+++ b/mingw-w64-osgearth/0005-Fixed-crash-due-to-probable-GCC-5.3.0-optimizer-bug.patch
@@ -1,0 +1,40 @@
+From 3fe3c3c82d19b711f892d7e55de0f2d9e058d92f Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Sat, 6 Feb 2016 11:17:46 +0100
+Subject: [PATCH 1/1] Fixed crash due to probable GCC 5.3.0 optimizer bug
+
+---
+ src/osgEarth/Units | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/osgEarth/Units b/src/osgEarth/Units
+index 7b3bad4..2395619 100644
+--- a/src/osgEarth/Units
++++ b/src/osgEarth/Units
+@@ -23,6 +23,14 @@
+ #include <osgEarth/Config>
+ #include <ostream>
+ 
++#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
++
++#if GCC_VERSION == 50300
++#define OPTIMIZE __attribute__((optimize("no-ipa-sra")))
++#else
++#define OPTIMIZE
++#endif
++
+ namespace osgEarth
+ {
+     class Registry;
+@@ -105,7 +113,7 @@ namespace osgEarth
+             return false;
+         }
+ 
+-        static double convert( const Units& from, const Units& to, double input ) {
++        static OPTIMIZE double convert( const Units& from, const Units& to, double input ) {
+             double output = input;
+             convert( from, to, input, output );
+             return output;
+-- 
+2.7.0
+

--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -5,15 +5,15 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 pkgver=2.7
 pkgrel=2
-pkgdesc="A terrain rendering toolkit for OpenSceneGraph (mingw-w64)"
 arch=('any')
 license=('LGPL')
 url="http://osgearth.org"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-cmake")
-depends=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
-         "${MINGW_PACKAGE_PREFIX}-gdal")
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
+             "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug"
+             "${MINGW_PACKAGE_PREFIX}-gdal")
 options=('staticlibs' 'strip')
 source=("https://github.com/gwaldron/osgearth/archive/${_realname}-${pkgver}.tar.gz"
         "0001-Fix-mingw-debug-build.patch"
@@ -68,9 +68,12 @@ build() {
 }
 
 package_release() {
+  depends=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
+           "${MINGW_PACKAGE_PREFIX}-gdal")
+  pkgdesc="A terrain rendering toolkit for OpenSceneGraph (mingw-w64)"
+
   cd Release-${MINGW_CHOST}
   make DESTDIR=${pkgdir} -j1 install
-
 }
 
 package_debug() {

--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -2,49 +2,100 @@
 
 _realname=osgearth
 pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug")
 pkgver=2.7
-pkgrel=1
-pkgdesc="A terrain rendering toolkit for OpenSceneGraph"
+pkgrel=2
+pkgdesc="A terrain rendering toolkit for OpenSceneGraph (mingw-w64)"
 arch=('any')
 license=('LGPL')
 url="http://osgearth.org"
-depends=("${MINGW_PACKAGE_PREFIX}-gdal" "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph")
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-OpenSceneGraph"
+         "${MINGW_PACKAGE_PREFIX}-gdal")
+options=('staticlibs' 'strip')
 source=("https://github.com/gwaldron/osgearth/archive/${_realname}-${pkgver}.tar.gz"
         "0001-Fix-mingw-debug-build.patch"
         "0002-Forced-include-headers-for-Qt5-moc-on-files-without-.patch"
-        "0003-Build-fix-against-OSG-3.4.0-and-OSG-3.5.0.patch")
+        "0003-Build-fix-against-OSG-3.4.0-and-OSG-3.5.0.patch"
+        "0004-Fixed-debug-library-names.patch")
 md5sums=('aad15a3ee27a34dcabc9b8f4922a1e96'
          '3beb4bfcdb4be556705ded174ae41c89'
          '4b682376141baae7628e9651a7fe578c'
-         '12fb399f93e0b92d295685d946c984b2')
+         '12fb399f93e0b92d295685d946c984b2'
+         '78a1c332045bc6da6ea0b7c7392d865a')
 
 prepare() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-Fix-mingw-debug-build.patch
   patch -p1 -i ${srcdir}/0002-Forced-include-headers-for-Qt5-moc-on-files-without-.patch
   patch -p1 -i ${srcdir}/0003-Build-fix-against-OSG-3.4.0-and-OSG-3.5.0.patch
+  patch -p1 -i ${srcdir}/0004-Fixed-debug-library-names.patch
 }
 
 build() {
   _pkgver=${_realname}-${pkgver} # How it's tagged in git
 
-  [[ -d ${srcdir}/build ]] && rm -rf ${srcdir}/build
-  mkdir -p ${srcdir}/build && cd ${srcdir}/build
+  export FREETYPE_DIR=${MINGW_PREFIX}
 
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
-    ../${_realname}-${_pkgver}
+  for builddir in {Release,Debug}-${MINGW_CHOST}; do
+    [[ -d ${builddir} ]] && rm -rf ${builddir}
+    mkdir -p ${builddir}
+    pushd ${builddir}
+      [[ "${builddir%-${MINGW_CHOST}}" == "Release" ]] && {
+        local _opts=""
+      } || {
+        local _opts=""
+      }
 
-  make
+      msg "Building ${builddir%-${MINGW_CHOST}} version..."
+
+      MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      ${MINGW_PREFIX}/bin/cmake.exe \
+        -G"MSYS Makefiles" \
+        -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+        -DCMAKE_BUILD_TYPE=${builddir%-${MINGW_CHOST}} \
+        ${_opts} \
+        ../${_realname}-${_pkgver}
+
+      make
+    popd
+  done
 }
 
-package() {
-  cd ${srcdir}/build
+package_release() {
+  cd Release-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} -j1 install
 
-  make install DESTDIR="${pkgdir}"
+}
+
+package_debug() {
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}=$pkgver"
+           "${MINGW_PACKAGE_PREFIX}-OpenSceneGraph-debug")
+  options=('staticlibs' '!strip')
+  pkgdesc="A terrain rendering toolkit for OpenSceneGraph (debug) (mingw-w64)"
+
+  cd Debug-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} -j1 install
+
+  rm -rf ${pkgdir}${MINGW_PREFIX}/include
+  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share
+}
+
+package_mingw-w64-i686-osgearth() {
+  package_release
+}
+
+package_mingw-w64-i686-osgearth-debug() {
+  package_debug
+}
+
+package_mingw-w64-x86_64-osgearth() {
+  package_release
+}
+
+package_mingw-w64-x86_64-osgearth-debug() {
+  package_debug
 }

--- a/mingw-w64-osgearth/PKGBUILD
+++ b/mingw-w64-osgearth/PKGBUILD
@@ -19,12 +19,14 @@ source=("https://github.com/gwaldron/osgearth/archive/${_realname}-${pkgver}.tar
         "0001-Fix-mingw-debug-build.patch"
         "0002-Forced-include-headers-for-Qt5-moc-on-files-without-.patch"
         "0003-Build-fix-against-OSG-3.4.0-and-OSG-3.5.0.patch"
-        "0004-Fixed-debug-library-names.patch")
+        "0004-Fixed-debug-library-names.patch"
+        "0005-Fixed-crash-due-to-probable-GCC-5.3.0-optimizer-bug.patch")
 md5sums=('aad15a3ee27a34dcabc9b8f4922a1e96'
          '3beb4bfcdb4be556705ded174ae41c89'
          '4b682376141baae7628e9651a7fe578c'
          '12fb399f93e0b92d295685d946c984b2'
-         '78a1c332045bc6da6ea0b7c7392d865a')
+         '78a1c332045bc6da6ea0b7c7392d865a'
+         'b165aede9c7b3d8b27e70ad90d59d8d9')
 
 prepare() {
   cd ${srcdir}/${_realname}-${_realname}-${pkgver}
@@ -32,6 +34,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0002-Forced-include-headers-for-Qt5-moc-on-files-without-.patch
   patch -p1 -i ${srcdir}/0003-Build-fix-against-OSG-3.4.0-and-OSG-3.5.0.patch
   patch -p1 -i ${srcdir}/0004-Fixed-debug-library-names.patch
+  patch -p1 -i ${srcdir}/0005-Fixed-crash-due-to-probable-GCC-5.3.0-optimizer-bug.patch
 }
 
 build() {


### PR DESCRIPTION
Adds debug package to osgearth (as done in OpenSceneGraph)

Also patches a crash due to a probable GCC 5.3.0 optimizer bug.

    $ ll *.xz
    -rw-r--r-- 1 Utilisateur None  7909732 Feb  6 11:50 mingw-w64-i686-osgearth-2.7-2-any.pkg.tar.xz
    -rw-r--r-- 1 Utilisateur None 92577072 Feb  6 11:51 mingw-w64-i686-osgearth-debug-2.7-2-any.pkg.tar.xz
    -rw-r--r-- 1 Utilisateur None  7727752 Feb  6 12:16 mingw-w64-x86_64-osgearth-2.7-2-any.pkg.tar.xz
    -rw-r--r-- 1 Utilisateur None 94028220 Feb  6 12:17 mingw-w64-x86_64-osgearth-debug-2.7-2-any.pkg.tar.xz