### PR TITLE
Fixes dependency renaming of LibRaw to libraw

### DIFF
--- a/mingw-w64-FreeImage/PKGBUILD
+++ b/mingw-w64-FreeImage/PKGBUILD
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-LibRaw"
+         "${MINGW_PACKAGE_PREFIX}-libraw"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-openexr")


### PR DESCRIPTION
The renaming of LibRaw to libraw breaks FreeImage due to missing dll.
FreeImage uses the old dependency.