### PR TITLE
Change MSYS2-specific paths in fontconfig.pc to use pkg-config prefixes

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -5,7 +5,7 @@ _realname=fontconfig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.11.94
-pkgrel=5
+pkgrel=6
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 url="http://www.fontconfig.org/release"
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libiconv")
 options=('staticlibs' 'strip')
 install=${_realname}-${CARCH}.install
-source=("http://www.fontconfig.org/release/fontconfig-${pkgver}.tar.bz2"
+source=("https://www.freedesktop.org/software/fontconfig/release/fontconfig-${pkgver}.tar.bz2"
         0001-fix-config-linking.all.patch
         0002-fix-mkdir.mingw.patch
         0004-fix-mkdtemp.mingw.patch
@@ -70,4 +70,8 @@ package() {
   mv ${pkgdir}{,${MINGW_PREFIX}}/var
 
   find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+
+  # Convert MSYS2-specific paths to pkg-config variables (see issue #872)
+  sed -i "s#${MINGW_PREFIX}/lib#\${libdir}#g" "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/fontconfig.pc
+  sed -i "s#${MINGW_PREFIX}/include#\${includedir}#g" "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/fontconfig.pc
 }


### PR DESCRIPTION
This allows native Windows software to understand the output of `pkg-config` when used with `fontconfig`. Fixes #872.

Please make sure that I'm replacing the paths in a way that's consistent with MSYS2's conventions, since this is my first contribution to MSYS2.