### PR TITLE
Continuous Integration: Upgrade system before installing dependencies.

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -14,7 +14,7 @@ git config --global user.name 'MSYS2 Continuous Integration'
 
 # Recipes
 cd "$(dirname "$0")"
-files=($(git show -m --pretty=format: --name-only))
+files=($(git show --pretty=format: --name-only $(git log -1 --pretty=format:%P | cut -d' ' -f1)..HEAD))
 for file in "${files[@]}"; do
     [[ "${file}" = */PKGBUILD ]] && recipes+=("${file}")
 done

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -21,6 +21,10 @@ done
 test -n "${files}"   || failure 'could not detect changed files'
 test -z "${recipes}" && success 'no changes in package recipes'
 
+# Refresh
+# ignore cache, force refresh database
+pacman --sync --refresh --refresh --sysupgrade --noconfirm --noprogressbar 
+
 # Build
 for recipe in "${recipes[@]}"; do
     cd "$(dirname ${recipe})"


### PR DESCRIPTION
Fix the build failure in http://wine-ci.org/Alexpux/MINGW-packages/52

Test in http://wine-ci.org/fracting/MINGW-packages/46

Do you prefer `pacman -Syyu`, or `pacman -Syy`, or anything else?

`pacman -Sy` doesn't work for me, i guess `pacman -Syu` doesn't work as well.

Please review before merge :)
If we agree on what's preferred, i'll submit a similar pull request to MSYS2-packages.

Thanks!