### PR TITLE
Continuous Integration: Avoid building a package repeatly if it was touched by multiple commits in a pull request.

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -14,7 +14,7 @@ git config --global user.name 'MSYS2 Continuous Integration'
 
 # Recipes
 cd "$(dirname "$0")"
-files=($(git show --pretty=format: --name-only $(git log -1 --pretty=format:%P | cut -d' ' -f1)..HEAD))
+files=($(git show --pretty=format: --name-only $(git log -1 --pretty=format:%P | cut -d' ' -f1)..HEAD | sort -u))
 for file in "${files[@]}"; do
     [[ "${file}" = */PKGBUILD ]] && recipes+=("${file}")
 done


### PR DESCRIPTION
This pull request is to fix the build failure discovered in http://wine-ci.org/Alexpux/MINGW-packages/65