### PR TITLE
Update catch to 1.3.4.

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=catch
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.3
+pkgver=1.3.4
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
 url='https://github.com/philsquared/Catch'
 license=('custom')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/philsquared/Catch/archive/v${pkgver}.tar.gz)
-sha256sums=('0845f901d743ddb404551ae603df3ffe9f23de0e359cb7c3a3d94c940586280e')
+sha256sums=('e2a83da57be37387cae25871e7969427cf72606223095413e2c3bbf10e0bfbbd')
 
 package() {
   cd "${srcdir}/Catch-${pkgver}"


### PR DESCRIPTION
Just updating to the next version of catch.  I tested that the package builds correctly and that the catch-based test suite of one of my projects passes.