### PR TITLE
mingw-w64-qt-installer-framework: Fix makedepends.

### DIFF
--- a/mingw-w64-qt-installer-framework/PKGBUILD
+++ b/mingw-w64-qt-installer-framework/PKGBUILD
@@ -10,7 +10,8 @@ url='http://qt-project.org/'
 license=('GPL3' 'LGPL' 'FDL' 'custom')
 provides=("${MINGW_PACKAGE_PREFIX}-qt-${_realname}")
 makedepends=("${MINGW_PACKAGE_PREFIX}-qt5-static" "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-make" "git")
+             "${MINGW_PACKAGE_PREFIX}-make" "${MINGW_PACKAGE_PREFIX}-libwebp"
+             "${MINGW_PACKAGE_PREFIX}-jasper" "git")
 options=('strip' 'staticlibs')
 #options=('!strip' 'debug' 'staticlibs')
 source=("${_realname}"::"git+https://github.com/qtproject/${_realname}.git"


### PR DESCRIPTION
Without this patch, qt-installer-framework failed to build:

```
C:/msys32/mingw32/bin/../lib/gcc/i686-w64-mingw32/5.3.0/../../../../i686-w64-mingw32/bin/ld.exe: cannot find -ljasper\r\r
C:/msys32/mingw32/bin/../lib/gcc/i686-w64-mingw32/5.3.0/../../../../i686-w64-mingw32/bin/ld.exe: cannot find -lwebp\r\r
collect2.exe: error: ld returned 1 exit status\r\r
Makefile.Release:83: recipe for target '../../bin/archivegen.exe' failed\r
```
http://wine-ci.org/fracting/MINGW-packages/6

Let's wait the CI build before merge :)