### PR TITLE
ruby: Fix the installation of the bundled gems.

### DIFF
--- a/mingw-w64-ruby/0004-rbinstall-destdir.patch
+++ b/mingw-w64-ruby/0004-rbinstall-destdir.patch
@@ -1,0 +1,11 @@
+diff -u -r ruby-2.3.0-orig/tool/rbinstall.rb ruby-2.3.0/tool/rbinstall.rb
+--- ruby-2.3.0-orig/tool/rbinstall.rb	2016-02-15 09:00:50.829489800 -0800
++++ ruby-2.3.0/tool/rbinstall.rb	2016-02-15 09:02:10.899131700 -0800
+@@ -282,7 +282,6 @@
+ 
+ def without_destdir(dir)
+   return dir if !$destdir or $destdir.empty? or !dir.start_with?($destdir)
+-  dir = dir.sub(/\A\w:/, '') if File::PATH_SEPARATOR == ';'
+   dir[$destdir.size..-1]
+ end
+ 

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -24,17 +24,20 @@ options=('staticlibs' 'strip')
 source=("http://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2"
         0001-mingw-w64-time-functions.patch
         0002-use-gnu-printf.patch
-        0003-fix-check-types.patch)
-md5sums=('f0d9f9bbdc87372ca98988a571875819'
-         'a29a6e09e324aa4d4c55ce83cca6e856'
-         '1107f3429fa995ff478a096e7a16bb2b'
-         'a797063f22fadbc97dd507341ef62558')
+        0003-fix-check-types.patch
+        0004-rbinstall-destdir.patch)
+sha256sums=('ec7579eaba2e4c402a089dbc86c98e5f1f62507880fd800b9b34ca30166bfa5e'
+            '329994d3bf7e692e18c1faffbedfbd076e5d00257b2100387a773b59b81ccd4e'
+            '578bd0830fe96efc7656c732ec46b0658fc436a7a30d8945cf3b8240797809f0'
+            '846d73ad389249c54ff4e009ad2fd4cdbc46714fce25c724bc706b3ec2f2fe3a'
+            '02382ec3b9e42d7dbb58edad3e41c361d98871711bb2f0320082c2acc6a82e2e')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-mingw-w64-time-functions.patch
   patch -p1 -i ${srcdir}/0002-use-gnu-printf.patch
   patch -p1 -i ${srcdir}/0003-fix-check-types.patch
+  patch -p1 -i ${srcdir}/0004-rbinstall-destdir.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
See #1070 for more discussion.

By the way, the ruby package installs some `.bat` and `.cmd` files to /mingw64/bin.  I'm not sure if we like that or not.

I can add myself as a maintainer for this package if you guys would like.  Ruby is my go-to language for a lot of things.