### PR TITLE
CI: Update core packages before full system upgrade.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,4 @@
 build_script:
+    # TODO: implement update-core --noconfirm and replace the below command line
+    - C:\msys64\usr\bin\pacman --sync --refresh --refresh --needed --noconfirm msys2-runtime msys2-runtime-devel bash pacman pacman-mirrors
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -15,7 +15,7 @@ status()  { echo -e "\n${cyan}[MSYS2 CI]${normal} ${@}\n"; }
 success() { echo -e "\n${green}[MSYS2 CI] SUCCESS:${normal} ${@}.\n"; exit 0; }
 failure() { echo -e "\n${red}[MSYS2 CI] FAILURE:${normal} ${@}.\n"; exit 1; }
 gitconf() { test -n "$(git config ${1})" && return 0; git config --global "${1}" "${2}"; }
-execute() { status "${package:+$package: }${1}"; ${@:2} || failure "${package}: ${1} failed"; }
+execute() { status "${package:+$package: }${1}"; ${@:2} || failure "${package:+$package: }${1} failed"; }
 
 # Detect
 cd "$(dirname "$0")"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -17,12 +17,6 @@ failure() { echo -e "\n${red}[MSYS2 CI] FAILURE:${normal} ${@}.\n"; exit 1; }
 gitconf() { test -n "$(git config ${1})" && return 0; git config --global "${1}" "${2}"; }
 execute() { status "${package:+$package: }${1}"; ${@:2} || failure "${package}: ${1} failed"; }
 
-# Prepare
-# TODO: implement update-core --noconfirm and move update process to outside this script
-execute 'Upgrading the system' pacman --sync --refresh --refresh --sysupgrade --noconfirm --noprogressbar
-gitconf user.name  'MSYS2 Continuous Integration' || failure 'Could not configure Git for makepkg'
-gitconf user.email 'ci@msys2.org'                 || failure 'Could not configure Git for makepkg'
-
 # Detect
 cd "$(dirname "$0")"
 commit_range="$(git log -1 --pretty=format:%P | cut -d' ' -f1)..HEAD"
@@ -30,6 +24,11 @@ files=($(git show --pretty=format: --name-only ${commit_range} | sort -u))
 for file in "${files[@]}"; do [[ "${file}" = */PKGBUILD ]] && packages+=("${file%/PKGBUILD}"); done
 test -n "${files}"    || failure 'Could not detect changed files'
 test -z "${packages}" && success 'No changes in package recipes'
+
+# Prepare
+execute 'Upgrading the system' pacman --sync --refresh --refresh --sysupgrade --noconfirm --noprogressbar
+gitconf user.name  'MSYS2 Continuous Integration' || failure 'Could not configure Git for makepkg'
+gitconf user.email 'ci@msys2.org'                 || failure 'Could not configure Git for makepkg'
 
 # Build and install
 status 'Building changed packages:'


### PR DESCRIPTION
** Please review before merge **

Dear folks,

This pull request has two changes:

Firstly, it adds `C:\msys64\usr\bin\pacman --sync --refresh --refresh --needed --noconfirm msys2-runtime msys2-runtime-devel bash pacman pacman-mirrors` to appveyor.yml, this is a workaround, once we support `update-core --noconfirm`, the long version of command line could be replaced.

Secondly, it moves `Prepare` after `Detect`, so when no package is changed, we don't need to waste time and waste bandwidth on system upgrade.

@renatosilva how do you think about this solution, which is slightly different to what we discussed last time? Please share your thoughts, thanks!