### PR TITLE
mingw-w64-gdb-git: Fix replaces.

### DIFF
--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -6,7 +6,7 @@ _gcc_ver=5.2.0
 pkgbase=mingw-w64-${_realname}
 _base_ver=7.10
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-replaces="${MINGW_PACKAGE_PREFIX}-${_realname}=${_base_ver}"
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}=${_base_ver}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=7.10.r85475.f5cc5a5
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
              "${MINGW_PACKAGE_PREFIX}-xz"
              "git")
 options=('staticlibs' '!distcc' '!ccache' 'debug' '!strip')
-source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git#branch=users/palves/mingw-cxx-conversion"
+source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git"
         gdbinit
         0001-MinGW-w64-Two-fixes-for-unusual-files.patch
         0002-MinGW-w64-Fix-libiberty-makefile.patch


### PR DESCRIPTION
For https://github.com/Alexpux/MINGW-packages/pull/1077#issuecomment-186880520