### PR TITLE
ncurses 6.0

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -2,24 +2,22 @@
 
 _realname=ncurses
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_base_ver=6.0
-_date_rev=20150627
-pkgver=${_base_ver}.${_date_rev}
-pkgrel=2
-pkgdesc="System V Release 4.0 curses emulation library"
+pkgver=6.0
+pkgrel=3
+pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-libsystre")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 url="https://www.gnu.org/software/ncurses/"
 license=('MIT')
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}.tar.gz"::http://invisible-island.net/datafiles/current/${_realname}.tar.gz
+source=("https://ftp.gnu.org/gnu/ncurses/${_realname}-${pkgver}.tar.gz"
         001-use-libsystre.patch)
-md5sums=('a2bed858184157081aa433671d9a02c4'
-         'b669861903d0699b6535b7c6e028880d')
+sha256sums=('f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260'
+            'eb28949297a4c1eda67da49cfbed1d60f181b83101a0b3715552a4564bd90ff3')
 
 prepare() {
-  cd $_realname-${_base_ver}-${_date_rev}
+  cd $_realname-${pkgver}
   patch -p1 -i ${srcdir}/001-use-libsystre.patch
 }
 
@@ -28,7 +26,7 @@ build() {
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
 
-  ../$_realname-${_base_ver}-${_date_rev}/configure \
+  ../$_realname-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --mandir=${MINGW_PREFIX}/share/man \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
* fix to point to a versioned source URL
  (to have a stable content/checksum)
* fix source to be the latest 6.0 (was 5.9?)
* use sha256 checksums

Ref: https://github.com/Alexpux/MINGW-packages/pull/1077