### PR TITLE
ncurses 6.0-20160220

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -3,20 +3,21 @@
 _realname=ncurses
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _base_ver=6.0
-_date_rev=20150627
+_date_rev=20160220
 pkgver=${_base_ver}.${_date_rev}
-pkgrel=2
-pkgdesc="System V Release 4.0 curses emulation library"
+pkgrel=1
+pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-libsystre")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 url="https://www.gnu.org/software/ncurses/"
 license=('MIT')
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}.tar.gz"::http://invisible-island.net/datafiles/current/${_realname}.tar.gz
+# ftp://invisible-island.net/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz
+source=("http://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz"
         001-use-libsystre.patch)
-md5sums=('a2bed858184157081aa433671d9a02c4'
-         'b669861903d0699b6535b7c6e028880d')
+sha256sums=('34387d968a37cbc2362f62d44d44bb9c27cd288261262bd06f3b053994c90401'
+            'eb28949297a4c1eda67da49cfbed1d60f181b83101a0b3715552a4564bd90ff3')
 
 prepare() {
   cd $_realname-${_base_ver}-${_date_rev}


### PR DESCRIPTION
* fix to point to a versioned source URL
  (to have a stable content/checksum)
* update source to the latest version
* use sha256 checksums
* fix 'pkgdesc'

Ref: https://github.com/Alexpux/MINGW-packages/pull/1077