### PR TITLE
atom-editor, atom-shell: fix invalid checksum-types

### DIFF
--- a/mingw-w64-atom-editor/PKGBUILD
+++ b/mingw-w64-atom-editor/PKGBUILD
@@ -10,7 +10,7 @@ arch=('any')
 url='https://atom.io'
 license=('MIT')
 options=()
-shasums=('SKIP')
+sha256sums=('SKIP')
 makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "git")

--- a/mingw-w64-atom-editor/PKGBUILD
+++ b/mingw-w64-atom-editor/PKGBUILD
@@ -11,6 +11,7 @@ url='https://atom.io'
 license=('MIT')
 options=()
 sha256sums=('SKIP')
+depends=("${MINGW_PACKAGE_PREFIX}-nodejs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "git")

--- a/mingw-w64-atom-shell/PKGBUILD
+++ b/mingw-w64-atom-shell/PKGBUILD
@@ -12,7 +12,7 @@ arch=('any')
 url='https://atom.io'
 license=('MIT')
 options=()
-shasums=('SKIP')
+sha256sums=('SKIP')
 makedepends=("${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "git")


### PR DESCRIPTION
* fix two `shasum` checksum types (with `SKIP` content) to `sha256sum`
* add a missing dependency