### PR TITLE
Path conversion in npm shell wrapper

### DIFF
--- a/mingw-w64-nodejs/0107-cygpath-conversion-in-npm-shell-wrapper.patch
+++ b/mingw-w64-nodejs/0107-cygpath-conversion-in-npm-shell-wrapper.patch
@@ -1,0 +1,33 @@
+From 6eb3fa82ca8634aa2b79d5b74ef09cb1a2e5d3e5 Mon Sep 17 00:00:00 2001
+From: Wolfgang Pupp <wolfgang.pupp@gmail.com>
+Date: Tue, 23 Feb 2016 08:11:36 +0100
+Subject: [PATCH] cygpath-conversion in npm-shell wrapper
+
+Always call cygpath if the command is available and the node executable
+is node.exe
+---
+ deps/npm/bin/npm | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/deps/npm/bin/npm b/deps/npm/bin/npm
+index 0b37c82..2c9754b 100755
+--- a/deps/npm/bin/npm
++++ b/deps/npm/bin/npm
+@@ -3,11 +3,10 @@
+ 
+ basedir=`dirname "$0"`
+ 
+-case `uname` in
+-    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+-esac
+-
+ if [ -x "$basedir/node.exe" ]; then
++  if [ -x "$(command -v cygpath)" ]; then
++    basedir=`cygpath -w "$basedir"`
++  fi
+   "$basedir/node" "$basedir/../lib/node_modules/npm/bin/npm-cli.js" "$@"
+ else
+   node "$basedir/../lib/node_modules/npm/bin/npm-cli.js" "$@"
+-- 
+2.7.0
+

--- a/mingw-w64-nodejs/PKGBUILD
+++ b/mingw-w64-nodejs/PKGBUILD
@@ -41,6 +41,7 @@ source=("http://nodejs.org/dist/v${pkgver}/node-v${pkgver}.tar.gz"
         "0104-Use-system-gyp.patch"
         "0105-Add-gyp-debug-option-to-configure.patch"
         "0106-MinGW-w64-add-platform-wintoolset-as-msvc-or-mingw-w64-for-node-gyp.patch"
+        "0107-cygpath-conversion-in-npm-shell-wrapper.patch"
 
         "0200-v8-3.26.33-Disable-USING_V8_SHARED-for-v8_snapshot-static-lib.patch"
         "0201-v8-3.26.33-Include-win32-headers-h-then-undef-MemoryBarrier.patch"
@@ -66,6 +67,7 @@ md5sums=('f6ef20f327ecd6cb1586c41c7184290c'
          'c79481c9c5010e4bcd7b4389cf44b7f9'
          '63013c0eeaee90e0985266fba9023a3e'
          '6274ba9c699f62da783b6d2a0446e2ae'
+         '03a67c21d13c86fa922f4e1a79d402b9'
          'dd82d12b16a416470bf73b56f0684163'
          '9828f204d7068faa656b83c738b67f5e'
          '0be71da4648801fba9aef222919cf611'
@@ -99,6 +101,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0104-Use-system-gyp.patch
   patch -p1 -i "${srcdir}"/0105-Add-gyp-debug-option-to-configure.patch
   patch -p1 -i "${srcdir}"/0106-MinGW-w64-add-platform-wintoolset-as-msvc-or-mingw-w64-for-node-gyp.patch
+  patch -p1 -i "${srcdir}"/0107-cygpath-conversion-in-npm-shell-wrapper.patch
 
   pushd deps/v8
   patch -p1 -i "${srcdir}"/0200-v8-3.26.33-Disable-USING_V8_SHARED-for-v8_snapshot-static-lib.patch


### PR DESCRIPTION
Make the npm shell script always calls cygpath if that command is
available and the node executable is "node.exe".

Fixes issue #1039.