### PR TITLE
Fixes typo in PKGBUILD script that prevents mingw-w64-lapack from bui…

### DIFF
--- a/mingw-w64-lapack/PKGBUILD
+++ b/mingw-w64-lapack/PKGBUILD
@@ -34,7 +34,7 @@ build()
     -DCMAKE_Fortran_COMPILER:PATH=${PREFIX_DEPS}/bin/gfortran.exe \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DCMAKE_NEED_RESPOSE=ON \
+    -DCMAKE_NEED_RESPONSE=ON \
     -DBUILD_TESTING=OFF \
     ../${_realname}-${pkgver}
   make


### PR DESCRIPTION
…lding.

Without this fix, you get the following error at the very end of the build process:

```
[100%] Linking Fortran shared library ../bin/liblapack.dll
/bin/sh: /C/msys64/mingw64/bin/ar.exe: Argument list too long
SRC/CMakeFiles/lapack.dir/build.make:42058: recipe for target 'bin/liblapack.dll                                                                                                                                                 ' failed
make[2]: *** [bin/liblapack.dll] Error 126
CMakeFiles/Makefile2:159: recipe for target 'SRC/CMakeFiles/lapack.dir/all' fail                                                                                                                                                 ed
make[1]: *** [SRC/CMakeFiles/lapack.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
```