### PR TITLE
ncurses: fix to recognize source package type

### DIFF
--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -14,7 +14,7 @@ url="https://www.gnu.org/software/ncurses/"
 license=('MIT')
 options=('staticlibs' 'strip')
 # ftp://invisible-island.net/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz
-source=("http://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz"
+source=("${pkgbase}-${pkgver}.tar.gz"::"http://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz"
         001-use-libsystre.patch)
 sha256sums=('34387d968a37cbc2362f62d44d44bb9c27cd288261262bd06f3b053994c90401'
             'eb28949297a4c1eda67da49cfbed1d60f181b83101a0b3715552a4564bd90ff3')


### PR DESCRIPTION
Taken from:
https://github.com/Alexpux/MSYS2-packages/blob/master/ncurses/PKGBUILD#L13
