### PR TITLE
mingw-w64-bzip2: Add mingw-w64-gcc-libs as depends.

### DIFF
--- a/mingw-w64-bzip2/PKGBUILD
+++ b/mingw-w64-bzip2/PKGBUILD
@@ -9,6 +9,7 @@ pkgdesc="A high-quality data compression program (mingw-w64)"
 arch=('any')
 url="http://www.bzip.org"
 license=("custom")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('strip' 'staticlibs')
 source=("http://www.bzip.org/${pkgver}/bzip2-${pkgver}.tar.gz"


### PR DESCRIPTION
Mingw bzip2 doesn't work when installed in fresh msys2.
Found this issue when debugging a Wine bug.

Cross Reference: https://bugs.wine-staging.com/show_bug.cgi?id=656
MINGW bzip2 randomly hang when call from `file -bizL ../babl-0.1.14.tar.bz2 `