### PR TITLE
fix git urls

### DIFF
--- a/mingw-w64-OpenBLAS-git/PKGBUILD
+++ b/mingw-w64-OpenBLAS-git/PKGBUILD
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran")
-source=("${_realname}"::"https://github.com/xianyi/${_realname}")
+source=("${_realname}"::"git+https://github.com/xianyi/${_realname}")
 sha256sums=('SKIP')
 
 pkgver() {

--- a/mingw-w64-atom-editor/PKGBUILD
+++ b/mingw-w64-atom-editor/PKGBUILD
@@ -5,7 +5,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r18372.d4f7e71
 pkgrel=2
 pkgdesc='Cross-platform desktop application shell (mingw-w64)'
-source=("${_realname}-${CARCH}"::"https://github.com/atom/atom#branch=master")
+source=("${_realname}-${CARCH}"::"git+https://github.com/atom/atom#branch=master")
 arch=('any')
 url='https://atom.io'
 license=('MIT')

--- a/mingw-w64-atom-shell/PKGBUILD
+++ b/mingw-w64-atom-shell/PKGBUILD
@@ -5,7 +5,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r2873.1a80bc7
 pkgrel=1
 pkgdesc='Cross-platform desktop application shell (mingw-w64)'
-source=("${_realname}-${CARCH}"::"https://github.com/atom/atom-shell.git#branch=master"
+source=("${_realname}-${CARCH}"::"git+https://github.com/atom/atom-shell.git#branch=master"
         "0001-python-python2.patch"
         "0002-Add-ninja-option.patch")
 arch=('any')

--- a/mingw-w64-babl/PKGBUILD
+++ b/mingw-w64-babl/PKGBUILD
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' 'staticlibs')
-source=(#"${_realname}"::"https://git.gnome.org/browse/babl"
+source=(#"${_realname}"::"git+https://git.gnome.org/browse/babl"
         #https://git.gnome.org/browse/babl/snapshot/BABL_${pkgver//./_}.tar.xz
         http://ftp.gtk.org/pub/babl/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2)
 sha256sums=('e6dcb112c8f8f75471823fdcc5a6a65f753b4d0e96e377979ea01a5d6fad7d4f')

--- a/mingw-w64-clutter/PKGBUILD
+++ b/mingw-w64-clutter/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-atk"
          "${MINGW_PACKAGE_PREFIX}-gtk3")
 options=(!libtool strip staticlibs)
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        #"https://git.gnome.org/browse/$_realname#tag=${pkgver}"
+        #"git+https://git.gnome.org/browse/$_realname#tag=${pkgver}"
         "0001-msys2-add-header-for-BOOL-defintion.patch"
         "0002-install-gtk-doc.patch")
 sha256sums=('9631c98cb4bcbfec15e1bbe9eaa6eef0f127201552fce40d7d28f2133803cd63'

--- a/mingw-w64-freerdp-git/PKGBUILD
+++ b/mingw-w64-freerdp-git/PKGBUILD
@@ -15,7 +15,7 @@ arch=('any')
 url="http://www.freerdp.com/"
 license=('Apache License 2.0')
 provides=("${MINGW_PACKAGE_PREFIX}-freerdp")
-source=("${_realname}::https://github.com/FreeRDP/FreeRDP.git")
+source=("${_realname}::git+https://github.com/FreeRDP/FreeRDP.git")
 
 sha256sums=('SKIP')
 

--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -49,7 +49,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
 #            "${MINGW_PACKAGE_PREFIX}-librsvg: for using the svg plugin"
 #            "${MINGW_PACKAGE_PREFIX}-jasper: for using the jasper plugin")
 #options=('!strip' 'debug')
-source=(#"${_realname}"::"https://git.gnome.org/browse/gegl"
+source=(#"${_realname}"::"git+https://git.gnome.org/browse/gegl"
         http://ftp.gtk.org/pub/gegl/${pkgver%.*}/${_realname}-${pkgver}.tar.bz2)
 sha256sums=('846290a790854d1e6b7c17a2d6f82ad7cb14c72e240bd3b81b98cc0ceddbc3ec')
 

--- a/mingw-w64-glib2-git/PKGBUILD
+++ b/mingw-w64-glib2-git/PKGBUILD
@@ -21,7 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-python2")
-source=("${_realname}::https://git.gnome.org/browse/glib"
+source=("${_realname}::git+https://git.gnome.org/browse/glib"
         0001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
         0003-g_abort.all.patch
         0004-glib-prefer-constructors-over-DllMain.patch

--- a/mingw-w64-gtk3-git/PKGBUILD
+++ b/mingw-w64-gtk3-git/PKGBUILD
@@ -31,7 +31,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('!strip' 'debug')
-source=("${_realname}::https://git.gnome.org/browse/gtk+")
+source=("${_realname}::git+https://git.gnome.org/browse/gtk+")
 sha256sums=('SKIP')
 
 pkgver() {

--- a/mingw-w64-libdvdcss/PKGBUILD
+++ b/mingw-w64-libdvdcss/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://download.videolan.org/pub/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        #"${_realname}-${pkgver}"::"https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+        #"${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
        )
 
 prepare() {

--- a/mingw-w64-libdvdnav/PKGBUILD
+++ b/mingw-w64-libdvdnav/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-libdvdread")
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}"::"https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+source=("${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
         #"https://www.videolan.org/pub/videolan/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         001-no-undefined.patch)
 sha256sums=('SKIP'

--- a/mingw-w64-libdvdread/PKGBUILD
+++ b/mingw-w64-libdvdread/PKGBUILD
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-libdvdcss")
 options=('staticlibs' 'strip')
 source=(#"https://download.videolan.org/pub/videolan/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        "${_realname}-${pkgver}"::"https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+        "${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
         0001-no-undefined-on.all.patch)
 sha256sums=('SKIP'
             '0a9664cce3a2e001445d150edfe5d8f06f3ca0d1affb91b50b1b5bde90c2713e')

--- a/mingw-w64-nanovg-git/PKGBUILD
+++ b/mingw-w64-nanovg-git/PKGBUILD
@@ -12,7 +12,7 @@ makedepends=("git" "${MINGW_PACKAGE_PREFIX}-premake")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
-source=("${_realname}"::'https://github.com/memononen/nanovg.git')
+source=("${_realname}"::'git+https://github.com/memononen/nanovg.git')
 sha256sums=('SKIP')
 options=('staticlibs')
 

--- a/mingw-w64-nim/PKGBUILD
+++ b/mingw-w64-nim/PKGBUILD
@@ -12,8 +12,8 @@ url='http://nim-lang.org/'
 license=('MIT')
 makedepends=('git')
 options=(!emptydirs)
-source=("${_realname}::https://github.com/Araq/Nim.git#tag=v${pkgver}"
-        "${_realname}-build::https://github.com/nim-lang/csources"
+source=("${_realname}::git+https://github.com/Araq/Nim.git#tag=v${pkgver}"
+        "${_realname}-build::git+https://github.com/nim-lang/csources"
         "0001-Use-unixy-filenames-even-on-Windows.patch"
         "0002-Recognize-mingw-in-build.sh.patch")
 sha256sums=('SKIP'

--- a/mingw-w64-nimble/PKGBUILD
+++ b/mingw-w64-nimble/PKGBUILD
@@ -10,7 +10,7 @@ url='https://github.com/nim-lang/nimble'
 license=('BSD')
 makedepends=('git'
              "${MINGW_PACKAGE_PREFIX}-nim")
-source=("${_realname}::https://github.com/nim-lang/nimble.git#tag=v${pkgver}")
+source=("${_realname}::git+https://github.com/nim-lang/nimble.git#tag=v${pkgver}")
 sha256sums=('SKIP')
 
 build() {

--- a/mingw-w64-octopi-git/PKGBUILD
+++ b/mingw-w64-octopi-git/PKGBUILD
@@ -17,7 +17,7 @@ conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _gitroot="https://github.com/aarnt/octopi.git"
 _gitname="octopi"
 #options=('debug' '!strip')
-source=("${_gitname}"::"${_gitroot}"
+source=("${_gitname}"::"git+${_gitroot}"
         "0001-Use-Q_PID-instead-of-int-reducing-QProcess-repititio.patch"
         "0002-Use-a-shared-QProcessEnvironment.patch"
         "0003-Win32-Link-to-Windows-Terminal-Services-wtsapi32.patch"

--- a/mingw-w64-opencollada-git/PKGBUILD
+++ b/mingw-w64-opencollada-git/PKGBUILD
@@ -14,7 +14,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('staticlibs' 'strip')
-source=("${_realname}"::"https://github.com/KhronosGroup/OpenCOLLADA.git"
+source=("${_realname}"::"git+https://github.com/KhronosGroup/OpenCOLLADA.git"
         fix-mingw-w64.patch
         fix-missing-include.patch)
 sha256sums=('SKIP'

--- a/mingw-w64-osmgpsmap-git/PKGBUILD
+++ b/mingw-w64-osmgpsmap-git/PKGBUILD
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gnome-common"
              "gtk-doc"
              "git")
 options=('staticlibs' 'strip' '!debug')
-source=("https://github.com/nzjrs/osm-gps-map"
+source=("git+https://github.com/nzjrs/osm-gps-map"
         001-fix-docdir.patch)
 sha256sums=('SKIP'
             '2c6165602198b9e316a3cfa4b1692ad687045bf49bdace4117669f7c1c71744d')

--- a/mingw-w64-pitivi-git/PKGBUILD
+++ b/mingw-w64-pitivi-git/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
         "${MINGW_PACKAGE_PREFIX}-python3-numpy"
         "${MINGW_PACKAGE_PREFIX}-gnonlin")
 options=(!libtool strip staticlibs)
-#source=(https://git.gnome.org/browse/$_realname)
+#source=(git+https://git.gnome.org/browse/$_realname)
 source=(${_realname}::"git+https://github.com/lubosz/$_realname#branch=msys2")
 sha256sums=('SKIP')
 

--- a/mingw-w64-vlc-git/PKGBUILD
+++ b/mingw-w64-vlc-git/PKGBUILD
@@ -111,8 +111,8 @@ makedepends=(
 #backup=('usr/share/vlc/lua/http/.hosts'
 #        'usr/share/vlc/lua/http/dialogs/.hosts')
 options=('strip' '!emptydirs')
-source=(#"${_realname}-${_ver_base}"::"https://git.videolan.org/git/${_realname}/${_realname}-${_ver_base}.git"
-        "${_realname}"::"https://git.videolan.org/git/${_realname}.git"
+source=(#"${_realname}-${_ver_base}"::"git+git://git.videolan.org/git/${_realname}/${_realname}-${_ver_base}.git"
+        "${_realname}"::"git+git://git.videolan.org/git/${_realname}.git"
         0001-Use-libdir-for-plugins-on-msys2.patch
         0002-MinGW-w64-lfind-s-_NumOfElements-is-an-unsigned-int.patch
         0003-MinGW-w64-don-t-pass-static-to-pkg-config-if-SYS-min.patch

--- a/mingw-w64-x264/PKGBUILD
+++ b/mingw-w64-x264/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" 
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-l-smash")
 options=('strip' 'staticlibs')
-source=("${_realname}"::"git://git.videolan.org/x264.git"
+source=("${_realname}"::"git+git://git.videolan.org/x264.git"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch)
 sha256sums=('SKIP'

--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2")
 makedepends=('git')
 options=('staticlibs')
 source=("http://zlib.net/current/${_realname}-${pkgver}.tar.gz"
-        "https://github.com/nmoinvaz/minizip.git"
+        "git+https://github.com/nmoinvaz/minizip.git"
         01-zlib-1.2.7-1-buildsys.mingw.patch
         02-no-undefined.mingw.patch
         03-dont-put-sodir-into-L.mingw.patch


### PR DESCRIPTION
* mark git urls as such with `git+` prefix
* revert git.videolang.org urls to use cleartext git protocol
  (http/https access appears to be down)