### PR TITLE
fix git.videolan.org urls and switch to secure again

### DIFF
--- a/mingw-w64-libdvdcss/PKGBUILD
+++ b/mingw-w64-libdvdcss/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://download.videolan.org/pub/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        #"${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+        #"${_realname}-${pkgver}"::"git+https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
        )
 
 prepare() {

--- a/mingw-w64-libdvdnav/PKGBUILD
+++ b/mingw-w64-libdvdnav/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "git")
 depends=("${MINGW_PACKAGE_PREFIX}-libdvdread")
 options=('staticlibs' 'strip')
-source=("${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+source=("${_realname}-${pkgver}"::"git+https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
         #"https://www.videolan.org/pub/videolan/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         001-no-undefined.patch)
 sha256sums=('SKIP'

--- a/mingw-w64-libdvdread/PKGBUILD
+++ b/mingw-w64-libdvdread/PKGBUILD
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-libdvdcss")
 options=('staticlibs' 'strip')
 source=(#"https://download.videolan.org/pub/videolan/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.bz2"
-        "${_realname}-${pkgver}"::"git+git://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
+        "${_realname}-${pkgver}"::"git+https://git.videolan.org/git/${_realname}.git#tag=${pkgver}"
         0001-no-undefined-on.all.patch)
 sha256sums=('SKIP'
             '0a9664cce3a2e001445d150edfe5d8f06f3ca0d1affb91b50b1b5bde90c2713e')

--- a/mingw-w64-vlc-git/PKGBUILD
+++ b/mingw-w64-vlc-git/PKGBUILD
@@ -111,8 +111,8 @@ makedepends=(
 #backup=('usr/share/vlc/lua/http/.hosts'
 #        'usr/share/vlc/lua/http/dialogs/.hosts')
 options=('strip' '!emptydirs')
-source=(#"${_realname}-${_ver_base}"::"git+git://git.videolan.org/git/${_realname}/${_realname}-${_ver_base}.git"
-        "${_realname}"::"git+git://git.videolan.org/git/${_realname}.git"
+source=(#"${_realname}-${_ver_base}"::"git+https://git.videolan.org/git/${_realname}/${_realname}-${_ver_base}.git"
+        "${_realname}"::"git+https://git.videolan.org/git/${_realname}.git"
         0001-Use-libdir-for-plugins-on-msys2.patch
         0002-MinGW-w64-lfind-s-_NumOfElements-is-an-unsigned-int.patch
         0003-MinGW-w64-don-t-pass-static-to-pkg-config-if-SYS-min.patch

--- a/mingw-w64-x264/PKGBUILD
+++ b/mingw-w64-x264/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" 
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-l-smash")
 options=('strip' 'staticlibs')
-source=("${_realname}"::"git+git://git.videolan.org/x264.git"
+source=("${_realname}"::"git+https://git.videolan.org/git/${_realname}.git"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch)
 sha256sums=('SKIP'


### PR DESCRIPTION
Apologise for not getting this right the first (and second) time around.

videolan.org Git URL is in the form of
secure: https://git.videolan.org/git/repo.git
insecure: git://git.videolan.org/repo.git
