### PR TITLE
update libxml2 with upstream

### DIFF
--- a/mingw-w64-libxml2/PKGBUILD
+++ b/mingw-w64-libxml2/PKGBUILD
@@ -3,8 +3,8 @@
 
 _realname=libxml2
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.9.2
-pkgrel=6
+pkgver=2.9.3
+pkgrel=1
 arch=('any')
 pkgdesc="XML parsing library, version 2 (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -18,7 +18,6 @@ url="http://www.xmlsoft.org/"
 install=${_realname}-${CARCH}.install
 source=("http://xmlsoft.org/sources/${_realname}-${pkgver}.tar.gz"
         "mingw32-libxml2-static-build-compile-fix.patch"
-        "libxml2-2.9.2-catalog-revert.patch"
         0004-detect-ws2tcpip.mingw.patch
         0005-fix-char-cast-warning.mingw.patch
         0006-fix-unused-var-warning.mingw.patch
@@ -38,9 +37,8 @@ source=("http://xmlsoft.org/sources/${_realname}-${pkgver}.tar.gz"
         0023-fix-sitedir-detection.mingw.patch
         0024-shrext-pyd.mingw.patch
         0025-mingw-python-dont-remove-dot.patch)
-sha256sums=('5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc'
+sha256sums=('4de9e31f46b44d34871c22f54bfc54398ef124d6f7cafb1f4a5958fbcd3ba12d'
             '0f86ded5d487ae7f38e1f039085c078d978af8d7aad6e05d5a4028d645d2115a'
-            '7bbda2c539d70860c8665997217bfcb8d80cb126374ca87734f6f7b4b0dc3d15'
             '6ae1cee98b4ac9944a26a0bac75db48ae718d755dad3d37638da9b33a65c5789'
             'd954213b42b5c9f2ccf9211420e40a223fc1cea798b306437c010b25f6c36cc5'
             '148da5aabe2c1213ba609e893557e455d79ac6490da276f2d0b53d2d4aa6274b'
@@ -65,7 +63,6 @@ prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np0 -i "${srcdir}"/mingw32-libxml2-static-build-compile-fix.patch
-  patch -p1 -i ${srcdir}/libxml2-2.9.2-catalog-revert.patch
 
   patch -p1 -i ${srcdir}/0004-detect-ws2tcpip.mingw.patch
   patch -p1 -i ${srcdir}/0005-fix-char-cast-warning.mingw.patch


### PR DESCRIPTION
Looks like the `libxml2-2.9.2-catalog-revert.patch` has been merged upstream.