### PR TITLE
catch: Update to 1.3.5, add a patch to fix a warning, and add check()

### DIFF
--- a/mingw-w64-catch/01-fix-paren-pragma.patch
+++ b/mingw-w64-catch/01-fix-paren-pragma.patch
@@ -1,0 +1,11 @@
+--- a/single_include/catch.hpp
++++ b/single_include/catch.hpp
+@@ -149,7 +149,7 @@
+ #   endif
+ 
+ #   if !defined(CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS) && defined(CATCH_CPP11_OR_GREATER)
+-#       define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS _Pragma( "gcc diagnostic ignored \"-Wparentheses\"" )
++#       define CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS _Pragma( "GCC diagnostic ignored \"-Wparentheses\"" )
+ #   endif
+ 
+ // - otherwise more recent versions define __cplusplus >= 201103L

--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -3,14 +3,33 @@
 _realname=catch
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.4
+pkgver=1.3.5
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
 url='https://github.com/philsquared/Catch'
+checkdepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+              "${MINGW_PACKAGE_PREFIX}-cmake")
 license=('custom')
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/philsquared/Catch/archive/v${pkgver}.tar.gz)
-sha256sums=('e2a83da57be37387cae25871e7969427cf72606223095413e2c3bbf10e0bfbbd')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/philsquared/Catch/archive/v${pkgver}.tar.gz
+       "01-fix-paren-pragma.patch")
+sha256sums=('8ce85366f33f73016a8c3209fa5eda6cad4695b582ecde35851278fbdc2122f2'
+            'aaf0f445892c55b2e718d1b4c8c592d9232e66e48c562f6330fac410896c1c04')
+
+prepare()
+{
+  cd "${srcdir}/Catch-${pkgver}"
+  patch -p1 -i ../01-fix-paren-pragma.patch
+}
+
+check() {
+  rm -rf "${srcdir}/test-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/test-${MINGW_CHOST}"
+  cd "${srcdir}/test-${MINGW_CHOST}"
+  cmake "../Catch-${pkgver}/projects/CMake" -G"MSYS Makefiles" -DCMAKE_CXX_FLAGS='--std=gnu++11'
+  make
+  ./SelfTest.exe
+}
 
 package() {
   cd "${srcdir}/Catch-${pkgver}"


### PR DESCRIPTION
The patch I'm adding in this pull request has also been sent to the upstream developer: https://github.com/philsquared/Catch/pull/604