### PR TITLE
Include OSD traineddata for tesseract

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -18,8 +18,10 @@ depends=(${MINGW_PACKAGE_PREFIX}-cairo
          ${MINGW_PACKAGE_PREFIX}-pango
          ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz)
-sha256sums=('57f63e1b14ae04c3932a2683e4be4954a2849e17edd638ffe91bc5a2156adc6a')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz
+	https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata)
+sha256sums=('57f63e1b14ae04c3932a2683e4be4954a2849e17edd638ffe91bc5a2156adc6a'
+            'd7c06843a771f30fb64b4109a1b059f9')
 
 prepare() {
   cd "${srcdir}/tesseract-${pkgver}"
@@ -55,4 +57,6 @@ package() {
   make DESTDIR="${pkgdir}" install
   make training
   make DESTDIR="${pkgdir}" training-install
+  mkdir -p $pkgdir/tessdata
+  install -Dm0644 osd.traineddata $pkgdir/tessdata/osd.traineddata
 }


### PR DESCRIPTION
osd.traineddata is REQUIRED for Orientation and script detection for all languages. Hence it should be included along with tesseract package.

Please check the hashsum. Thanks!