### PR TITLE
 tesseract data for all languages other than english

### DIFF
--- a/mingw-w64-tesseract-ocr-osd/PKGBUILD
+++ b/mingw-w64-tesseract-ocr-osd/PKGBUILD
@@ -1,47 +1,45 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
-# The traineddata files from the source should be unpacked in tesseract ocr's tessdata directory
+# The traineddata and related files for all languages should be placed in tesseract ocr's tessdata directory
 
+_langs=(afr amh ara asm aze aze_cyrl bel ben bod bos bul cat ceb ces
+chi_sim chi_tra chr cym dan dan_frak deu deu_frak dzo ell enm epo
+equ est eus fas fin fra frk frm gle glg grc guj hat heb hin hrv hun
+iku ind isl ita ita_old jav jpn kan kat kat_old kaz khm kir kor kur
+lao lat lav lit mal mar mkd mlt msa mya nep nld nor ori pan pol
+por pus ron rus san sin slk slk_frak slv spa spa_old sqi srp srp_latn
+swa swe syr tam tel tgk tgl tha tir tur uig ukr urd uzb uzb_cyrl vie yid)
 
-_realname=tesseract-ocr-osd
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.04.rc1
+pkgbase=tesseract-data
+pkgname=($(for l in ${_langs[@]}; do echo ${MINGW_PACKAGE_PREFIX}-tesseract-data-${l}; done) )
+pkgver=3.04.00
 pkgrel=1
-pkgdesc="Orientation & Script Detection Data data for Tesseract  OCR engine"
+pkgdesc="Language tessdata for Tesseract OCR engine (mingw-w64)"
 arch=('any')
 url="https://github.com/tesseract-ocr/tessdata"
 license=("Apache License 2.0")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
-        ${MINGW_PACKAGE_PREFIX}-tesseract-ocr
-        ${MINGW_PACKAGE_PREFIX}-zlib)
-options=('!libtool' 'strip')
-source=("https://github.com/tesseract-ocr/tessdata/blob/master/osd.traineddata")
-sha256sums=('SKIP')
 
-prepare() {
-  cd "$srcdir/${_realname}-master"
-}
+depends=()
+source=($pkgbase-$pkgver.tar.gz::https://github.com/tesseract-ocr/tessdata/archive/$pkgver.tar.gz)
+sha256sums=('5dcb37198336b6953843b461ee535df1401b41008d550fc9e43d0edabca7adb1')
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
-
-
-  ${srcdir}/${_realname}-master/configure \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --prefix=${MINGW_PREFIX} \
-    LIBLEPT_HEADERSDIR=${MINGW_PREFIX}/include \
-
-  make
+  true
 }
 
+# Declare the package functions for tessdata
+for l in ${_langs[@]}; do
+    eval "
+package_${MINGW_PACKAGE_PREFIX}-tesseract-data-${l}(){
+    pkgdesc=\"($l) Language tessdata for Tesseract OCR engine (mingw-w64)\"
+    pkgver=3.04.00
+    pkgrel=1
+    depends=()
+    groups=('tesseract-data')
 
-package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR="$pkgdir" install-lang
+    mkdir -p \$pkgdir/usr/share/tessdata
+    cp \$srcdir/tessdata-$pkgver/${l}.* \$pkgdir/usr/share/tessdata/
+    find \$pkgdir/usr/share/tessdata -type f -exec chmod 0644 {} \;
 }
+    "
+done

--- a/mingw-w64-tesseract-ocr-osd/PKGBUILD
+++ b/mingw-w64-tesseract-ocr-osd/PKGBUILD
@@ -1,6 +1,7 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
-# The traineddata and related files for all languages should be placed in tesseract ocr's tessdata directory
+# The traineddata and related files for all languages should be placed in tessdata directory
+# tessdata for all languages other than English. osd.traineddata is included with tesseract-ocr
 
 _langs=(afr amh ara asm aze aze_cyrl bel ben bod bos bul cat ceb ces
 chi_sim chi_tra chr cym dan dan_frak deu deu_frak dzo ell enm epo
@@ -9,9 +10,9 @@ iku ind isl ita ita_old jav jpn kan kat kat_old kaz khm kir kor kur
 lao lat lav lit mal mar mkd mlt msa mya nep nld nor ori pan pol
 por pus ron rus san sin slk slk_frak slv spa spa_old sqi srp srp_latn
 swa swe syr tam tel tgk tgl tha tir tur uig ukr urd uzb uzb_cyrl vie yid)
-
-pkgbase=tesseract-data
-pkgname=($(for l in ${_langs[@]}; do echo ${MINGW_PACKAGE_PREFIX}-tesseract-data-${l}; done) )
+_realname=tesseract-data
+pkgbase=mingw-w64-${_realname}
+pkgname=($(for l in ${_langs[@]}; do echo ${MINGW_PACKAGE_PREFIX}-${_realname}-${l}; done) )
 pkgver=3.04.00
 pkgrel=1
 pkgdesc="Language tessdata for Tesseract OCR engine (mingw-w64)"
@@ -20,7 +21,7 @@ url="https://github.com/tesseract-ocr/tessdata"
 license=("Apache License 2.0")
 
 depends=()
-source=($pkgbase-$pkgver.tar.gz::https://github.com/tesseract-ocr/tessdata/archive/$pkgver.tar.gz)
+source=(${_realname}-$pkgver.tar.gz::https://github.com/tesseract-ocr/tessdata/archive/$pkgver.tar.gz)
 sha256sums=('5dcb37198336b6953843b461ee535df1401b41008d550fc9e43d0edabca7adb1')
 
 build() {
@@ -30,16 +31,16 @@ build() {
 # Declare the package functions for tessdata
 for l in ${_langs[@]}; do
     eval "
-package_${MINGW_PACKAGE_PREFIX}-tesseract-data-${l}(){
+package_${MINGW_PACKAGE_PREFIX}-${_realname}-${l}(){
     pkgdesc=\"($l) Language tessdata for Tesseract OCR engine (mingw-w64)\"
     pkgver=3.04.00
     pkgrel=1
     depends=()
-    groups=('tesseract-data')
+    groups=(${_realname})
 
-    mkdir -p \$pkgdir/usr/share/tessdata
-    cp \$srcdir/tessdata-$pkgver/${l}.* \$pkgdir/usr/share/tessdata/
-    find \$pkgdir/usr/share/tessdata -type f -exec chmod 0644 {} \;
+    mkdir -p \$pkgdir/${MINGW_PREFIX}/share/tessdata
+    cp \$srcdir/tessdata-$pkgver/${l}.* \$pkgdir/${MINGW_PREFIX}/share/tessdata/
+    find \$pkgdir/${MINGW_PREFIX}/share/tessdata -type f -exec chmod 0644 {} \;
 }
     "
 done


### PR DESCRIPTION
Based on pkgbuild in archlinux

--
Alternately, both tesseract-ocr-osd and tesseract-ocr-eng can be deleted and replaced by a new group
tesseract-data which handles all languages.