### PR TITLE
cpptest version 1.1.2 (package release 1)

### DIFF
--- a/mingw-w64-cpptest/PKGBUILD
+++ b/mingw-w64-cpptest/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Diego Sogari <diego.sogari@falker.com.br>
+
+_realname=cpptest
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.1.2
+pkgrel=1
+pkgdesc="A C++ Unit Testing Framework (mingw-w64)"
+arch=('any')
+url="http://cpptest.sourceforge.net/"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "automake" "autoconf")
+source=("http://downloads.sourceforge.net/project/${_realname}/${_realname}/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "${_realname}-${pkgver}.patch")
+sha256sums=('9e4fdf156b709397308536eb6b921e3aea1f463c6613f9a0c1dfec9614386027'
+            'e583639839ab25651d35c954daf166f92fcaa431abb3159e562959b104126d80')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "../${_realname}-${pkgver}.patch"
+  mkdir -p m4
+  autoreconf -fvi
+}
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --includedir=${MINGW_PREFIX}/include/cpptest
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-cpptest/cpptest-1.1.2.patch
+++ b/mingw-w64-cpptest/cpptest-1.1.2.patch
@@ -1,0 +1,225 @@
+diff -c -r cpptest-1.1.2.orig/Makefile.am cpptest-1.1.2/Makefile.am
+*** cpptest-1.1.2.orig/Makefile.am	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/Makefile.am	Sun Mar  6 02:17:51 2016
+***************
+*** 23,29 ****
+  ## Boston, MA 02111-1307, USA.
+  ##
+  ## ---
+! 
+  SUBDIRS = src test
+  if DOC
+  SUBDIRS += doc
+--- 23,29 ----
+  ## Boston, MA 02111-1307, USA.
+  ##
+  ## ---
+! ACLOCAL_AMFLAGS = -I m4
+  SUBDIRS = src test
+  if DOC
+  SUBDIRS += doc
+diff -c -r cpptest-1.1.2.orig/configure.ac cpptest-1.1.2/configure.ac
+*** cpptest-1.1.2.orig/configure.ac	Thu Oct  4 12:35:59 2012
+--- cpptest-1.1.2/configure.ac	Sun Mar  6 02:21:15 2016
+***************
+*** 34,39 ****
+--- 34,40 ----
+  
+  AM_INIT_AUTOMAKE([1.8 gnu dist-zip])
+  AM_CONFIG_HEADER(config/config.h)
++ AC_CONFIG_MACRO_DIR([m4])
+  
+  # LibTool versioning
+  #
+***************
+*** 97,102 ****
+--- 98,111 ----
+  AC_PROG_MAKE_SET
+  AM_PROG_LIBTOOL
+  
++ ## Toggle build options specific to Windows
++ case "${host}" in
++ 	*-*-mingw*) WIN32="yes" ;;
++ 	*cygwin*) WIN32="yes" ;;
++ 	*) WIN32="no" ;;
++ esac
++ AM_CONDITIONAL([WIN32], test "$WIN32" = "yes")
++ 
+  if test "$enable_doc" = "yes"; then
+  	AC_CHECK_PROG(x_doxygen, doxygen, yes, no)
+  	if test "$x_doxygen" = "no"; then
+diff -c -r cpptest-1.1.2.orig/src/Makefile.am cpptest-1.1.2/src/Makefile.am
+*** cpptest-1.1.2.orig/src/Makefile.am	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/Makefile.am	Sun Mar  6 02:15:54 2016
+***************
+*** 34,39 ****
+--- 34,42 ----
+  lib_LTLIBRARIES		= libcpptest.la
+  
+  libcpptest_la_LDFLAGS	= -version-info $(LT_VERSION)
++ if WIN32
++ libcpptest_la_LDFLAGS += -no-undefined
++ endif
+  
+  libcpptest_la_SOURCES	= \
+  	collectoroutput.cpp \
+diff -c -r cpptest-1.1.2.orig/src/collectoroutput.cpp cpptest-1.1.2/src/collectoroutput.cpp
+*** cpptest-1.1.2.orig/src/collectoroutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/collectoroutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/htmloutput.cpp cpptest-1.1.2/src/htmloutput.cpp
+*** cpptest-1.1.2.orig/src/htmloutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/htmloutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 27,33 ****
+  #include <algorithm>
+  #include <sstream>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 27,33 ----
+  #include <algorithm>
+  #include <sstream>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/missing.cpp cpptest-1.1.2/src/missing.cpp
+*** cpptest-1.1.2.orig/src/missing.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/missing.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/missing.h cpptest-1.1.2/src/missing.h
+*** cpptest-1.1.2.orig/src/missing.h	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/missing.h	Sun Mar  6 01:37:44 2016
+***************
+*** 27,33 ****
+  #ifndef CPPTEST_MISSING_H
+  #define CPPTEST_MISSING_H
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 27,33 ----
+  #ifndef CPPTEST_MISSING_H
+  #define CPPTEST_MISSING_H
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/suite.cpp cpptest-1.1.2/src/suite.cpp
+*** cpptest-1.1.2.orig/src/suite.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/suite.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 30,36 ****
+  #include <functional>
+  #include <numeric>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 30,36 ----
+  #include <functional>
+  #include <numeric>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/textoutput.cpp cpptest-1.1.2/src/textoutput.cpp
+*** cpptest-1.1.2.orig/src/textoutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/textoutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 26,32 ****
+  
+  #include <algorithm>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 26,32 ----
+  
+  #include <algorithm>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/time.cpp cpptest-1.1.2/src/time.cpp
+*** cpptest-1.1.2.orig/src/time.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/time.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/utils.cpp cpptest-1.1.2/src/utils.cpp
+*** cpptest-1.1.2.orig/src/utils.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/utils.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 25,31 ****
+  // ---
+  
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 25,31 ----
+  // ---
+  
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"


### PR DESCRIPTION
Add the CppTest library (http://cpptest.sourceforge.net/). It is a check dependency for the uriparser library (http://uriparser.sourceforge.net/), which in turn is a hard runtime dependency for the libkml (https://github.com/google/libkml/) library.