### PR TITLE
Add uriparser

### DIFF
--- a/mingw-w64-cpptest/PKGBUILD
+++ b/mingw-w64-cpptest/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Diego Sogari <diego.sogari@falker.com.br>
+
+_realname=cpptest
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.1.2
+pkgrel=1
+pkgdesc="A C++ Unit Testing Framework (mingw-w64)"
+arch=('any')
+url="http://cpptest.sourceforge.net/"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "automake" "autoconf")
+source=("http://downloads.sourceforge.net/project/${_realname}/${_realname}/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "${_realname}-${pkgver}.patch")
+sha256sums=('9e4fdf156b709397308536eb6b921e3aea1f463c6613f9a0c1dfec9614386027'
+            'e583639839ab25651d35c954daf166f92fcaa431abb3159e562959b104126d80')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "../${_realname}-${pkgver}.patch"
+  mkdir -p m4
+  autoreconf -fvi
+}
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --includedir=${MINGW_PREFIX}/include/cpptest
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-cpptest/cpptest-1.1.2.patch
+++ b/mingw-w64-cpptest/cpptest-1.1.2.patch
@@ -1,0 +1,225 @@
+diff -c -r cpptest-1.1.2.orig/Makefile.am cpptest-1.1.2/Makefile.am
+*** cpptest-1.1.2.orig/Makefile.am	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/Makefile.am	Sun Mar  6 02:17:51 2016
+***************
+*** 23,29 ****
+  ## Boston, MA 02111-1307, USA.
+  ##
+  ## ---
+! 
+  SUBDIRS = src test
+  if DOC
+  SUBDIRS += doc
+--- 23,29 ----
+  ## Boston, MA 02111-1307, USA.
+  ##
+  ## ---
+! ACLOCAL_AMFLAGS = -I m4
+  SUBDIRS = src test
+  if DOC
+  SUBDIRS += doc
+diff -c -r cpptest-1.1.2.orig/configure.ac cpptest-1.1.2/configure.ac
+*** cpptest-1.1.2.orig/configure.ac	Thu Oct  4 12:35:59 2012
+--- cpptest-1.1.2/configure.ac	Sun Mar  6 02:21:15 2016
+***************
+*** 34,39 ****
+--- 34,40 ----
+  
+  AM_INIT_AUTOMAKE([1.8 gnu dist-zip])
+  AM_CONFIG_HEADER(config/config.h)
++ AC_CONFIG_MACRO_DIR([m4])
+  
+  # LibTool versioning
+  #
+***************
+*** 97,102 ****
+--- 98,111 ----
+  AC_PROG_MAKE_SET
+  AM_PROG_LIBTOOL
+  
++ ## Toggle build options specific to Windows
++ case "${host}" in
++ 	*-*-mingw*) WIN32="yes" ;;
++ 	*cygwin*) WIN32="yes" ;;
++ 	*) WIN32="no" ;;
++ esac
++ AM_CONDITIONAL([WIN32], test "$WIN32" = "yes")
++ 
+  if test "$enable_doc" = "yes"; then
+  	AC_CHECK_PROG(x_doxygen, doxygen, yes, no)
+  	if test "$x_doxygen" = "no"; then
+diff -c -r cpptest-1.1.2.orig/src/Makefile.am cpptest-1.1.2/src/Makefile.am
+*** cpptest-1.1.2.orig/src/Makefile.am	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/Makefile.am	Sun Mar  6 02:15:54 2016
+***************
+*** 34,39 ****
+--- 34,42 ----
+  lib_LTLIBRARIES		= libcpptest.la
+  
+  libcpptest_la_LDFLAGS	= -version-info $(LT_VERSION)
++ if WIN32
++ libcpptest_la_LDFLAGS += -no-undefined
++ endif
+  
+  libcpptest_la_SOURCES	= \
+  	collectoroutput.cpp \
+diff -c -r cpptest-1.1.2.orig/src/collectoroutput.cpp cpptest-1.1.2/src/collectoroutput.cpp
+*** cpptest-1.1.2.orig/src/collectoroutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/collectoroutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/htmloutput.cpp cpptest-1.1.2/src/htmloutput.cpp
+*** cpptest-1.1.2.orig/src/htmloutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/htmloutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 27,33 ****
+  #include <algorithm>
+  #include <sstream>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 27,33 ----
+  #include <algorithm>
+  #include <sstream>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/missing.cpp cpptest-1.1.2/src/missing.cpp
+*** cpptest-1.1.2.orig/src/missing.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/missing.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/missing.h cpptest-1.1.2/src/missing.h
+*** cpptest-1.1.2.orig/src/missing.h	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/missing.h	Sun Mar  6 01:37:44 2016
+***************
+*** 27,33 ****
+  #ifndef CPPTEST_MISSING_H
+  #define CPPTEST_MISSING_H
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 27,33 ----
+  #ifndef CPPTEST_MISSING_H
+  #define CPPTEST_MISSING_H
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/suite.cpp cpptest-1.1.2/src/suite.cpp
+*** cpptest-1.1.2.orig/src/suite.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/suite.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 30,36 ****
+  #include <functional>
+  #include <numeric>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 30,36 ----
+  #include <functional>
+  #include <numeric>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/textoutput.cpp cpptest-1.1.2/src/textoutput.cpp
+*** cpptest-1.1.2.orig/src/textoutput.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/textoutput.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 26,32 ****
+  
+  #include <algorithm>
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 26,32 ----
+  
+  #include <algorithm>
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/time.cpp cpptest-1.1.2/src/time.cpp
+*** cpptest-1.1.2.orig/src/time.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/time.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 24,30 ****
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 24,30 ----
+  //
+  // ---
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+diff -c -r cpptest-1.1.2.orig/src/utils.cpp cpptest-1.1.2/src/utils.cpp
+*** cpptest-1.1.2.orig/src/utils.cpp	Thu Oct  4 12:05:16 2012
+--- cpptest-1.1.2/src/utils.cpp	Sun Mar  6 01:37:44 2016
+***************
+*** 25,31 ****
+  // ---
+  
+  
+! #if (defined(__WIN32__) || defined(WIN32))
+  # include "winconfig.h"
+  #else
+  # include "config.h"
+--- 25,31 ----
+  // ---
+  
+  
+! #if (defined(__WIN32__) || defined(WIN32)) && not defined __MINGW32__
+  # include "winconfig.h"
+  #else
+  # include "config.h"

--- a/mingw-w64-uriparser/PKGBUILD
+++ b/mingw-w64-uriparser/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Diego Sogari <diego.sogari@falker.com.br>
+
+_realname=uriparser
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.8.4
+pkgrel=1
+pkgdesc="RFC 3986 URI parsing and processing libary (mingw-w64)"
+arch=('any')
+url="http://uriparser.sourceforge.net/"
+license=('New BSD License')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "automake" "autoconf")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-cpptest")
+source=("http://downloads.sourceforge.net/project/${_realname}/Sources/${pkgver}/${_realname}-${pkgver}.tar.bz2"
+        "${_realname}-${pkgver}.patch")
+sha256sums=('ce7ccda4136974889231e8426a785e7578e66a6283009cfd13f1b24a5e657b23'
+            'f1f542c77e0f27a34ce990ea1c8bd2bba0094a6d553fca06ceb1a8db81f672fe')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "../${_realname}-${pkgver}.patch"
+  autoreconf -fvi
+}
+
+build() {
+  rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  
+  ../${_realname}-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --disable-doc
+
+  make
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make check
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-uriparser/uriparser-0.8.4.patch
+++ b/mingw-w64-uriparser/uriparser-0.8.4.patch
@@ -1,0 +1,86 @@
+diff -c -r uriparser-0.8.4.orig/configure.ac uriparser-0.8.4/configure.ac
+*** uriparser-0.8.4.orig/configure.ac	2015-10-12 12:45:01.000000000 -0300
+--- uriparser-0.8.4/configure.ac	2016-03-07 08:42:07.221252700 -0300
+***************
+*** 19,24 ****
+--- 19,27 ----
+  esac
+  AM_CONDITIONAL([WIN32], test "$WIN32" = "yes")
+  
++ dnl Let Makefile know if we are GCC.
++ AM_CONDITIONAL(GCC, test "$GCC" = yes)
++ 
+  
+  ## Check for wprintf
+  AC_MSG_CHECKING(for wprintf)
+diff -c -r uriparser-0.8.4.orig/Makefile.am uriparser-0.8.4/Makefile.am
+*** uriparser-0.8.4.orig/Makefile.am	2015-10-12 12:30:00.000000000 -0300
+--- uriparser-0.8.4/Makefile.am	2016-03-07 08:42:06.286861000 -0300
+***************
+*** 18,24 ****
+  uriparse_CFLAGS = -Iinclude
+  uriparse_LDADD = $(top_builddir)/liburiparser.la
+  uriparse_DEPENDENCIES = $(top_builddir)/liburiparser.la
+! 
+  
+  pkgconfig_DATA = liburiparser.pc
+  
+--- 18,26 ----
+  uriparse_CFLAGS = -Iinclude
+  uriparse_LDADD = $(top_builddir)/liburiparser.la
+  uriparse_DEPENDENCIES = $(top_builddir)/liburiparser.la
+! if WIN32
+! uriparse_LDADD += -lws2_32
+! endif
+  
+  pkgconfig_DATA = liburiparser.pc
+  
+***************
+*** 63,69 ****
+  if URI_TEST_ENABLED
+  test_uriparser_test_LDFLAGS = @CPPTEST_LIBS@
+  
+! test_uriparser_test_CFLAGS = @CPPTEST_CFLAGS@
+  
+  test_uriparser_test_LDADD = liburiparser.la
+  
+--- 65,74 ----
+  if URI_TEST_ENABLED
+  test_uriparser_test_LDFLAGS = @CPPTEST_LIBS@
+  
+! test_uriparser_test_CPPFLAGS = @CPPTEST_CFLAGS@
+! if GCC
+!     test_uriparser_test_CPPFLAGS += -D_GNU_SOURCE
+! endif
+  
+  test_uriparser_test_LDADD = liburiparser.la
+  
+diff -c -r uriparser-0.8.4.orig/tool/uriparse.c uriparser-0.8.4/tool/uriparse.c
+*** uriparser-0.8.4.orig/tool/uriparse.c	2014-01-08 19:07:11.000000000 -0200
+--- uriparser-0.8.4/tool/uriparse.c	2016-03-07 08:40:24.823617300 -0300
+***************
+*** 39,47 ****
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <uriparser/Uri.h>
+! #include <arpa/inet.h>
+! #include <netinet/in.h>
+! 
+  
+  #define RANGE(x)  (int)((x).afterLast-(x).first), ((x).first)
+  
+--- 39,52 ----
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <uriparser/Uri.h>
+! #ifdef _WIN32
+! #   include <winsock2.h>
+! #   include <Ws2tcpip.h>
+! WINSOCK_API_LINKAGE const char WSAAPI inet_ntop(int af, const void *src, char *dst, socklen_t size);
+! #else
+! #   include <arpa/inet.h>
+! #   include <netinet/in.h>
+! #endif
+  
+  #define RANGE(x)  (int)((x).afterLast-(x).first), ((x).first)
+  


### PR DESCRIPTION
Add the uriparser library (http://uriparser.sourceforge.net/). It is a hard runtime dependency for the libkml (https://github.com/google/libkml/) library, which in turn is an optional runtime dependency for the GDAL (http://www.gdal.org/) library.