### PR TITLE
upgrade iso-codes to 3.66 and specify valid pgp key fingerprints for …

### DIFF
--- a/mingw-w64-iso-codes/PKGBUILD
+++ b/mingw-w64-iso-codes/PKGBUILD
@@ -3,15 +3,17 @@
 _realname=iso-codes
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.63
+pkgver=3.66
 pkgrel=1
 pkgdesc="Lists of the country, language, and currency names (mingw-w64)"
 arch=('any')
 license=('LGPL')
 url="https://pkg-isocodes.alioth.debian.org/"
 source=(https://pkg-isocodes.alioth.debian.org/downloads/${_realname}-${pkgver}.tar.xz{,.sig})
-sha256sums=('60600e56952dc92b3a8cd8a7044348f7cfa35be528bab2491c3c18582fb5277f'
+sha256sums=('6c1fa9535382223b9e938fb1c6052fac9a837c99a5772e7636cf8e2f5d2169f5'
             'SKIP')
+validpgpkeys=('D1CB8F39BC5DED24C5D2C78C1302F1F036EBEB19' #Dr. Tobias Quathamer <t.quathamer@mailbox.org>
+   'F972A168A2703B34CC23E09FD4E5EDACC0143D2D') # Christian Perrier <christian.perrier@onera.fr>
 
 build() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
…verification.