### PR TITLE
Fix package

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -30,7 +30,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "groff")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc")
 #options=('debug' '!strip')
-validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg, Google.
 source=(http://llvm.org/releases/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         http://llvm.org/releases/${pkgver}/cfe-${pkgver}.src.tar.xz{,.sig}
         http://llvm.org/releases/${pkgver}/compiler-rt-${pkgver}.src.tar.xz{,.sig}
@@ -86,8 +85,8 @@ sha256sums=('555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46'
             '0e45e76ee6d6658de52edb7b508a8bcc9f10ff0b295ff2a4e35577136a40c6a5'
             'a0933775b979b4879e220358b1076d8eeb9170403d0d190b1340d179fcd3cd1e'
             '5b8edbbb638c906216e20229529e8348abc50d5886d20e07af08543e1e574e94')
+validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D') #Hans Wennborg, Google
 
-validpgpkeys=('11E521D646982372EB577A1F8F0871F202119294')
 noextract=(cfe-${pkgver}.src.tar.xz
            #libcxx-${pkgver}.src.tar.xz
            lldb-${pkgver}.src.tar.xz
@@ -134,12 +133,12 @@ prepare() {
   cd "${srcdir}"/llvm-${pkgver}.src
   mv "${srcdir}/cfe-${pkgver}.src"               tools/clang
   mv "${srcdir}/clang-tools-extra-${pkgver}.src" tools/clang/tools/extra
-  mv "${srcdir}/lld-${pkgver}.src"               tools/lld
+  mv "${srcdir}/lld-${pkgver}.src"               tools/lld | true
   #mv "${srcdir}/lldb-${pkgver}.src"              tools/lldb
-  mv "${srcdir}/compiler-rt-${pkgver}.src"       projects/compiler-rt
-  mv "${srcdir}/libcxxabi-${pkgver}.src"         projects/libcxxabi
-  mv "${srcdir}/libcxx-${pkgver}.src"            projects/libcxx
-  #mv "${srcdir}/testsuite-${pkgver}.src"         projects/test-suite
+  mv "${srcdir}/compiler-rt-${pkgver}.src"       projects/compiler-rt | true
+  mv "${srcdir}/libcxxabi-${pkgver}.src"         projects/libcxxabi | true
+  mv "${srcdir}/libcxx-${pkgver}.src"            projects/libcxx | true
+  #mv "${srcdir}/testsuite-${pkgver}.src"         projects/test-suite | true
 }
 
 build() {


### PR DESCRIPTION
Just fix issue with validpgpkeys.  Also ignore failure when moving files
from src to the llvm source-code tree.  A build process might have done
that earlier.

Note that I wish to deal with libunwind as a separate issue.