### PR TITLE
cppcheck: make some dependencies optional

### DIFF
--- a/mingw-w64-cppcheck/PKGBUILD
+++ b/mingw-w64-cppcheck/PKGBUILD
@@ -9,10 +9,11 @@ pkgdesc="static analysis of C/C++ code (mingw-w64)"
 arch=('any')
 url="http://cppcheck.sourceforge.net/"
 license=('GPL3')
-depends=("${MINGW_PACKAGE_PREFIX}-qt5"
-         "${MINGW_PACKAGE_PREFIX}-python2"
-         "${MINGW_PACKAGE_PREFIX}-python2-pygments")
-makedepends=("${MINGW_PACKAGE_PREFIX}-docbook-xsl")
+depends=()
+makedepends=("${MINGW_PACKAGE_PREFIX}-docbook-xsl"
+             "${MINGW_PACKAGE_PREFIX}-qt5")
+optdepends=("${MINGW_PACKAGE_PREFIX}-qt5: cppcheck-gui"
+            "${MINGW_PACKAGE_PREFIX}-python2-pygments: cppcheck-htmlreport")
 source=("https://github.com/danmar/cppcheck/archive/${pkgver}.tar.gz"
         '0010-change-language-files-path.patch')
 sha256sums=('c718949e1ec22a8a0dca7e2953a55c502ef65e53ff9922fb91759388618faa7f'


### PR DESCRIPTION
* To avoid to install Qt5 and python2 if not needed