### PR TITLE
Adjust libkml dependencies

### DIFF
--- a/mingw-w64-libkml/PKGBUILD
+++ b/mingw-w64-libkml/PKGBUILD
@@ -4,19 +4,20 @@ _realname=libkml
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Reference implementation of OGC KML 2.2 (mingw-w64)"
 arch=('any')
 url="https://github.com/google/libkml/"
 license=('New BSD License')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-curl"
-             "${MINGW_PACKAGE_PREFIX}-python2"
-             "automake" "autoconf")
+makedepends=("automake" "autoconf"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-python2")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-uriparser"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-curl"
+              "${MINGW_PACKAGE_PREFIX}-gtest")
+optdepends=("${MINGW_PACKAGE_PREFIX}-python2")
 commit=8609edf7c8d13ae2ddb6eac2bca7c8e49c67a5f8
 source=("${_realname}-${pkgver}.zip::https://github.com/google/libkml/archive/${commit}.zip"
         "${_realname}-${pkgver}.patch"

--- a/mingw-w64-libkml/PKGBUILD
+++ b/mingw-w64-libkml/PKGBUILD
@@ -10,13 +10,13 @@ arch=('any')
 url="https://github.com/google/libkml/"
 license=('New BSD License')
 makedepends=("automake" "autoconf"
+             "${MINGW_PACKAGE_PREFIX}-curl"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2")
 depends=("${MINGW_PACKAGE_PREFIX}-boost"
          "${MINGW_PACKAGE_PREFIX}-uriparser"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-curl"
-              "${MINGW_PACKAGE_PREFIX}-gtest")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-gtest")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python2")
 commit=8609edf7c8d13ae2ddb6eac2bca7c8e49c67a5f8
 source=("${_realname}-${pkgver}.zip::https://github.com/google/libkml/archive/${commit}.zip"


### PR DESCRIPTION
curl is a check dependency, python is both a make and optional dependency (using libkml python bindings should be up to the user)