### PR TITLE
Fix header installation for glog

### DIFF
--- a/mingw-w64-glog/PKGBUILD
+++ b/mingw-w64-glog/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glog
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.3.4.4d391fe
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ implementation of the Google logging module (mingw-w64)"
 arch=('any')
 url="https://github.com/google/glog"
@@ -15,7 +15,7 @@ commit=4d391fe692ae6b9e0105f473945c415a3ce5a401
 source=("${_realname}-${commit}.zip::https://codeload.github.com/google/glog/zip/${commit}"
         "${_realname}-${pkgver}.patch")
 sha256sums=('aef60d6c6a6e334defcb56cbe5f007786a7fb6a7beb3da79ac02e6dfafa2807e'
-            'e1631b2697f78b4eae4113609b572839ef18015cdcd72303093d1a0f26e4e6fd')
+            '154dafa6663b68a979c56ae4fae2a4f12513613ae0a84947a7a73565735d5691')
 
 prepare() {
   cd "${srcdir}/${_realname}-${commit}"

--- a/mingw-w64-glog/glog-0.3.4.4d391fe.patch
+++ b/mingw-w64-glog/glog-0.3.4.4d391fe.patch
@@ -1,6 +1,29 @@
+diff -c -r glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/CMakeLists.txt glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/CMakeLists.txt
+*** glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/CMakeLists.txt	2015-12-17 05:31:55.000000000 -0200
+--- glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/CMakeLists.txt	2016-03-16 18:27:21.309311200 -0300
+***************
+*** 333,339 ****
+  set (CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+  
+  set (GLOG_PUBLIC_H
+-   ${CMAKE_CURRENT_BINARY_DIR}/config.h
+    ${CMAKE_CURRENT_BINARY_DIR}/glog/logging.h
+    ${CMAKE_CURRENT_BINARY_DIR}/glog/raw_logging.h
+    ${CMAKE_CURRENT_BINARY_DIR}/glog/stl_logging.h
+--- 333,338 ----
+***************
+*** 343,348 ****
+--- 342,348 ----
+  
+  set (GLOG_SRCS
+    ${GLOG_PUBLIC_H}
++   ${CMAKE_CURRENT_BINARY_DIR}/config.h
+    src/base/commandlineflags.h
+    src/base/googleinit.h
+    src/base/mutex.h
 diff -c -r glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/src/logging_unittest.cc glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/logging_unittest.cc
 *** glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/src/logging_unittest.cc	2015-12-17 05:31:55.000000000 -0200
---- glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/logging_unittest.cc	2016-03-11 06:51:18.961698500 -0300
+--- glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/logging_unittest.cc	2016-03-16 18:27:21.309311200 -0300
 ***************
 *** 317,323 ****
 --- 317,327 ----
@@ -17,7 +40,7 @@ diff -c -r glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/src/logging_unitte
     int j = 1000;
 diff -c -r glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/src/windows/port.h glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/windows/port.h
 *** glog-4d391fe692ae6b9e0105f473945c415a3ce5a401.orig/src/windows/port.h	2015-12-17 05:31:55.000000000 -0200
---- glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/windows/port.h	2016-03-11 06:39:23.350098300 -0300
+--- glog-4d391fe692ae6b9e0105f473945c415a3ce5a401/src/windows/port.h	2016-03-16 18:27:21.324936500 -0300
 ***************
 *** 136,141 ****
 --- 136,142 ----


### PR DESCRIPTION
Installation of config.h is not necessary because it is not used by the public headers