### PR TITLE
nanodbc: compile both unicode and non-unicode

### DIFF
--- a/mingw-w64-nanodbc/PKGBUILD
+++ b/mingw-w64-nanodbc/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nanodbc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A small C++ wrapper for the native C ODBC API (mingw-w64)"
 arch=('any')
 url="http://lexicalunit.github.io/nanodbc/"
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("${_realname}-${pkgver}.tar.gz::https://codeload.github.com/lexicalunit/nanodbc/tar.gz/v${pkgver}"
         "${_realname}-${pkgver}.patch")
 sha256sums=('92734da7af16d08d5c7b59d74e9601f633b509b6dd1cd732de04ee7a7c318554'
-            '5759e837673b27c195d23bbbbca548a373ac1fce50b83d4b24ab8120888cbe00')
+            '0c71a705508ca0ac19740943d6ba253603d2dcaff1ae80727bf257b6838c1506')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -29,7 +29,6 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DNANODBC_USE_UNICODE=YES \
     "../${_realname}-${pkgver}"
 
   make

--- a/mingw-w64-nanodbc/nanodbc-2.12.1.patch
+++ b/mingw-w64-nanodbc/nanodbc-2.12.1.patch
@@ -1,25 +1,63 @@
 diff -c -r nanodbc-2.12.1.orig/CMakeLists.txt nanodbc-2.12.1/CMakeLists.txt
 *** nanodbc-2.12.1.orig/CMakeLists.txt	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/CMakeLists.txt	2016-03-11 10:25:23.701539500 -0300
+--- nanodbc-2.12.1/CMakeLists.txt	2016-03-17 10:22:04.329025800 -0300
 ***************
-*** 4,10 ****
-  option(NANODBC_USE_UNICODE "build with unicode support turned on" OFF)
+*** 1,13 ****
+  cmake_minimum_required(VERSION 2.8.7)
+  project(nanodbc)
+  
+- option(NANODBC_USE_UNICODE "build with unicode support turned on" OFF)
   option(NANODBC_USE_BOOST_CONVERT "build using Boost.Locale for string convert" OFF)
   option(NANODBC_HANDLE_NODATA_BUG "enable special handling for SQL_NO_DATA (required for vertica)" OFF)
 - option(NANODBC_STATIC "build static instead of shared library" OFF)
   option(NANODBC_EXAMPLES "build examples" ON)
   option(NANODBC_TEST "build tests" ON)
-  option(NANODBC_INSTALL "generate install target" ON)
---- 4,9 ----
+- option(NANODBC_INSTALL "generate install target" ON)
+  option(NANODBC_ENABLE_LIBCXX "Use libc++ if available." ON)
+  
+  if(APPLE)
+--- 1,10 ----
 ***************
-*** 178,210 ****
+*** 106,114 ****
+  			set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
+  			execute_process(COMMAND ${ODBC_CONFIG} --libs
+  				OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+- 			if(NANODBC_USE_UNICODE)
+- 				add_definitions(-DNANODBC_USE_IODBC_WIDE_STRINGS)
+- 			endif()
+  		endif()
+  	endif()
+  
+--- 103,108 ----
+***************
+*** 130,146 ****
+  	add_definitions(-DNANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION})
+  endif()
+  
+- if(NANODBC_USE_UNICODE)
+- 	message(STATUS "Unicode support: Turned on")
+- 	add_definitions(-DNANODBC_USE_UNICODE)
+- 	if(MSVC)
+- 		# Sets "Use Unicode Character Set" property in Visual Studio projects
+- 		add_definitions(-DUNICODE -D_UNICODE)
+- 	endif()
+- else()
+- 	message(STATUS "Unicode support: Turned off")
+- endif()
+- 
+  if(NANODBC_USE_BOOST_CONVERT)
+  	message(STATUS "Boost string convert: Turned on")
+  	add_definitions(-DNANODBC_USE_BOOST_CONVERT)
+--- 124,129 ----
+***************
+*** 178,215 ****
   	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
   elseif(MSVC)
   	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
   endif()
   
   ########################################
-  ## nanodbc library target
+! ## nanodbc library target
   ########################################
 ! if(NANODBC_STATIC)
 ! 	add_library(nanodbc STATIC src/nanodbc.cpp src/nanodbc.h)
@@ -28,7 +66,7 @@ diff -c -r nanodbc-2.12.1.orig/CMakeLists.txt nanodbc-2.12.1/CMakeLists.txt
 ! 	add_library(nanodbc SHARED src/nanodbc.cpp src/nanodbc.h)
 ! 	target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
 ! 	message(STATUS "Build target: SHARED")
-! endif()
+  endif()
   
   if(UNIX)
 ! 	set_target_properties(nanodbc PROPERTIES
@@ -36,84 +74,162 @@ diff -c -r nanodbc-2.12.1.orig/CMakeLists.txt nanodbc-2.12.1/CMakeLists.txt
   		LIBRARY_OUTPUT_DIRECTORY "lib")
   endif()
   
-  if(NANODBC_INSTALL)
+! if(NANODBC_INSTALL)
 ! 	install(FILES src/nanodbc.h DESTINATION include)
 ! 	if(NANODBC_STATIC)
 ! 		install(TARGETS nanodbc ARCHIVE DESTINATION lib)
 ! 	else()
 ! 		install(TARGETS nanodbc LIBRARY DESTINATION lib)
 ! 	endif()
-  	message(STATUS "Target install: Turned on")
-  else()
-  	message(STATUS "Target install: Turned off")
---- 177,218 ----
+! 	message(STATUS "Target install: Turned on")
+! else()
+! 	message(STATUS "Target install: Turned off")
+  endif()
+  
+  ########################################
+  ## examples
+  ########################################
+--- 161,269 ----
   	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
   elseif(MSVC)
   	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
-+ elseif(WIN32)
++ elseif(MINGW)
 + 	set(ODBC_LIBRARIES odbc32 odbccp32)
   endif()
   
   ########################################
-  ## nanodbc library target
+! ## nanodbc static library target - non unicode
   ########################################
 ! add_library(nanodbc_static STATIC src/nanodbc.cpp src/nanodbc.h)
-! add_library(nanodbc_shared SHARED src/nanodbc.cpp src/nanodbc.h)
-! 
 ! set_target_properties(nanodbc_static PROPERTIES OUTPUT_NAME nanodbc)
-! set_target_properties(nanodbc_shared PROPERTIES OUTPUT_NAME nanodbc)
+! target_link_libraries(nanodbc_static PUBLIC ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
 ! 
-! target_link_libraries(nanodbc_static ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
-! target_link_libraries(nanodbc_shared ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
-  
-  if(UNIX)
+! if(UNIX)
 ! 	set_target_properties(nanodbc_static PROPERTIES
 ! 		COMPILE_FLAGS "${ODBC_CFLAGS}"
-!         ARCHIVE_OUTPUT_DIRECTORY "lib")
+!         LIBRARY_OUTPUT_DIRECTORY "lib")
+  endif()
+  
++ install(
++     TARGETS nanodbc_static
++     LIBRARY DESTINATION lib
++     ARCHIVE DESTINATION lib)
++ 
++ ########################################
++ ## nanodbc shared library target - non unicode
++ ########################################
++ add_library(nanodbc_shared SHARED src/nanodbc.cpp src/nanodbc.h)
++ set_target_properties(nanodbc_shared PROPERTIES OUTPUT_NAME nanodbc)
++ target_link_libraries(nanodbc_shared PUBLIC ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
++ 
+  if(UNIX)
 ! 	set_target_properties(nanodbc_shared PROPERTIES
   		COMPILE_FLAGS "${ODBC_CFLAGS}"
   		LIBRARY_OUTPUT_DIRECTORY "lib")
   endif()
   
-  if(NANODBC_INSTALL)
-!     install(FILES src/nanodbc.h DESTINATION include)
-!     install(
-!         TARGETS nanodbc_static
-!         LIBRARY DESTINATION lib
-!         ARCHIVE DESTINATION lib)
-!     install(
-!         TARGETS nanodbc_shared
-!         RUNTIME DESTINATION bin
-!         LIBRARY DESTINATION lib
-!         ARCHIVE DESTINATION lib)
-  	message(STATUS "Target install: Turned on")
-  else()
-  	message(STATUS "Target install: Turned off")
+! install(
+!     TARGETS nanodbc_shared
+!     RUNTIME DESTINATION bin
+!     LIBRARY DESTINATION lib
+!     ARCHIVE DESTINATION lib)
+! 
+! ########################################
+! ## nanodbc static library target - unicode
+! ########################################
+! add_library(nanodbc_unicode_static STATIC src/nanodbc.cpp src/nanodbc.h)
+! set_target_properties(nanodbc_unicode_static PROPERTIES OUTPUT_NAME nanodbc_unicode)
+! target_link_libraries(nanodbc_unicode_static PUBLIC ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
+! target_compile_definitions(nanodbc_unicode_static PUBLIC -DNANODBC_USE_UNICODE)
+! 
+! if(MSVC)
+!     # Sets "Use Unicode Character Set" property in Visual Studio projects
+!     target_compile_definitions(nanodbc_unicode_static PUBLIC -DUNICODE -D_UNICODE)
+  endif()
+  
++ if(ODBC_CONFIG)
++     target_compile_definitions(nanodbc_unicode_static PUBLIC -DNANODBC_USE_IODBC_WIDE_STRINGS)
++ endif()
++ 
++ if(UNIX)
++ 	set_target_properties(nanodbc_unicode_static PROPERTIES
++ 		COMPILE_FLAGS "${ODBC_CFLAGS}"
++ 		LIBRARY_OUTPUT_DIRECTORY "lib")
++ endif()
++ 
++ install(
++     TARGETS nanodbc_unicode_static
++     LIBRARY DESTINATION lib
++     ARCHIVE DESTINATION lib)
++ 
++ ########################################
++ ## nanodbc shared library target - unicode
++ ########################################
++ add_library(nanodbc_unicode_shared SHARED src/nanodbc.cpp src/nanodbc.h)
++ set_target_properties(nanodbc_unicode_shared PROPERTIES OUTPUT_NAME nanodbc_unicode)
++ target_link_libraries(nanodbc_unicode_shared PUBLIC ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
++ target_compile_definitions(nanodbc_unicode_shared PUBLIC -DNANODBC_USE_UNICODE)
++ 
++ if(MSVC)
++     # Sets "Use Unicode Character Set" property in Visual Studio projects
++     target_compile_definitions(nanodbc_unicode_shared PUBLIC -DUNICODE -D_UNICODE)
++ endif()
++ 
++ if(ODBC_CONFIG)
++     target_compile_definitions(nanodbc_unicode_shared PUBLIC -DNANODBC_USE_IODBC_WIDE_STRINGS)
++ endif()
++ 
++ if(UNIX)
++ 	set_target_properties(nanodbc_unicode_shared PROPERTIES
++ 		COMPILE_FLAGS "${ODBC_CFLAGS}"
++ 		LIBRARY_OUTPUT_DIRECTORY "lib")
++ endif()
++ 
++ install(
++     TARGETS nanodbc_unicode_shared
++     RUNTIME DESTINATION bin
++     LIBRARY DESTINATION lib
++     ARCHIVE DESTINATION lib)
++ 
++ ########################################
++ ## headers
++ ########################################
++ install(FILES src/nanodbc.h DESTINATION include)
++ 
+  ########################################
+  ## examples
+  ########################################
 diff -c -r nanodbc-2.12.1.orig/examples/CMakeLists.txt nanodbc-2.12.1/examples/CMakeLists.txt
 *** nanodbc-2.12.1.orig/examples/CMakeLists.txt	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/examples/CMakeLists.txt	2016-03-11 10:09:27.497870400 -0300
+--- nanodbc-2.12.1/examples/CMakeLists.txt	2016-03-17 10:29:14.957820900 -0300
 ***************
-*** 6,15 ****
+*** 4,15 ****
+  include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${ODBC_INCLUDE_DIR})
+  link_directories(${CMAKE_BINARY_DIR}/lib)
   
-  foreach(example ${examples})
-  	add_executable(example_${example} ${example}.cpp)
+! foreach(example ${examples})
+! 	add_executable(example_${example} ${example}.cpp)
 ! 	if (NANODBC_STATIC)
 ! 		target_link_libraries(example_${example} nanodbc ${ODBC_LIBRARIES})
 ! 	else()
 ! 		target_link_libraries(example_${example} nanodbc "${ODBC_LINK_FLAGS}")
 ! 	endif()
-  	add_dependencies(examples example_${example})
+! 	add_dependencies(examples example_${example})
   endforeach()
---- 6,11 ----
+--- 4,13 ----
+  include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${ODBC_INCLUDE_DIR})
+  link_directories(${CMAKE_BINARY_DIR}/lib)
   
-  foreach(example ${examples})
-  	add_executable(example_${example} ${example}.cpp)
-! 	target_link_libraries(example_${example} nanodbc_shared ${ODBC_LIBRARIES})
-  	add_dependencies(examples example_${example})
+! foreach(config "" "_unicode")
+!     foreach(example ${examples})
+!         add_executable(example_${example}${config} ${example}.cpp)
+!         target_link_libraries(example_${example}${config} nanodbc${config}_shared)
+!         add_dependencies(examples example_${example}${config})
+!     endforeach()
   endforeach()
 diff -c -r nanodbc-2.12.1.orig/examples/table_schema.cpp nanodbc-2.12.1/examples/table_schema.cpp
 *** nanodbc-2.12.1.orig/examples/table_schema.cpp	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/examples/table_schema.cpp	2016-03-11 10:11:49.274315000 -0300
+--- nanodbc-2.12.1/examples/table_schema.cpp	2016-03-17 09:04:58.340335600 -0300
 ***************
 *** 11,17 ****
   #include <string>
@@ -133,7 +249,7 @@ diff -c -r nanodbc-2.12.1.orig/examples/table_schema.cpp nanodbc-2.12.1/examples
   #include <sql.h>
 diff -c -r nanodbc-2.12.1.orig/src/nanodbc.cpp nanodbc-2.12.1/src/nanodbc.cpp
 *** nanodbc-2.12.1.orig/src/nanodbc.cpp	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/src/nanodbc.cpp	2016-03-11 10:06:09.272939000 -0300
+--- nanodbc-2.12.1/src/nanodbc.cpp	2016-03-17 09:04:58.344338800 -0300
 ***************
 *** 44,50 ****
   
@@ -153,7 +269,7 @@ diff -c -r nanodbc-2.12.1.orig/src/nanodbc.cpp nanodbc-2.12.1/src/nanodbc.cpp
   
 diff -c -r nanodbc-2.12.1.orig/test/base_test_fixture.h nanodbc-2.12.1/test/base_test_fixture.h
 *** nanodbc-2.12.1.orig/test/base_test_fixture.h	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/test/base_test_fixture.h	2016-03-11 15:56:20.941816800 -0300
+--- nanodbc-2.12.1/test/base_test_fixture.h	2016-03-17 09:04:58.349342100 -0300
 ***************
 *** 31,37 ****
   
@@ -526,25 +642,45 @@ diff -c -r nanodbc-2.12.1.orig/test/base_test_fixture.h nanodbc-2.12.1/test/base
           execute(connection, NANODBC_TEXT("create table transaction_test (i int);"));
 diff -c -r nanodbc-2.12.1.orig/test/CMakeLists.txt nanodbc-2.12.1/test/CMakeLists.txt
 *** nanodbc-2.12.1.orig/test/CMakeLists.txt	2016-03-07 15:56:59.000000000 -0300
---- nanodbc-2.12.1/test/CMakeLists.txt	2016-03-11 10:44:55.248381200 -0300
+--- nanodbc-2.12.1/test/CMakeLists.txt	2016-03-17 10:30:08.797809700 -0300
 ***************
-*** 27,37 ****
-  	set(test_name ${test_item}_tests)
-  	add_executable(${test_name} ${test_item}_test.cpp ${headers})
-  	add_dependencies(${test_name} catch)
+*** 23,42 ****
+  file(GLOB headers *.h *.hpp)
+  add_custom_target(tests DEPENDS tests catch)
+  set(test_list mysql odbc sqlite)
+! foreach(test_item ${test_list})
+! 	set(test_name ${test_item}_tests)
+! 	add_executable(${test_name} ${test_item}_test.cpp ${headers})
+! 	add_dependencies(${test_name} catch)
 ! 	if (NANODBC_STATIC)
 ! 		target_link_libraries(${test_name} nanodbc ${ODBC_LIBRARIES})
 ! 	else()
 ! 		target_link_libraries(${test_name} nanodbc "${ODBC_LINK_FLAGS}")
 ! 	endif()
-  	add_test(NAME ${test_name} COMMAND ${test_name})
-  	add_custom_target(${test_item}_test
-  		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name})
---- 27,33 ----
-  	set(test_name ${test_item}_tests)
-  	add_executable(${test_name} ${test_item}_test.cpp ${headers})
-  	add_dependencies(${test_name} catch)
-! 	target_link_libraries(${test_name} nanodbc_shared ${ODBC_LIBRARIES})
-  	add_test(NAME ${test_name} COMMAND ${test_name})
-  	add_custom_target(${test_item}_test
-  		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name})
+! 	add_test(NAME ${test_name} COMMAND ${test_name})
+! 	add_custom_target(${test_item}_test
+! 		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name})
+! 	add_custom_target(${test_item}_check
+! 		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name}
+! 		DEPENDS ${test_name})
+! 	add_dependencies(tests ${test_name})
+  endforeach()
+--- 23,40 ----
+  file(GLOB headers *.h *.hpp)
+  add_custom_target(tests DEPENDS tests catch)
+  set(test_list mysql odbc sqlite)
+! foreach(config "" "_unicode")
+!     foreach(test_item ${test_list})
+!         set(test_name ${test_item}${config}_tests)
+!         add_executable(${test_name} ${test_item}_test.cpp ${headers})
+!         add_dependencies(${test_name} catch)
+!         target_link_libraries(${test_name} nanodbc${config}_shared)
+!         add_test(NAME ${test_name} COMMAND ${test_name})
+!         add_custom_target(${test_item}${config}_test
+!             COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name})
+!         add_custom_target(${test_item}${config}_check
+!             COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure -R ${test_name}
+!             DEPENDS ${test_name})
+!         add_dependencies(tests ${test_name})
+!     endforeach()
+  endforeach()


### PR DESCRIPTION
Updated CMakeLists.txt:
- Removed unicode option. Instead, build both libraries
- Lib with unicode support postfixed with "_unicode"