### PR TITLE
SDL_mixer: move openal to makedepends

### DIFF
--- a/mingw-w64-SDL_mixer/PKGBUILD
+++ b/mingw-w64-SDL_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=1.2.12
-pkgrel=4
+pkgrel=5
 pkgdesc="A simple multi-channel audio mixer (mingw-w64)"
 arch=('any')
 url="https://libsdl.org/projects/SDL_mixer/"
@@ -14,11 +14,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-SDL"
          "${MINGW_PACKAGE_PREFIX}-libmikmod"
          "${MINGW_PACKAGE_PREFIX}-libmad"
          "${MINGW_PACKAGE_PREFIX}-flac"
-         "${MINGW_PACKAGE_PREFIX}-openal"
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-fluidsynth")
+             "${MINGW_PACKAGE_PREFIX}-fluidsynth"
+             "${MINGW_PACKAGE_PREFIX}-openal")
 optdepends=("${MINGW_PACKAGE_PREFIX}-fluidsynth: MIDI software synth, replaces built-in timidity")
 source=(https://libsdl.org/projects/SDL_mixer/release/${_realname}-${pkgver}.tar.gz
         mikmod1.patch


### PR DESCRIPTION
It turns out that openal is not a run-time dependency of sdl_mixer, not even of libmikmod. It is merely needed to build the test compile triggered by sdl_mixer's configure script, because the string returned by `libmikmod-config --libs` contains `-lopenal`.