### PR TITLE
libmikmod: move openal from makedepends to depends

### DIFF
--- a/mingw-w64-libmikmod/PKGBUILD
+++ b/mingw-w64-libmikmod/PKGBUILD
@@ -12,7 +12,8 @@ license=("GPL" "LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              #"${MINGW_PACKAGE_PREFIX}-SDL"
-             #"${MINGW_PACKAGE_PREFIX}-SDL2")
+             #"${MINGW_PACKAGE_PREFIX}-SDL2"
+             )
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openal")
 options=('strip' 'staticlibs')

--- a/mingw-w64-libmikmod/PKGBUILD
+++ b/mingw-w64-libmikmod/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libmikmod
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.3.8
-pkgrel=1
+pkgrel=2
 pkgdesc="A portable sound library (mingw-w64)"
 arch=('any')
 url="http://mikmod.sourceforge.net"
@@ -12,9 +12,9 @@ license=("GPL" "LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              #"${MINGW_PACKAGE_PREFIX}-SDL"
-             #"${MINGW_PACKAGE_PREFIX}-SDL2"
-             "${MINGW_PACKAGE_PREFIX}-openal")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+             #"${MINGW_PACKAGE_PREFIX}-SDL2")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-openal")
 options=('strip' 'staticlibs')
 source=(https://downloads.sourceforge.net/mikmod/${_realname}-${pkgver}.tar.gz)
 sha256sums=('4acf6634a477d8b95f18b55a3e2e76052c149e690d202484e8b0ac7589cf37a2')


### PR DESCRIPTION
Turns out openal is indeed a run-time dependency of libmikmod:
```
$ objdump -x /mingw32/bin/libmikmod-3.dll | grep 'DLL Name'
        DLL Name: dsound.dll
        DLL Name: KERNEL32.dll
        DLL Name: msvcrt.dll
        DLL Name: USER32.dll
        DLL Name: WINMM.DLL
        DLL Name: libopenal-1.dll
        DLL Name: libgcc_s_dw2-1.dll
```