### PR TITLE
mingw-w64-SDL_mixer: Add mingw-w64-smpeg as makedepends.

### DIFF
--- a/mingw-w64-SDL_mixer/PKGBUILD
+++ b/mingw-w64-SDL_mixer/PKGBUILD
@@ -18,7 +18,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-SDL"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-fluidsynth"
-             "${MINGW_PACKAGE_PREFIX}-openal")
+             "${MINGW_PACKAGE_PREFIX}-openal"
+             "${MINGW_PACKAGE_PREFIX}-smpeg")
 optdepends=("${MINGW_PACKAGE_PREFIX}-fluidsynth: MIDI software synth, replaces built-in timidity")
 source=(https://libsdl.org/projects/SDL_mixer/release/${_realname}-${pkgver}.tar.gz
         mikmod1.patch


### PR DESCRIPTION
Fix configure error:

```
aclocal-1.15: warning: autoconf input should be named 'configure.ac', not 'configure.in'
configure.in:579: warning: macro 'AM_PATH_SMPEG' not found in library
autoreconf: running: /usr/bin/autoconf --force
configure.in:580: error: possibly undefined macro: AM_PATH_SMPEG
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
==> ERROR: A failure occurred in prepare().
    Aborting...
==> Removing installed dependencies...
```