### PR TITLE
Theme engines for GTK+ 2 (mingw-w64)

### DIFF
--- a/mingw-w64-gtk-engines/PKGBUILD
+++ b/mingw-w64-gtk-engines/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Aleksandr Palamar <void995@gmail.com>
+
+_realname=gtk-engines
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.21.0
+pkgrel=2
+pkgdesc="Theme engines for GTK+ 2 (mingw-w64)"
+arch=('any')
+license=('GPL' 'LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-gtk2>=2.22.0")
+makedepends=('pkg-config' 'intltool')
+url="http://live.gnome.org/GnomeArt"
+options=('staticlibs' 'strip')
+source=(https://sources.archlinux.org/other/gtk-engines/${_realname}-${pkgver}.tar.gz)
+conflicts=("${MINGW_PACKAGE_PREFIX}-lighthouse-gtk2" "${MINGW_PACKAGE_PREFIX}-clearlooks-gtk2")
+replaces=("${MINGW_PACKAGE_PREFIX}-lighthouse-gtk2")
+md5sums=('d82ae66d6eb045d83c30b78b13818d41')
+
+build() {
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-animation
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
Would be great to have in MSYS2 if you are developing for GTK2 or using it from MSYS2. This PKGBUILD is an direct port from ArchLinux. Works great on both versions even with custom themes - i686 & x86_64.