### PR TITLE
Delete intl/canonicalize.h because that is created by a patch.  Neces…

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -87,8 +87,8 @@ prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
 
   #remove files the patches will create (so they aren't in the way the 2nd time round)
-  rm -f intl/canonicalize.c intl/relocatex.c intl/relocatex.h > /dev/null 2>&1 || true
-
+  rm -f intl/canonicalize.c intl/relocatex.c intl/canonicalize.h intl/relocatex.h > /dev/null 2>&1 || true
+ 
   # hack! - some configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {libiberty,gcc}/configure
 


### PR DESCRIPTION
…sary for second go-around.