### PR TITLE
Improvements for continuous integration

### DIFF
--- a/ci-library.sh
+++ b/ci-library.sh
@@ -86,6 +86,7 @@ _build_add() {
     _package_info "${package}" depends makedepends
     for dependency in "${depends[@]}" "${makedepends[@]}"; do
         for unsorted_package in "${packages[@]}"; do
+            [[ "${package}" = "${unsorted_package}" ]] && continue
             _package_provides "${unsorted_package}" "${dependency}" && _build_add "${unsorted_package}"
         done
     done


### PR DESCRIPTION
Fix build ordering not returning. For example, MINGW GCC depends on itself for building, which was causing the build ordering to run indefinitely. Reported by Qian Hong.