### PR TITLE
glbinding: Add missing glfw dependency for tools

### DIFF
--- a/mingw-w64-glbinding/PKGBUILD
+++ b/mingw-w64-glbinding/PKGBUILD
@@ -5,11 +5,12 @@ _realname=glbinding
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://github.com/cginternals/glbinding'
 pkgdesc="A C++ binding for the OpenGL API, generated using the gl.xml specification (mingw-w64)"
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-glfw")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen")


### PR DESCRIPTION
Adds some useful tools like:
```
mingw-w64-x86_64-glbinding /mingw64/bin/glcontexts.exe
mingw-w64-x86_64-glbinding /mingw64/bin/glfunctions.exe
mingw-w64-x86_64-glbinding /mingw64/bin/glmeta.exe
mingw-w64-x86_64-glbinding /mingw64/bin/glqueries.exe
```

P.S I have asked upstream about including static libraries: [issue](https://github.com/cginternals/glbinding/issues/165)