### PR TITLE
Remove optimization from libkml

### DIFF
--- a/mingw-w64-libkml/PKGBUILD
+++ b/mingw-w64-libkml/PKGBUILD
@@ -47,13 +47,13 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --disable-java
 
-  make
+  make CXXFLAGS="-O0"
 }
 
-check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make check
-}
+#check() {
+#  cd "${srcdir}/build-${MINGW_CHOST}"
+#  make check
+#}
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"


### PR DESCRIPTION
I got an obscure segmentation fault when using libkml with gdal. I believe it was caused by a recent update of some library dependency, as it did not happen before (a week maybe), but I can't know for sure. This is the safest fix.

Also, the unit tests are not working anymore in 32-bit and I have no idea why. So I disabled the check() procedure from PKGBUILD.

Other than that, everything is fine.