### PR TITLE
qt5-git: fix the package stage to complete the process

### DIFF
--- a/mingw-w64-qt5-git/PKGBUILD
+++ b/mingw-w64-qt5-git/PKGBUILD
@@ -28,6 +28,7 @@ _system_harfbuzz=yes
 _build_examples=yes
 _build_tools=yes
 _build_tests=yes
+_make_docs=yes
 
 # Set the way opengl should be compiled. Possible values are 'angle', 'desktop' or 'dynamic'
 _opengl=desktop
@@ -123,7 +124,7 @@ qt_modules=(
 	qtserialport
 	qtsvg
 	qttools
-	qttranslations
+	#qttranslations
 	qtvirtualkeyboard
 	qtwebchannel
 	qtwebsockets
@@ -337,7 +338,7 @@ prepare() {
 build() {
 
   cd ${srcdir}
-  cd qt5
+  cd ${_basename}
 
   local _buildpkgdir=${pkgdirbase}/${pkgname}/${_qt5_prefix}
   mkdir -p ${_buildpkgdir}
@@ -358,7 +359,7 @@ build() {
   local -a _extra_libpaths=()
   local -a _extra_libs=()
 
-  export PATH="${srcdir}/${CARCH}/qtbase/bin:${srcdir}/${CARCH}/qtbase/lib:${PATH}"
+  export PATH="${srcdir}/${_basename}/qtbase/bin:${srcdir}/${_basename}/qtbase/lib:${PATH}"
   
   # Qt manages the compiler flags for release / debug configs separately, so having our own values (-O2) is harmful here ..
   unset CFLAGS
@@ -435,27 +436,29 @@ build() {
 
 package() {
 
-  cd build-${CARCH}
+  cd ${srcdir}
+  cd ${_basename}
 
-  export PATH=${pkgdir}${MINGW_PREFIX}/bin:${srcdir}/${_basename}/qtbase/bin:${srcdir}/${_basename}/qtbase/lib:${PATH}
+  export PATH=${pkgdir}${_qt5_prefix}/bin:${srcdir}/${_basename}/qtbase/bin:${srcdir}/${_basename}/qtbase/lib:${PATH}
 
   make install
-  make docs
-  make install_qch_docs
+  if [ "$_make_docs" == "yes" ]; then
+    make docs
+    make install_qch_docs
+  fi
 
-  install -D -m644 LGPL_EXCEPTION.txt \
-  "${pkgdir}${MINGW_PREFIX}"/share/licenses/qt5/LGPL_EXCEPTION.txt
+  install -D -m644 LGPL_EXCEPTION.txt "${pkgdir}${_qt5_prefix}"/share/licenses/qt5/LGPL_EXCEPTION.txt
 
   # Remove dll's from lib
-  rm -f "${pkgdir}${MINGW_PREFIX}/lib"/*.dll
+  rm -f "${pkgdir}${_qt5_prefix}/lib"/*.dll
 
   # Workaround for installing empty .pc files
   plain "---> Fix pkgconfig files..."
-  local _pc_files=( $(find ${srcdir}/build-${CARCH} -type f -name Qt5*.pc) )
-  cp -f ${_pc_files[@]} ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/
+  local _pc_files=( $(find ${srcdir}/${_basename} -type f -name Qt5*.pc) )
+  cp -f ${_pc_files[@]} ${pkgdir}${_qt5_prefix}/lib/pkgconfig/
   
   # Fix paths in qconfig.pri and qmodule.pri:
-  #   $(cygpath -m ${MINGW_PREFIX}) -> $(cygpath -m ${pkgdir}${MINGW_PREFIX})
+  #   $(cygpath -m ${_qt5_prefix}) -> $(cygpath -m ${pkgdir}${_qt5_prefix})
   MINGW_PREFIX_WIN=$(cygpath -m ${_qt5_prefix})
   PKGDIR_MINGW_PREFIX_WIN=$(cygpath -m ${pkgdir}${_qt5_prefix})
   find "${pkgdir}${_qt5_prefix}/share/qt5" -type f -name '*.pri' \


### PR DESCRIPTION
With this, it finally completes the package creation process.
I had to disable the qttranslations module due to a lrelease issue described in #1180 
Also, I've added the _make_doc flag to allow to speed up the final phase