### PR TITLE
editrights: fix pkgbuild

### DIFF
--- a/mingw-w64-editrights/PKGBUILD
+++ b/mingw-w64-editrights/PKGBUILD
@@ -10,8 +10,9 @@ arch=('any')
 url="https://cygwin.org/"
 license=('custom')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=("http://cygwin.cybermirror.org/release/${_realname}/${_realname}-${pkgver}-1-src.tar.xz"
+source=("https://mirrors.kernel.org/sourceware/cygwin/x86_64/release/${_realname}/${_realname}-${pkgver}-1-src.tar.xz"
         'uncygwinize.patch')
+sha256sums=('c38718c87af54bde0c6c96b8dcf407b95ed8dc141d9970d39a8eb77ef0129da8'
             'b84e66761b8cd691a07c4f61c552e18f992d801db0401559cd733f0261895fa6')
 
 


### PR DESCRIPTION
Changed mirror since cybermirror.org is under maintenace and is not even listed on https://cygwin.com/mirrors.html
Also fix PKGBUILD.