### PR TITLE
Add wkhtmltopdf

### DIFF
--- a/mingw-w64-wkhtmltopdf/PKGBUILD
+++ b/mingw-w64-wkhtmltopdf/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: Diego Sogari <diego.sogari@gmail.com>
+
+_realname=wkhtmltopdf
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+_basever=0.13
+pkgver=0.13.r925.e03f1d1
+pkgrel=1
+pkgdesc="Convert HTML to PDF using QtWebkit (mingw-w64)"
+arch=('any')
+url="http://wkhtmltopdf.org/"
+license=('LGPLv3')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-icu"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+source=("${_realname}::git://github.com/wkhtmltopdf/wkhtmltopdf#branch=${_basever}"
+        "${_realname}-${_basever}.patch")
+sha256sums=('SKIP'
+            '4671af5d8bc79102531c946b8a8f559d48f8000c0bdfd3d16eaedf3a71b5d243')
+           
+pkgver() {
+  cd "${srcdir}/${_realname}"
+  printf "%s.r%s.%s" "${_basever}" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd "${srcdir}/${_realname}"
+  patch -Np1 -i "../${_realname}-${_basever}.patch"
+}
+
+build() {
+  cd "${srcdir}/${_realname}"
+
+  ln -fs `which windres` ./${MINGW_CHOST}-windres
+  export PREFIX=${MINGW_PREFIX}
+  PATH=`pwd`:$PATH
+
+  # detect architecture
+  if [[ ${MINGW_CHOST} == *"i686"* ]]; then
+    target=mingw-w64-cross-win32
+  else
+    target=mingw-w64-cross-win64
+  fi
+
+  ./scripts/build.py ${target}
+}
+
+package() {
+  cd "${srcdir}/${_realname}"
+  
+  # detect architecture
+  if [[ ${MINGW_CHOST} == *"i686"* ]]; then
+    target=mingw-w64-cross-win32
+  else
+    target=mingw-w64-cross-win64
+  fi
+
+  install -D ./include/wkhtmltox/dllbegin.inc "${pkgdir}${MINGW_PREFIX}/include/wkhtmltox/dllbegin.inc"
+  install -D ./include/wkhtmltox/dllend.inc "${pkgdir}${MINGW_PREFIX}/include/wkhtmltox/dllend.inc"
+  install -D ./include/wkhtmltox/image.h "${pkgdir}${MINGW_PREFIX}/include/wkhtmltox/image.h"
+  install -D ./include/wkhtmltox/pdf.h "${pkgdir}${MINGW_PREFIX}/include/wkhtmltox/pdf.h"
+  
+  install -d "${pkgdir}${MINGW_PREFIX}/bin"
+  install "./static-build/${target}/app/bin/"*.dll "${pkgdir}${MINGW_PREFIX}/bin"
+  install "./static-build/${target}/app/bin/"*.exe "${pkgdir}${MINGW_PREFIX}/bin"
+  
+  install -d "${pkgdir}${MINGW_PREFIX}/lib"
+  install "./static-build/${target}/app/bin/"*.a "${pkgdir}${MINGW_PREFIX}/lib"
+}

--- a/mingw-w64-wkhtmltopdf/PKGBUILD
+++ b/mingw-w64-wkhtmltopdf/PKGBUILD
@@ -10,7 +10,7 @@ pkgdesc="Convert HTML to PDF using QtWebkit (mingw-w64)"
 arch=('any')
 url="http://wkhtmltopdf.org/"
 license=('LGPLv3')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("git" "${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"

--- a/mingw-w64-wkhtmltopdf/PKGBUILD
+++ b/mingw-w64-wkhtmltopdf/PKGBUILD
@@ -15,6 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-qt5"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("${_realname}::git://github.com/wkhtmltopdf/wkhtmltopdf#branch=${_basever}"
         "${_realname}-${_basever}.patch")

--- a/mingw-w64-wkhtmltopdf/wkhtmltopdf-0.13.patch
+++ b/mingw-w64-wkhtmltopdf/wkhtmltopdf-0.13.patch
@@ -1,0 +1,85 @@
+diff -c -r wkhtmltopdf-0.13.orig/scripts/build.py wkhtmltopdf-0.13/scripts/build.py
+*** wkhtmltopdf-0.13.orig/scripts/build.py	2015-07-25 05:14:00.000000000 -0300
+--- wkhtmltopdf-0.13/scripts/build.py	2016-04-01 15:20:57.365883600 -0300
+***************
+*** 983,1011 ****
+  
+  def build_mingw64_cross(config, basedir):
+      version, simple_version = get_version(basedir)
+!     build_deplibs(config, basedir, mingw_w64=MINGW_W64_PREFIX.get(rchop(config, '-dbg')))
+! 
+!     libdir = os.path.join(basedir, config, 'deplibs')
+!     qtdir  = os.path.join(basedir, config, 'qt')
+  
+      configure_args = qt_config('mingw-w64-cross',
+!         '--prefix=%s/qtbase' % qtdir,
+!         '-I%s/include'       % libdir,
+!         '-L%s/lib'           % libdir,
+          '-device-option CROSS_COMPILE=%s-' % MINGW_W64_PREFIX[rchop(config, '-dbg')])
+  
+!     os.environ['OPENSSL_LIBS']  = '-lssl -lcrypto -L%s/lib -lws2_32 -lgdi32 -lcrypt32' % libdir
+!     os.environ['SQLITE3SRCDIR'] = '%s/../qt/qtbase/src/3rdparty/sqlite' % basedir
+! 
+!     mkdir_p(qtdir)
+!     build_qtmodule(qtdir, 'qtbase', 'make -j%d' % CPU_COUNT,
+!         '%s/../qt/qtbase/configure %s' % (basedir, configure_args))
+!     build_qtmodule(qtdir, 'qtsvg',  'make -j%d' % CPU_COUNT,
+!         '%s/qtbase/bin/qmake %s/../qt/qtsvg/qtsvg.pro' % (qtdir, basedir))
+!     build_qtmodule(qtdir, 'qtxmlpatterns', 'make -j%d' % CPU_COUNT,
+!         '%s/qtbase/bin/qmake %s/../qt/qtxmlpatterns/qtxmlpatterns.pro' % (qtdir, basedir))
+!     build_qtmodule(qtdir, 'qtwebkit', 'make -j%d' % CPU_COUNT,
+!         '%s/qtbase/bin/qmake %s/../qt/qtwebkit/WebKit.pro WEBKIT_CONFIG-=build_webkit2' % (qtdir, basedir))
+  
+      appdir = os.path.join(basedir, config, 'app')
+      mkdir_p(appdir)
+--- 983,997 ----
+  
+  def build_mingw64_cross(config, basedir):
+      version, simple_version = get_version(basedir)
+!     prefix = os.environ['PREFIX']
+  
+      configure_args = qt_config('mingw-w64-cross',
+!         '--prefix=%s'  % prefix,
+!         '-I%s/include' % prefix,
+!         '-L%s/lib'     % prefix,
+          '-device-option CROSS_COMPILE=%s-' % MINGW_W64_PREFIX[rchop(config, '-dbg')])
+  
+!     os.environ['OPENSSL_LIBS']  = '-lssl -lcrypto -L%s/lib -lws2_32 -lgdi32 -lcrypt32' % prefix
+  
+      appdir = os.path.join(basedir, config, 'app')
+      mkdir_p(appdir)
+***************
+*** 1014,1023 ****
+  
+      # set up cross compiling prefix correctly
+      os.environ['WKHTMLTOX_VERSION'] = version
+!     shell('%s/qtbase/bin/qmake -set CROSS_COMPILE %s-' % (qtdir, MINGW_W64_PREFIX[rchop(config, '-dbg')]))
+!     shell('%s/qtbase/bin/qmake -spec win32-g++ %s/../wkhtmltopdf.pro' % (qtdir, basedir))
+      shell('make')
+-     shutil.copy('bin/libwkhtmltox0.a', 'bin/wkhtmltox.lib')
+      shell('rm -f bin/lib*.dll')
+      for dll in ['libgcc_s_sjlj-1.dll', 'libgcc_s_seh-1.dll', 'libstdc++-6.dll']:
+          dll_path = get_output('dpkg', '-S', dll)
+--- 1000,1008 ----
+  
+      # set up cross compiling prefix correctly
+      os.environ['WKHTMLTOX_VERSION'] = version
+!     shell('%s/bin/qmake -set CROSS_COMPILE %s-' % (prefix, MINGW_W64_PREFIX[rchop(config, '-dbg')]))
+!     shell('%s/bin/qmake -spec win32-g++ %s/../wkhtmltopdf.pro' % (prefix, basedir))
+      shell('make')
+      shell('rm -f bin/lib*.dll')
+      for dll in ['libgcc_s_sjlj-1.dll', 'libgcc_s_seh-1.dll', 'libstdc++-6.dll']:
+          dll_path = get_output('dpkg', '-S', dll)
+***************
+*** 1027,1036 ****
+                  if exists(loc) and MINGW_W64_PREFIX[rchop(config, '-dbg')] in loc and '-posix' not in loc:
+                      shell('cp %s bin/' % loc)
+  
+-     os.chdir(os.path.join(basedir, '..'))
+-     shell('makensis -DVERSION=%s -DSIMPLE_VERSION=%s -DTARGET=%s -DMINGW -DARCH=%s wkhtmltox.nsi' % \
+-             (version, nsis_version(simple_version), config, rchop(config, '-dbg').split('-')[-1]))
+- 
+  # -------------------------------------------------- Linux schroot environment
+  
+  def check_linux_schroot(config):
+--- 1012,1017 ----


### PR DESCRIPTION
Add wkhtmltopdf library (http://wkhtmltopdf.org/).

Note: I could not use the release tarball from version 0.12, as it depends on Qt 4.8. I had to take the development version from git branch labeled "0.13", which is already using Qt 5.x