### PR TITLE
jucipp-git: Update PKGBUILD

### DIFF
--- a/mingw-w64-jucipp-git/PKGBUILD
+++ b/mingw-w64-jucipp-git/PKGBUILD
@@ -58,7 +58,7 @@ build() {
       "${extra_config[@]}" \
       ../${_realname}
 
-  make
+  make -j1
 }
 
 package() {

--- a/mingw-w64-jucipp-git/PKGBUILD
+++ b/mingw-w64-jucipp-git/PKGBUILD
@@ -5,15 +5,15 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1164.79f497a
+pkgver=1403.3134396
 pkgrel=1
-pkgdesc="A lightweight platform independent C++-IDE with support for C++11 and C++14 (mingw-w64)"
+pkgdesc="A lightweight, cross-platform C++-IDE supporting C++11, C++14, and experimental C++17 features (mingw-w64)"
 arch=('any')
 url="https://github.com/cppit/jucipp"
 license=('MIT')
 validpgpkeys=('gpg_KEY')
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
-             'git')
+             "git")
 depends=("${MINGW_PACKAGE_PREFIX}-clang"
          "${MINGW_PACKAGE_PREFIX}-gtkmm3"
          "${MINGW_PACKAGE_PREFIX}-gtksourceviewmm3"


### PR DESCRIPTION
Feel free to make this package installable through pacman -S. juCi++ has been very stable since v1.0.0 release, and I'll update the pkgver whenever we have major changes. 