### PR TITLE
angleproject: update to fix build of mpv 32-bit

### DIFF
--- a/mingw-w64-angleproject-git/PKGBUILD
+++ b/mingw-w64-angleproject-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=angleproject
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=2.1.r5634
+pkgver=2.1.r5679
 pkgrel=1
 pkgdesc='ANGLE project built from git source (mingw-w64)'
 arch=('any')


### PR DESCRIPTION
Local build of mingw-w64-i686-mpv doesn't fail anymore however still fails on Tea-CI. AppVeyor still on angleprojct build.

Tea-ci:
```
Checking for MinGW                                                : no 
Checking for POSIX environment                                    : no 
Checking for development environment                              : not found any of mingw, posix 
Unable to find either POSIX or MinGW-w64 environment, or compiler does not work.
```
AppVeyor:
```
looking for conflicting packages...
:: gyp-git and gyp-svn are in conflict (gyp). Remove gyp-svn? [y/N] error: unresolvable package conflicts detected
error: failed to prepare transaction (conflicting dependencies)
 
:: gyp-git and gyp-svn are in conflict
==> ERROR: 'pacman' failed to install missing dependencies.
==> WARNING: Failed to remove installed dependencies.
```