### PR TITLE
Fix crash in libidn on Win64

### DIFF
--- a/mingw-w64-libidn/0003-nfkc.c-Fix-Win64-crash.patch
+++ b/mingw-w64-libidn/0003-nfkc.c-Fix-Win64-crash.patch
@@ -1,0 +1,20 @@
+--- a/lib/nfkc.c
++++ b/lib/nfkc.c
+@@ -362,7 +362,7 @@ g_unichar_to_utf8 (gunichar c, gchar * outbuf)
+  *               This value must be freed with g_free().
+  **/
+ static gunichar *
+-g_utf8_to_ucs4_fast (const gchar * str, glong len, glong * items_written)
++g_utf8_to_ucs4_fast (const gchar * str, gssize len, gsize * items_written)
+ {
+   gunichar *result;
+   gsize n_chars, i;
+@@ -1011,7 +1011,7 @@ stringprep_utf8_to_ucs4 (const char *str, ssize_t len, size_t * items_written)
+   if (u8_check ((const uint8_t *) str, n))
+     return NULL;
+ 
+-  return g_utf8_to_ucs4_fast (str, (glong) len, (glong *) items_written);
++  return g_utf8_to_ucs4_fast (str, len, items_written);
+ }
+ 
+ /**

--- a/mingw-w64-libidn/0004-nfkc.c-Fixed-invalid-var-types.patch
+++ b/mingw-w64-libidn/0004-nfkc.c-Fixed-invalid-var-types.patch
@@ -1,0 +1,31 @@
+--- a/lib/nfkc.c
++++ b/lib/nfkc.c
+@@ -462,13 +462,13 @@ g_utf8_to_ucs4_fast (const gchar * str, gssize len, gsize * items_written)
+  **/
+ static gchar *
+ g_ucs4_to_utf8 (const gunichar * str,
+-		glong len,
+-		glong * items_read, glong * items_written)
++		gssize len,
++		gsize * items_read, gsize * items_written)
+ {
+-  gint result_length;
++  gsize result_length;
+   gchar *result = NULL;
+   gchar *p;
+-  gint i;
++  gsize i;
+ 
+   result_length = 0;
+   for (i = 0; len < 0 || i < len; i++)
+@@ -1035,8 +1035,7 @@ char *
+ stringprep_ucs4_to_utf8 (const uint32_t * str, ssize_t len,
+ 			 size_t * items_read, size_t * items_written)
+ {
+-  return g_ucs4_to_utf8 (str, len, (glong *) items_read,
+-			 (glong *) items_written);
++  return g_ucs4_to_utf8 (str, len, items_read, items_written);
+ }
+ 
+ /**
+

--- a/mingw-w64-libidn/PKGBUILD
+++ b/mingw-w64-libidn/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libidn
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.32
-pkgrel=2
+pkgrel=3
 pkgdesc="Implementation of the Stringprep, Punycode and IDNA specifications (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/libidn"
@@ -14,15 +14,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 options=('staticlibs' 'strip')
 source=("https://ftp.gnu.org/gnu/libidn/${_realname}-${pkgver}.tar.gz"
         0001-fix-gtkdoc.all.patch
-        0002-fix-gdoc.all.patch)
+        0002-fix-gdoc.all.patch
+        0003-nfkc.c-Fix-Win64-crash.patch
+        0004-nfkc.c-Fixed-invalid-var-types.patch)
 sha256sums=('ba5d5afee2beff703a34ee094668da5c6ea5afa38784cebba8924105e185c4f5'
             '3c6498f1682aae763ea0e4264db0c16eda83837a77b59c2d458f836a16a94f69'
-            '02d9b9e6e3f966cff2d4d763c0de9219da6c8cf444248011caa8eb2fb3067a24')
+            '02d9b9e6e3f966cff2d4d763c0de9219da6c8cf444248011caa8eb2fb3067a24'
+            '6293c730a98af32a337149a95d848f3c4619df8dc367e0bf0251a509b09f5963'
+            '2a2c45dc6f595705a226687c8954390baf926e135168e1919baeadef5e5478cc')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-fix-gtkdoc.all.patch
   patch -p1 -i ${srcdir}/0002-fix-gdoc.all.patch
+  patch -p1 -i ${srcdir}/0003-nfkc.c-Fix-Win64-crash.patch
+  patch -p1 -i ${srcdir}/0004-nfkc.c-Fixed-invalid-var-types.patch
 
   autopoint --force
   autoreconf -i


### PR DESCRIPTION
As title says.
Patch 0003 is most important.
Upstream was informed but no reaction for a few days.
Discovered while debugging crash in curl's simple command `curl -v http://яндекс.рф`.
More info:
https://github.com/curl/curl/issues/731
http://lists.gnu.org/archive/html/help-libidn/2016-03/msg00002.html