### PR TITLE
python-numpy: add patch to disable 64-bit warning

### DIFF
--- a/mingw-w64-python-numpy/0007-disable-64bit-experimental-warning.patch
+++ b/mingw-w64-python-numpy/0007-disable-64bit-experimental-warning.patch
@@ -1,0 +1,18 @@
+diff -urN numpy-1.10.2.orig/numpy/core/src/multiarray/multiarraymodule.c numpy-1.10.2/numpy/core/src/multiarray/multiarraymodule.c
+--- numpy-1.10.2.orig/numpy/core/src/multiarray/multiarraymodule.c	2015-11-12 13:04:51.000000000 -0700
++++ numpy-1.10.2/numpy/core/src/multiarray/multiarraymodule.c	2016-03-30 06:20:16.617824700 -0700
+@@ -4476,15 +4476,6 @@
+         goto err;
+     }
+
+-#if defined(MS_WIN64) && defined(__GNUC__)
+-  PyErr_WarnEx(PyExc_Warning,
+-        "Numpy built with MINGW-W64 on Windows 64 bits is experimental, " \
+-        "and only available for \n" \
+-        "testing. You are advised not to use it for production. \n\n" \
+-        "CRASHES ARE TO BE EXPECTED - PLEASE REPORT THEM TO NUMPY DEVELOPERS",
+-        1);
+-#endif
+-
+     /* Initialize access to the PyDateTime API */
+     numpy_pydatetime_import();

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Duong Pham <dthpham@gmail.com>
 
 _realname=numpy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.10.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -23,14 +24,16 @@ source=(https://downloads.sourceforge.net/numpy/${_realname}-${pkgver}.tar.gz
         0003-gfortran-better-version-check.patch
         0004-fix-testsuite.patch
         0005-mincoming-stack-boundary-32bit-optimized-64bit.patch
-        0006-disable-visualcompaq-for-mingw.patch)
+        0006-disable-visualcompaq-for-mingw.patch
+        0007-disable-64bit-experimental-warning.patch)
 sha256sums=('23a3befdf955db4d616f8bb77b324680a80a323e0c42a7e8d7388ef578d8ffa9'
             '94e48602f59a69a9d56886e5b1dab62ffc4fb30b00c5d62d2a818d67d4fd079a'
             'f3864b418791d6f6c1f5a8800c955402934188bdae0614d9e49b1c84f23690d9'
             '77c342fbb13de981d682bdc1889709d9d2507a1566d5ee63004f0b764a62a988'
             '1f9783c356196327a424113e9a5d39c04fc70fef5529fd0d43288ff5274494f4'
             '429d3379e6840dd39763c629488a687a04dc3c4540e58565e75f9809e57f778d'
-            '707ce38e179d24a97b6bd01f5f76d0087042c4fbb17eca8e630ad7c6807ada24')
+            '707ce38e179d24a97b6bd01f5f76d0087042c4fbb17eca8e630ad7c6807ada24'
+            '00eac381f73172cb03f54fc71a845a3e72a998d78e88cbce752cf52672fc6bd1')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -42,6 +45,7 @@ prepare() {
   # in a test compilation, AFAICT.
   patch -Np1 -i ${srcdir}/0005-mincoming-stack-boundary-32bit-optimized-64bit.patch
   patch -Np1 -i ${srcdir}/0006-disable-visualcompaq-for-mingw.patch
+  patch -Np1 -i ${srcdir}/0007-disable-64bit-experimental-warning.patch
   cd ..
 
   cp -a numpy-${pkgver} ${_realname}-py2-${CARCH}


### PR DESCRIPTION
Every time a user, or another python program, imports numpy on a 64-bit Windows machine, it prints a warning telling people to report bugs upstream.

```
>>> import numpy
C:\msys64\mingw64\lib\python2.7\site-packages/numpy/core/__init__.py:14: Warning: Numpy built with MINGW-W64 on Windows 64 bits is experimental, and only available for
testing. You are advised not to use it for production.

CRASHES ARE TO BE EXPECTED - PLEASE REPORT THEM TO NUMPY DEVELOPERS
  from . import multiarray
```

Now, I use numpy and programs that depend on it a lot, and seeing this thing pop up all the time in my terminal is extremely annoying. I'm positive that other developers that use the 64-bit numpy package would appreciate that the warning be disabled by default, so here's a patch that takes it out.