### PR TITLE
avrdude: Update to 6.3.

### DIFF
--- a/mingw-w64-avrdude/PKGBUILD
+++ b/mingw-w64-avrdude/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=avrdude
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.2
-pkgrel=2
+pkgver=6.3
+pkgrel=1
 pkgdesc='Software for programming Atmel AVR Microcontrollers (mingw-w64)'
 arch=('any')
 url="http://www.nongnu.org/avrdude/"
@@ -27,7 +27,7 @@ source=(#http://download.savannah.gnu.org/releases/avrdude/avrdude-${pkgver}.tar
 
 validpgpkeys=('EF497ABE47ED91B3FC3D7EA54D902FF7723BDEE9'
               '5E84F980C3CAFD4BB5841070F48CA81B69A85873')
-sha256sums=('e65f833493b7d63a4436c7056694a0f04ae5b437b72cc084e32c58bc543b0f91'
+sha256sums=('0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196'
             'SKIP'
             '3a5c041f97e8fcd6706b08ae24fe21337fd1df13319479e2d49c3f82529ba054'
             '7b52523834e492281347bc92a064ca924dc5d09e2d653e7076c5a966d03f7768'


### PR DESCRIPTION
I tested this pull request by programming an AVR with the resulting (32-bit) AVRDUDE package.