### PR TITLE
python-cx_Freeze: add patch to fix manifest arch

### DIFF
--- a/mingw-w64-python-cx_Freeze/0001-fix-manifest-processor-arch.patch
+++ b/mingw-w64-python-cx_Freeze/0001-fix-manifest-processor-arch.patch
@@ -1,0 +1,21 @@
+diff -urN cx_Freeze-4.3.3.orig/source/bases/manifest.txt cx_Freeze-4.3.3/source/bases/manifest.txt
+--- cx_Freeze-4.3.3.orig/source/bases/manifest.txt	2012-02-27 07:52:03.000000000 -0700
++++ cx_Freeze-4.3.3/source/bases/manifest.txt	2016-03-30 08:16:18.423882000 -0700
+@@ -8,7 +8,7 @@
+   </trustInfo>
+   <dependency>
+     <dependentAssembly>
+-      <assemblyIdentity type="win32" name="Microsoft.VC90.CRT" version="9.0.21022.8" processorArchitecture="x86" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
++      <assemblyIdentity type="win32" name="Microsoft.VC90.CRT" version="9.0.21022.8" processorArchitecture="*" publicKeyToken="1fc8b3b9a1e18e3b"></assemblyIdentity>
+     </dependentAssembly>
+   </dependency>
+   <dependency>
+@@ -17,7 +17,7 @@
+               type="win32"
+               name="Microsoft.Windows.Common-Controls"
+               version="6.0.0.0"
+-              processorArchitecture="X86"
++              processorArchitecture="*"
+               publicKeyToken="6595b64144ccf1df"
+               language="*"
+           />

--- a/mingw-w64-python-cx_Freeze/PKGBUILD
+++ b/mingw-w64-python-cx_Freeze/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Frode Solheim <frode@fs-uae.net>
+# Contributor: Duong Pham <dthpham@gmail.com>
 
 _realname=cx_Freeze
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-cx_Freeze"
          "${MINGW_PACKAGE_PREFIX}-python3-cx_Freeze")
 pkgver=4.3.3
-pkgrel=5
+pkgrel=6
 pkgdesc="Python package for freezing scripts into executables (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -13,10 +14,16 @@ url="http://cx-freeze.sourceforge.net/"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3")
 options=('staticlibs' 'strip' '!debug')
-source=("https://pypi.python.org/packages/source/c/cx_Freeze/cx_Freeze-${pkgver}.tar.gz")
-sha256sums=('0c8b3ce53127ffacdfea6229616086887b1573f95ff56cdc3dbf07fae8942302')
+source=(https://pypi.python.org/packages/source/c/cx_Freeze/cx_Freeze-${pkgver}.tar.gz
+        0001-fix-manifest-processor-arch.patch)
+sha256sums=('0c8b3ce53127ffacdfea6229616086887b1573f95ff56cdc3dbf07fae8942302'
+            'f6fec29ae94600e3912a6201b6588b95faa6e265098fe322dd944d1b431170b5')
 
 prepare() {
+  cd ${_realname}-${pkgver}
+  patch -Np1 -i ${srcdir}/0001-fix-manifest-processor-arch.patch
+  cd ..
+
   rm -Rf python2-cx_Freeze-${pkgver}-${CARCH}
   cp -a cx_Freeze-${pkgver} python2-cx_Freeze-${pkgver}-${CARCH}
   rm -Rf python3-cx_Freeze-${pkgver}-${CARCH}


### PR DESCRIPTION
This patch fixes `ImportError: DLL load failed: %1 is not a valid Win32 application.` when running modules packaged by cx_freeze on 64bit machines. This has to do with mixing Python 64 with 32bit modules. Switching the application manifest's `processorArchitecture="x86"` to `processorArchitecture="*"` fixes this problem. The star indicates that all processor architectures are supported.

This was [fixed upstream](https://bitbucket.org/anthony_tuininga/cx_freeze/pull-requests/71/changed-x86-in-windows-manifest-to/diff) in cx_Freeze 4.3.4. This patch wouldn't be necessary if the package itself was updated, but I was never able to get the latest version to successfully build.