### PR TITLE
qt5: updated sha256 for qtwebkit-opensource-src-5.6.0.tar.xz

### DIFF
--- a/mingw-w64-libjpeg-turbo/0002-md5sum-fix.patch
+++ b/mingw-w64-libjpeg-turbo/0002-md5sum-fix.patch
@@ -1,0 +1,73 @@
+diff -Naur libjpeg-turbo-1.4.2/md5/md5cmp.c libjpeg-turbo-1.4.2.new/md5/md5cmp.c
+--- libjpeg-turbo-1.4.2/md5/md5cmp.c	2015-09-21 20:48:32.000000000 +0200
++++ libjpeg-turbo-1.4.2.new/md5/md5cmp.c	2016-04-07 21:37:46.396809300 +0200
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (C)2013 D. R. Commander.  All Rights Reserved.
++ * Copyright (C)2013, 2016 D. R. Commander.  All Rights Reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+@@ -30,6 +30,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include "./md5.h"
++#include "../tjutil.h"
+ 
+ int main(int argc, char *argv[])
+ {
+diff -Naur libjpeg-turbo-1.4.2/md5/md5hl.c libjpeg-turbo-1.4.2.new/md5/md5hl.c
+--- libjpeg-turbo-1.4.2/md5/md5hl.c	2015-09-21 20:48:32.000000000 +0200
++++ libjpeg-turbo-1.4.2.new/md5/md5hl.c	2016-04-07 21:38:31.170288900 +0200
+@@ -4,12 +4,25 @@
+  * can do whatever you want with this stuff. If we meet some day, and you think
+  * this stuff is worth it, you can buy me a beer in return.   Poul-Henning Kamp
+  * ----------------------------------------------------------------------------
++ * libjpeg-turbo Modifications:
++ * Copyright (C) 2016, D. R. Commander
++ * Modifications are under the same license as the original code (see above)
++ * ----------------------------------------------------------------------------
+  */
+ 
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#ifdef _WIN32
++#include <io.h>
++#define close _close
++#define fstat _fstat
++#define lseek _lseek
++#define read _read
++#define stat _stat
++#else
+ #include <unistd.h>
++#endif
+ 
+ #include <errno.h>
+ #include <stdio.h>
+@@ -55,7 +68,11 @@
+ 	off_t n;
+ 
+ 	MD5Init(&ctx);
++#if _WIN32
++	f = _open(filename, O_RDONLY|O_BINARY);
++#else
+ 	f = open(filename, O_RDONLY);
++#endif
+ 	if (f < 0)
+ 		return 0;
+ 	if (fstat(f, &stbuf) < 0)
+@@ -73,11 +90,11 @@
+ 			i = read(f, buffer, sizeof(buffer));
+ 		else
+ 			i = read(f, buffer, n);
+-		if (i < 0) 
++		if (i < 0)
+ 			break;
+ 		MD5Update(&ctx, buffer, i);
+ 		n -= i;
+-	} 
++	}
+ 	e = errno;
+ 	close(f);
+ 	errno = e;

--- a/mingw-w64-libjpeg-turbo/PKGBUILD
+++ b/mingw-w64-libjpeg-turbo/PKGBUILD
@@ -18,15 +18,18 @@ replaces=("${MINGW_PACKAGE_PREFIX}-libjpeg")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/libjpeg-turbo/${_realname}-${pkgver}.tar.gz"
         "0001-header-compat.mingw.patch"
-        "libjpeg-turbo-1.3.1-libmng-compatibility.patch")
+        "libjpeg-turbo-1.3.1-libmng-compatibility.patch"
+	"0002-md5sum-fix.patch")
 sha256sums=('521bb5d3043e7ac063ce3026d9a59cc2ab2e9636c655a2515af5f4706122233e'
             '166264f617734b33ac55ec8b70e6636d4e409c0d837667afe158e9d28200e6dd'
-            '16336caddc949a8a082f39c218b3289288d144bb3b87f62565ed1b294ff8e526')
+            '16336caddc949a8a082f39c218b3289288d144bb3b87f62565ed1b294ff8e526'
+	    'c22fd95d1796cf8fd31617fd3cee87377f7c0a23f4c509a7f82978b3947933ef')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0001-header-compat.mingw.patch
   patch -p1 -i ${srcdir}/libjpeg-turbo-1.3.1-libmng-compatibility.patch
+  patch -p1 -i ${srcdir}/0002-md5sum-fix.patch
 }
 
 build() {

--- a/mingw-w64-nlopt/PKGBUILD
+++ b/mingw-w64-nlopt/PKGBUILD
@@ -4,42 +4,64 @@ _realname=nlopt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.4.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for nonlinear optimization (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-swig")
 url='http://ab-initio.mit.edu/wiki/index.php/NLopt'
 license=('LGPLv2.1+')
 
-source=("https://github.com/stevengj/nlopt/archive/${_realname}-${pkgver}.tar.gz"
+source=(#"https://github.com/stevengj/nlopt/archive/${_realname}-${pkgver}.tar.gz"
+        "http://ab-initio.mit.edu/${_realname}/${_realname}-${pkgver}.tar.gz"
         "config.sub"
         "config.guess")
 
-sha256sums=('d838b5b4b1c6b6493666ff61a8817a4ebcee924f54fb95f6f64e5f727ddbf2a6'
+sha256sums=('8099633de9d71cbc06cd435da993eb424bbcdbded8f803cdaa9fb8c6e09c8e89'
             '75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3'
             '467e0886e3d4b06087e704dc9e22bbb8f93eb8c7b81aeae1ee0000d06aa4c45f')
 
 prepare() {
-  cd "${srcdir}"/${_realname}-${_realname}-${pkgver}
-  cp -f "${srcdir}"/config.{sub,guess} .
-  ./autogen.sh --no-configure
+  cd "${srcdir}"/${_realname}-${pkgver}
+  #cp -f "${srcdir}"/config.{sub,guess} .
+  #./autogen.sh --no-configure
 }
 
 build() {
-  cd "$srcdir"/${_realname}-${_realname}-${pkgver}
+  cd "$srcdir"/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
-  ../${_realname}-${_realname}-${pkgver}/configure \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --enable-maintainer-mode \
-    --enable-static \
-    --enable-shared \
+
+  # If switching back to the github 'release' tarballs, add this config flag.
+  # --enable-maintainer-mode
+
+  # Build static C++ library, on Linux you can get a shared C++ library
+  # but not so on Windows. We still ask for one anyway. The .pc files are
+  # incorrect on all systems. They never refer to nlopt_cxx.
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX}          \
+    --build=${MINGW_CHOST}            \
+    --host=${MINGW_CHOST}             \
+    --target=${MINGW_CHOST}           \
+    --enable-static                   \
+    --enable-shared                   \
+    --with-cxx                        \
     --without-python
 
-  # -j1 because build system is a bit racy around the swig scm and scm.in file.
+  # build system is a bit racy around the swig scm and scm.in file.
+  make -j1
+  cp "${srcdir}"/build-${CARCH}/.libs/libnlopt_cxx.a "${srcdir}"/build-${CARCH}/libnlopt_cxx.a
+
+  # Build static and shared C libraries.
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX}          \
+    --build=${MINGW_CHOST}            \
+    --host=${MINGW_CHOST}             \
+    --target=${MINGW_CHOST}           \
+    --enable-static                   \
+    --enable-shared                   \
+    --without-python
+
+  # build system is a bit racy around the swig scm and scm.in file.
   make -j1
 }
 
@@ -51,4 +73,5 @@ check() {
 package() {
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
+  mv "${srcdir}"/build-${CARCH}/libnlopt_cxx.a "${pkgdir}"${MINGW_PREFIX}/lib
 }

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -679,7 +679,7 @@ package() {
 # E:/m2/repo/mingw-w64-qt5/src/i686/qtbase/bin/qmake.exe -o Makefile qml.pro
 
 sha256sums=('76a95cf6c1503290f75a641aa25079cd0c5a8fcd7cff07ddebff80a955b07de7'
-            'd5c4daac8eef1b24290cda59db432ccc390761af17661f64f3028482647521a1'
+            '9ca72373841f3a868a7bcc696956cdb0ad7f5e678c693659f6f0b919fdd16dfe'
             '7363ae7695af2f5278e9d91f6e52b3533dea4139ef252284bb82abfd025630d9'
             '609ab74b93ef11f24ef4d7c1bd0a2e81c4280b07fa455dfcf003a2364ab72745'
             '1b3aace0abc6c1ab1d077a57f7b2b0b7772e63c5b61519b633e955bbbc6d5485'


### PR DESCRIPTION
For update from Wed, 06 Apr 2016 08:55:14 GMT (Unix time: 1459932914)