### PR TITLE
libjpeg-turbo: fix md5 code with backport from trunk

### DIFF
--- a/mingw-w64-libjpeg-turbo/0002-md5sum-fix.patch
+++ b/mingw-w64-libjpeg-turbo/0002-md5sum-fix.patch
@@ -1,0 +1,73 @@
+diff -Naur libjpeg-turbo-1.4.2/md5/md5cmp.c libjpeg-turbo-1.4.2.new/md5/md5cmp.c
+--- libjpeg-turbo-1.4.2/md5/md5cmp.c	2015-09-21 20:48:32.000000000 +0200
++++ libjpeg-turbo-1.4.2.new/md5/md5cmp.c	2016-04-07 21:37:46.396809300 +0200
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (C)2013 D. R. Commander.  All Rights Reserved.
++ * Copyright (C)2013, 2016 D. R. Commander.  All Rights Reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+@@ -30,6 +30,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include "./md5.h"
++#include "../tjutil.h"
+ 
+ int main(int argc, char *argv[])
+ {
+diff -Naur libjpeg-turbo-1.4.2/md5/md5hl.c libjpeg-turbo-1.4.2.new/md5/md5hl.c
+--- libjpeg-turbo-1.4.2/md5/md5hl.c	2015-09-21 20:48:32.000000000 +0200
++++ libjpeg-turbo-1.4.2.new/md5/md5hl.c	2016-04-07 21:38:31.170288900 +0200
+@@ -4,12 +4,25 @@
+  * can do whatever you want with this stuff. If we meet some day, and you think
+  * this stuff is worth it, you can buy me a beer in return.   Poul-Henning Kamp
+  * ----------------------------------------------------------------------------
++ * libjpeg-turbo Modifications:
++ * Copyright (C) 2016, D. R. Commander
++ * Modifications are under the same license as the original code (see above)
++ * ----------------------------------------------------------------------------
+  */
+ 
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#ifdef _WIN32
++#include <io.h>
++#define close _close
++#define fstat _fstat
++#define lseek _lseek
++#define read _read
++#define stat _stat
++#else
+ #include <unistd.h>
++#endif
+ 
+ #include <errno.h>
+ #include <stdio.h>
+@@ -55,7 +68,11 @@
+ 	off_t n;
+ 
+ 	MD5Init(&ctx);
++#if _WIN32
++	f = _open(filename, O_RDONLY|O_BINARY);
++#else
+ 	f = open(filename, O_RDONLY);
++#endif
+ 	if (f < 0)
+ 		return 0;
+ 	if (fstat(f, &stbuf) < 0)
+@@ -73,11 +90,11 @@
+ 			i = read(f, buffer, sizeof(buffer));
+ 		else
+ 			i = read(f, buffer, n);
+-		if (i < 0) 
++		if (i < 0)
+ 			break;
+ 		MD5Update(&ctx, buffer, i);
+ 		n -= i;
+-	} 
++	}
+ 	e = errno;
+ 	close(f);
+ 	errno = e;

--- a/mingw-w64-libjpeg-turbo/PKGBUILD
+++ b/mingw-w64-libjpeg-turbo/PKGBUILD
@@ -18,15 +18,18 @@ replaces=("${MINGW_PACKAGE_PREFIX}-libjpeg")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/libjpeg-turbo/${_realname}-${pkgver}.tar.gz"
         "0001-header-compat.mingw.patch"
-        "libjpeg-turbo-1.3.1-libmng-compatibility.patch")
+        "libjpeg-turbo-1.3.1-libmng-compatibility.patch"
+        "0002-md5sum-fix.patch")
 sha256sums=('521bb5d3043e7ac063ce3026d9a59cc2ab2e9636c655a2515af5f4706122233e'
             '166264f617734b33ac55ec8b70e6636d4e409c0d837667afe158e9d28200e6dd'
-            '16336caddc949a8a082f39c218b3289288d144bb3b87f62565ed1b294ff8e526')
+            '16336caddc949a8a082f39c218b3289288d144bb3b87f62565ed1b294ff8e526'
+            'c22fd95d1796cf8fd31617fd3cee87377f7c0a23f4c509a7f82978b3947933ef')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0001-header-compat.mingw.patch
   patch -p1 -i ${srcdir}/libjpeg-turbo-1.3.1-libmng-compatibility.patch
+  patch -p1 -i ${srcdir}/0002-md5sum-fix.patch
 }
 
 build() {


### PR DESCRIPTION
Fixes a check() error that md5cmp hangs on all inputs