### PR TITLE
ccache: update to 3.2.4

### DIFF
--- a/mingw-w64-ccache/MinGW-add-ifdeds.patch
+++ b/mingw-w64-ccache/MinGW-add-ifdeds.patch
@@ -1,0 +1,75 @@
+diff -urN ccache-3.2.4.orig/ccache.c ccache-3.2.4/ccache.c
+--- ccache-3.2.4.orig/ccache.c	2015-10-08 21:14:23.000000000 +0200
++++ ccache-3.2.4/ccache.c	2016-04-09 14:42:04.140732100 +0200
+@@ -239,11 +239,13 @@
+ /* Temporary files to remove at program exit. */
+ static struct pending_tmp_file *pending_tmp_files = NULL;
+ 
++#ifndef _WIN32
+ static sigset_t fatal_signal_set;
+ 
+ /* PID of currently executing compiler that we have started, if any. 0 means no
+  * ongoing compilation. */
+ static pid_t compiler_pid = 0;
++#endif
+ 
+ /*
+  * This is a string that identifies the current "version" of the hash sum
+@@ -323,15 +325,19 @@
+ void
+ block_signals(void)
+ {
++#ifndef _WIN32
+ 	sigprocmask(SIG_BLOCK, &fatal_signal_set, NULL);
++#endif
+ }
+ 
+ void
+ unblock_signals(void)
+ {
++#ifndef _WIN32
+ 	sigset_t empty;
+ 	sigemptyset(&empty);
+ 	sigprocmask(SIG_SETMASK, &empty, NULL);
++#endif
+ }
+ 
+ static void
+@@ -368,6 +374,7 @@
+ 	unblock_signals();
+ }
+ 
++#ifndef _WIN32
+ static void
+ signal_handler(int signum)
+ {
+@@ -428,6 +435,7 @@
+ 	register_signal_handler(SIGQUIT);
+ #endif
+ }
++#endif /* _WIN32 */
+ 
+ static void
+ clean_up_internal_tempdir(void)
+@@ -2944,7 +2952,9 @@
+ 	/* Arguments to send to the real compiler. */
+ 	struct args *compiler_args;
+ 
++#ifndef _WIN32
+ 	set_up_signal_handlers();
++#endif
+ 
+ 	orig_args = args_init(argc, argv);
+ 
+diff -urN ccache-3.2.4.orig/ccache.h ccache-3.2.4/ccache.h
+--- ccache-3.2.4.orig/ccache.h	2015-10-08 21:14:23.000000000 +0200
++++ ccache-3.2.4/ccache.h	2016-04-09 14:22:19.195114800 +0200
+@@ -268,7 +268,7 @@
+ #    define link(src,dst) (CreateHardLink(dst,src,NULL) ? 0 : -1)
+ #    define lstat(a,b) stat(a,b)
+ #    define execv(a,b) win32execute(a,b,0,-1,-1)
+-#    define execute(a,b,c) win32execute(*(a),a,1,b,c)
++#    define execute(a,b,c,d) win32execute(*(a),a,1,b,c)
+ #    define PATH_DELIM ";"
+ #    define F_RDLCK 0
+ #    define F_WRLCK 0

--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -3,24 +3,29 @@
 _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.2.2
-pkgrel=2
+pkgver=3.2.4
+pkgrel=1
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('any')
 url="https://ccache.samba.org/"
-license=("MIT")
+license=("GPL3")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
-source=(https://samba.org/ftp/ccache/${_realname}-${pkgver}.tar.bz2{,.asc})
-sha256sums=('440f5e15141cc72d2bfff467c977020979810eb800882e3437ad1a7153cce7b2'
-            'SKIP')
+source=(https://samba.org/ftp/ccache/${_realname}-${pkgver}.tar.bz2{,.asc}
+        "MinGW-add-ifdeds.patch")
+sha256sums=('ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e'
+            'SKIP'
+            '30977bff713a10de0392aeeff86f8aa09f13ccf76823edb985b028790d0da472')
 
 prepare() {
   cd ${_realname}-${pkgver}
   #./autogen.sh
+  
+  #backported patch from git; fixed in unreleased 3.3
+  patch -p1 -i "${srcdir}"/MinGW-add-ifdeds.patch
 }
 
 build() {


### PR DESCRIPTION
Patching these 2 files seems to be enough. Upstream patch https://git.samba.org/?p=ccache.git;a=commit;h=361d9ad46d3276148f5b64654bb775205b728318

makepkg*.config flag `ccache` doesn't work, maybe we should change package() and install it Arch way? https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/ccache

Adressing https://github.com/Alexpux/MINGW-packages/issues/1292

EDIT: fixed links
EDIT2: Updated license