### PR TITLE
mingw-w64-ghostscript: refresh patches

### DIFF
--- a/mingw-w64-ghostscript/PKGBUILD
+++ b/mingw-w64-ghostscript/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ghostscript
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.19
-pkgrel=1
+pkgrel=2
 arch=('any')
 license=('AGPL' 'custom')
 pkgdesc="An interpreter for the PostScript language (mingw-w64)"
@@ -28,9 +28,9 @@ source=(https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/
         libspectre.patch)
 options=('staticlibs' 'strip')
 sha256sums=('f67acdcfcde1f86757ff3553cd719f12eac2d7681a0e96d8bdd1f40a0f47b45b'
-            '1aee59c0041d3dcdcd191fd469fe74f411ffb87bc60670b79ef2eaaffe28c32d'
-            'c08c7e1354aaa243e753517c61ff86a799a49e0177c7bf6fe0029abc693386f6'
-            'af949728b146120790e35ef9592cf38fabf9f14879f36b8bc50855a4c73fef69')
+            '9da2b4342aad18927d7f766a05e16b354b73b4c68e991fe3088280d98714d780'
+            '9cf9805e6b8329e83656c16475c9fc7b7b8c3e459a782b4755abdabbb8f22df4'
+            '5b0ef04d59658885f183a6c820a5dbbb89e57e4c43774bc6c90ae4fb742b2be7')
 noextract=(ghostscript-${pkgver}.tar.bz2)
 
 prepare() {

--- a/mingw-w64-ghostscript/ghostscript-sys-zlib.patch
+++ b/mingw-w64-ghostscript/ghostscript-sys-zlib.patch
@@ -1,7 +1,6 @@
-diff -up ghostscript-9.12/configure.ac.sys-zlib ghostscript-9.12/configure.ac
---- ghostscript-9.12/configure.ac.sys-zlib	2014-03-26 11:48:54.983972222 +0000
-+++ ghostscript-9.12/configure.ac	2014-03-26 11:49:36.807230531 +0000
-@@ -854,7 +854,7 @@ AC_MSG_CHECKING([for local zlib source])
+--- a/configure.ac
++++ b/configure.ac
+@@ -912,7 +912,7 @@
  dnl zlib is needed for language level 3, and libpng
  # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
  # this seems a harmless default
@@ -10,16 +9,3 @@ diff -up ghostscript-9.12/configure.ac.sys-zlib ghostscript-9.12/configure.ac
  AUX_SHARED_ZLIB=
  
  if test -d $srcdir/zlib; then
-diff -up ghostscript-9.12/configure.sys-zlib ghostscript-9.12/configure
---- ghostscript-9.12/configure.sys-zlib	2014-03-26 11:49:45.547284521 +0000
-+++ ghostscript-9.12/configure	2014-03-26 11:49:56.171350127 +0000
-@@ -6254,7 +6254,7 @@ fi
- $as_echo_n "checking for local zlib source... " >&6; }
- # we must define ZLIBDIR regardless because png.mak does a -I$(ZLIBDIR)
- # this seems a harmless default
--ZLIBDIR=src
-+ZLIBDIR=$includedir
- AUX_SHARED_ZLIB=
- 
- if test -d $srcdir/zlib; then
-

--- a/mingw-w64-ghostscript/libspectre.patch
+++ b/mingw-w64-ghostscript/libspectre.patch
@@ -1,6 +1,6 @@
---- ghostscript-9.14-orig/psi/iapi.h	2014-03-26 13:53:47.000000000 +0100
-+++ ghostscript-9.14/psi/iapi.h	2014-08-09 13:56:25.245374500 +0200
-@@ -229,6 +229,7 @@
+--- a/psi/iapi.h
++++ b/psi/iapi.h
+@@ -246,6 +246,7 @@
      int argc, char **argv);
  
  #ifdef __WIN32__

--- a/mingw-w64-ghostscript/mingw-build.patch
+++ b/mingw-w64-ghostscript/mingw-build.patch
@@ -1,7 +1,6 @@
-diff -Naur ghostscript-9.10-orig/base/gp_mswin.c ghostscript-9.10/base/gp_mswin.c
---- ghostscript-9.10-orig/base/gp_mswin.c	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/gp_mswin.c	2014-01-22 20:16:23.009800000 +0400
-@@ -866,7 +866,7 @@
+--- a/base/gp_mswin.c
++++ b/base/gp_mswin.c
+@@ -989,7 +989,7 @@
  
  /* -------------------------  _snprintf -----------------------------*/
  
@@ -10,9 +9,8 @@ diff -Naur ghostscript-9.10-orig/base/gp_mswin.c ghostscript-9.10/base/gp_mswin.
  #  define STDC99
  #else
  /* Microsoft Visual C++ 2005  doesn't properly define snprintf,
-diff -Naur ghostscript-9.10-orig/base/gp_mswin.h ghostscript-9.10/base/gp_mswin.h
---- ghostscript-9.10-orig/base/gp_mswin.h	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/gp_mswin.h	2014-01-22 17:21:46.232600000 +0400
+--- a/base/gp_mswin.h
++++ b/base/gp_mswin.h
 @@ -56,4 +56,13 @@
  
  #endif /* !defined(RC_INVOKED) */
@@ -27,21 +25,19 @@ diff -Naur ghostscript-9.10-orig/base/gp_mswin.h ghostscript-9.10/base/gp_mswin.
 +#endif
 +
  #endif /* gp_mswin_INCLUDED */
-diff -Naur ghostscript-9.10-orig/base/gs.mak ghostscript-9.10/base/gs.mak
---- ghostscript-9.10-orig/base/gs.mak	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/gs.mak	2014-01-22 17:21:46.248200000 +0400
-@@ -440,6 +440,7 @@
+--- a/base/gs.mak
++++ b/base/gs.mak
+@@ -520,6 +520,7 @@
  # save our set of makefile variables that are defined in every build (paths, etc.)
- $(gconfigd_h) : $(ECHOGS_XE) $(GS_MAK) $(TOP_MAKEFILES) $(GLSRCDIR)$(D)version.mak
+ $(gconfigd_h) : $(ECHOGS_XE) $(GS_MAK) $(GLSRCDIR)$(D)version.mak $(MAKEDIRS)
  	$(EXP)$(ECHOGS_XE) -w $(gconfigd_h) -x 23 define -s -u GS_LIB_DEFAULT -x 2022 $(GS_LIB_DEFAULT) -x 22
 +	$(MINGW_FONTPATH_PATCH_OR_EMPTY_COMMAND)
  	$(EXP)$(ECHOGS_XE) -a $(gconfigd_h) -x 23 define -s -u GS_DEV_DEFAULT -x 2022 $(GS_DEV_DEFAULT) -x 22
  	$(EXP)$(ECHOGS_XE) -a $(gconfigd_h) -x 23 define -s -u GS_CACHE_DIR -x 2022 $(GS_CACHE_DIR) -x 22
  	$(EXP)$(ECHOGS_XE) -a $(gconfigd_h) -x 23 define -s -u SEARCH_HERE_FIRST -s $(SEARCH_HERE_FIRST)
-diff -Naur ghostscript-9.10-orig/base/lib.mak ghostscript-9.10/base/lib.mak
---- ghostscript-9.10-orig/base/lib.mak	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/lib.mak	2014-01-23 06:33:46.689000000 +0400
-@@ -41,13 +41,13 @@
+--- a/base/lib.mak
++++ b/base/lib.mak
+@@ -42,13 +42,13 @@
  # We can't use $(CC_) for GLLCMSCC becuase that includes /Za on
  # msvc builds, and lcms configures itself to depend on msvc extensions
  # (inline asm, including windows.h) when compiled under msvc.
@@ -57,14 +53,12 @@ diff -Naur ghostscript-9.10-orig/base/lib.mak ghostscript-9.10/base/lib.mak
  lcms2_h=$(LCMS2SRCDIR)$(D)include$(D)lcms2.h
  lcms2_plugin_h=$(LCMS2SRCDIR)$(D)include$(D)lcms2_plugin.h
  
-diff -Naur ghostscript-9.10-orig/base/mingw-fp.sh ghostscript-9.10/base/mingw-fp.sh
---- ghostscript-9.10-orig/base/mingw-fp.sh	1970-01-01 03:00:00.000000000 +0300
-+++ ghostscript-9.10/base/mingw-fp.sh	2014-01-22 22:30:58.082800000 +0400
+--- /dev/null
++++ b/base/mingw-fp.sh
 @@ -0,0 +1 @@
 +sed -i -e 's?\\?/?g' $1
-diff -Naur ghostscript-9.10-orig/base/mingw-fs.mak ghostscript-9.10/base/mingw-fs.mak
---- ghostscript-9.10-orig/base/mingw-fs.mak	1970-01-01 03:00:00.000000000 +0300
-+++ ghostscript-9.10/base/mingw-fs.mak	2014-01-22 17:21:46.248200000 +0400
+--- /dev/null
++++ b/base/mingw-fs.mak
 @@ -0,0 +1,34 @@
 +# MSys/MinGW file- and operating-system section
 +# adapted from winplat.mak
@@ -100,9 +94,8 @@ diff -Naur ghostscript-9.10-orig/base/mingw-fs.mak ghostscript-9.10/base/mingw-f
 + $(dos__h) $(malloc__h) $(stdio__h) $(string__h) $(windows__h)\
 + $(gp_h) $(gsmemory_h) $(gstypes_h)
 +	$(GLCC) $(GLO_)gp_wsync.$(OBJ) $(C_) $(GLSRC)gp_wsync.c
-diff -Naur ghostscript-9.10-orig/base/mingwlib.mak ghostscript-9.10/base/mingwlib.mak
---- ghostscript-9.10-orig/base/mingwlib.mak	1970-01-01 03:00:00.000000000 +0300
-+++ ghostscript-9.10/base/mingwlib.mak	2014-01-22 17:21:46.248200000 +0400
+--- /dev/null
++++ b/base/mingwlib.mak
 @@ -0,0 +1,76 @@
 +# Common makefile section for MSys/MinGW
 +# adapted from winlib.mak
@@ -180,9 +173,8 @@ diff -Naur ghostscript-9.10-orig/base/mingwlib.mak ghostscript-9.10/base/mingwli
 +	$(GLCC) $(GLO_)gp_mspol.$(OBJ) $(C_) $(GLSRC)gp_mspol.c
 +
 +# end of mingwlib.mak
-diff -Naur ghostscript-9.10-orig/base/time_.h ghostscript-9.10/base/time_.h
---- ghostscript-9.10-orig/base/time_.h	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/time_.h	2014-01-22 22:04:50.786200000 +0400
+--- a/base/time_.h
++++ b/base/time_.h
 @@ -78,7 +78,7 @@
  #endif
  
@@ -192,11 +184,10 @@ diff -Naur ghostscript-9.10-orig/base/time_.h ghostscript-9.10/base/time_.h
  #  include <sys/times.h>
  #  define use_times_for_usertime 1
                  /* Posix 1003.1b-1993 section 4.8.1.5 says that
-diff -Naur ghostscript-9.10-orig/base/unix-aux.mak ghostscript-9.10/base/unix-aux.mak
---- ghostscript-9.10-orig/base/unix-aux.mak	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/unix-aux.mak	2014-01-22 20:08:25.945400000 +0400
-@@ -66,6 +66,13 @@
-  $(MAKEDIRS)
+--- a/base/unix-aux.mak
++++ b/base/unix-aux.mak
+@@ -69,6 +69,13 @@
+  $(UNIX_AUX_MAK) $(MAKEDIRS)
  	$(GLCC) $(GLO_)gp_sysv.$(OBJ) $(C_) $(GLSRC)gp_sysv.c
  
 +# the MINGW platform / build environment, joining unix for the ride 
@@ -208,8 +199,8 @@ diff -Naur ghostscript-9.10-orig/base/unix-aux.mak ghostscript-9.10/base/unix-au
 +
  # -------------------------- Auxiliary programs --------------------------- #
  
- $(ECHOGS_XE): $(GLSRC)echogs.c $(AK) $(stdpre_h) $(MAKEDIRS)
-@@ -88,18 +95,31 @@
+ $(ECHOGS_XE): $(GLSRC)echogs.c $(AK) $(stdpre_h) $(UNIX_AUX_MAK) $(MAKEDIRS)
+@@ -91,18 +98,31 @@
  # To get GS to use the system zlib, you remove/hide the gs/zlib directory
  # which means that the mkromfs build can't find the zlib source it needs.
  # So it's split into two targets, one using the zlib source directly.....
@@ -248,9 +239,8 @@ diff -Naur ghostscript-9.10-orig/base/unix-aux.mak ghostscript-9.10/base/unix-au
  
  $(MKROMFS_XE)_1: $(GLSRC)mkromfs.c $(MKROMFS_COMMON_DEPS) $(MKROMFS_OBJS_1) $(UNIX_AUX_MAK) $(MAKEDIRS)
  	$(CCAUX_) $(GENOPT) $(CFLAGS) $(I_)$(GLSRCDIR)$(_I) $(I_)$(GLOBJ)$(_I) $(I_)$(ZSRCDIR)$(_I) $(GLSRC)mkromfs.c $(O_)$(MKROMFS_XE)_1 $(MKROMFS_OBJS_1) $(AUXEXTRALIBS)
-diff -Naur ghostscript-9.19-orig/base/unix-dll.mak ghostscript-9.19/base/unix-dll.mak
---- ghostscript-9.19-orig/base/unix-dll.mak	2016-03-23 11:22:48.000000000 +0300
-+++ ghostscript-9.19/base/unix-dll.mak	2016-04-08 08:59:56.810265600 +0300
+--- a/base/unix-dll.mak
++++ b/base/unix-dll.mak
 @@ -35,17 +35,38 @@
  # Shared object names
  
@@ -357,10 +347,9 @@ diff -Naur ghostscript-9.19-orig/base/unix-dll.mak ghostscript-9.19/base/unix-dl
  	$(INSTALL_DATA) $(PSSRC)iapi.h $(DESTDIR)$(gsincludedir)iapi.h
  	$(INSTALL_DATA) $(PSSRC)ierrors.h $(DESTDIR)$(gsincludedir)ierrors.h
  	$(INSTALL_DATA) $(GLSRC)gserrors.h $(DESTDIR)$(gsincludedir)gserrors.h
-diff -Naur ghostscript-9.10-orig/base/unix-gcc.mak ghostscript-9.10/base/unix-gcc.mak
---- ghostscript-9.10-orig/base/unix-gcc.mak	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/unix-gcc.mak	2014-01-22 22:02:03.959800000 +0400
-@@ -57,7 +57,7 @@
+--- a/base/unix-gcc.mak
++++ b/base/unix-gcc.mak
+@@ -79,7 +79,7 @@
  INSTALL_DATA = $(INSTALL) -m 644
  INSTALL_SHARED = 
  
@@ -369,18 +358,17 @@ diff -Naur ghostscript-9.10-orig/base/unix-gcc.mak ghostscript-9.10/base/unix-gc
  exec_prefix = ${prefix}
  bindir = ${exec_prefix}/bin
  scriptdir = $(bindir)
-@@ -71,7 +71,7 @@
- gssharedir = $(libdir)/ghostscript/$(GS_DOT_VERSION)
- gsincludedir = $(includedir)/ghostscript/
+@@ -98,7 +98,7 @@
+ gssharedir = ${exec_prefix}/lib/ghostscript/$(GS_DOT_VERSION)
+ gsincludedir = ${prefix}/include/ghostscript/
  
 -docdir=$(gsdatadir)/doc
 +docdir=$(gsdatadir)/doc/ghostscript-$(GS_DOT_VERSION)
  exdir=$(gsdatadir)/examples
  GS_DOCDIR=$(docdir)
  
-diff -Naur ghostscript-9.10-orig/base/unixhead.mak ghostscript-9.10/base/unixhead.mak
---- ghostscript-9.10-orig/base/unixhead.mak	2013-08-30 14:37:28.000000000 +0400
-+++ ghostscript-9.10/base/unixhead.mak	2014-01-22 20:26:04.888400000 +0400
+--- a/base/unixhead.mak
++++ b/base/unixhead.mak
 @@ -22,7 +22,12 @@
  # Define the platform name.  For a "stock" System V platform,
  # use sysv_ instead of unix_.
@@ -405,11 +393,10 @@ diff -Naur ghostscript-9.10-orig/base/unixhead.mak ghostscript-9.10/base/unixhea
 +else
 +	MINGW_FONTPATH_PATCH_OR_EMPTY_COMMAND=
 +endif
-diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
---- ghostscript-9.10-orig/configure.ac	2013-08-30 14:37:29.000000000 +0400
-+++ ghostscript-9.10/configure.ac	2014-01-22 19:17:58.671800000 +0400
-@@ -180,6 +180,26 @@
-             CC_DBG_FLAGS_TO_TRY="-g -O0"
+--- a/configure.ac
++++ b/configure.ac
+@@ -187,6 +187,26 @@
+             SET_DT_SONAME="so"
          fi
          ;;
 +		MINGW*)
@@ -435,7 +422,7 @@ diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
  esac
  
  AC_SUBST(SET_DT_SONAME)
-@@ -1403,12 +1423,41 @@
+@@ -1521,12 +1541,41 @@
  AC_SUBST(SHARE_JPX)
  AC_SUBST(JPXDEVS)
  
@@ -478,7 +465,7 @@ diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
  if test "x$enable_gtk" != "xno"; then
      # Try GTK+ 3.x first...
      if test "x$PKGCONFIG" != x; then
-@@ -1441,9 +1490,15 @@
+@@ -1559,9 +1608,15 @@
    SOC_LOADER="dxmainc.c"
  fi
  
@@ -494,8 +481,8 @@ diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
  
  dnl look for omni implementation
  AC_ARG_WITH([omni], AC_HELP_STRING([--with-omni],
-@@ -1920,6 +1975,12 @@
-           DYNAMIC_LIBS=""
+@@ -2103,6 +2158,12 @@
+           DYNAMIC_LDFLAGS="-shared -Wl,-brtl,-G -fPIC"
            SO_LIB_EXT=".so"
          ;;
 +        MINGW*)
@@ -507,7 +494,7 @@ diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
  esac
  
  AC_ARG_ENABLE([dynamic], AC_HELP_STRING([--enable-dynamic],
-@@ -1992,6 +2053,20 @@
+@@ -2175,6 +2236,20 @@
  fi
  
  dnl Fix "fontpath" variable...
@@ -528,11 +515,10 @@ diff -Naur ghostscript-9.10-orig/configure.ac ghostscript-9.10/configure.ac
  if test "x$fontpath" = "x"; then
          # These font directories are used by various Linux distributions...
          fontpath="$datadir/fonts/default/ghostscript"
-diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
---- ghostscript-9.10-orig/Makefile.in	2013-08-30 14:37:29.000000000 +0400
-+++ ghostscript-9.10/Makefile.in	2014-01-22 22:30:09.450000000 +0400
-@@ -38,6 +38,14 @@
- PSOBJDIR=./$(BUILDDIRPREFIX)@OBJDIR_BSDMAKE_WORKAROUND@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -60,6 +60,14 @@
+ 
  CONTRIBDIR=@srcdir@/contrib
  
 +# ------ MINGW options ------ #
@@ -546,7 +532,7 @@ diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
  # Do not edit the next group of lines.
  
  include $(GLSRCDIR)/version.mak
-@@ -387,8 +404,8 @@
+@@ -433,8 +441,8 @@
  # Solaris may need -lnsl -lsocket -lposix4.
  # (Libraries required by individual drivers are handled automatically.)
  
@@ -557,7 +543,7 @@ diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
  
  # Define the standard libraries to search at the end of linking.
  # Most platforms require -lpthread for the POSIX threads library;
-@@ -438,9 +455,10 @@
+@@ -484,9 +492,10 @@
  RM=rm -f
  
  # ------ Dynamic loader options ------- #
@@ -571,7 +557,7 @@ diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
  
  # on virtually every Unix-a-like system, this is "so",
  # but Apple just had to be different, so it's now set
-@@ -568,7 +586,17 @@
+@@ -637,7 +646,17 @@
  
  CCFLAGS=$(GENOPT) $(CAPOPT) $(CFLAGS)
  CC_=$(CC) $(CCFLAGS)
@@ -590,7 +576,7 @@ diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
  CC_LEAF=$(CC_)
  # note gcc can't use -fomit-frame-pointer with -pg.
  CC_LEAF_PG=$(CC_)
-@@ -622,6 +650,12 @@
+@@ -707,6 +726,12 @@
  @CONTRIBINCLUDE@
  @CUPSINCLUDE@
  
@@ -603,8 +589,8 @@ diff -Naur ghostscript-9.10-orig/Makefile.in ghostscript-9.10/Makefile.in
  # Clean up after the autotools scripts
  distclean : clean config-clean soclean pgclean debugclean mementoclean
  	-$(RM_) -r $(BINDIR) $(GLOBJDIR) $(PSOBJDIR) $(AUXDIR)
---- ghostscript-9.18/base/stat_.h.orig	2015-10-13 10:13:06.284676300 +0300
-+++ ghostscript-9.18/base/stat_.h	2015-10-13 10:13:24.677192400 +0300
+--- a/base/stat_.h
++++ b/base/stat_.h
 @@ -43,7 +43,7 @@
   * Microsoft C uses _stat instead of stat,
   * for both the function name and the structure name.


### PR DESCRIPTION
Patches refreshed. Also removed `configure' from ghostscript-sys-zlib.patch since
the PKGBUILD will run autoconf anyway.