### PR TITLE
mpv: update to 0.17.0

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.16.0
+pkgver=0.17.0
 pkgrel=1
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="http://mpv.io"
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-angleproject-git"
          "${MINGW_PACKAGE_PREFIX}-ffmpeg"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libarchive"
-		 "${MINGW_PACKAGE_PREFIX}-libass"
+         "${MINGW_PACKAGE_PREFIX}-libass"
          "${MINGW_PACKAGE_PREFIX}-libcaca"
          #"${MINGW_PACKAGE_PREFIX}-libcdio-paranoia"
          "${MINGW_PACKAGE_PREFIX}-libdvdnav"
@@ -32,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "pkg-config"
              "python")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mpv-player/${_realname}/archive/v${pkgver}.tar.gz)
-sha256sums=('fc3619de0ede16fbb023ac72589090e8e77fd9d9e03a81adc728105d50ef38ba')
+sha256sums=('602cd2b0f5fc7e43473234fbb96e3f7bbb6418f15eb8fa720d9433cce31eba6e')
 
 # strip doesn't work well with the mpv.com wrapper, so strip manually instead
 options=(!strip !emptydirs)
@@ -96,7 +96,9 @@ package() {
 
   # Move encoding-profiles.conf to share/doc alongside the example .conf files.
   # mpv doesn't search /etc for configuration on MinGW.
-  mv "${pkgdir}${MINGW_PREFIX}/etc/mpv/"*.conf "${pkgdir}${MINGW_PREFIX}/share/doc/mpv/"
+  # 
+  # Encoding is disabled by default since it uses deprecated API
+  #mv "${pkgdir}${MINGW_PREFIX}/etc/mpv/"*.conf "${pkgdir}${MINGW_PREFIX}/share/doc/mpv/"
 
   # mpv needs winpty for key bindings to work on the terminal
   mv "${pkgdir}${MINGW_PREFIX}/bin/mpv.exe" "${pkgdir}${MINGW_PREFIX}/bin/mpv_exe"


### PR DESCRIPTION
No problems locally, hope bots will build now.

Commented line moving encoding-profiles.conf because it isn't created without `--enable-encoding` flag:
https://github.com/mpv-player/mpv/releases/tag/v0.17.0
> build: disable encoding mode by default (uses deprecated FFmpeg APIs)

EDIT: Finally AppVeyor didn't fail.