### PR TITLE
Improvements for Pidgin and Pidgin++

### DIFF
--- a/mingw-w64-pidgin++-bzr/001-autotools-and-fhs-pidgin.patch
+++ b/mingw-w64-pidgin++-bzr/001-autotools-and-fhs-pidgin.patch
@@ -1,0 +1,2042 @@
+diff -aurN 000/source/configure.ac 001/source/configure.ac
+--- 000/source/configure.ac
++++ 001/source/configure.ac
+@@ -120,10 +120,44 @@
+ dnl Check for Sun compiler
+ AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
+ 
++dnl ******************************
++dnl Win32
++dnl ******************************
++AC_MSG_CHECKING([for Win32])
++case "$host" in
++*-mingw*)
++	os_win32=yes
++	not_os_win32=no
++	NO_UNDEFINED='-no-undefined'
++	AVOID_VERSION='-avoid-version'
++	AC_CHECK_TOOL(WINDRES, windres)
++	PURPLE_LIBS='$(top_builddir)/libpurple/libpurple.la'
++	PIDGIN_LIBS='$(top_builddir)/pidgin/libpidgin.la'
++	;;
++*)
++	os_win32=no
++	not_os_win32=yes
++	NO_UNDEFINED=
++	AVOID_VERSION=
++	PURPLE_LIBS=
++	PIDGIN_LIBS=
++	;;
++esac
++AC_MSG_RESULT([$os_win32])
++AM_CONDITIONAL(OS_WIN32, [test $os_win32 = yes])
++AC_SUBST(NO_UNDEFINED)
++AC_SUBST(AVOID_VERSION)
++AC_SUBST(PURPLE_LIBS)
++AC_SUBST(PIDGIN_LIBS)
++
+ dnl Checks for header files.
+ AC_HEADER_STDC
+ AC_HEADER_SYS_WAIT
+-AC_CHECK_HEADERS(arpa/nameser_compat.h fcntl.h sys/time.h unistd.h locale.h signal.h stdint.h regex.h)
++AC_CHECK_HEADERS(arpa/nameser_compat.h fcntl.h sys/time.h unistd.h locale.h stdint.h)
++dnl signal.h is not good in mingw
++if test "$os_win32" != yes; then
++	AC_CHECK_HEADERS(signal.h regex.h)
++fi
+ 
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+@@ -145,6 +179,7 @@
+ 	AC_LIBOBJ(getopt1)
+ ])
+ 
++if test "$os_win32" != yes; then
+ dnl Check for inet_aton
+ AC_CHECK_FUNC(inet_aton, , [AC_CHECK_LIB(resolv, inet_aton, ,
+ 				         [AC_MSG_ERROR([inet_aton not found])])])
+@@ -152,6 +187,8 @@
+ AC_CHECK_LIB(nsl, gethostent)
+ AC_CHECK_FUNC(socket, ,
+ 	[AC_CHECK_LIB(socket, socket, , [AC_MSG_ERROR([socket not found])])])
++fi
++
+ dnl If all goes well, by this point the previous two checks will have
+ dnl pulled in -lsocket and -lnsl if we need them.
+ AC_CHECK_FUNC(getaddrinfo,
+@@ -161,6 +198,8 @@
+ 		[AC_DEFINE([HAVE_GETADDRINFO]) LIBS="-lsocket -lsnl $LIBS"], , , -lnsl)])
+ AC_CHECK_FUNCS(inet_ntop)
+ AC_CHECK_FUNCS(getifaddrs)
++
++if test "$os_win32" != yes; then
+ dnl Check for socklen_t (in Unix98)
+ AC_MSG_CHECKING(for socklen_t)
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+@@ -182,6 +221,7 @@
+ 		AC_DEFINE(socklen_t, int, [socklen_t size])
+ 	])
+ ])
++fi
+ 
+ dnl Some systems do not have sa_len field for struct sockaddr.
+ AC_CHECK_MEMBER([struct sockaddr.sa_len],
+@@ -332,6 +372,18 @@
+ AM_CONDITIONAL(INSTALL_I18N, test "x$enable_i18n" = "xyes")
+ 
+ dnl #######################################################################
++dnl # Check for Zlib
++dnl #######################################################################
++PKG_CHECK_MODULES([ZLIB],[zlib],[],[
++	AC_CHECK_HEADER(zlib.h, [ZLIB_CFLAGS=],
++		[AC_MSG_ERROR(zlib.h not found. install zlib)], [])
++	AC_CHECK_LIB(z, inflate, [ ZLIB_LIBS=-lz ],
++		[AC_MSG_ERROR(zlib not found or functional)], [])
++])
++AC_SUBST(ZLIB_CFLAGS)
++AC_SUBST(ZLIB_LIBS)
++
++dnl #######################################################################
+ dnl # Check for GLib 2.16 (required)
+ dnl #######################################################################
+ PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.16.0 gobject-2.0 gmodule-2.0 gthread-2.0], , [
+@@ -1267,7 +1319,7 @@
+ AM_CONDITIONAL(STATIC_SILC, test "x$static_silc" = "xyes" -a "x$have_silc" = "xyes")
+ AM_CONDITIONAL(STATIC_SIMPLE, test "x$static_simple" = "xyes")
+ AM_CONDITIONAL(STATIC_YAHOO, test "x$static_yahoo" = "xyes")
+-AM_CONDITIONAL(STATIC_ZEPHYR, test "x$static_zephyr" = "xyes")
++AM_CONDITIONAL(STATIC_ZEPHYR, test "x$static_zephyr" = "xyes" -a "x$enable_zephyr" = "xyes")
+ AC_SUBST(STATIC_LINK_LIBS)
+ AC_DEFINE_UNQUOTED(STATIC_PROTO_INIT, $extern_init static void static_proto_init(void) { $load_proto },
+ 	[Loads static protocol plugin module initialization functions.])
+@@ -1288,6 +1340,10 @@
+ if test "x$silc10includes" != "xyes" -o "x$silc10client" != "xyes"; then
+ 	DYNAMIC_PRPLS=`echo $DYNAMIC_PRPLS | $sedpath 's/silc10//'`
+ fi
++if test "x$enable_zephyr" != "xyes"; then
++	DYNAMIC_PRPLS=`echo $DYNAMIC_PRPLS | $sedpath 's/zephyr//'`
++fi
++
+ AC_SUBST(DYNAMIC_PRPLS)
+ for i in $DYNAMIC_PRPLS ; do
+ 	case $i in
+@@ -2640,6 +2696,11 @@
+ 		   pidgin/plugins/perl/Makefile
+ 		   pidgin/plugins/perl/common/Makefile.PL
+ 		   pidgin/plugins/ticker/Makefile
++		   pidgin/plugins/win32/Makefile
++		   pidgin/plugins/win32/transparency/Makefile
++		   pidgin/plugins/win32/winprefs/Makefile
++		   pidgin/win32/pidgin_dll_rc.rc
++		   pidgin/win32/pidgin_exe_rc.rc
+ 		   libpurple/data/gconf/Makefile
+ 		   libpurple/data/purple.pc
+ 		   libpurple/data/purple-uninstalled.pc
+@@ -2676,6 +2737,7 @@
+ 		   libpurple/tests/Makefile
+ 		   libpurple/purple.h
+ 		   libpurple/version.h
++		   libpurple/win32/libpurplerc.rc
+ 		   share/sounds/Makefile
+ 		   share/ca-certs/Makefile
+ 		   finch/finch.pc
+diff -aurN 000/source/finch/gntsound.c 001/source/finch/gntsound.c
+--- 000/source/finch/gntsound.c
++++ 001/source/finch/gntsound.c
+@@ -616,7 +616,7 @@
+ 		if (!filename || !strlen(filename)) {
+ 			g_free(filename);
+ 			/* XXX Consider creating a constant for "sounds/purple" to be shared with Pidgin */
+-			filename = g_build_filename(DATADIR, "sounds", "purple", sounds[event].def, NULL);
++			filename = g_build_filename(PURPLE_DATADIR, "sounds", "purple", sounds[event].def, NULL);
+ 		}
+ 
+ 		purple_sound_play_file(filename, NULL);
+diff -aurN 000/source/finch/libgnt/wms/Makefile.am 001/source/finch/libgnt/wms/Makefile.am
+--- 000/source/finch/libgnt/wms/Makefile.am
++++ 001/source/finch/libgnt/wms/Makefile.am
+@@ -29,7 +29,7 @@
+ EXTRA_DIST = 
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\"
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/finch \
+ 	-I$(top_srcdir)/finch/libgnt \
+diff -aurN 000/source/finch/Makefile.am 001/source/finch/Makefile.am
+--- 000/source/finch/Makefile.am
++++ 001/source/finch/Makefile.am
+@@ -78,11 +78,11 @@
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
+ AM_CPPFLAGS = \
+-	-DSTANDALONE \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/finch/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DFINCH_LIBDIR=\"$(libdir)/finch/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
++	-DSTANDALONE \
+ 	-I$(top_srcdir)/libpurple/ \
+ 	-I$(top_srcdir) \
+ 	-I$(srcdir)/libgnt/ \
+diff -aurN 000/source/finch/plugins/Makefile.am 001/source/finch/plugins/Makefile.am
+--- 000/source/finch/plugins/Makefile.am
++++ 001/source/finch/plugins/Makefile.am
+@@ -39,7 +39,7 @@
+ EXTRA_DIST = pietray.py
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir) \
+diff -aurN 000/source/libpurple/certificate.c 001/source/libpurple/certificate.c
+--- 000/source/libpurple/certificate.c
++++ 001/source/libpurple/certificate.c
+@@ -856,15 +856,15 @@
+ {
+ 	/* Attempt to point at the appropriate system path */
+ 	if (NULL == x509_ca_paths) {
+-#ifdef _WIN32
+-		x509_ca_paths = g_list_append(NULL, g_build_filename(DATADIR,
++#if defined(_WIN32) && !defined(USE_FHS)
++		x509_ca_paths = g_list_append(NULL, g_build_filename(PURPLE_DATADIR,
+ 						   "ca-certs", NULL));
+ #else
+ # ifdef SSL_CERTIFICATES_DIR
+ 		x509_ca_paths = g_list_append(NULL, g_strdup(SSL_CERTIFICATES_DIR));
+ # endif
+ 		x509_ca_paths = g_list_append(x509_ca_paths,
+-			g_build_filename(DATADIR, "purple", "ca-certs", NULL));
++			g_build_filename(PURPLE_DATADIR, "purple", "ca-certs", NULL));
+ #endif
+ 	}
+ 
+diff -aurN 000/source/libpurple/data/purple.pc.in 001/source/libpurple/data/purple.pc.in
+--- 000/source/libpurple/data/purple.pc.in
++++ 001/source/libpurple/data/purple.pc.in
+@@ -13,5 +13,5 @@
+ Description: libpurple is a GLib-based instant messenger library.
+ Version: @VERSION@
+ Requires: glib-2.0
+-Cflags: -I${includedir}/libpurple
++Cflags: -I${includedir}/libpurple -I${includedir}/libpurple/win32
+ Libs: -L${libdir} -lpurple
+diff -aurN 000/source/libpurple/dnsquery.c 001/source/libpurple/dnsquery.c
+--- 000/source/libpurple/dnsquery.c
++++ 001/source/libpurple/dnsquery.c
+@@ -744,7 +744,8 @@
+ 
+ 	query_data = data;
+ 
+-#ifdef USE_IDN
++	
++#if defined(USE_IDN) && defined(HAVE_GETADDRINFO)
+ 	if (!dns_str_is_ascii(query_data->hostname)) {
+ 		rc = purple_network_convert_idn_to_ascii(query_data->hostname, &hostname);
+ 		if (rc != 0) {
+diff -aurN 000/source/libpurple/example/Makefile.am 001/source/libpurple/example/Makefile.am
+--- 000/source/libpurple/example/Makefile.am
++++ 001/source/libpurple/example/Makefile.am
+@@ -12,11 +12,9 @@
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
+ AM_CPPFLAGS = \
+-	-DSTANDALONE \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
++	-DSTANDALONE \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir) \
+diff -aurN 000/source/libpurple/example/nullclient.c 001/source/libpurple/example/nullclient.c
+--- 000/source/libpurple/example/nullclient.c
++++ 001/source/libpurple/example/nullclient.c
+@@ -308,7 +308,11 @@
+ 	account = purple_account_new(name, prpl);
+ 
+ 	/* Get the password for the account */
++#ifndef _WIN32
+ 	password = getpass("Password: ");
++#else
++	password = "password";
++#endif
+ 	purple_account_set_password(account, password);
+ 
+ 	/* It's necessary to enable the account first. */
+diff -aurN 000/source/libpurple/Makefile.am 001/source/libpurple/Makefile.am
+--- 000/source/libpurple/Makefile.am
++++ 001/source/libpurple/Makefile.am
+@@ -15,21 +15,25 @@
+ 		data/purple-uninstalled.pc.in \
+ 		win32/global.mak \
+ 		win32/libc_interface.c \
+-		win32/libc_interface.h \
+-		win32/libc_internal.h \
+ 		win32/libpurplerc.rc.in \
+ 		win32/rules.mak \
+ 		win32/targets.mak \
+-		win32/wpurpleerror.h \
+ 		win32/win32dep.c \
+-		win32/giowin32.c \
++		win32/giowin32.c
++		
++if !OS_WIN32
++EXTRA_DIST += \
++		win32/libc_interface.h \
++		win32/libc_internal.h \
++		win32/wpurpleerror.h \
+ 		win32/win32dep.h
++endif
+ 
+ if USE_GCONFTOOL
+ GCONF_DIR=data/gconf
+ endif
+ 
+-SUBDIRS = $(GCONF_DIR) plugins protocols ciphers . tests example
++SUBDIRS = $(GCONF_DIR) ciphers . plugins protocols tests example
+ 
+ purple_coresources = \
+ 	account.c \
+@@ -94,6 +98,20 @@
+ 	xmlnode.c \
+ 	whiteboard.c
+ 
++if OS_WIN32
++purple_coresources += \
++	win32/giowin32.c \
++	win32/libc_interface.c \
++	win32/win32dep.c
++
++libpurple_win32_res = libpurple-win32-res.o
++libpurple_win32_res_ldflag = -Wl,$(libpurple_win32_res)
++
++libpurple-win32-res.o: win32/libpurplerc.rc
++	$(WINDRES) -I$(top_srcdir)/libpurple -i $< -o $@
++
++endif
++
+ purple_builtsources = \
+ 	marshallers.c
+ 
+@@ -163,6 +181,14 @@
+ 	codec.h \
+ 	enum-types.h
+ 
++if OS_WIN32
++purple_win32headers = \
++	libc_interface.h \
++	libc_internal.h \
++	wpurpleerror.h \
++	win32dep.h
++endif
++
+ purple_builtheaders = purple.h version.h marshallers.h
+ 
+ marshallers.h: marshallers.list
+@@ -297,8 +323,15 @@
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = data/purple.pc
+ 
+-libpurple_la_DEPENDENCIES = $(STATIC_LINK_LIBS)
+-libpurple_la_LDFLAGS = -export-dynamic -version-info $(PURPLE_LT_VERSION_INFO) -no-undefined
++if OS_WIN32
++win32includedir=$(includedir)/libpurple/win32
++win32include_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(purple_win32headers))
++endif
++
++libpurple_la_DEPENDENCIES = $(STATIC_LINK_LIBS) $(libpurple_win32_res)
++libpurple_la_LDFLAGS = -export-dynamic -version-info $(PURPLE_LT_VERSION_INFO) $(AVOID_VERSION) \
++	$(NO_UNDEFINED) $(libpurple_win32_res_ldflag)
+ libpurple_la_LIBADD = \
+ 	$(STATIC_LINK_LIBS) \
+ 	$(DBUS_LIBS) \
+@@ -315,9 +348,14 @@
+ 	ciphers/libpurple-ciphers.la \
+ 	-lm
+ 
++if OS_WIN32
++libpurple_la_LIBADD += \
++	-lws2_32 -ldnsapi
++endif
++
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DPURPLE_LIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	$(GLIB_CFLAGS) \
+@@ -332,6 +370,12 @@
+ 	$(IDN_CFLAGS) \
+ 	$(NETWORKMANAGER_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DUSE_FHS \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ # INSTALL_SSL_CERTIFICATES is true when SSL_CERTIFICATES_DIR is empty.
+ # We want to use SSL_CERTIFICATES_DIR when it's not empty.
+ if ! INSTALL_SSL_CERTIFICATES
+diff -aurN 000/source/libpurple/plugin.c 001/source/libpurple/plugin.c
+--- 000/source/libpurple/plugin.c
++++ 001/source/libpurple/plugin.c
+@@ -1179,7 +1179,7 @@
+ purple_plugins_init(void) {
+ 	void *handle = purple_plugins_get_handle();
+ 
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(PURPLE_LIBDIR);
+ 
+ 	purple_signal_register(handle, "plugin-load",
+ 						 purple_marshal_VOID__POINTER,
+diff -aurN 000/source/libpurple/plugins/Makefile.am 001/source/libpurple/plugins/Makefile.am
+--- 000/source/libpurple/plugins/Makefile.am
++++ 001/source/libpurple/plugins/Makefile.am
+@@ -24,27 +24,27 @@
+ 
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-autoaccept_la_LDFLAGS       = -module -avoid-version
+-buddynote_la_LDFLAGS        = -module -avoid-version
+-ciphertest_la_LDFLAGS		= -module -avoid-version
+-codeinline_la_LDFLAGS		= -module -avoid-version
+-debug_example_la_LDFLAGS    = -module -avoid-version
+-helloworld_la_LDFLAGS       = -module -avoid-version
+-idle_la_LDFLAGS             = -module -avoid-version
+-joinpart_la_LDFLAGS         = -module -avoid-version
+-log_reader_la_LDFLAGS       = -module -avoid-version
+-newline_la_LDFLAGS          = -module -avoid-version
+-notify_example_la_LDFLAGS   = -module -avoid-version
+-offlinemsg_la_LDFLAGS       = -module -avoid-version
+-one_time_password_la_LDFLAGS	= -module -avoid-version
+-pluginpref_example_la_LDFLAGS = -module -avoid-version
+-psychic_la_LDFLAGS          = -module -avoid-version
+-signals_test_la_LDFLAGS		= -module -avoid-version
+-simple_la_LDFLAGS			= -module -avoid-version
+-statenotify_la_LDFLAGS      = -module -avoid-version
++autoaccept_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++buddynote_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++ciphertest_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++codeinline_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++debug_example_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
++helloworld_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++idle_la_LDFLAGS             = -module -avoid-version $(NO_UNDEFINED)
++joinpart_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++log_reader_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++newline_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++notify_example_la_LDFLAGS   = -module -avoid-version $(NO_UNDEFINED)
++offlinemsg_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++one_time_password_la_LDFLAGS	= -module -avoid-version $(NO_UNDEFINED)
++pluginpref_example_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++psychic_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++signals_test_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++simple_la_LDFLAGS			= -module -avoid-version $(NO_UNDEFINED)
++statenotify_la_LDFLAGS      = -module -avoid-version $(NO_UNDEFINED)
+ 
+ # this can't be in a conditional otherwise automake 1.4 yells
+-dbus_example_la_LDFLAGS     = -module -avoid-version
++dbus_example_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -90,29 +90,30 @@
+ simple_la_SOURCES			= simple.c
+ statenotify_la_SOURCES      = statenotify.c
+ 
+-autoaccept_la_LIBADD        = $(GLIB_LIBS)
+-buddynote_la_LIBADD         = $(GLIB_LIBS)
+-ciphertest_la_LIBADD		= $(GLIB_LIBS)
+-codeinline_la_LIBADD		= $(GLIB_LIBS)
+-idle_la_LIBADD              = $(GLIB_LIBS)
+-joinpart_la_LIBADD          = $(GLIB_LIBS)
+-log_reader_la_LIBADD        = $(GLIB_LIBS)
+-newline_la_LIBADD           = $(GLIB_LIBS)
+-notify_example_la_LIBADD    = $(GLIB_LIBS)
+-offlinemsg_la_LIBADD        = $(GLIB_LIBS)
+-one_time_password_la_LIBADD = $(GLIB_LIBS)
+-pluginpref_example_la_LIBADD = $(GLIB_LIBS)
+-psychic_la_LIBADD           = $(GLIB_LIBS)
+-signals_test_la_LIBADD		= $(GLIB_LIBS)
+-simple_la_LIBADD			= $(GLIB_LIBS)
+-statenotify_la_LIBADD       = $(GLIB_LIBS)
++
++autoaccept_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++buddynote_la_LIBADD         = $(GLIB_LIBS) $(PURPLE_LIBS)
++ciphertest_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++codeinline_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++idle_la_LIBADD              = $(GLIB_LIBS) $(PURPLE_LIBS)
++joinpart_la_LIBADD          = $(GLIB_LIBS) $(PURPLE_LIBS)
++log_reader_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++newline_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
++notify_example_la_LIBADD    = $(GLIB_LIBS) $(PURPLE_LIBS)
++offlinemsg_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++one_time_password_la_LIBADD = $(GLIB_LIBS) $(PURPLE_LIBS)
++pluginpref_example_la_LIBADD = $(GLIB_LIBS) $(PURPLE_LIBS)
++psychic_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
++signals_test_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++simple_la_LIBADD			= $(GLIB_LIBS) $(PURPLE_LIBS)
++statenotify_la_LIBADD       = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ if ENABLE_DBUS
+ 
+ CLEANFILES              = dbus-example-bindings.c
+ dbus_example_la_SOURCES = dbus-example.c
+ 
+-dbus_example_la_LIBADD      = $(GLIB_LIBS) $(DBUS_LIBS)
++dbus_example_la_LIBADD      = $(GLIB_LIBS) $(DBUS_LIBS) $(PURPLE_LIBS)
+ 
+ .PHONY: always
+ 
+@@ -140,7 +141,7 @@
+ 	startup.py
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	$(DEBUG_CFLAGS) \
+@@ -148,6 +149,11 @@
+ 	$(PLUGIN_CFLAGS) \
+ 	$(DBUS_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ #
+ # This part allows people to build their own plugins in here.
+ # Yes, it's a mess.
+diff -aurN 000/source/libpurple/plugins/perl/Makefile.am 001/source/libpurple/plugins/perl/Makefile.am
+--- 000/source/libpurple/plugins/perl/Makefile.am
++++ 001/source/libpurple/plugins/perl/Makefile.am
+@@ -165,7 +165,6 @@
+ 	-I$(top_srcdir) \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)\" \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(PLUGIN_CFLAGS) \
+diff -aurN 000/source/libpurple/plugins/ssl/Makefile.am 001/source/libpurple/plugins/ssl/Makefile.am
+--- 000/source/libpurple/plugins/ssl/Makefile.am
++++ 001/source/libpurple/plugins/ssl/Makefile.am
+@@ -3,10 +3,10 @@
+ 
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-ssl_la_LDFLAGS        = -module -avoid-version
+-ssl_gnutls_la_LDFLAGS = -module -avoid-version
+-ssl_nss_la_LDFLAGS    = -module -avoid-version
+-nss_prefs_la_LDFLAGS  = -module -avoid-version
++ssl_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++ssl_gnutls_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++ssl_nss_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
++nss_prefs_la_LDFLAGS  = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -43,15 +43,15 @@
+ ssl_nss_la_SOURCES    = ssl-nss.c
+ nss_prefs_la_SOURCES  = nss-prefs.c
+ 
+-ssl_la_LIBADD        = $(GLIB_LIBS)
+-ssl_gnutls_la_LIBADD = $(GLIB_LIBS) $(GNUTLS_LIBS)
+-ssl_nss_la_LIBADD    = $(GLIB_LIBS) $(NSS_LIBS)
+-nss_prefs_la_LIBADD  = $(GLIB_LIBS) $(NSS_LIBS)
++ssl_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++ssl_gnutls_la_LIBADD = $(GLIB_LIBS) $(GNUTLS_LIBS) $(PURPLE_LIBS)
++ssl_nss_la_LIBADD    = $(GLIB_LIBS) $(NSS_LIBS) $(PURPLE_LIBS)
++nss_prefs_la_LIBADD  = $(GLIB_LIBS) $(NSS_LIBS) $(PURPLE_LIBS)
+ 
+ endif # PLUGINS
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-DLIBDIR=\"$(libdir)/libpurple\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+@@ -59,6 +59,12 @@
+ 	$(GLIB_CFLAGS) \
+ 	$(PLUGIN_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DWIN32_LEAN_AND_MEAN \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ ssl_gnutls_la_CFLAGS = $(AM_CPPFLAGS) $(GNUTLS_CFLAGS)
+ ssl_nss_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
+ nss_prefs_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
+diff -aurN 000/source/libpurple/plugins/tcl/Makefile.am 001/source/libpurple/plugins/tcl/Makefile.am
+--- 000/source/libpurple/plugins/tcl/Makefile.am
++++ 001/source/libpurple/plugins/tcl/Makefile.am
+@@ -1,13 +1,13 @@
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-tcl_la_LDFLAGS = -module -avoid-version
++tcl_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ plugin_LTLIBRARIES = tcl.la
+ 
+ tcl_la_SOURCES = tcl.c tcl_glib.c tcl_glib.h tcl_cmds.c tcl_signals.c tcl_purple.h \
+                  tcl_ref.c tcl_cmd.c
+ 
+-tcl_la_LIBADD = $(GLIB_LIBS) $(TCL_LIBS) $(TK_LIBS)
++tcl_la_LIBADD = $(GLIB_LIBS) $(TCL_LIBS) $(TK_LIBS) $(PURPLE_LIBS)
+ 
+ EXTRA_DIST = signal-test.tcl Makefile.mingw
+ 
+@@ -20,3 +20,8 @@
+ 	$(PLUGIN_CFLAGS) \
+ 	$(TK_CFLAGS) \
+ 	$(TCL_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+\ No newline at end of file
+diff -aurN 000/source/libpurple/protocols/bonjour/Makefile.am 001/source/libpurple/protocols/bonjour/Makefile.am
+--- 000/source/libpurple/protocols/bonjour/Makefile.am
++++ 001/source/libpurple/protocols/bonjour/Makefile.am
+@@ -40,7 +40,7 @@
+ st =
+ pkg_LTLIBRARIES       = libbonjour.la
+ libbonjour_la_SOURCES = $(BONJOURSOURCES)
+-libbonjour_la_LIBADD  = $(GLIB_LIBS) $(LIBXML_LIBS) $(AVAHI_LIBS)
++libbonjour_la_LIBADD  = $(GLIB_LIBS) $(LIBXML_LIBS) $(AVAHI_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+diff -aurN 000/source/libpurple/protocols/gg/Makefile.am 001/source/libpurple/protocols/gg/Makefile.am
+--- 000/source/libpurple/protocols/gg/Makefile.am
++++ 001/source/libpurple/protocols/gg/Makefile.am
+@@ -96,6 +96,10 @@
+ 	$(GNUTLS_CFLAGS) \
+ 	-DGG_IGNORE_DEPRECATED
+ 
++if OS_WIN32
++INTGG_CFLAGS += -include win32dep.h
++endif
++
+ endif
+ 
+ GGSOURCES = \
+@@ -113,7 +117,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libgg_la_LDFLAGS = -module -avoid-version
++libgg_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_GG
+ 
+@@ -121,14 +125,14 @@
+ noinst_LTLIBRARIES = libgg.la
+ libgg_la_SOURCES = $(GGSOURCES)
+ libgg_la_CFLAGS  = $(AM_CFLAGS)
+-libgg_la_LIBADD  = $(LIBGADU_LIBS) $(INTGG_LIBS)
++libgg_la_LIBADD  = $(LIBGADU_LIBS) $(INTGG_LIBS) $(PURPLE_LIBS)
+ 
+ else
+ 
+ st =
+ pkg_LTLIBRARIES = libgg.la
+ libgg_la_SOURCES = $(GGSOURCES)
+-libgg_la_LIBADD  = $(GLIB_LIBS) $(LIBGADU_LIBS) $(INTGG_LIBS)
++libgg_la_LIBADD  = $(GLIB_LIBS) $(LIBGADU_LIBS) $(INTGG_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -139,3 +143,7 @@
+ 	$(INTGG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/irc/Makefile.am 001/source/libpurple/protocols/irc/Makefile.am
+--- 000/source/libpurple/protocols/irc/Makefile.am
++++ 001/source/libpurple/protocols/irc/Makefile.am
+@@ -13,7 +13,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libirc_la_LDFLAGS = -module -avoid-version
++libirc_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_IRC
+ 
+@@ -27,7 +27,7 @@
+ st =
+ pkg_LTLIBRARIES   = libirc.la
+ libirc_la_SOURCES = $(IRCSOURCES)
+-libirc_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS)
++libirc_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -36,3 +36,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/jabber/Makefile.am 001/source/libpurple/protocols/jabber/Makefile.am
+--- 000/source/libpurple/protocols/jabber/Makefile.am
++++ 001/source/libpurple/protocols/jabber/Makefile.am
+@@ -95,7 +95,8 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libxmpp_la_LDFLAGS = -module -avoid-version
++libxmpp_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libjabber_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ 
+ if USE_CYRUS_SASL
+ JABBERSOURCES += auth_cyrus.c
+@@ -111,12 +112,20 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES      = libjabber.la libxmpp.la
++pkg_LTLIBRARIES      = libxmpp.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = libjabber.la
++else
++pkg_LTLIBRARIES    += libjabber.la
++endif
++
+ libjabber_la_SOURCES = $(JABBERSOURCES)
+ libjabber_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS) $(LIBXML_LIBS) $(IDN_LIBS)\
+ 	$(FARSIGHT_LIBS) \
+ 	$(GSTREAMER_LIBS) \
+-	$(GSTINTERFACES_LIBS)
++	$(GSTINTERFACES_LIBS) \
++	$(PURPLE_LIBS)
+ 
+ libxmpp_la_SOURCES = libxmpp.c
+ libxmpp_la_LIBADD = libjabber.la
+@@ -133,3 +142,10 @@
+ 	$(FARSIGHT_CFLAGS) \
+ 	$(GSTREAMER_CFLAGS) \
+ 	$(GSTINTERFACES_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/libpurple/protocols/jabber/win32
++endif
++
+diff -aurN 000/source/libpurple/protocols/msn/Makefile.am 001/source/libpurple/protocols/msn/Makefile.am
+--- 000/source/libpurple/protocols/msn/Makefile.am
++++ 001/source/libpurple/protocols/msn/Makefile.am
+@@ -77,7 +77,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmsn_la_LDFLAGS = -module -avoid-version
++libmsn_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MSN
+ 
+@@ -91,7 +91,7 @@
+ st =
+ pkg_LTLIBRARIES   = libmsn.la
+ libmsn_la_SOURCES = $(MSNSOURCES)
+-libmsn_la_LIBADD  = $(GLIB_LIBS)
++libmsn_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -100,3 +100,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/mxit/Makefile.am 001/source/libpurple/protocols/mxit/Makefile.am
+--- 000/source/libpurple/protocols/mxit/Makefile.am
++++ 001/source/libpurple/protocols/mxit/Makefile.am
+@@ -40,7 +40,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmxit_la_LDFLAGS = -module -avoid-version
++libmxit_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MXIT
+ 
+@@ -54,7 +54,7 @@
+ st =
+ pkg_LTLIBRARIES   = libmxit.la
+ libmxit_la_SOURCES = $(MXITSOURCES)
+-libmxit_la_LIBADD  = $(GLIB_LIBS)
++libmxit_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -63,3 +63,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/mxit/markup.c 001/source/libpurple/protocols/mxit/markup.c
+--- 000/source/libpurple/protocols/mxit/markup.c
++++ 001/source/libpurple/protocols/mxit/markup.c
+@@ -231,7 +231,7 @@
+ 		return -1;
+ 	}
+ 
+-	len = (guint8)data[1]; /* length field [1 byte] */
++	len = data[1]; /* length field [1 byte] */
+ 	if ( data_len - 2 < len ) {
+ 		/* not enough bytes left in data! */
+ 		return -1;
+diff -aurN 000/source/libpurple/protocols/myspace/Makefile.am 001/source/libpurple/protocols/myspace/Makefile.am
+--- 000/source/libpurple/protocols/myspace/Makefile.am
++++ 001/source/libpurple/protocols/myspace/Makefile.am
+@@ -19,7 +19,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmyspace_la_LDFLAGS = -module -avoid-version
++libmyspace_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MYSPACE
+ 
+@@ -33,7 +33,7 @@
+ st =
+ pkg_LTLIBRARIES       = libmyspace.la
+ libmyspace_la_SOURCES = $(MSIMSOURCES)
+-libmyspace_la_LIBADD  = $(GLIB_LIBS)
++libmyspace_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -42,3 +42,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/novell/Makefile.am 001/source/libpurple/protocols/novell/Makefile.am
+--- 000/source/libpurple/protocols/novell/Makefile.am
++++ 001/source/libpurple/protocols/novell/Makefile.am
+@@ -28,7 +28,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libnovell_la_LDFLAGS = -module -avoid-version
++libnovell_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_NOVELL
+ 
+@@ -42,7 +42,7 @@
+ st =
+ pkg_LTLIBRARIES      = libnovell.la
+ libnovell_la_SOURCES = $(NOVELLSOURCES)
+-libnovell_la_LIBADD  = $(GLIB_LIBS)
++libnovell_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -51,3 +51,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/null/Makefile.am 001/source/libpurple/protocols/null/Makefile.am
+--- 000/source/libpurple/protocols/null/Makefile.am
++++ 001/source/libpurple/protocols/null/Makefile.am
+@@ -14,10 +14,15 @@
+ st =
+ pkg_LTLIBRARIES    = libnull.la
+ libnull_la_SOURCES = $(NULLSOURCES)
+-libnull_la_LIBADD  = $(GLIB_LIBS)
++libnull_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/oscar/Makefile.am 001/source/libpurple/protocols/oscar/Makefile.am
+--- 000/source/libpurple/protocols/oscar/Makefile.am
++++ 001/source/libpurple/protocols/oscar/Makefile.am
+@@ -50,8 +50,9 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libaim_la_LDFLAGS = -module -avoid-version
+-libicq_la_LDFLAGS = -module -avoid-version
++libaim_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libicq_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++liboscar_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ if STATIC_OSCAR
+ 
+ st = -DPURPLE_STATIC_PRPL
+@@ -62,9 +63,16 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES     = liboscar.la libaim.la libicq.la
++pkg_LTLIBRARIES     = libaim.la libicq.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = liboscar.la
++else
++pkg_LTLIBRARIES    += liboscar.la
++endif
++
+ liboscar_la_SOURCES = $(OSCARSOURCES)
+-liboscar_la_LIBADD  = $(GLIB_LIBS)
++liboscar_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ libaim_la_SOURCES   = libaim.c
+ libaim_la_LIBADD    = liboscar.la
+@@ -79,3 +87,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/sametime/Makefile.am 001/source/libpurple/protocols/sametime/Makefile.am
+--- 000/source/libpurple/protocols/sametime/Makefile.am
++++ 001/source/libpurple/protocols/sametime/Makefile.am
+@@ -24,8 +24,8 @@
+ endif
+ 
+ libsametime_la_SOURCES = $(SAMETIMESOURCES)
+-libsametime_la_LDFLAGS = -module -avoid-version
+-libsametime_la_LIBADD = $(GLIB_LIBS) $(MEANWHILE_LIBS)
++libsametime_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libsametime_la_LIBADD = $(GLIB_LIBS) $(MEANWHILE_LIBS) $(PURPLE_LIBS)
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/libpurple \
+@@ -35,3 +35,7 @@
+ 	$(MEANWHILE_CFLAGS) \
+ 	-DG_LOG_DOMAIN=\"sametime\"
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/silc/Makefile.am 001/source/libpurple/protocols/silc/Makefile.am
+--- 000/source/libpurple/protocols/silc/Makefile.am
++++ 001/source/libpurple/protocols/silc/Makefile.am
+@@ -19,7 +19,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libsilcpurple_la_LDFLAGS = -module -avoid-version
++libsilcpurple_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_SILC
+ 
+@@ -34,7 +34,7 @@
+ st = $(SILC_CFLAGS)
+ pkg_LTLIBRARIES          = libsilcpurple.la
+ libsilcpurple_la_SOURCES = $(SILCSOURCES)
+-libsilcpurple_la_LIBADD  = $(GLIB_LIBS) $(SILC_LIBS)
++libsilcpurple_la_LIBADD  = $(GLIB_LIBS) $(SILC_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -44,3 +44,8 @@
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(SILC_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/simple/Makefile.am 001/source/libpurple/protocols/simple/Makefile.am
+--- 000/source/libpurple/protocols/simple/Makefile.am
++++ 001/source/libpurple/protocols/simple/Makefile.am
+@@ -11,7 +11,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libsimple_la_LDFLAGS = -module -avoid-version
++libsimple_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_SIMPLE
+ 
+@@ -25,7 +25,7 @@
+ st =
+ pkg_LTLIBRARIES      = libsimple.la
+ libsimple_la_SOURCES = $(SIMPLESOURCES)
+-libsimple_la_LIBADD  = $(GLIB_LIBS)
++libsimple_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -34,3 +34,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/yahoo/Makefile.am 001/source/libpurple/protocols/yahoo/Makefile.am
+--- 000/source/libpurple/protocols/yahoo/Makefile.am
++++ 001/source/libpurple/protocols/yahoo/Makefile.am
+@@ -27,8 +27,9 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libyahoo_la_LDFLAGS = -module -avoid-version
+-libyahoojp_la_LDFLAGS = -module -avoid-version
++libyahoo_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libyahoojp_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libymsg_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ 
+ if STATIC_YAHOO
+ 
+@@ -40,10 +41,16 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES     = libymsg.la libyahoo.la libyahoojp.la
++pkg_LTLIBRARIES     = libyahoo.la libyahoojp.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = libymsg.la
++else
++pkg_LTLIBRARIES    += libymsg.la
++endif
+ 
+ libymsg_la_SOURCES = $(YAHOOSOURCES)
+-libymsg_la_LIBADD  = $(GLIB_LIBS)
++libymsg_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ libyahoo_la_SOURCES = libyahoo.c
+ libyahoo_la_LIBADD = libymsg.la
+@@ -58,3 +65,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/win32/libc_interface.h 001/source/libpurple/win32/libc_interface.h
+--- 000/source/libpurple/win32/libc_interface.h
++++ 001/source/libpurple/win32/libc_interface.h
+@@ -23,6 +23,7 @@
+ #ifndef _LIBC_INTERFACE_H_
+ #define _LIBC_INTERFACE_H_
+ #include <winsock2.h>
++#undef socklen_t
+ #include <ws2tcpip.h>
+ #include <io.h>
+ #include <errno.h>
+diff -aurN 000/source/libpurple/win32/libpurplerc.rc.in 001/source/libpurple/win32/libpurplerc.rc.in
+--- 000/source/libpurple/win32/libpurplerc.rc.in
++++ 001/source/libpurple/win32/libpurplerc.rc.in
+@@ -2,8 +2,8 @@
+ #include "version.h"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32
+diff -aurN 000/source/libpurple/win32/win32dep.c 001/source/libpurple/win32/win32dep.c
+--- 000/source/libpurple/win32/win32dep.c
++++ 001/source/libpurple/win32/win32dep.c
+@@ -28,12 +28,18 @@
+ 
+ #include "debug.h"
+ #include "notify.h"
++#ifdef USE_FHS
++#include "version.h"
++#endif
+ 
+ /*
+  * LOCALS
+  */
+ static char *app_data_dir = NULL, *install_dir = NULL,
+ 	*lib_dir = NULL, *locale_dir = NULL;
++#ifdef USE_FHS
++static char *share_dir = NULL;
++#endif
+ 
+ static HINSTANCE libpurpledll_hInstance = NULL;
+ 
+@@ -153,13 +159,39 @@
+ 	return install_dir;
+ }
+ 
++#ifdef USE_FHS
++const char *wpurple_share_dir(void) {
++	static gboolean initialized = FALSE;
++
++	if (!initialized) {
++		const char *inst_dir = wpurple_install_dir();
++		if (inst_dir != NULL) {
++			share_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "share", inst_dir);
++			initialized = TRUE;
++		} else {
++			return NULL;
++		}
++	}
++
++	return share_dir;
++}
++#else
++const char *wpurple_share_dir(void) {
++	return wpurple_install_dir();
++}
++#endif
++
+ const char *wpurple_lib_dir(void) {
+ 	static gboolean initialized = FALSE;
+ 
+ 	if (!initialized) {
+ 		const char *inst_dir = wpurple_install_dir();
+ 		if (inst_dir != NULL) {
++#ifdef USE_FHS
++			lib_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "lib" G_DIR_SEPARATOR_S "purple-%i" , inst_dir, PURPLE_MAJOR_VERSION);
++#else
+ 			lib_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S "plugins", inst_dir);
++#endif
+ 			initialized = TRUE;
+ 		} else {
+ 			return NULL;
+@@ -175,7 +207,11 @@
+ 	if (!initialized) {
+ 		const char *inst_dir = wpurple_install_dir();
+ 		if (inst_dir != NULL) {
++#ifdef USE_FHS
++			locale_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "share" G_DIR_SEPARATOR_S "locale", inst_dir);
++#else
+ 			locale_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S "locale", inst_dir);
++#endif
+ 			initialized = TRUE;
+ 		} else {
+ 			return NULL;
+@@ -375,6 +411,11 @@
+ 	lib_dir = NULL;
+ 	locale_dir = NULL;
+ 
++#ifdef USE_FHS
++	g_free(share_dir);
++	share_dir = NULL;	
++#endif
++
+ 	libpurpledll_hInstance = NULL;
+ }
+ 
+diff -aurN 000/source/libpurple/win32/win32dep.h 001/source/libpurple/win32/win32dep.h
+--- 000/source/libpurple/win32/win32dep.h
++++ 001/source/libpurple/win32/win32dep.h
+@@ -65,6 +65,7 @@
+ const char *wpurple_install_dir(void);
+ const char *wpurple_lib_dir(void);
+ const char *wpurple_locale_dir(void);
++const char *wpurple_share_dir(void);
+ const char *wpurple_data_dir(void);
+ 
+ /* init / cleanup */
+@@ -80,9 +81,14 @@
+ /*
+  *  Purple specific
+  */
+-#define DATADIR wpurple_install_dir()
+-#define LIBDIR wpurple_lib_dir()
++#undef PURPLE_DATADIR
++#define PURPLE_DATADIR wpurple_share_dir()
++#undef PURPLE_LIBDIR
++#define PURPLE_LIBDIR wpurple_lib_dir()
++#undef LOCALEDIR
+ #define LOCALEDIR wpurple_locale_dir()
++/* TODO: SYSCONFDIR should be the allusers AppData? */
++#undef SYSCONFDIR
+ 
+ #ifdef __cplusplus
+ }
+diff -aurN 000/source/pidgin/data/pidgin.pc.in 001/source/pidgin/data/pidgin.pc.in
+--- 000/source/pidgin/data/pidgin.pc.in
++++ 001/source/pidgin/data/pidgin.pc.in
+@@ -12,5 +12,6 @@
+ Description: Pidgin is a GTK2-based instant messenger application.
+ Version: @VERSION@
+ Requires: gtk+-2.0 purple
+-Cflags: -I${includedir}/pidgin
++Cflags: -I${includedir}/pidgin -I${includedir}/pidgin/win32
++Libs: -L${libdir} -lpidgin
+ 
+diff -aurN 000/source/pidgin/data/pidgin-2.pc.in 001/source/pidgin/data/pidgin-2.pc.in
+--- 000/source/pidgin/data/pidgin-2.pc.in
++++ 001/source/pidgin/data/pidgin-2.pc.in
+@@ -13,3 +13,4 @@
+ Version: @VERSION@
+ Requires: gtk+-2.0 purple
+ Cflags: -I${includedir}
++Libs: -L${libdir} -lpidgin
+diff -aurN 000/source/pidgin/gtkblist.c 001/source/pidgin/gtkblist.c
+--- 000/source/pidgin/gtkblist.c
++++ 001/source/pidgin/gtkblist.c
+@@ -3369,14 +3369,14 @@
+ 	char *path;
+ 
+ 	if (!strcmp(mood, "busy")) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "status", "16", "busy.png", NULL);
+ 	} else if (!strcmp(mood, "hiptop")) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "emblems", "16", "hiptop.png", NULL);
+ 	} else {
+ 		char *filename = g_strdup_printf("%s.png", mood);
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "emotes", "small", filename, NULL);
+ 		g_free(filename);
+ 	}
+@@ -4026,7 +4026,7 @@
+ 		if (purple_presence_is_status_primitive_active(p, PURPLE_STATUS_MOBILE)) {
+ 			/* This emblem comes from the small emoticon set now,
+ 			 * to reduce duplication. */
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes",
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes",
+ 						"small", "mobile.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+@@ -4043,7 +4043,7 @@
+ 	g_return_val_if_fail(buddy != NULL, NULL);
+ 
+ 	if (!purple_privacy_check(buddy->account, purple_buddy_get_name(buddy))) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "blocked.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "blocked.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4054,7 +4054,7 @@
+ 
+ 	if (purple_presence_is_status_primitive_active(p, PURPLE_STATUS_MOBILE)) {
+ 		/* This emblem comes from the small emoticon set now, to reduce duplication. */
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", "small", "mobile.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", "small", "mobile.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4063,18 +4063,18 @@
+ 		/* Only in MSN.
+ 		 * TODO: Replace "Tune" with generalized "Media" in 3.0. */
+ 		if (purple_status_get_attr_string(tune, "game") != NULL) {
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "game.png", NULL);
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "game.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+ 		/* Only in MSN.
+ 		 * TODO: Replace "Tune" with generalized "Media" in 3.0. */
+ 		if (purple_status_get_attr_string(tune, "office") != NULL) {
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "office.png", NULL);
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "office.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+ 		/* Regular old "tune" is the only one in all protocols. */
+ 		/* This emblem comes from the small emoticon set now, to reduce duplication. */
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", "small", "music.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", "small", "music.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4101,7 +4101,7 @@
+ 		path = get_mood_icon_path(name);
+ 	} else {
+ 		filename = g_strdup_printf("%s.png", name);
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", filename, NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", filename, NULL);
+ 		g_free(filename);
+ 	}
+ 
+diff -aurN 000/source/pidgin/gtkdialogs.c 001/source/pidgin/gtkdialogs.c
+--- 000/source/pidgin/gtkdialogs.c
++++ 001/source/pidgin/gtkdialogs.c
+@@ -471,7 +471,7 @@
+ 	gtk_window_set_default_size(GTK_WINDOW(win), width? width : 600, height? height : 600);
+ 
+ 	/* Generate a logo with a version number */
+-	filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "logo.png", NULL);
++	filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "logo.png", NULL);
+ 	pixbuf = pidgin_pixbuf_new_from_file(filename);
+ 	g_free(filename);
+ 
+diff -aurN 000/source/pidgin/gtkdnd-hints.c 001/source/pidgin/gtkdnd-hints.c
+--- 000/source/pidgin/gtkdnd-hints.c
++++ 001/source/pidgin/gtkdnd-hints.c
+@@ -121,7 +121,7 @@
+ 	for (i = 0; hint_windows[i].filename != NULL; i++) {
+ 		gchar *fname;
+ 
+-		fname = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		fname = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 								 hint_windows[i].filename, NULL);
+ 
+ 		hint_windows[i].widget = dnd_hints_init_window(fname);
+diff -aurN 000/source/pidgin/gtkdocklet-gtk.c 001/source/pidgin/gtkdocklet-gtk.c
+--- 000/source/pidgin/gtkdocklet-gtk.c
++++ 001/source/pidgin/gtkdocklet-gtk.c
+@@ -291,6 +291,6 @@
+ 	}
+ 
+ 	gtk_icon_theme_append_search_path(gtk_icon_theme_get_default(),
+-		DATADIR G_DIR_SEPARATOR_S "pixmaps" G_DIR_SEPARATOR_S "pidgin" G_DIR_SEPARATOR_S "tray");
++		PURPLE_DATADIR G_DIR_SEPARATOR_S "pixmaps" G_DIR_SEPARATOR_S "pidgin" G_DIR_SEPARATOR_S "tray");
+ }
+ 
+diff -aurN 000/source/pidgin/gtkmain.c 001/source/pidgin/gtkmain.c
+--- 000/source/pidgin/gtkmain.c
++++ 001/source/pidgin/gtkmain.c
+@@ -269,7 +269,7 @@
+ #ifndef _WIN32
+ 	/* use the nice PNG icon for all the windows */
+ 	for(i=0; i<G_N_ELEMENTS(icon_sizes); i++) {
+-		icon_path = g_build_filename(DATADIR, "icons", "hicolor", icon_sizes[i].dir, "apps", icon_sizes[i].filename, NULL);
++		icon_path = g_build_filename(PURPLE_DATADIR, "icons", "hicolor", icon_sizes[i].dir, "apps", icon_sizes[i].filename, NULL);
+ 		icon = pidgin_pixbuf_new_from_file(icon_path);
+ 		g_free(icon_path);
+ 		if (icon) {
+diff -aurN 000/source/pidgin/gtkprefs.c 001/source/pidgin/gtkprefs.c
+--- 000/source/pidgin/gtkprefs.c
++++ 001/source/pidgin/gtkprefs.c
+@@ -528,7 +528,7 @@
+ 	/* refresh the list of themes in the manager */
+ 	purple_theme_manager_refresh();
+ 
+-	tmp = g_build_filename(DATADIR, "icons", "hicolor", "32x32", "apps", "pidgin.png", NULL);
++	tmp = g_build_filename(PURPLE_DATADIR, "icons", "hicolor", "32x32", "apps", "pidgin.png", NULL);
+ 	pixbuf = pidgin_pixbuf_new_from_file_at_scale(tmp, PREFS_OPTIMAL_ICON_SIZE, PREFS_OPTIMAL_ICON_SIZE, TRUE);
+ 	g_free(tmp);
+ 
+diff -aurN 000/source/pidgin/gtksound.c 001/source/pidgin/gtksound.c
+--- 000/source/pidgin/gtksound.c
++++ 001/source/pidgin/gtksound.c
+@@ -614,7 +614,7 @@
+ 			g_free(filename);
+ 
+ 			/* XXX Consider creating a constant for "sounds/purple" to be shared with Finch */
+-			filename = g_build_filename(DATADIR, "sounds", "purple", sounds[event].def, NULL);
++			filename = g_build_filename(PURPLE_DATADIR, "sounds", "purple", sounds[event].def, NULL);
+ 		}
+ 
+ 		purple_sound_play_file(filename, NULL);
+diff -aurN 000/source/pidgin/gtkthemes.c 001/source/pidgin/gtkthemes.c
+--- 000/source/pidgin/gtkthemes.c
++++ 001/source/pidgin/gtkthemes.c
+@@ -389,7 +389,7 @@
+ 
+ 	pidgin_smiley_themes_remove_non_existing();
+ 
+-	probedirs[0] = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", NULL);
++	probedirs[0] = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", NULL);
+ 	probedirs[1] = g_build_filename(purple_user_dir(), "smileys", NULL);
+ 	probedirs[2] = 0;
+ 	for (l=0; probedirs[l]; l++) {
+diff -aurN 000/source/pidgin/gtkutils.c 001/source/pidgin/gtkutils.c
+--- 000/source/pidgin/gtkutils.c
++++ 001/source/pidgin/gtkutils.c
+@@ -607,7 +607,7 @@
+ 	 */
+ 	tmp = g_strconcat(protoname, ".png", NULL);
+ 
+-	filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++	filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 				    size == PIDGIN_PRPL_ICON_SMALL ? "16" :
+ 				    size == PIDGIN_PRPL_ICON_MEDIUM ? "22" : "48",
+ 				    tmp, NULL);
+@@ -698,7 +698,7 @@
+ 		plugin = (PurplePlugin *)p->data;
+ 
+ 		if (gtalk_name && strcmp(gtalk_name, plugin->info->name) < 0) {
+-			char *filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++			char *filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 			                                  "16", "google-talk.png", NULL);
+ 			GtkWidget *item;
+ 
+@@ -721,7 +721,7 @@
+ 		}
+ 
+ 		if (facebook_name && strcmp(facebook_name, plugin->info->name) < 0) {
+-			char *filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++			char *filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 			                                  "16", "facebook.png", NULL);
+ 			GtkWidget *item;
+ 
+diff -aurN 000/source/pidgin/Makefile.am 001/source/pidgin/Makefile.am
+--- 000/source/pidgin/Makefile.am
++++ 001/source/pidgin/Makefile.am
+@@ -31,13 +31,28 @@
+ 		win32/nsis/create_nsis_translations.pl \
+ 		win32/nsis/nsis_translations.desktop.in
+ 
++if !OS_WIN32
++EXTRA_DIST += \
++		win32/MinimizeToTray.c \
++		win32/MinimizeToTray.h \
++		win32/gtkdocklet-win32.c \
++		win32/gtkwin32dep.c \
++		win32/gtkwin32dep.h \
++		win32/resource.h \
++		win32/untar.c \
++		win32/untar.h \
++		win32/winpidgin.c \
++		win32/wspell.c \
++		win32/wspell.h
++endif
++
+ if ENABLE_GTK
+ 
+-SUBDIRS = pixmaps plugins
++SUBDIRS = . pixmaps plugins
+ 
+ bin_PROGRAMS = pidgin
+ 
+-pidgin_SOURCES = \
++common_SOURCES = \
+ 	pidginstock.c \
+ 	gtkaccount.c \
+ 	gtkblist.c \
+@@ -51,7 +66,6 @@
+ 	gtkdialogs.c \
+ 	gtkdnd-hints.c \
+ 	gtkdocklet.c \
+-	gtkdocklet-gtk.c \
+ 	gtkeventloop.c \
+ 	gtkft.c \
+ 	gtkicon-theme.c \
+@@ -139,14 +153,30 @@
+ 	pidgintooltip.h \
+ 	pidgin.h
+ 
++if OS_WIN32
++pidgin_win32headers = \
++	gtkwin32dep.h
++pidgin_win32noinstheaders = \
++	MinimizeToTray.h \
++	resource.h \
++	untar.h \
++	wspell.h
++endif
++
+ pidginincludedir=$(includedir)/pidgin
+ pidgininclude_HEADERS = \
+ 	$(pidgin_headers)
+ 
++if OS_WIN32
++win32includedir=$(includedir)/pidgin/win32
++win32include_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(pidgin_win32headers))
++noinst_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(pidgin_win32noinstheaders))
++endif
+ 
+ pidgin_DEPENDENCIES = @LIBOBJS@
+-pidgin_LDFLAGS = -export-dynamic
+-pidgin_LDADD = \
++common_LDADD = \
+ 	@LIBOBJS@ \
+ 	$(GLIB_LIBS) \
+ 	$(DBUS_LIBS) \
+@@ -160,9 +190,47 @@
+ 	$(GTK_LIBS) \
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
++if OS_WIN32
++lib_LTLIBRARIES = libpidgin.la
++
++pidgin_SOURCES = \
++	win32/pidgin_exe_rc.rc \
++	win32/winpidgin.c
++
++libpidgin_la_SOURCES = \
++	$(common_SOURCES) \
++	win32/MinimizeToTray.c \
++	win32/gtkdocklet-win32.c \
++	win32/gtkwin32dep.c \
++	win32/untar.c \
++	win32/wspell.c \
++	win32/pidgin_dll_rc.rc
++
++libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
++libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
++
++pidgin_LDFLAGS = -mwindows
++pidgin_LDADD =
++	
++.rc.o:
++	$(WINDRES) $^ -o $@
++%.o : %.rc
++	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -i $< -o $@
++
++else
++pidgin_SOURCES = \
++	$(common_SOURCES) \
++	gtkdocklet-gtk.c
++
++pidgin_CFLAGS = $(AM_CFLAGS)
++pidgin_LDFLAGS = -export-dynamic
++
++pidgin_LDADD = $(common_LDADD)
++endif
++
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/pidgin/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DPIDGIN_LIBDIR=\"$(libdir)/pidgin/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	-I$(top_builddir)/libpurple \
+@@ -178,6 +246,14 @@
+ 	$(LIBXML_CFLAGS) \
+ 	$(INTGG_CFLAGS)
+ 
++	
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DUSE_FHS \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++	
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = data/pidgin.pc
+ 
+diff -aurN 000/source/pidgin/pidginstock.c 001/source/pidgin/pidginstock.c
+--- 000/source/pidgin/pidginstock.c
++++ 001/source/pidgin/pidginstock.c
+@@ -241,7 +241,7 @@
+ 			return filename;
+ 		g_free(filename);
+ 	}
+-	filename = g_build_filename(DATADIR, name, NULL);
++	filename = g_build_filename(PURPLE_DATADIR, name, NULL);
+ 	if (g_file_test(filename, G_FILE_TEST_EXISTS))
+ 		return filename;
+ 	g_free(filename);
+diff -aurN 000/source/pidgin/plugins/cap/Makefile.am 001/source/pidgin/plugins/cap/Makefile.am
+--- 000/source/pidgin/plugins/cap/Makefile.am
++++ 001/source/pidgin/plugins/cap/Makefile.am
+@@ -18,7 +18,7 @@
+ cap_la_LIBADD = $(GTK_LIBS) $(SQLITE3_LIBS)
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+diff -aurN 000/source/pidgin/plugins/disco/gtkdisco.c 001/source/pidgin/plugins/disco/gtkdisco.c
+--- 000/source/pidgin/plugins/disco/gtkdisco.c
++++ 001/source/pidgin/plugins/disco/gtkdisco.c
+@@ -119,14 +119,14 @@
+ 
+ 	if (service->type == XMPP_DISCO_SERVICE_TYPE_GATEWAY && service->gateway_type) {
+ 		char *tmp = g_strconcat(service->gateway_type, ".png", NULL);
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols", size, tmp, NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols", size, tmp, NULL);
+ 		g_free(tmp);
+ #if 0
+ 	} else if (service->type == XMPP_DISCO_SERVICE_TYPE_USER) {
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "status", size, "person.png", NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "status", size, "person.png", NULL);
+ #endif
+ 	} else if (service->type == XMPP_DISCO_SERVICE_TYPE_CHAT)
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "status", size, "chat.png", NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "status", size, "chat.png", NULL);
+ 
+ 	if (filename) {
+ 		pixbuf = gdk_pixbuf_new_from_file(filename, NULL);
+diff -aurN 000/source/pidgin/plugins/disco/Makefile.am 001/source/pidgin/plugins/disco/Makefile.am
+--- 000/source/pidgin/plugins/disco/Makefile.am
++++ 001/source/pidgin/plugins/disco/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-xmppdisco_la_LDFLAGS = -module -avoid-version
++xmppdisco_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ EXTRA_DIST = \
+         Makefile.mingw
+@@ -15,14 +19,21 @@
+ 	xmppdisco.c \
+ 	xmppdisco.h
+ 
+-xmppdisco_la_LIBADD = $(GTK_LIBS)
++xmppdisco_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++
+diff -aurN 000/source/pidgin/plugins/gestures/Makefile.am 001/source/pidgin/plugins/gestures/Makefile.am
+--- 000/source/pidgin/plugins/gestures/Makefile.am
++++ 001/source/pidgin/plugins/gestures/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-gestures_la_LDFLAGS = -module -avoid-version
++gestures_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -13,14 +17,20 @@
+ 	stroke.c \
+ 	stroke-draw.c
+ 
+-gestures_la_LIBADD = $(GTK_LIBS)
++gestures_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS) $(GLIB_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+\ No newline at end of file
+diff -aurN 000/source/pidgin/plugins/gevolution/Makefile.am 001/source/pidgin/plugins/gevolution/Makefile.am
+--- 000/source/pidgin/plugins/gevolution/Makefile.am
++++ 001/source/pidgin/plugins/gevolution/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-gevolution_la_LDFLAGS = -module -avoid-version
++gevolution_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -15,15 +19,22 @@
+ 	new_person_dialog.c \
+ 	eds-utils.c
+ 
+-gevolution_la_LIBADD = $(EVOLUTION_ADDRESSBOOK_LIBS) $(GTK_LIBS)
++gevolution_la_LIBADD = $(EVOLUTION_ADDRESSBOOK_LIBS) $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS) $(GLIB_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(EVOLUTION_ADDRESSBOOK_CFLAGS) \
++	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/Makefile.am 001/source/pidgin/plugins/Makefile.am
+--- 000/source/pidgin/plugins/Makefile.am
++++ 001/source/pidgin/plugins/Makefile.am
+@@ -1,4 +1,4 @@
+-DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker
++DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker win32
+ 
+ if BUILD_GEVOLUTION
+ GEVOLUTION_DIR = gevolution
+@@ -143,6 +143,12 @@
+ 	$(GSTREAMER_CFLAGS) \
+ 	$(PLUGIN_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++
+ #
+ # This part allows people to build their own plugins in here.
+ # Yes, it's a mess.
+@@ -150,7 +156,7 @@
+ SUFFIXES = .c .so
+ .c.so:
+ 	$(LIBTOOL) --mode=compile $(CC) -DHAVE_CONFIG_H -I$(top_builddir) $(AM_CPPFLAGS) $(CFLAGS) -c $< -o tmp$@.lo $(PLUGIN_CFLAGS)
+-	$(LIBTOOL) --mode=link    $(CC) $(CFLAGS) -o libtmp$@.la -rpath $(plugindir) tmp$@.lo $(LIBS) $(LDFLAGS) -module -avoid-version $(PLUGIN_LIBS)
++	$(LIBTOOL) --mode=link    $(CC) $(CFLAGS) -o libtmp$@.la -rpath $(plugindir) tmp$@.lo $(LIBS) $(LDFLAGS) -module -avoid-version $(NO_UNDEFINED) $(PLUGIN_LIBS)
+ 	@rm -f tmp$@.lo tmp$@.o libtmp$@.la
+ 	@cp .libs/libtmp$@*.so $@
+ 	@rm -rf .libs/libtmp$@.*
+diff -aurN 000/source/pidgin/plugins/musicmessaging/Makefile.am 001/source/pidgin/plugins/musicmessaging/Makefile.am
+--- 000/source/pidgin/plugins/musicmessaging/Makefile.am
++++ 001/source/pidgin/plugins/musicmessaging/Makefile.am
+@@ -1,7 +1,11 @@
+ EXTRA_DIST = \
+ 	music.png
+ 
++if OS_WIN32
++musicmessagingdir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ musicmessagingdir = $(libdir)/pidgin
++endif
+ 
+ musicmessaging_la_LDFLAGS = -module -avoid-version
+ 
+@@ -16,7 +20,7 @@
+ musicmessaging_la_SOURCES = \
+ 	musicmessaging.c
+ 
+-musicmessaging_la_LIBADD = $(GTK_LIBS) $(DBUS_LIBS)
++musicmessaging_la_LIBADD = $(GTK_LIBS) $(DBUS_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ CLEANFILES              = music-messaging-bindings.c
+ 
+@@ -35,10 +39,16 @@
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS) \
+ 	$(DBUS_CFLAGS)
++	
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/musicmessaging/musicmessaging.c 001/source/pidgin/plugins/musicmessaging/musicmessaging.c
+--- 000/source/pidgin/plugins/musicmessaging/musicmessaging.c
++++ 001/source/pidgin/plugins/musicmessaging/musicmessaging.c
+@@ -548,11 +548,13 @@
+ 
+ static void kill_editor (MMConversation *mmconv)
+ {
++#ifndef _WIN32
+ 	if (mmconv->pid)
+ 	{
+ 		kill(mmconv->pid, SIGINT);
+ 		mmconv->pid = 0;
+ 	}
++#endif
+ }
+ 
+ static void init_conversation (PurpleConversation *conv)
+@@ -595,7 +597,7 @@
+ 
+ 	g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(music_button_toggled), mmconv);
+ 
+-	file_path = g_build_filename(DATADIR, "pixmaps", "purple", "buttons",
++	file_path = g_build_filename(PURPLE_DATADIR, "pixmaps", "purple", "buttons",
+ 										"music.png", NULL);
+ 	image = gtk_image_new_from_file(file_path);
+ 	g_free(file_path);
+diff -aurN 000/source/pidgin/plugins/ticker/Makefile.am 001/source/pidgin/plugins/ticker/Makefile.am
+--- 000/source/pidgin/plugins/ticker/Makefile.am
++++ 001/source/pidgin/plugins/ticker/Makefile.am
+@@ -1,9 +1,13 @@
+ EXTRA_DIST = \
+ 		Makefile.mingw
+ 
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-ticker_la_LDFLAGS = -module -avoid-version
++ticker_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -14,14 +18,20 @@
+ 	gtkticker.h \
+ 	ticker.c
+ 
+-ticker_la_LIBADD = $(GTK_LIBS)
++ticker_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/win32/Makefile.am 001/source/pidgin/plugins/win32/Makefile.am
+--- 000/source/pidgin/plugins/win32/Makefile.am
++++ 001/source/pidgin/plugins/win32/Makefile.am
+@@ -0,0 +1,9 @@
++DIST_SUBDIRS = transparency winprefs
++
++if OS_WIN32
++SUBDIRS = $(DIST_SUBDIRS)
++endif
++
++EXTRA_DIST = \
++	Makefile.mingw
++
+diff -aurN 000/source/pidgin/plugins/win32/transparency/Makefile.am 001/source/pidgin/plugins/win32/transparency/Makefile.am
+--- 000/source/pidgin/plugins/win32/transparency/Makefile.am
++++ 001/source/pidgin/plugins/win32/transparency/Makefile.am
+@@ -0,0 +1,31 @@
++EXTRA_DIST = \
++	Makefile.mingw \
++	win2ktrans.c
++
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++
++win2ktrans_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++
++if PLUGINS
++
++plugin_LTLIBRARIES = win2ktrans.la
++
++win2ktrans_la_SOURCES = \
++	win2ktrans.c
++
++win2ktrans_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
++
++endif
++
++AM_CPPFLAGS = \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-I$(top_srcdir)/libpurple \
++	-I$(top_builddir)/libpurple \
++	-I$(top_srcdir)/pidgin \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32 \
++	$(DEBUG_CFLAGS) \
++	$(GTK_CFLAGS)
++
++endif
+diff -aurN 000/source/pidgin/plugins/win32/winprefs/gtkappbar.c 001/source/pidgin/plugins/win32/winprefs/gtkappbar.c
+--- 000/source/pidgin/plugins/win32/winprefs/gtkappbar.c
++++ 001/source/pidgin/plugins/win32/winprefs/gtkappbar.c
+@@ -27,6 +27,7 @@
+  *  - Move 'App on top' feature from Trans plugin to here
+  *  - Bug: Multiple Show/Hide Desktop calls causes client area to disappear
+  */
++#define WINVER 0x500
+ #include <windows.h>
+ #include <winver.h>
+ #include <stdio.h>
+diff -aurN 000/source/pidgin/plugins/win32/winprefs/Makefile.am 001/source/pidgin/plugins/win32/winprefs/Makefile.am
+--- 000/source/pidgin/plugins/win32/winprefs/Makefile.am
++++ 001/source/pidgin/plugins/win32/winprefs/Makefile.am
+@@ -0,0 +1,35 @@
++EXTRA_DIST = \
++	gtkappbar.c \
++	gtkappbar.h \
++	winprefs.c \
++	Makefile.mingw
++
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++
++winprefs_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++
++if PLUGINS
++
++plugin_LTLIBRARIES = winprefs.la
++
++winprefs_la_SOURCES = \
++	gtkappbar.c \
++	gtkappbar.h \
++	winprefs.c
++
++winprefs_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
++
++endif
++
++AM_CPPFLAGS = \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-I$(top_srcdir)/libpurple \
++	-I$(top_builddir)/libpurple \
++	-I$(top_srcdir)/pidgin \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32 \
++	$(DEBUG_CFLAGS) \
++	$(GTK_CFLAGS)
++
++endif
+diff -aurN 000/source/pidgin/win32/gtkwin32dep.h 001/source/pidgin/win32/gtkwin32dep.h
+--- 000/source/pidgin/win32/gtkwin32dep.h
++++ 001/source/pidgin/win32/gtkwin32dep.h
+@@ -25,6 +25,10 @@
+ #include <windows.h>
+ #include <gtk/gtk.h>
+ #include "conversation.h"
++#include "win32dep.h"
++
++#undef PIDGIN_LIBDIR
++#define PIDGIN_LIBDIR PURPLE_LIBDIR
+ 
+ HINSTANCE winpidgin_dll_hinstance(void);
+ HINSTANCE winpidgin_exe_hinstance(void);
+diff -aurN 000/source/pidgin/win32/MinimizeToTray.c 001/source/pidgin/win32/MinimizeToTray.c
+--- 000/source/pidgin/win32/MinimizeToTray.c
++++ 001/source/pidgin/win32/MinimizeToTray.c
+@@ -14,7 +14,7 @@
+  *
+  * Copyright 2000 Matthew Ellis <m.t.ellis@bigfoot.com>
+  */
+-#define _WIN32_WINNT 0x0500
++#define _WIN32_WINNT 0x0501
+ #include <windows.h>
+ #include "MinimizeToTray.h"
+ 
+diff -aurN 000/source/pidgin/win32/pidgin_exe_rc.rc.in 001/source/pidgin/win32/pidgin_exe_rc.rc.in
+--- 000/source/pidgin/win32/pidgin_exe_rc.rc.in
++++ 001/source/pidgin/win32/pidgin_exe_rc.rc.in
+@@ -7,8 +7,8 @@
+ CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "pidgin.manifest.xml"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32
+diff -aurN 000/source/pidgin/win32/winpidgin.c 001/source/pidgin/win32/winpidgin.c
+--- 000/source/pidgin/win32/winpidgin.c
++++ 001/source/pidgin/win32/winpidgin.c
+@@ -321,11 +321,19 @@
+ 					posix = L"sr@Latn"; break;
+ 				case SUBLANG_SERBIAN_CYRILLIC:
+ 					posix = L"sr"; break;
++/* for some reason mingw-w64 doesn't have these definitions yet */
++#ifdef SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_CYRILLIC
+ 				case SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_CYRILLIC:
++					posix = L"bs"; break;
++#endif
++#ifdef SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_LATIN
+ 				case SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_LATIN:
+ 					posix = L"bs"; break;
++#endif
++#ifdef SUBLANG_CROATIAN_BOSNIA_HERZEGOVINA_LATIN
+ 				case SUBLANG_CROATIAN_BOSNIA_HERZEGOVINA_LATIN:
+ 					posix = L"hr"; break;
++#endif
+ 			}
+ 			break;
+ 		case LANG_SWEDISH: posix = L"sv"; break;
+@@ -660,7 +668,7 @@
+ 			return 0;
+ 
+ 	/* Now we are ready for Pidgin .. */
+-	wcscat(pidgin_dir, L"\\pidgin.dll");
++	wcscat(pidgin_dir, L"\\libpidgin.dll");
+ 	if ((hmod = LoadLibraryW(pidgin_dir)))
+ 		pidgin_main = (LPFNPIDGINMAIN) GetProcAddress(hmod, "pidgin_main");
+ 
+@@ -673,7 +681,7 @@
+ 		BOOL mod_not_found = (dw == ERROR_MOD_NOT_FOUND || dw == ERROR_DLL_NOT_FOUND);
+ 		const wchar_t *err_msg = get_win32_error_message(dw);
+ 
+-		_snwprintf(errbuf, 512, L"Error loading pidgin.dll.\nError: (%u) %s%s%s",
++		_snwprintf(errbuf, 512, L"Error loading libpidgin.dll.\nError: (%u) %s%s%s",
+ 			(UINT) dw, err_msg,
+ 			mod_not_found ? L"\n" : L"",
+ 			mod_not_found ? L"This probably means that GTK+ can't be found." : L"");

--- a/mingw-w64-pidgin++-bzr/002-autotools-and-fhs-pidgin++.patch
+++ b/mingw-w64-pidgin++-bzr/002-autotools-and-fhs-pidgin++.patch
@@ -1,0 +1,189 @@
+diff -aurN 001/source/finch/finch.c 002/source/finch/finch.c
+--- 001/source/finch/finch.c
++++ 002/source/finch/finch.c
+@@ -377,7 +377,7 @@
+ 	purple_idle_set_ui_ops(finch_idle_get_ui_ops());
+ 
+ 	plugin_search_path_add_user_directories();
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(FINCH_LIBDIR);
+ 
+ 	if (!purple_core_init(FINCH_UI))
+ 	{
+diff -aurN 001/source/pidgin/gtkmain.c 002/source/pidgin/gtkmain.c
+--- 001/source/pidgin/gtkmain.c
++++ 002/source/pidgin/gtkmain.c
+@@ -807,7 +807,7 @@
+ 	 * in user's home directory.
+ 	 */
+ 	plugin_search_path_add_user_directories();
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(PIDGIN_LIBDIR);
+ 
+ 	if (!purple_core_init(PIDGIN_UI)) {
+ 		fprintf(stderr,
+diff -aurN 001/source/pidgin/Makefile.am 002/source/pidgin/Makefile.am
+--- 001/source/pidgin/Makefile.am
++++ 002/source/pidgin/Makefile.am
+@@ -7,19 +7,8 @@
+ 		data/pidgin.desktop.in \
+ 		data/pidgin.pc.in \
+ 		data/pidgin-uninstalled.pc.in \
+-		win32/MinimizeToTray.h \
+-		win32/MinimizeToTray.c \
+ 		win32/pidgin_dll_rc.rc.in \
+ 		win32/pidgin_exe_rc.rc.in \
+-		win32/gtkdocklet-win32.c \
+-		win32/gtkwin32dep.c \
+-		win32/gtkwin32dep.h \
+-		win32/resource.h \
+-		win32/untar.c \
+-		win32/untar.h \
+-		win32/winpidgin.c \
+-		win32/wspell.c \
+-		win32/wspell.h \
+ 		win32/nsis/integrate_gtk.sh \
+ 		win32/nsis/rpm2zip.sh \
+ 		win32/nsis/pixmaps/pidgin-header.bmp \
+diff -aurN 001/source/pidgin/plugins/Makefile.am 002/source/pidgin/plugins/Makefile.am
+--- 001/source/pidgin/plugins/Makefile.am
++++ 002/source/pidgin/plugins/Makefile.am
+@@ -27,28 +27,33 @@
+ 	$(MUSICMESSAGING_DIR) \
+ 	$(PERL_DIR) \
+ 	disco \
+-	ticker
++	ticker \
++	win32
+ 
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-convcolors_la_LDFLAGS       = -module -avoid-version
+-contact_priority_la_LDFLAGS = -module -avoid-version
+-extplacement_la_LDFLAGS     = -module -avoid-version
+-gtk_signals_test_la_LDFLAGS = -module -avoid-version
+-gtkbuddynote_la_LDFLAGS     = -module -avoid-version
+-history_la_LDFLAGS          = -module -avoid-version
+-iconaway_la_LDFLAGS         = -module -avoid-version
+-markerline_la_LDFLAGS       = -module -avoid-version
+-notify_la_LDFLAGS           = -module -avoid-version
+-pidginrc_la_LDFLAGS         = -module -avoid-version
+-sendbutton_la_LDFLAGS       = -module -avoid-version
+-spellchk_la_LDFLAGS         = -module -avoid-version
+-themeedit_la_LDFLAGS        = -module -avoid-version
+-timestamp_la_LDFLAGS        = -module -avoid-version
+-timestamp_format_la_LDFLAGS = -module -avoid-version
+-unity_la_LDFLAGS            = -module -avoid-version
+-vvconfig_la_LDFLAGS         = -module -avoid-version
+-xmppconsole_la_LDFLAGS      = -module -avoid-version
++convcolors_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++contact_priority_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++extplacement_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
++gtk_signals_test_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++gtkbuddynote_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
++history_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++iconaway_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++markerline_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++notify_la_LDFLAGS           = -module -avoid-version $(NO_UNDEFINED)
++pidginrc_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++sendbutton_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++spellchk_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++themeedit_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++timestamp_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++timestamp_format_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++unity_la_LDFLAGS            = -module -avoid-version $(NO_UNDEFINED)
++vvconfig_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++xmppconsole_la_LDFLAGS      = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -99,41 +104,34 @@
+ vvconfig_la_SOURCES         = vvconfig.c
+ xmppconsole_la_SOURCES      = xmppconsole.c
+ 
+-convcolors_la_LIBADD        = $(GTK_LIBS)
+-contact_priority_la_LIBADD  = $(GTK_LIBS)
+-extplacement_la_LIBADD      = $(GTK_LIBS)
+-gtk_signals_test_la_LIBADD  = $(GTK_LIBS)
+-gtkbuddynote_la_LIBADD      = $(GTK_LIBS)
+-history_la_LIBADD           = $(GTK_LIBS)
+-iconaway_la_LIBADD          = $(GTK_LIBS)
+-markerline_la_LIBADD        = $(GTK_LIBS)
+-notify_la_LIBADD            = $(GTK_LIBS)
+-pidginrc_la_LIBADD          = $(GTK_LIBS)
+-sendbutton_la_LIBADD        = $(GTK_LIBS)
+-spellchk_la_LIBADD          = $(GTK_LIBS)
+-themeedit_la_LIBADD         = $(GTK_LIBS)
+-timestamp_la_LIBADD         = $(GTK_LIBS)
+-timestamp_format_la_LIBADD  = $(GTK_LIBS)
+-unity_la_LIBADD             = $(GTK_LIBS) $(UNITY_LIBS)
+-vvconfig_la_LIBADD          = $(GTK_LIBS) $(GSTREAMER_LIBS)
+-xmppconsole_la_LIBADD       = $(GTK_LIBS)
++convcolors_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++contact_priority_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++extplacement_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
++gtk_signals_test_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++gtkbuddynote_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
++history_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
++iconaway_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++markerline_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++notify_la_LIBADD            = $(GTK_LIBS) $(PIDGIN_LIBS)
++pidginrc_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++sendbutton_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++spellchk_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++themeedit_la_LIBADD         = $(GTK_LIBS) $(PIDGIN_LIBS)
++timestamp_la_LIBADD         = $(GTK_LIBS) $(PIDGIN_LIBS)
++timestamp_format_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++unity_la_LIBADD             = $(GTK_LIBS) $(UNITY_LIBS) $(PIDGIN_LIBS)
++vvconfig_la_LIBADD          = $(GTK_LIBS) $(GSTREAMER_LIBS) $(PIDGIN_LIBS)
++xmppconsole_la_LIBADD       = $(GTK_LIBS) $(PIDGIN_LIBS)
+ 
+ endif # PLUGINS
+ 
+ EXTRA_DIST = \
+-	Makefile.mingw \
+ 	mailchk.c \
+ 	pidgininc.c \
+-	raw.c \
+-	win32/transparency/Makefile.mingw \
+-	win32/transparency/win2ktrans.c \
+-	win32/winprefs/gtkappbar.c \
+-	win32/winprefs/gtkappbar.h \
+-	win32/winprefs/Makefile.mingw \
+-	win32/winprefs/winprefs.c
++	raw.c
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+diff -aurN 001/source/pidgin/win32/gtkdocklet-win32.c 002/source/pidgin/win32/gtkdocklet-win32.c
+--- 001/source/pidgin/win32/gtkdocklet-win32.c
++++ 002/source/pidgin/win32/gtkdocklet-win32.c
+@@ -21,7 +21,7 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  * 02111-1301, USA.
+  */
+-#define _WIN32_IE 0x0500
++#define _WIN32_IE 0x0501
+ #include "internal.h"
+ #include <windows.h>
+ #include <gdk/gdkwin32.h>
+diff -aurN 001/source/pidgin/win32/pidgin_exe_rc.rc.in 002/source/pidgin/win32/pidgin_exe_rc.rc.in
+--- 001/source/pidgin/win32/pidgin_exe_rc.rc.in
++++ 002/source/pidgin/win32/pidgin_exe_rc.rc.in
+@@ -24,7 +24,7 @@
+         VALUE "FileVersion", "@APPLICATION_VERSION@"
+         VALUE "InternalName", "pidgin"
+         VALUE "LegalCopyright", "Copyright (C) 1998-2015 The @APPLICATION_NAME@ developer community"
+-        VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
++        VALUE "OriginalFilename", "pidgin.exe"
+         VALUE "ProductName", "@APPLICATION_NAME@"
+         VALUE "ProductVersion", "@DISPLAY_VERSION_FULL@"
+       END

--- a/mingw-w64-pidgin++-bzr/003-autotools-and-fhs-adaptation.patch
+++ b/mingw-w64-pidgin++-bzr/003-autotools-and-fhs-adaptation.patch
@@ -1,0 +1,140 @@
+diff -aurN 002/source/configure.ac 003/source/configure.ac
+--- 002/source/configure.ac
++++ 003/source/configure.ac
+@@ -82,6 +82,8 @@
+ PURPLE_MINOR_VERSION=purple_minor_version
+ PURPLE_MICRO_VERSION=purple_micro_version
+ PURPLE_VERSION=[purple_display_version]
++APPLICATION_VERSION=purple_display_version
++AC_SUBST(APPLICATION_VERSION)
+ AC_SUBST(PURPLE_MAJOR_VERSION)
+ AC_SUBST(PURPLE_MINOR_VERSION)
+ AC_SUBST(PURPLE_MICRO_VERSION)
+@@ -406,10 +408,17 @@
+ 						   [extra version number to be displayed in Help->About and --help (for packagers)]),
+ 						   EXTRA_VERSION=$withval)
+ 
++DISPLAY_VERSION_FULL='purple_version_suffix'
++DISPLAY_VERSION_FULL="${DISPLAY_VERSION_FULL#-}"
++DISPLAY_VERSION="${DISPLAY_VERSION_FULL%.0}"
++AC_SUBST(DISPLAY_VERSION_FULL)
++
+ if test x"$EXTRA_VERSION" != "x" ; then
+-	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$VERSION-$EXTRA_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$DISPLAY_VERSION-$EXTRA_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION_FULL, "$DISPLAY_VERSION_FULL-$EXTRA_VERSION", [display version info])
+ else
+-	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$DISPLAY_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION_FULL, "$DISPLAY_VERSION_FULL", [display version info])
+ fi
+ 
+ AC_ARG_ENABLE(missing-dependencies, [AC_HELP_STRING([--disable-missing-dependencies],
+diff -aurN 002/source/libpurple/plugins/Makefile.am 003/source/libpurple/plugins/Makefile.am
+--- 002/source/libpurple/plugins/Makefile.am
++++ 003/source/libpurple/plugins/Makefile.am
+@@ -31,6 +31,7 @@
+ debug_example_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
+ helloworld_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ idle_la_LDFLAGS             = -module -avoid-version $(NO_UNDEFINED)
++irchelper_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
+ joinpart_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
+ log_reader_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ newline_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+@@ -52,6 +53,7 @@
+ 	autoaccept.la       \
+ 	buddynote.la        \
+ 	idle.la             \
++	irchelper.la        \
+ 	joinpart.la         \
+ 	log_reader.la       \
+ 	newline.la          \
+@@ -78,6 +80,7 @@
+ debug_example_la_SOURCES = debug_example.c
+ helloworld_la_SOURCES       = helloworld.c
+ idle_la_SOURCES             = idle.c
++irchelper_la_SOURCES        = irchelper.c
+ joinpart_la_SOURCES         = joinpart.c
+ log_reader_la_SOURCES       = log_reader.c
+ newline_la_SOURCES          = newline.c
+@@ -96,6 +99,7 @@
+ ciphertest_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
+ codeinline_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
+ idle_la_LIBADD              = $(GLIB_LIBS) $(PURPLE_LIBS)
++irchelper_la_LIBADD         = $(GLIB_LIBS) $(PURPLE_LIBS)
+ joinpart_la_LIBADD          = $(GLIB_LIBS) $(PURPLE_LIBS)
+ log_reader_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
+ newline_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
+diff -aurN 002/source/pidgin/Makefile.am 003/source/pidgin/Makefile.am
+--- 002/source/pidgin/Makefile.am
++++ 003/source/pidgin/Makefile.am
+@@ -177,7 +177,10 @@
+ 	$(GTKSPELL_LIBS) \
+ 	$(LIBXML_LIBS) \
+ 	$(GTK_LIBS) \
+-	$(top_builddir)/libpurple/libpurple.la
++	$(top_builddir)/libpurple/libpurple.la \
++	-lwinsparkle \
++	-lcomctl32 \
++	-lexchndl
+ 
+ if OS_WIN32
+ lib_LTLIBRARIES = libpidgin.la
+@@ -199,12 +202,12 @@
+ libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
+ 
+ pidgin_LDFLAGS = -mwindows
+-pidgin_LDADD =
++pidgin_LDADD = -lexchndl
+ 	
+ .rc.o:
+ 	$(WINDRES) $^ -o $@
+ %.o : %.rc
+-	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -i $< -o $@
++	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -I$(top_srcdir)/libpurple/win32 $(shell pkg-config --cflags-only-I gtk+-2.0) -i $< -o $@
+ 
+ else
+ pidgin_SOURCES = \
+@@ -218,6 +221,7 @@
+ endif
+ 
+ AM_CPPFLAGS = \
++	-DBUILD_DATE=\"$(shell date +%Y%m%d)\" \
+ 	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-DPIDGIN_LIBDIR=\"$(libdir)/pidgin/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+diff -aurN 002/source/pidgin/plugins/Makefile.am 003/source/pidgin/plugins/Makefile.am
+--- 002/source/pidgin/plugins/Makefile.am
++++ 003/source/pidgin/plugins/Makefile.am
+@@ -43,6 +43,7 @@
+ gtkbuddynote_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
+ history_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+ iconaway_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++ircaway_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+ markerline_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ notify_la_LDFLAGS           = -module -avoid-version $(NO_UNDEFINED)
+ pidginrc_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
+@@ -63,6 +64,7 @@
+ 	gtkbuddynote.la     \
+ 	history.la          \
+ 	iconaway.la         \
++	ircaway.la          \
+ 	markerline.la       \
+ 	notify.la           \
+ 	pidginrc.la         \
+@@ -92,6 +94,7 @@
+ gtkbuddynote_la_SOURCES     = gtkbuddynote.c
+ history_la_SOURCES          = history.c
+ iconaway_la_SOURCES         = iconaway.c
++ircaway_la_SOURCES          = ircaway.c
+ markerline_la_SOURCES       = markerline.c
+ notify_la_SOURCES           = notify.c
+ pidginrc_la_SOURCES         = pidginrc.c
+@@ -111,6 +114,7 @@
+ gtkbuddynote_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
+ history_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
+ iconaway_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++ircaway_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
+ markerline_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
+ notify_la_LIBADD            = $(GTK_LIBS) $(PIDGIN_LIBS)
+ pidginrc_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)

--- a/mingw-w64-pidgin++-bzr/004-build-fixes.patch
+++ b/mingw-w64-pidgin++-bzr/004-build-fixes.patch
@@ -1,0 +1,68 @@
+diff -aurN 003/source/configure.ac 004/source/configure.ac
+--- 003/source/configure.ac
++++ 004/source/configure.ac
+@@ -703,7 +703,7 @@
+ 	if test "x$enable_consoleui" = "xyes"; then
+ 		dnl # Some distros put the headers in ncursesw/, some don't
+ 		found_ncurses_h=no
+-		for location in $ac_ncurses_includes $NCURSES_HEADERS /usr/include/ncursesw /usr/include
++		for location in $ac_ncurses_includes $NCURSES_HEADERS ${prefix}/include/ncursesw ${prefix}/include
+ 		do
+ 			f="$location/ncurses.h"
+ 			orig_CFLAGS="$CFLAGS"
+diff -aurN 003/source/libpurple/dbus-server.h 004/source/libpurple/dbus-server.h
+--- 003/source/libpurple/dbus-server.h
++++ 004/source/libpurple/dbus-server.h
+@@ -199,7 +199,9 @@
+ 
+  */
+ 
++#ifndef HAVE_DBUS
+ #define DBUS_EXPORT
++#endif
+ 
+ /*
+    Here we include the list of #PURPLE_DBUS_DECLARE_TYPE statements for
+diff -aurN 003/source/pidgin/Makefile.am 004/source/pidgin/Makefile.am
+--- 003/source/pidgin/Makefile.am
++++ 004/source/pidgin/Makefile.am
+@@ -195,10 +195,10 @@
+ 	win32/gtkdocklet-win32.c \
+ 	win32/gtkwin32dep.c \
+ 	win32/untar.c \
+-	win32/wspell.c \
+-	win32/pidgin_dll_rc.rc
++	win32/wspell.c
+ 
+-libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
++libpidgin_la_DEPENDENCIES = win32/pidgin_dll_rc.o
++libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED) -Wl,win32/pidgin_dll_rc.o
+ libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
+ 
+ pidgin_LDFLAGS = -mwindows
+diff -aurN 003/source/pidgin/plugins/musicmessaging/Makefile.am 004/source/pidgin/plugins/musicmessaging/Makefile.am
+--- 003/source/pidgin/plugins/musicmessaging/Makefile.am
++++ 004/source/pidgin/plugins/musicmessaging/Makefile.am
+@@ -7,7 +7,7 @@
+ musicmessagingdir = $(libdir)/pidgin
+ endif
+ 
+-musicmessaging_la_LDFLAGS = -module -avoid-version
++musicmessaging_la_LDFLAGS = -module -avoid-version -no-undefined
+ 
+ if PLUGINS
+ if ENABLE_DBUS
+diff -aurN 003/source/pidgin/win32/pidgin_dll_rc.rc.in 004/source/pidgin/win32/pidgin_dll_rc.rc.in
+--- 003/source/pidgin/win32/pidgin_dll_rc.rc.in
++++ 004/source/pidgin/win32/pidgin_dll_rc.rc.in
+@@ -4,8 +4,8 @@
+ #include "pidgin.h"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32

--- a/mingw-w64-pidgin++-bzr/005-fix-save-suffix.patch
+++ b/mingw-w64-pidgin++-bzr/005-fix-save-suffix.patch
@@ -1,0 +1,12 @@
+diff -aurN 004/source/libpurple/util.c 005/source/libpurple/util.c
+--- 004/source/libpurple/util.c
++++ 005/source/libpurple/util.c
+@@ -2719,7 +2719,7 @@
+ 		g_free(filename_temp);
+ 		return FALSE;
+ 	}
+-#ifndef __COVERITY__
++#if !defined(__COVERITY__) && !defined(_WIN32)
+ 	/* Use stat to be absolutely sure.
+ 	 * It causes TOCTOU coverity warning (against g_rename below),
+ 	 * but it's not a threat for us.

--- a/mingw-w64-pidgin++-bzr/006-gtk-customizations.patch
+++ b/mingw-w64-pidgin++-bzr/006-gtk-customizations.patch
@@ -1,0 +1,22 @@
+diff -aurN 005/source/pidgin/win32/gtkwin32dep.c 006/source/pidgin/win32/gtkwin32dep.c
+--- 005/source/pidgin/win32/gtkwin32dep.c
++++ 006/source/pidgin/win32/gtkwin32dep.c
+@@ -393,6 +393,7 @@
+ void winpidgin_init(HINSTANCE hint) {
+ 	gchar *debug_dir, *locale_debug_dir;
+ 	INITCOMMONCONTROLSEX icc;
++	GtkSettings *settings;
+ 
+ 	purple_debug_info("winpidgin", "winpidgin_init start\n");
+ 
+@@ -401,6 +402,10 @@
+ 	icc.dwICC = ICC_STANDARD_CLASSES;
+ 	InitCommonControlsEx(&icc);
+ 
++	/* Set GTK+ theme */
++	settings = gtk_settings_get_default();
++	gtk_settings_set_string_property(settings, "gtk-theme-name", APPLICATION_NAME, NULL);
++
+ 	exe_hInstance = hint;
+ 	debug_dir = g_build_filename(purple_user_dir(), "pidgin.rpt", NULL);
+ 	locale_debug_dir = g_locale_from_utf8(debug_dir, -1, NULL, NULL, NULL);

--- a/mingw-w64-pidgin++-bzr/PKGBUILD
+++ b/mingw-w64-pidgin++-bzr/PKGBUILD
@@ -1,0 +1,154 @@
+# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Zach Bacon <11doctorwhocanada@gmail.com>
+
+_realname='pidgin++'
+pkgbase="mingw-w64-${_realname}-bzr"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-bzr"
+pkgver=r383.16.1.0
+pkgrel=1
+pkgdesc='An improved version of Pidgin (mingw-w64)'
+url='http://pidgin.renatosilva.net'
+license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
+arch=('any')
+
+options=(!libtool strip staticlibs)
+source=(${_realname}::'bzr+https://code.launchpad.net/~renatosilva/pidgin++/trunk'
+        001-autotools-and-fhs-pidgin.patch
+        002-autotools-and-fhs-pidgin++.patch
+        003-autotools-and-fhs-adaptation.patch
+        004-build-fixes.patch
+        005-fix-save-suffix.patch
+        006-gtk-customizations.patch)
+sha256sums=('SKIP'
+            'e17b9e5236dc3d7e2705266181e1ffb58f2dde235e7b2b6b8333299f3ce26b66'
+            '2af6a6267db17a4d4b9b72da1ed345848c85d3822c984cc3e3b0d3c2a2af82b6'
+            'ff527bf67c62367b7c19ab28f152e144bd3989e035d4a0f10aa94553bbdb8f99'
+            'c00ba02c209172408b7c5ffca4313ba85f6891b903d894e05406effbd1aa990a'
+            'bf587810750a4f0c54a692994f5eff369cd0afd026a6f7efbda7595f64a63de6'
+            '2545720a791ec20ca4e49a24a6771fa58d8170b6c33a22b35fb4fcc9ce73ec1b')
+
+conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}
+           ${MINGW_PACKAGE_PREFIX}-pidgin)
+provides=(${MINGW_PACKAGE_PREFIX}-${_realname}
+          ${MINGW_PACKAGE_PREFIX}-pidgin
+          ${MINGW_PACKAGE_PREFIX}-libpurple)
+depends=(${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme
+         ${MINGW_PACKAGE_PREFIX}-ca-certificates
+         #${MINGW_PACKAGE_PREFIX}-cyrus-sasl
+         #${MINGW_PACKAGE_PREFIX}-dbus
+         ${MINGW_PACKAGE_PREFIX}-drmingw
+         #${MINGW_PACKAGE_PREFIX}-farstream
+         ${MINGW_PACKAGE_PREFIX}-freetype
+         ${MINGW_PACKAGE_PREFIX}-fontconfig
+         ${MINGW_PACKAGE_PREFIX}-gettext
+         ${MINGW_PACKAGE_PREFIX}-gnutls
+         ${MINGW_PACKAGE_PREFIX}-gsasl
+         ${MINGW_PACKAGE_PREFIX}-gst-plugins-base
+         ${MINGW_PACKAGE_PREFIX}-gst-plugins-good
+         ${MINGW_PACKAGE_PREFIX}-gtk2
+         ${MINGW_PACKAGE_PREFIX}-gtkspell
+         ${MINGW_PACKAGE_PREFIX}-libgadu
+         ${MINGW_PACKAGE_PREFIX}-libidn
+         #${MINGW_PACKAGE_PREFIX}-libxml2
+         ${MINGW_PACKAGE_PREFIX}-meanwhile
+         #${MINGW_PACKAGE_PREFIX}-nspr
+         ${MINGW_PACKAGE_PREFIX}-nss
+         ${MINGW_PACKAGE_PREFIX}-ncurses
+         ${MINGW_PACKAGE_PREFIX}-silc-toolkit
+         ${MINGW_PACKAGE_PREFIX}-winsparkle
+         ${MINGW_PACKAGE_PREFIX}-zlib)
+makedepends=(gtk-doc rsync easyoptions bzr
+             #${MINGW_PACKAGE_PREFIX}-dbus-glib
+             ${MINGW_PACKAGE_PREFIX}-doxygen
+             ${MINGW_PACKAGE_PREFIX}-gcc
+             ${MINGW_PACKAGE_PREFIX}-pkg-config
+             ${MINGW_PACKAGE_PREFIX}-python2
+             ${MINGW_PACKAGE_PREFIX}-xmlstarlet)
+
+_get_string_macro() {
+    local -n nameref_macro="${2}"
+    nameref_macro="$(grep --extended-regexp "#define\s+${2}\s" ${1})"
+    nameref_macro="${nameref_macro#*\"}"
+    nameref_macro="${nameref_macro%\"*}"
+}
+
+pkgver() {
+    cd "${srcdir}/${_realname}"
+    printf 'r%s.%s' "$(bzr revno)" "$(build/changelog.sh --version-full)"
+}
+
+prepare() {
+    cd "${srcdir}/${_realname}"
+
+    # From https://build.opensuse.org/package/view_file/windows:mingw:win32/mingw32-pidgin/pidgin-2.10.11-autotools.patch
+    rm -f source/pidgin/plugins/win32/Makefile.am
+    rm -f source/pidgin/plugins/win32/transparency/Makefile.am
+    rm -f source/pidgin/plugins/win32/winprefs/Makefile.am
+    patch -p1 < "${srcdir}/001-autotools-and-fhs-pidgin.patch"
+    patch -p1 < "${srcdir}/002-autotools-and-fhs-pidgin++.patch"
+
+    patch -p1 < "${srcdir}/003-autotools-and-fhs-adaptation.patch"
+    patch -p1 < "${srcdir}/004-build-fixes.patch"
+    patch -p1 < "${srcdir}/005-fix-save-suffix.patch"
+    patch -p1 < "${srcdir}/006-gtk-customizations.patch"
+
+    cd source
+    libtoolize --force --copy --install
+    autoreconf -f -i
+}
+
+build() {
+    msg2 'Synchronizing build directory'
+    rsync --recursive --times "${srcdir}/${_realname}/source"/* "${srcdir}/${_realname}.build.${CARCH}"
+    cd "${srcdir}/${_realname}.build.${CARCH}"
+
+    case "${CARCH}" in
+        x86_64) APPLICATION_BITNESS='64' ;;
+        i686)   APPLICATION_BITNESS='32' ;;
+        *)      APPLICATION_BITNESS='BITNESS'
+    esac
+    _get_string_macro 'libpurple/internal.h' APPLICATION_NAME
+    _get_string_macro 'libpurple/internal.h' APPLICATION_WEBSITE
+
+    sed -i "s#env python#env python2#" */plugins/*.py
+    sed -i "s#env python#env python2#" libpurple/purple-{remote,notifications-example,url-handler}
+    sed -i "s/@APPLICATION_BITNESS@/${APPLICATION_BITNESS:-bitness}/g" */win32/*.rc.in
+    sed -i "s/@APPLICATION_WEBSITE@/${APPLICATION_WEBSITE//\//\\\/}/g" */win32/*.rc.in
+    sed -i "s/@APPLICATION_NAME@/${APPLICATION_NAME}/g" */win32/*.rc.in
+
+    CPPFLAGS+=' -DENABLE_UPDATE_CHECK'
+    CPPFLAGS+=' -D_WIN32_WINNT=0x501 -DHAVE_GETADDRINFO' # Enable IPv6
+
+    INTLTOOL_PERL=/usr/bin/perl ./configure \
+        --prefix=${MINGW_PREFIX} \
+        --build=${MINGW_CHOST} \
+        --host=${MINGW_CHOST} \
+        --sysconfdir=${MINGW_PREFIX}/etc \
+        --with-python=${MINGW_PREFIX}/bin/python2 \
+        --with-system-ssl-certs=${MINGW_PREFIX}/ssl/certs \
+        --without-x \
+        --disable-avahi \
+        --disable-schemas-install \
+        --disable-screensaver \
+        --disable-perl \
+        --disable-tcl \
+        --disable-tk \
+        --disable-sm \
+        --disable-nm \
+        --disable-vv \
+        --disable-dbus \
+        #--enable-cyrus-sasl
+
+    make
+}
+
+package() {
+    cd "${srcdir}/${_realname}.build.${CARCH}"
+    make DESTDIR="${pkgdir}" install
+    install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+
+    # Changelog
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+    cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+    "${srcdir}/${_realname}/build/changelog.sh" --html --screenshot-prefix '../../' --output 'CHANGELOG.html'
+}

--- a/mingw-w64-pidgin++/001-autotools-and-fhs-pidgin.patch
+++ b/mingw-w64-pidgin++/001-autotools-and-fhs-pidgin.patch
@@ -1,0 +1,2042 @@
+diff -aurN 000/source/configure.ac 001/source/configure.ac
+--- 000/source/configure.ac
++++ 001/source/configure.ac
+@@ -120,10 +120,44 @@
+ dnl Check for Sun compiler
+ AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
+ 
++dnl ******************************
++dnl Win32
++dnl ******************************
++AC_MSG_CHECKING([for Win32])
++case "$host" in
++*-mingw*)
++	os_win32=yes
++	not_os_win32=no
++	NO_UNDEFINED='-no-undefined'
++	AVOID_VERSION='-avoid-version'
++	AC_CHECK_TOOL(WINDRES, windres)
++	PURPLE_LIBS='$(top_builddir)/libpurple/libpurple.la'
++	PIDGIN_LIBS='$(top_builddir)/pidgin/libpidgin.la'
++	;;
++*)
++	os_win32=no
++	not_os_win32=yes
++	NO_UNDEFINED=
++	AVOID_VERSION=
++	PURPLE_LIBS=
++	PIDGIN_LIBS=
++	;;
++esac
++AC_MSG_RESULT([$os_win32])
++AM_CONDITIONAL(OS_WIN32, [test $os_win32 = yes])
++AC_SUBST(NO_UNDEFINED)
++AC_SUBST(AVOID_VERSION)
++AC_SUBST(PURPLE_LIBS)
++AC_SUBST(PIDGIN_LIBS)
++
+ dnl Checks for header files.
+ AC_HEADER_STDC
+ AC_HEADER_SYS_WAIT
+-AC_CHECK_HEADERS(arpa/nameser_compat.h fcntl.h sys/time.h unistd.h locale.h signal.h stdint.h regex.h)
++AC_CHECK_HEADERS(arpa/nameser_compat.h fcntl.h sys/time.h unistd.h locale.h stdint.h)
++dnl signal.h is not good in mingw
++if test "$os_win32" != yes; then
++	AC_CHECK_HEADERS(signal.h regex.h)
++fi
+ 
+ dnl Checks for typedefs, structures, and compiler characteristics.
+ AC_C_CONST
+@@ -145,6 +179,7 @@
+ 	AC_LIBOBJ(getopt1)
+ ])
+ 
++if test "$os_win32" != yes; then
+ dnl Check for inet_aton
+ AC_CHECK_FUNC(inet_aton, , [AC_CHECK_LIB(resolv, inet_aton, ,
+ 				         [AC_MSG_ERROR([inet_aton not found])])])
+@@ -152,6 +187,8 @@
+ AC_CHECK_LIB(nsl, gethostent)
+ AC_CHECK_FUNC(socket, ,
+ 	[AC_CHECK_LIB(socket, socket, , [AC_MSG_ERROR([socket not found])])])
++fi
++
+ dnl If all goes well, by this point the previous two checks will have
+ dnl pulled in -lsocket and -lnsl if we need them.
+ AC_CHECK_FUNC(getaddrinfo,
+@@ -161,6 +198,8 @@
+ 		[AC_DEFINE([HAVE_GETADDRINFO]) LIBS="-lsocket -lsnl $LIBS"], , , -lnsl)])
+ AC_CHECK_FUNCS(inet_ntop)
+ AC_CHECK_FUNCS(getifaddrs)
++
++if test "$os_win32" != yes; then
+ dnl Check for socklen_t (in Unix98)
+ AC_MSG_CHECKING(for socklen_t)
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+@@ -182,6 +221,7 @@
+ 		AC_DEFINE(socklen_t, int, [socklen_t size])
+ 	])
+ ])
++fi
+ 
+ dnl Some systems do not have sa_len field for struct sockaddr.
+ AC_CHECK_MEMBER([struct sockaddr.sa_len],
+@@ -332,6 +372,18 @@
+ AM_CONDITIONAL(INSTALL_I18N, test "x$enable_i18n" = "xyes")
+ 
+ dnl #######################################################################
++dnl # Check for Zlib
++dnl #######################################################################
++PKG_CHECK_MODULES([ZLIB],[zlib],[],[
++	AC_CHECK_HEADER(zlib.h, [ZLIB_CFLAGS=],
++		[AC_MSG_ERROR(zlib.h not found. install zlib)], [])
++	AC_CHECK_LIB(z, inflate, [ ZLIB_LIBS=-lz ],
++		[AC_MSG_ERROR(zlib not found or functional)], [])
++])
++AC_SUBST(ZLIB_CFLAGS)
++AC_SUBST(ZLIB_LIBS)
++
++dnl #######################################################################
+ dnl # Check for GLib 2.16 (required)
+ dnl #######################################################################
+ PKG_CHECK_MODULES(GLIB, [glib-2.0 >= 2.16.0 gobject-2.0 gmodule-2.0 gthread-2.0], , [
+@@ -1169,7 +1221,7 @@
+ AM_CONDITIONAL(STATIC_SILC, test "x$static_silc" = "xyes" -a "x$have_silc" = "xyes")
+ AM_CONDITIONAL(STATIC_SIMPLE, test "x$static_simple" = "xyes")
+ AM_CONDITIONAL(STATIC_YAHOO, test "x$static_yahoo" = "xyes")
+-AM_CONDITIONAL(STATIC_ZEPHYR, test "x$static_zephyr" = "xyes")
++AM_CONDITIONAL(STATIC_ZEPHYR, test "x$static_zephyr" = "xyes" -a "x$enable_zephyr" = "xyes")
+ AC_SUBST(STATIC_LINK_LIBS)
+ AC_DEFINE_UNQUOTED(STATIC_PROTO_INIT, $extern_init static void static_proto_init(void) { $load_proto },
+ 	[Loads static protocol plugin module initialization functions.])
+@@ -1190,6 +1242,10 @@
+ if test "x$silc10includes" != "xyes" -o "x$silc10client" != "xyes"; then
+ 	DYNAMIC_PRPLS=`echo $DYNAMIC_PRPLS | $sedpath 's/silc10//'`
+ fi
++if test "x$enable_zephyr" != "xyes"; then
++	DYNAMIC_PRPLS=`echo $DYNAMIC_PRPLS | $sedpath 's/zephyr//'`
++fi
++
+ AC_SUBST(DYNAMIC_PRPLS)
+ for i in $DYNAMIC_PRPLS ; do
+ 	case $i in
+@@ -2542,6 +2598,11 @@
+ 		   pidgin/plugins/perl/Makefile
+ 		   pidgin/plugins/perl/common/Makefile.PL
+ 		   pidgin/plugins/ticker/Makefile
++		   pidgin/plugins/win32/Makefile
++		   pidgin/plugins/win32/transparency/Makefile
++		   pidgin/plugins/win32/winprefs/Makefile
++		   pidgin/win32/pidgin_dll_rc.rc
++		   pidgin/win32/pidgin_exe_rc.rc
+ 		   libpurple/data/gconf/Makefile
+ 		   libpurple/data/purple.pc
+ 		   libpurple/data/purple-uninstalled.pc
+@@ -2578,6 +2639,7 @@
+ 		   libpurple/tests/Makefile
+ 		   libpurple/purple.h
+ 		   libpurple/version.h
++		   libpurple/win32/libpurplerc.rc
+ 		   share/sounds/Makefile
+ 		   share/ca-certs/Makefile
+ 		   finch/finch.pc
+diff -aurN 000/source/finch/gntsound.c 001/source/finch/gntsound.c
+--- 000/source/finch/gntsound.c
++++ 001/source/finch/gntsound.c
+@@ -615,7 +615,7 @@
+ 		if (!filename || !strlen(filename)) {
+ 			g_free(filename);
+ 			/* XXX Consider creating a constant for "sounds/purple" to be shared with Pidgin */
+-			filename = g_build_filename(DATADIR, "sounds", "purple", sounds[event].def, NULL);
++			filename = g_build_filename(PURPLE_DATADIR, "sounds", "purple", sounds[event].def, NULL);
+ 		}
+ 
+ 		purple_sound_play_file(filename, NULL);
+diff -aurN 000/source/finch/libgnt/wms/Makefile.am 001/source/finch/libgnt/wms/Makefile.am
+--- 000/source/finch/libgnt/wms/Makefile.am
++++ 001/source/finch/libgnt/wms/Makefile.am
+@@ -29,7 +29,7 @@
+ EXTRA_DIST = 
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\"
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/finch \
+ 	-I$(top_srcdir)/finch/libgnt \
+diff -aurN 000/source/finch/Makefile.am 001/source/finch/Makefile.am
+--- 000/source/finch/Makefile.am
++++ 001/source/finch/Makefile.am
+@@ -77,11 +77,11 @@
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
+ AM_CPPFLAGS = \
+-	-DSTANDALONE \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/finch/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DFINCH_LIBDIR=\"$(libdir)/finch/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
++	-DSTANDALONE \
+ 	-I$(top_srcdir)/libpurple/ \
+ 	-I$(top_srcdir) \
+ 	-I$(srcdir)/libgnt/ \
+diff -aurN 000/source/finch/plugins/Makefile.am 001/source/finch/plugins/Makefile.am
+--- 000/source/finch/plugins/Makefile.am
++++ 001/source/finch/plugins/Makefile.am
+@@ -39,7 +39,7 @@
+ EXTRA_DIST = pietray.py
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir) \
+diff -aurN 000/source/libpurple/certificate.c 001/source/libpurple/certificate.c
+--- 000/source/libpurple/certificate.c
++++ 001/source/libpurple/certificate.c
+@@ -856,15 +856,15 @@
+ {
+ 	/* Attempt to point at the appropriate system path */
+ 	if (NULL == x509_ca_paths) {
+-#ifdef _WIN32
+-		x509_ca_paths = g_list_append(NULL, g_build_filename(DATADIR,
++#if defined(_WIN32) && !defined(USE_FHS)
++		x509_ca_paths = g_list_append(NULL, g_build_filename(PURPLE_DATADIR,
+ 						   "ca-certs", NULL));
+ #else
+ # ifdef SSL_CERTIFICATES_DIR
+ 		x509_ca_paths = g_list_append(NULL, g_strdup(SSL_CERTIFICATES_DIR));
+ # endif
+ 		x509_ca_paths = g_list_append(x509_ca_paths,
+-			g_build_filename(DATADIR, "purple", "ca-certs", NULL));
++			g_build_filename(PURPLE_DATADIR, "purple", "ca-certs", NULL));
+ #endif
+ 	}
+ 
+diff -aurN 000/source/libpurple/data/purple.pc.in 001/source/libpurple/data/purple.pc.in
+--- 000/source/libpurple/data/purple.pc.in
++++ 001/source/libpurple/data/purple.pc.in
+@@ -12,5 +12,5 @@
+ Description: libpurple is a GLib-based instant messenger library.
+ Version: @VERSION@
+ Requires: glib-2.0
+-Cflags: -I${includedir}/libpurple
++Cflags: -I${includedir}/libpurple -I${includedir}/libpurple/win32
+ Libs: -L${libdir} -lpurple
+diff -aurN 000/source/libpurple/dnsquery.c 001/source/libpurple/dnsquery.c
+--- 000/source/libpurple/dnsquery.c
++++ 001/source/libpurple/dnsquery.c
+@@ -744,7 +744,8 @@
+ 
+ 	query_data = data;
+ 
+-#ifdef USE_IDN
++	
++#if defined(USE_IDN) && defined(HAVE_GETADDRINFO)
+ 	if (!dns_str_is_ascii(query_data->hostname)) {
+ 		rc = purple_network_convert_idn_to_ascii(query_data->hostname, &hostname);
+ 		if (rc != 0) {
+diff -aurN 000/source/libpurple/example/Makefile.am 001/source/libpurple/example/Makefile.am
+--- 000/source/libpurple/example/Makefile.am
++++ 001/source/libpurple/example/Makefile.am
+@@ -11,11 +11,9 @@
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
+ AM_CPPFLAGS = \
+-	-DSTANDALONE \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
++	-DSTANDALONE \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir) \
+diff -aurN 000/source/libpurple/example/nullclient.c 001/source/libpurple/example/nullclient.c
+--- 000/source/libpurple/example/nullclient.c
++++ 001/source/libpurple/example/nullclient.c
+@@ -308,7 +308,11 @@
+ 	account = purple_account_new(name, prpl);
+ 
+ 	/* Get the password for the account */
++#ifndef _WIN32
+ 	password = getpass("Password: ");
++#else
++	password = "password";
++#endif
+ 	purple_account_set_password(account, password);
+ 
+ 	/* It's necessary to enable the account first. */
+diff -aurN 000/source/libpurple/Makefile.am 001/source/libpurple/Makefile.am
+--- 000/source/libpurple/Makefile.am
++++ 001/source/libpurple/Makefile.am
+@@ -15,21 +15,25 @@
+ 		data/purple-uninstalled.pc.in \
+ 		win32/global.mak \
+ 		win32/libc_interface.c \
+-		win32/libc_interface.h \
+-		win32/libc_internal.h \
+ 		win32/libpurplerc.rc.in \
+ 		win32/rules.mak \
+ 		win32/targets.mak \
+-		win32/wpurpleerror.h \
+ 		win32/win32dep.c \
+-		win32/giowin32.c \
++		win32/giowin32.c
++		
++if !OS_WIN32
++EXTRA_DIST += \
++		win32/libc_interface.h \
++		win32/libc_internal.h \
++		win32/wpurpleerror.h \
+ 		win32/win32dep.h
++endif
+ 
+ if USE_GCONFTOOL
+ GCONF_DIR=data/gconf
+ endif
+ 
+-SUBDIRS = $(GCONF_DIR) plugins protocols ciphers . tests example
++SUBDIRS = $(GCONF_DIR) ciphers . plugins protocols tests example
+ 
+ purple_coresources = \
+ 	account.c \
+@@ -94,6 +98,20 @@
+ 	xmlnode.c \
+ 	whiteboard.c
+ 
++if OS_WIN32
++purple_coresources += \
++	win32/giowin32.c \
++	win32/libc_interface.c \
++	win32/win32dep.c
++
++libpurple_win32_res = libpurple-win32-res.o
++libpurple_win32_res_ldflag = -Wl,$(libpurple_win32_res)
++
++libpurple-win32-res.o: win32/libpurplerc.rc
++	$(WINDRES) -I$(top_srcdir)/libpurple -i $< -o $@
++
++endif
++
+ purple_builtsources = \
+ 	marshallers.c
+ 
+@@ -163,6 +181,14 @@
+ 	codec.h \
+ 	enum-types.h
+ 
++if OS_WIN32
++purple_win32headers = \
++	libc_interface.h \
++	libc_internal.h \
++	wpurpleerror.h \
++	win32dep.h
++endif
++
+ purple_builtheaders = purple.h version.h marshallers.h
+ 
+ marshallers.h: marshallers.list
+@@ -297,8 +323,15 @@
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = data/purple.pc
+ 
+-libpurple_la_DEPENDENCIES = $(STATIC_LINK_LIBS)
+-libpurple_la_LDFLAGS = -export-dynamic -version-info $(PURPLE_LT_VERSION_INFO) -no-undefined
++if OS_WIN32
++win32includedir=$(includedir)/libpurple/win32
++win32include_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(purple_win32headers))
++endif
++
++libpurple_la_DEPENDENCIES = $(STATIC_LINK_LIBS) $(libpurple_win32_res)
++libpurple_la_LDFLAGS = -export-dynamic -version-info $(PURPLE_LT_VERSION_INFO) $(AVOID_VERSION) \
++	$(NO_UNDEFINED) $(libpurple_win32_res_ldflag)
+ libpurple_la_LIBADD = \
+ 	$(STATIC_LINK_LIBS) \
+ 	$(DBUS_LIBS) \
+@@ -313,9 +346,14 @@
+ 	ciphers/libpurple-ciphers.la \
+ 	-lm
+ 
++if OS_WIN32
++libpurple_la_LIBADD += \
++	-lws2_32 -ldnsapi
++endif
++
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DPURPLE_LIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	$(GLIB_CFLAGS) \
+@@ -328,6 +366,12 @@
+ 	$(IDN_CFLAGS) \
+ 	$(NETWORKMANAGER_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DUSE_FHS \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ # INSTALL_SSL_CERTIFICATES is true when SSL_CERTIFICATES_DIR is empty.
+ # We want to use SSL_CERTIFICATES_DIR when it's not empty.
+ if ! INSTALL_SSL_CERTIFICATES
+diff -aurN 000/source/libpurple/plugin.c 001/source/libpurple/plugin.c
+--- 000/source/libpurple/plugin.c
++++ 001/source/libpurple/plugin.c
+@@ -1179,7 +1179,7 @@
+ purple_plugins_init(void) {
+ 	void *handle = purple_plugins_get_handle();
+ 
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(PURPLE_LIBDIR);
+ 
+ 	purple_signal_register(handle, "plugin-load",
+ 						 purple_marshal_VOID__POINTER,
+diff -aurN 000/source/libpurple/plugins/Makefile.am 001/source/libpurple/plugins/Makefile.am
+--- 000/source/libpurple/plugins/Makefile.am
++++ 001/source/libpurple/plugins/Makefile.am
+@@ -24,27 +24,27 @@
+ 
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-autoaccept_la_LDFLAGS       = -module -avoid-version
+-buddynote_la_LDFLAGS        = -module -avoid-version
+-ciphertest_la_LDFLAGS		= -module -avoid-version
+-codeinline_la_LDFLAGS		= -module -avoid-version
+-debug_example_la_LDFLAGS    = -module -avoid-version
+-helloworld_la_LDFLAGS       = -module -avoid-version
+-idle_la_LDFLAGS             = -module -avoid-version
+-joinpart_la_LDFLAGS         = -module -avoid-version
+-log_reader_la_LDFLAGS       = -module -avoid-version
+-newline_la_LDFLAGS          = -module -avoid-version
+-notify_example_la_LDFLAGS   = -module -avoid-version
+-offlinemsg_la_LDFLAGS       = -module -avoid-version
+-one_time_password_la_LDFLAGS	= -module -avoid-version
+-pluginpref_example_la_LDFLAGS = -module -avoid-version
+-psychic_la_LDFLAGS          = -module -avoid-version
+-signals_test_la_LDFLAGS		= -module -avoid-version
+-simple_la_LDFLAGS			= -module -avoid-version
+-statenotify_la_LDFLAGS      = -module -avoid-version
++autoaccept_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++buddynote_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++ciphertest_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++codeinline_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++debug_example_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
++helloworld_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++idle_la_LDFLAGS             = -module -avoid-version $(NO_UNDEFINED)
++joinpart_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++log_reader_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++newline_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++notify_example_la_LDFLAGS   = -module -avoid-version $(NO_UNDEFINED)
++offlinemsg_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++one_time_password_la_LDFLAGS	= -module -avoid-version $(NO_UNDEFINED)
++pluginpref_example_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++psychic_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++signals_test_la_LDFLAGS		= -module -avoid-version $(NO_UNDEFINED)
++simple_la_LDFLAGS			= -module -avoid-version $(NO_UNDEFINED)
++statenotify_la_LDFLAGS      = -module -avoid-version $(NO_UNDEFINED)
+ 
+ # this can't be in a conditional otherwise automake 1.4 yells
+-dbus_example_la_LDFLAGS     = -module -avoid-version
++dbus_example_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -90,29 +90,30 @@
+ simple_la_SOURCES			= simple.c
+ statenotify_la_SOURCES      = statenotify.c
+ 
+-autoaccept_la_LIBADD        = $(GLIB_LIBS)
+-buddynote_la_LIBADD         = $(GLIB_LIBS)
+-ciphertest_la_LIBADD		= $(GLIB_LIBS)
+-codeinline_la_LIBADD		= $(GLIB_LIBS)
+-idle_la_LIBADD              = $(GLIB_LIBS)
+-joinpart_la_LIBADD          = $(GLIB_LIBS)
+-log_reader_la_LIBADD        = $(GLIB_LIBS)
+-newline_la_LIBADD           = $(GLIB_LIBS)
+-notify_example_la_LIBADD    = $(GLIB_LIBS)
+-offlinemsg_la_LIBADD        = $(GLIB_LIBS)
+-one_time_password_la_LIBADD = $(GLIB_LIBS)
+-pluginpref_example_la_LIBADD = $(GLIB_LIBS)
+-psychic_la_LIBADD           = $(GLIB_LIBS)
+-signals_test_la_LIBADD		= $(GLIB_LIBS)
+-simple_la_LIBADD			= $(GLIB_LIBS)
+-statenotify_la_LIBADD       = $(GLIB_LIBS)
++
++autoaccept_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++buddynote_la_LIBADD         = $(GLIB_LIBS) $(PURPLE_LIBS)
++ciphertest_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++codeinline_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++idle_la_LIBADD              = $(GLIB_LIBS) $(PURPLE_LIBS)
++joinpart_la_LIBADD          = $(GLIB_LIBS) $(PURPLE_LIBS)
++log_reader_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++newline_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
++notify_example_la_LIBADD    = $(GLIB_LIBS) $(PURPLE_LIBS)
++offlinemsg_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++one_time_password_la_LIBADD = $(GLIB_LIBS) $(PURPLE_LIBS)
++pluginpref_example_la_LIBADD = $(GLIB_LIBS) $(PURPLE_LIBS)
++psychic_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
++signals_test_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
++simple_la_LIBADD			= $(GLIB_LIBS) $(PURPLE_LIBS)
++statenotify_la_LIBADD       = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ if ENABLE_DBUS
+ 
+ CLEANFILES              = dbus-example-bindings.c
+ dbus_example_la_SOURCES = dbus-example.c
+ 
+-dbus_example_la_LIBADD      = $(GLIB_LIBS) $(DBUS_LIBS)
++dbus_example_la_LIBADD      = $(GLIB_LIBS) $(DBUS_LIBS) $(PURPLE_LIBS)
+ 
+ .PHONY: always
+ 
+@@ -140,7 +141,7 @@
+ 	startup.py
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	$(DEBUG_CFLAGS) \
+@@ -148,6 +149,11 @@
+ 	$(PLUGIN_CFLAGS) \
+ 	$(DBUS_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ #
+ # This part allows people to build their own plugins in here.
+ # Yes, it's a mess.
+diff -aurN 000/source/libpurple/plugins/perl/Makefile.am 001/source/libpurple/plugins/perl/Makefile.am
+--- 000/source/libpurple/plugins/perl/Makefile.am
++++ 001/source/libpurple/plugins/perl/Makefile.am
+@@ -165,7 +165,6 @@
+ 	-I$(top_srcdir) \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+-	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)\" \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(PLUGIN_CFLAGS) \
+diff -aurN 000/source/libpurple/plugins/ssl/Makefile.am 001/source/libpurple/plugins/ssl/Makefile.am
+--- 000/source/libpurple/plugins/ssl/Makefile.am
++++ 001/source/libpurple/plugins/ssl/Makefile.am
+@@ -3,10 +3,10 @@
+ 
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-ssl_la_LDFLAGS        = -module -avoid-version
+-ssl_gnutls_la_LDFLAGS = -module -avoid-version
+-ssl_nss_la_LDFLAGS    = -module -avoid-version
+-nss_prefs_la_LDFLAGS  = -module -avoid-version
++ssl_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++ssl_gnutls_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++ssl_nss_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
++nss_prefs_la_LDFLAGS  = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -43,15 +43,15 @@
+ ssl_nss_la_SOURCES    = ssl-nss.c
+ nss_prefs_la_SOURCES  = nss-prefs.c
+ 
+-ssl_la_LIBADD        = $(GLIB_LIBS)
+-ssl_gnutls_la_LIBADD = $(GLIB_LIBS) $(GNUTLS_LIBS)
+-ssl_nss_la_LIBADD    = $(GLIB_LIBS) $(NSS_LIBS)
+-nss_prefs_la_LIBADD  = $(GLIB_LIBS) $(NSS_LIBS)
++ssl_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
++ssl_gnutls_la_LIBADD = $(GLIB_LIBS) $(GNUTLS_LIBS) $(PURPLE_LIBS)
++ssl_nss_la_LIBADD    = $(GLIB_LIBS) $(NSS_LIBS) $(PURPLE_LIBS)
++nss_prefs_la_LIBADD  = $(GLIB_LIBS) $(NSS_LIBS) $(PURPLE_LIBS)
+ 
+ endif # PLUGINS
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-DLIBDIR=\"$(libdir)/libpurple\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+@@ -59,6 +59,12 @@
+ 	$(GLIB_CFLAGS) \
+ 	$(PLUGIN_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DWIN32_LEAN_AND_MEAN \
++	-I$(top_srcdir)/libpurple/win32
++endif
++
+ ssl_gnutls_la_CFLAGS = $(AM_CPPFLAGS) $(GNUTLS_CFLAGS)
+ ssl_nss_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
+ nss_prefs_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
+diff -aurN 000/source/libpurple/plugins/tcl/Makefile.am 001/source/libpurple/plugins/tcl/Makefile.am
+--- 000/source/libpurple/plugins/tcl/Makefile.am
++++ 001/source/libpurple/plugins/tcl/Makefile.am
+@@ -1,13 +1,13 @@
+ plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
+ 
+-tcl_la_LDFLAGS = -module -avoid-version
++tcl_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ plugin_LTLIBRARIES = tcl.la
+ 
+ tcl_la_SOURCES = tcl.c tcl_glib.c tcl_glib.h tcl_cmds.c tcl_signals.c tcl_purple.h \
+                  tcl_ref.c tcl_cmd.c
+ 
+-tcl_la_LIBADD = $(GLIB_LIBS) $(TCL_LIBS) $(TK_LIBS)
++tcl_la_LIBADD = $(GLIB_LIBS) $(TCL_LIBS) $(TK_LIBS) $(PURPLE_LIBS)
+ 
+ EXTRA_DIST = signal-test.tcl Makefile.mingw
+ 
+@@ -20,3 +20,8 @@
+ 	$(PLUGIN_CFLAGS) \
+ 	$(TK_CFLAGS) \
+ 	$(TCL_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+\ No newline at end of file
+diff -aurN 000/source/libpurple/protocols/bonjour/Makefile.am 001/source/libpurple/protocols/bonjour/Makefile.am
+--- 000/source/libpurple/protocols/bonjour/Makefile.am
++++ 001/source/libpurple/protocols/bonjour/Makefile.am
+@@ -40,7 +40,7 @@
+ st =
+ pkg_LTLIBRARIES       = libbonjour.la
+ libbonjour_la_SOURCES = $(BONJOURSOURCES)
+-libbonjour_la_LIBADD  = $(GLIB_LIBS) $(LIBXML_LIBS) $(AVAHI_LIBS)
++libbonjour_la_LIBADD  = $(GLIB_LIBS) $(LIBXML_LIBS) $(AVAHI_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+diff -aurN 000/source/libpurple/protocols/gg/Makefile.am 001/source/libpurple/protocols/gg/Makefile.am
+--- 000/source/libpurple/protocols/gg/Makefile.am
++++ 001/source/libpurple/protocols/gg/Makefile.am
+@@ -96,6 +96,10 @@
+ 	$(GNUTLS_CFLAGS) \
+ 	-DGG_IGNORE_DEPRECATED
+ 
++if OS_WIN32
++INTGG_CFLAGS += -include win32dep.h
++endif
++
+ endif
+ 
+ GGSOURCES = \
+@@ -113,7 +117,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libgg_la_LDFLAGS = -module -avoid-version
++libgg_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_GG
+ 
+@@ -121,14 +125,14 @@
+ noinst_LTLIBRARIES = libgg.la
+ libgg_la_SOURCES = $(GGSOURCES)
+ libgg_la_CFLAGS  = $(AM_CFLAGS)
+-libgg_la_LIBADD  = $(LIBGADU_LIBS) $(INTGG_LIBS)
++libgg_la_LIBADD  = $(LIBGADU_LIBS) $(INTGG_LIBS) $(PURPLE_LIBS)
+ 
+ else
+ 
+ st =
+ pkg_LTLIBRARIES = libgg.la
+ libgg_la_SOURCES = $(GGSOURCES)
+-libgg_la_LIBADD  = $(GLIB_LIBS) $(LIBGADU_LIBS) $(INTGG_LIBS)
++libgg_la_LIBADD  = $(GLIB_LIBS) $(LIBGADU_LIBS) $(INTGG_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -139,3 +143,7 @@
+ 	$(INTGG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/irc/Makefile.am 001/source/libpurple/protocols/irc/Makefile.am
+--- 000/source/libpurple/protocols/irc/Makefile.am
++++ 001/source/libpurple/protocols/irc/Makefile.am
+@@ -13,7 +13,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libirc_la_LDFLAGS = -module -avoid-version
++libirc_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_IRC
+ 
+@@ -27,7 +27,7 @@
+ st =
+ pkg_LTLIBRARIES   = libirc.la
+ libirc_la_SOURCES = $(IRCSOURCES)
+-libirc_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS)
++libirc_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -36,3 +36,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/jabber/Makefile.am 001/source/libpurple/protocols/jabber/Makefile.am
+--- 000/source/libpurple/protocols/jabber/Makefile.am
++++ 001/source/libpurple/protocols/jabber/Makefile.am
+@@ -95,7 +95,8 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libxmpp_la_LDFLAGS = -module -avoid-version
++libxmpp_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libjabber_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ 
+ if USE_CYRUS_SASL
+ JABBERSOURCES += auth_cyrus.c
+@@ -111,12 +112,20 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES      = libjabber.la libxmpp.la
++pkg_LTLIBRARIES      = libxmpp.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = libjabber.la
++else
++pkg_LTLIBRARIES    += libjabber.la
++endif
++
+ libjabber_la_SOURCES = $(JABBERSOURCES)
+ libjabber_la_LIBADD  = $(GLIB_LIBS) $(SASL_LIBS) $(LIBXML_LIBS) $(IDN_LIBS)\
+ 	$(FARSIGHT_LIBS) \
+ 	$(GSTREAMER_LIBS) \
+-	$(GSTINTERFACES_LIBS)
++	$(GSTINTERFACES_LIBS) \
++	$(PURPLE_LIBS)
+ 
+ libxmpp_la_SOURCES = libxmpp.c
+ libxmpp_la_LIBADD = libjabber.la
+@@ -133,3 +142,10 @@
+ 	$(FARSIGHT_CFLAGS) \
+ 	$(GSTREAMER_CFLAGS) \
+ 	$(GSTINTERFACES_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/libpurple/protocols/jabber/win32
++endif
++
+diff -aurN 000/source/libpurple/protocols/msn/Makefile.am 001/source/libpurple/protocols/msn/Makefile.am
+--- 000/source/libpurple/protocols/msn/Makefile.am
++++ 001/source/libpurple/protocols/msn/Makefile.am
+@@ -77,7 +77,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmsn_la_LDFLAGS = -module -avoid-version
++libmsn_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MSN
+ 
+@@ -91,7 +91,7 @@
+ st =
+ pkg_LTLIBRARIES   = libmsn.la
+ libmsn_la_SOURCES = $(MSNSOURCES)
+-libmsn_la_LIBADD  = $(GLIB_LIBS)
++libmsn_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -100,3 +100,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/mxit/Makefile.am 001/source/libpurple/protocols/mxit/Makefile.am
+--- 000/source/libpurple/protocols/mxit/Makefile.am
++++ 001/source/libpurple/protocols/mxit/Makefile.am
+@@ -40,7 +40,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmxit_la_LDFLAGS = -module -avoid-version
++libmxit_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MXIT
+ 
+@@ -54,7 +54,7 @@
+ st =
+ pkg_LTLIBRARIES   = libmxit.la
+ libmxit_la_SOURCES = $(MXITSOURCES)
+-libmxit_la_LIBADD  = $(GLIB_LIBS)
++libmxit_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -63,3 +63,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/mxit/markup.c 001/source/libpurple/protocols/mxit/markup.c
+--- 000/source/libpurple/protocols/mxit/markup.c
++++ 001/source/libpurple/protocols/mxit/markup.c
+@@ -231,7 +231,7 @@
+ 		return -1;
+ 	}
+ 
+-	len = (guint8)data[1]; /* length field [1 byte] */
++	len = data[1]; /* length field [1 byte] */
+ 	if ( data_len - 2 < len ) {
+ 		/* not enough bytes left in data! */
+ 		return -1;
+diff -aurN 000/source/libpurple/protocols/myspace/Makefile.am 001/source/libpurple/protocols/myspace/Makefile.am
+--- 000/source/libpurple/protocols/myspace/Makefile.am
++++ 001/source/libpurple/protocols/myspace/Makefile.am
+@@ -19,7 +19,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libmyspace_la_LDFLAGS = -module -avoid-version
++libmyspace_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_MYSPACE
+ 
+@@ -33,7 +33,7 @@
+ st =
+ pkg_LTLIBRARIES       = libmyspace.la
+ libmyspace_la_SOURCES = $(MSIMSOURCES)
+-libmyspace_la_LIBADD  = $(GLIB_LIBS)
++libmyspace_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -42,3 +42,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/novell/Makefile.am 001/source/libpurple/protocols/novell/Makefile.am
+--- 000/source/libpurple/protocols/novell/Makefile.am
++++ 001/source/libpurple/protocols/novell/Makefile.am
+@@ -28,7 +28,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libnovell_la_LDFLAGS = -module -avoid-version
++libnovell_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_NOVELL
+ 
+@@ -42,7 +42,7 @@
+ st =
+ pkg_LTLIBRARIES      = libnovell.la
+ libnovell_la_SOURCES = $(NOVELLSOURCES)
+-libnovell_la_LIBADD  = $(GLIB_LIBS)
++libnovell_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -51,3 +51,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/null/Makefile.am 001/source/libpurple/protocols/null/Makefile.am
+--- 000/source/libpurple/protocols/null/Makefile.am
++++ 001/source/libpurple/protocols/null/Makefile.am
+@@ -14,10 +14,15 @@
+ st =
+ pkg_LTLIBRARIES    = libnull.la
+ libnull_la_SOURCES = $(NULLSOURCES)
+-libnull_la_LIBADD  = $(GLIB_LIBS)
++libnull_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/oscar/Makefile.am 001/source/libpurple/protocols/oscar/Makefile.am
+--- 000/source/libpurple/protocols/oscar/Makefile.am
++++ 001/source/libpurple/protocols/oscar/Makefile.am
+@@ -50,8 +50,9 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libaim_la_LDFLAGS = -module -avoid-version
+-libicq_la_LDFLAGS = -module -avoid-version
++libaim_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libicq_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++liboscar_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ if STATIC_OSCAR
+ 
+ st = -DPURPLE_STATIC_PRPL
+@@ -62,9 +63,16 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES     = liboscar.la libaim.la libicq.la
++pkg_LTLIBRARIES     = libaim.la libicq.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = liboscar.la
++else
++pkg_LTLIBRARIES    += liboscar.la
++endif
++
+ liboscar_la_SOURCES = $(OSCARSOURCES)
+-liboscar_la_LIBADD  = $(GLIB_LIBS)
++liboscar_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ libaim_la_SOURCES   = libaim.c
+ libaim_la_LIBADD    = liboscar.la
+@@ -79,3 +87,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/sametime/Makefile.am 001/source/libpurple/protocols/sametime/Makefile.am
+--- 000/source/libpurple/protocols/sametime/Makefile.am
++++ 001/source/libpurple/protocols/sametime/Makefile.am
+@@ -24,8 +24,8 @@
+ endif
+ 
+ libsametime_la_SOURCES = $(SAMETIMESOURCES)
+-libsametime_la_LDFLAGS = -module -avoid-version
+-libsametime_la_LIBADD = $(GLIB_LIBS) $(MEANWHILE_LIBS)
++libsametime_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libsametime_la_LIBADD = $(GLIB_LIBS) $(MEANWHILE_LIBS) $(PURPLE_LIBS)
+ 
+ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/libpurple \
+@@ -35,3 +35,7 @@
+ 	$(MEANWHILE_CFLAGS) \
+ 	-DG_LOG_DOMAIN=\"sametime\"
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/silc/Makefile.am 001/source/libpurple/protocols/silc/Makefile.am
+--- 000/source/libpurple/protocols/silc/Makefile.am
++++ 001/source/libpurple/protocols/silc/Makefile.am
+@@ -19,7 +19,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libsilcpurple_la_LDFLAGS = -module -avoid-version
++libsilcpurple_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_SILC
+ 
+@@ -34,7 +34,7 @@
+ st = $(SILC_CFLAGS)
+ pkg_LTLIBRARIES          = libsilcpurple.la
+ libsilcpurple_la_SOURCES = $(SILCSOURCES)
+-libsilcpurple_la_LIBADD  = $(GLIB_LIBS) $(SILC_LIBS)
++libsilcpurple_la_LIBADD  = $(GLIB_LIBS) $(SILC_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -44,3 +44,8 @@
+ 	$(DEBUG_CFLAGS) \
+ 	$(GLIB_CFLAGS) \
+ 	$(SILC_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/simple/Makefile.am 001/source/libpurple/protocols/simple/Makefile.am
+--- 000/source/libpurple/protocols/simple/Makefile.am
++++ 001/source/libpurple/protocols/simple/Makefile.am
+@@ -11,7 +11,7 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libsimple_la_LDFLAGS = -module -avoid-version
++libsimple_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if STATIC_SIMPLE
+ 
+@@ -25,7 +25,7 @@
+ st =
+ pkg_LTLIBRARIES      = libsimple.la
+ libsimple_la_SOURCES = $(SIMPLESOURCES)
+-libsimple_la_LIBADD  = $(GLIB_LIBS)
++libsimple_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ endif
+ 
+@@ -34,3 +34,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/protocols/yahoo/Makefile.am 001/source/libpurple/protocols/yahoo/Makefile.am
+--- 000/source/libpurple/protocols/yahoo/Makefile.am
++++ 001/source/libpurple/protocols/yahoo/Makefile.am
+@@ -27,8 +27,9 @@
+ 
+ AM_CFLAGS = $(st)
+ 
+-libyahoo_la_LDFLAGS = -module -avoid-version
+-libyahoojp_la_LDFLAGS = -module -avoid-version
++libyahoo_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libyahoojp_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++libymsg_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
+ 
+ if STATIC_YAHOO
+ 
+@@ -40,10 +41,16 @@
+ else
+ 
+ st =
+-pkg_LTLIBRARIES     = libymsg.la libyahoo.la libyahoojp.la
++pkg_LTLIBRARIES     = libyahoo.la libyahoojp.la
++
++if OS_WIN32
++lib_LTLIBRARIES     = libymsg.la
++else
++pkg_LTLIBRARIES    += libymsg.la
++endif
+ 
+ libymsg_la_SOURCES = $(YAHOOSOURCES)
+-libymsg_la_LIBADD  = $(GLIB_LIBS)
++libymsg_la_LIBADD  = $(GLIB_LIBS) $(PURPLE_LIBS)
+ 
+ libyahoo_la_SOURCES = libyahoo.c
+ libyahoo_la_LIBADD = libymsg.la
+@@ -58,3 +65,8 @@
+ 	-I$(top_builddir)/libpurple \
+ 	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32
++endif
+diff -aurN 000/source/libpurple/win32/libc_interface.h 001/source/libpurple/win32/libc_interface.h
+--- 000/source/libpurple/win32/libc_interface.h
++++ 001/source/libpurple/win32/libc_interface.h
+@@ -23,6 +23,7 @@
+ #ifndef _LIBC_INTERFACE_H_
+ #define _LIBC_INTERFACE_H_
+ #include <winsock2.h>
++#undef socklen_t
+ #include <ws2tcpip.h>
+ #include <io.h>
+ #include <errno.h>
+diff -aurN 000/source/libpurple/win32/libpurplerc.rc.in 001/source/libpurple/win32/libpurplerc.rc.in
+--- 000/source/libpurple/win32/libpurplerc.rc.in
++++ 001/source/libpurple/win32/libpurplerc.rc.in
+@@ -2,8 +2,8 @@
+ #include "version.h"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32
+diff -aurN 000/source/libpurple/win32/win32dep.c 001/source/libpurple/win32/win32dep.c
+--- 000/source/libpurple/win32/win32dep.c
++++ 001/source/libpurple/win32/win32dep.c
+@@ -28,12 +28,18 @@
+ 
+ #include "debug.h"
+ #include "notify.h"
++#ifdef USE_FHS
++#include "version.h"
++#endif
+ 
+ /*
+  * LOCALS
+  */
+ static char *app_data_dir = NULL, *install_dir = NULL,
+ 	*lib_dir = NULL, *locale_dir = NULL;
++#ifdef USE_FHS
++static char *share_dir = NULL;
++#endif
+ 
+ static HINSTANCE libpurpledll_hInstance = NULL;
+ 
+@@ -153,13 +159,39 @@
+ 	return install_dir;
+ }
+ 
++#ifdef USE_FHS
++const char *wpurple_share_dir(void) {
++	static gboolean initialized = FALSE;
++
++	if (!initialized) {
++		const char *inst_dir = wpurple_install_dir();
++		if (inst_dir != NULL) {
++			share_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "share", inst_dir);
++			initialized = TRUE;
++		} else {
++			return NULL;
++		}
++	}
++
++	return share_dir;
++}
++#else
++const char *wpurple_share_dir(void) {
++	return wpurple_install_dir();
++}
++#endif
++
+ const char *wpurple_lib_dir(void) {
+ 	static gboolean initialized = FALSE;
+ 
+ 	if (!initialized) {
+ 		const char *inst_dir = wpurple_install_dir();
+ 		if (inst_dir != NULL) {
++#ifdef USE_FHS
++			lib_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "lib" G_DIR_SEPARATOR_S "purple-%i" , inst_dir, PURPLE_MAJOR_VERSION);
++#else
+ 			lib_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S "plugins", inst_dir);
++#endif
+ 			initialized = TRUE;
+ 		} else {
+ 			return NULL;
+@@ -175,7 +207,11 @@
+ 	if (!initialized) {
+ 		const char *inst_dir = wpurple_install_dir();
+ 		if (inst_dir != NULL) {
++#ifdef USE_FHS
++			locale_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S ".." G_DIR_SEPARATOR_S "share" G_DIR_SEPARATOR_S "locale", inst_dir);
++#else
+ 			locale_dir = g_strdup_printf("%s" G_DIR_SEPARATOR_S "locale", inst_dir);
++#endif
+ 			initialized = TRUE;
+ 		} else {
+ 			return NULL;
+@@ -375,6 +411,11 @@
+ 	lib_dir = NULL;
+ 	locale_dir = NULL;
+ 
++#ifdef USE_FHS
++	g_free(share_dir);
++	share_dir = NULL;	
++#endif
++
+ 	libpurpledll_hInstance = NULL;
+ }
+ 
+diff -aurN 000/source/libpurple/win32/win32dep.h 001/source/libpurple/win32/win32dep.h
+--- 000/source/libpurple/win32/win32dep.h
++++ 001/source/libpurple/win32/win32dep.h
+@@ -65,6 +65,7 @@
+ const char *wpurple_install_dir(void);
+ const char *wpurple_lib_dir(void);
+ const char *wpurple_locale_dir(void);
++const char *wpurple_share_dir(void);
+ const char *wpurple_data_dir(void);
+ 
+ /* init / cleanup */
+@@ -80,9 +81,14 @@
+ /*
+  *  Purple specific
+  */
+-#define DATADIR wpurple_install_dir()
+-#define LIBDIR wpurple_lib_dir()
++#undef PURPLE_DATADIR
++#define PURPLE_DATADIR wpurple_share_dir()
++#undef PURPLE_LIBDIR
++#define PURPLE_LIBDIR wpurple_lib_dir()
++#undef LOCALEDIR
+ #define LOCALEDIR wpurple_locale_dir()
++/* TODO: SYSCONFDIR should be the allusers AppData? */
++#undef SYSCONFDIR
+ 
+ #ifdef __cplusplus
+ }
+diff -aurN 000/source/pidgin/data/pidgin.pc.in 001/source/pidgin/data/pidgin.pc.in
+--- 000/source/pidgin/data/pidgin.pc.in
++++ 001/source/pidgin/data/pidgin.pc.in
+@@ -12,5 +12,6 @@
+ Description: Pidgin is a GTK2-based instant messenger application.
+ Version: @VERSION@
+ Requires: gtk+-2.0 purple
+-Cflags: -I${includedir}/pidgin
++Cflags: -I${includedir}/pidgin -I${includedir}/pidgin/win32
++Libs: -L${libdir} -lpidgin
+ 
+diff -aurN 000/source/pidgin/data/pidgin-2.pc.in 001/source/pidgin/data/pidgin-2.pc.in
+--- 000/source/pidgin/data/pidgin-2.pc.in
++++ 001/source/pidgin/data/pidgin-2.pc.in
+@@ -13,3 +13,4 @@
+ Version: @VERSION@
+ Requires: gtk+-2.0 purple
+ Cflags: -I${includedir}
++Libs: -L${libdir} -lpidgin
+diff -aurN 000/source/pidgin/gtkblist.c 001/source/pidgin/gtkblist.c
+--- 000/source/pidgin/gtkblist.c
++++ 001/source/pidgin/gtkblist.c
+@@ -3369,14 +3369,14 @@
+ 	char *path;
+ 
+ 	if (!strcmp(mood, "busy")) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "status", "16", "busy.png", NULL);
+ 	} else if (!strcmp(mood, "hiptop")) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "emblems", "16", "hiptop.png", NULL);
+ 	} else {
+ 		char *filename = g_strdup_printf("%s.png", mood);
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 		                        "emotes", "small", filename, NULL);
+ 		g_free(filename);
+ 	}
+@@ -4026,7 +4026,7 @@
+ 		if (purple_presence_is_status_primitive_active(p, PURPLE_STATUS_MOBILE)) {
+ 			/* This emblem comes from the small emoticon set now,
+ 			 * to reduce duplication. */
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes",
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes",
+ 						"small", "mobile.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+@@ -4043,7 +4043,7 @@
+ 	g_return_val_if_fail(buddy != NULL, NULL);
+ 
+ 	if (!purple_privacy_check(buddy->account, purple_buddy_get_name(buddy))) {
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "blocked.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "blocked.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4054,7 +4054,7 @@
+ 
+ 	if (purple_presence_is_status_primitive_active(p, PURPLE_STATUS_MOBILE)) {
+ 		/* This emblem comes from the small emoticon set now, to reduce duplication. */
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", "small", "mobile.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", "small", "mobile.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4063,18 +4063,18 @@
+ 		/* Only in MSN.
+ 		 * TODO: Replace "Tune" with generalized "Media" in 3.0. */
+ 		if (purple_status_get_attr_string(tune, "game") != NULL) {
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "game.png", NULL);
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "game.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+ 		/* Only in MSN.
+ 		 * TODO: Replace "Tune" with generalized "Media" in 3.0. */
+ 		if (purple_status_get_attr_string(tune, "office") != NULL) {
+-			path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", "office.png", NULL);
++			path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", "office.png", NULL);
+ 			return _pidgin_blist_get_cached_emblem(path);
+ 		}
+ 		/* Regular old "tune" is the only one in all protocols. */
+ 		/* This emblem comes from the small emoticon set now, to reduce duplication. */
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", "small", "music.png", NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", "small", "music.png", NULL);
+ 		return _pidgin_blist_get_cached_emblem(path);
+ 	}
+ 
+@@ -4101,7 +4101,7 @@
+ 		path = get_mood_icon_path(name);
+ 	} else {
+ 		filename = g_strdup_printf("%s.png", name);
+-		path = g_build_filename(DATADIR, "pixmaps", "pidgin", "emblems", "16", filename, NULL);
++		path = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emblems", "16", filename, NULL);
+ 		g_free(filename);
+ 	}
+ 
+diff -aurN 000/source/pidgin/gtkdialogs.c 001/source/pidgin/gtkdialogs.c
+--- 000/source/pidgin/gtkdialogs.c
++++ 001/source/pidgin/gtkdialogs.c
+@@ -468,7 +468,7 @@
+ 	gtk_window_set_default_size(GTK_WINDOW(win), width? width : 600, height? height : 600);
+ 
+ 	/* Generate a logo with a version number */
+-	filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "logo.png", NULL);
++	filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "logo.png", NULL);
+ 	pixbuf = pidgin_pixbuf_new_from_file(filename);
+ 	g_free(filename);
+ 
+diff -aurN 000/source/pidgin/gtkdnd-hints.c 001/source/pidgin/gtkdnd-hints.c
+--- 000/source/pidgin/gtkdnd-hints.c
++++ 001/source/pidgin/gtkdnd-hints.c
+@@ -121,7 +121,7 @@
+ 	for (i = 0; hint_windows[i].filename != NULL; i++) {
+ 		gchar *fname;
+ 
+-		fname = g_build_filename(DATADIR, "pixmaps", "pidgin",
++		fname = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin",
+ 								 hint_windows[i].filename, NULL);
+ 
+ 		hint_windows[i].widget = dnd_hints_init_window(fname);
+diff -aurN 000/source/pidgin/gtkdocklet-gtk.c 001/source/pidgin/gtkdocklet-gtk.c
+--- 000/source/pidgin/gtkdocklet-gtk.c
++++ 001/source/pidgin/gtkdocklet-gtk.c
+@@ -291,6 +291,6 @@
+ 	}
+ 
+ 	gtk_icon_theme_append_search_path(gtk_icon_theme_get_default(),
+-		DATADIR G_DIR_SEPARATOR_S "pixmaps" G_DIR_SEPARATOR_S "pidgin" G_DIR_SEPARATOR_S "tray");
++		PURPLE_DATADIR G_DIR_SEPARATOR_S "pixmaps" G_DIR_SEPARATOR_S "pidgin" G_DIR_SEPARATOR_S "tray");
+ }
+ 
+diff -aurN 000/source/pidgin/gtkmain.c 001/source/pidgin/gtkmain.c
+--- 000/source/pidgin/gtkmain.c
++++ 001/source/pidgin/gtkmain.c
+@@ -269,7 +269,7 @@
+ #ifndef _WIN32
+ 	/* use the nice PNG icon for all the windows */
+ 	for(i=0; i<G_N_ELEMENTS(icon_sizes); i++) {
+-		icon_path = g_build_filename(DATADIR, "icons", "hicolor", icon_sizes[i].dir, "apps", icon_sizes[i].filename, NULL);
++		icon_path = g_build_filename(PURPLE_DATADIR, "icons", "hicolor", icon_sizes[i].dir, "apps", icon_sizes[i].filename, NULL);
+ 		icon = pidgin_pixbuf_new_from_file(icon_path);
+ 		g_free(icon_path);
+ 		if (icon) {
+diff -aurN 000/source/pidgin/gtkprefs.c 001/source/pidgin/gtkprefs.c
+--- 000/source/pidgin/gtkprefs.c
++++ 001/source/pidgin/gtkprefs.c
+@@ -528,7 +528,7 @@
+ 	/* refresh the list of themes in the manager */
+ 	purple_theme_manager_refresh();
+ 
+-	tmp = g_build_filename(DATADIR, "icons", "hicolor", "32x32", "apps", "pidgin.png", NULL);
++	tmp = g_build_filename(PURPLE_DATADIR, "icons", "hicolor", "32x32", "apps", "pidgin.png", NULL);
+ 	pixbuf = pidgin_pixbuf_new_from_file_at_scale(tmp, PREFS_OPTIMAL_ICON_SIZE, PREFS_OPTIMAL_ICON_SIZE, TRUE);
+ 	g_free(tmp);
+ 
+diff -aurN 000/source/pidgin/gtksound.c 001/source/pidgin/gtksound.c
+--- 000/source/pidgin/gtksound.c
++++ 001/source/pidgin/gtksound.c
+@@ -613,7 +613,7 @@
+ 			g_free(filename);
+ 
+ 			/* XXX Consider creating a constant for "sounds/purple" to be shared with Finch */
+-			filename = g_build_filename(DATADIR, "sounds", "purple", sounds[event].def, NULL);
++			filename = g_build_filename(PURPLE_DATADIR, "sounds", "purple", sounds[event].def, NULL);
+ 		}
+ 
+ 		purple_sound_play_file(filename, NULL);
+diff -aurN 000/source/pidgin/gtkthemes.c 001/source/pidgin/gtkthemes.c
+--- 000/source/pidgin/gtkthemes.c
++++ 001/source/pidgin/gtkthemes.c
+@@ -389,7 +389,7 @@
+ 
+ 	pidgin_smiley_themes_remove_non_existing();
+ 
+-	probedirs[0] = g_build_filename(DATADIR, "pixmaps", "pidgin", "emotes", NULL);
++	probedirs[0] = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "emotes", NULL);
+ 	probedirs[1] = g_build_filename(purple_user_dir(), "smileys", NULL);
+ 	probedirs[2] = 0;
+ 	for (l=0; probedirs[l]; l++) {
+diff -aurN 000/source/pidgin/gtkutils.c 001/source/pidgin/gtkutils.c
+--- 000/source/pidgin/gtkutils.c
++++ 001/source/pidgin/gtkutils.c
+@@ -607,7 +607,7 @@
+ 	 */
+ 	tmp = g_strconcat(protoname, ".png", NULL);
+ 
+-	filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++	filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 				    size == PIDGIN_PRPL_ICON_SMALL ? "16" :
+ 				    size == PIDGIN_PRPL_ICON_MEDIUM ? "22" : "48",
+ 				    tmp, NULL);
+@@ -698,7 +698,7 @@
+ 		plugin = (PurplePlugin *)p->data;
+ 
+ 		if (gtalk_name && strcmp(gtalk_name, plugin->info->name) < 0) {
+-			char *filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++			char *filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 			                                  "16", "google-talk.png", NULL);
+ 			GtkWidget *item;
+ 
+@@ -721,7 +721,7 @@
+ 		}
+ 
+ 		if (facebook_name && strcmp(facebook_name, plugin->info->name) < 0) {
+-			char *filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols",
++			char *filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols",
+ 			                                  "16", "facebook.png", NULL);
+ 			GtkWidget *item;
+ 
+diff -aurN 000/source/pidgin/Makefile.am 001/source/pidgin/Makefile.am
+--- 000/source/pidgin/Makefile.am
++++ 001/source/pidgin/Makefile.am
+@@ -31,13 +31,28 @@
+ 		win32/nsis/create_nsis_translations.pl \
+ 		win32/nsis/nsis_translations.desktop.in
+ 
++if !OS_WIN32
++EXTRA_DIST += \
++		win32/MinimizeToTray.c \
++		win32/MinimizeToTray.h \
++		win32/gtkdocklet-win32.c \
++		win32/gtkwin32dep.c \
++		win32/gtkwin32dep.h \
++		win32/resource.h \
++		win32/untar.c \
++		win32/untar.h \
++		win32/winpidgin.c \
++		win32/wspell.c \
++		win32/wspell.h
++endif
++
+ if ENABLE_GTK
+ 
+-SUBDIRS = pixmaps plugins
++SUBDIRS = . pixmaps plugins
+ 
+ bin_PROGRAMS = pidgin
+ 
+-pidgin_SOURCES = \
++common_SOURCES = \
+ 	pidginstock.c \
+ 	gtkaccount.c \
+ 	gtkblist.c \
+@@ -51,7 +66,6 @@
+ 	gtkdialogs.c \
+ 	gtkdnd-hints.c \
+ 	gtkdocklet.c \
+-	gtkdocklet-gtk.c \
+ 	gtkeventloop.c \
+ 	gtkft.c \
+ 	gtkicon-theme.c \
+@@ -139,14 +153,30 @@
+ 	pidgintooltip.h \
+ 	pidgin.h
+ 
++if OS_WIN32
++pidgin_win32headers = \
++	gtkwin32dep.h
++pidgin_win32noinstheaders = \
++	MinimizeToTray.h \
++	resource.h \
++	untar.h \
++	wspell.h
++endif
++
+ pidginincludedir=$(includedir)/pidgin
+ pidgininclude_HEADERS = \
+ 	$(pidgin_headers)
+ 
++if OS_WIN32
++win32includedir=$(includedir)/pidgin/win32
++win32include_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(pidgin_win32headers))
++noinst_HEADERS = \
++	$(addprefix $(srcdir)/win32/, $(pidgin_win32noinstheaders))
++endif
+ 
+ pidgin_DEPENDENCIES = @LIBOBJS@
+-pidgin_LDFLAGS = -export-dynamic
+-pidgin_LDADD = \
++common_LDADD = \
+ 	@LIBOBJS@ \
+ 	$(GLIB_LIBS) \
+ 	$(DBUS_LIBS) \
+@@ -159,9 +189,47 @@
+ 	$(GTK_LIBS) \
+ 	$(top_builddir)/libpurple/libpurple.la
+ 
++if OS_WIN32
++lib_LTLIBRARIES = libpidgin.la
++
++pidgin_SOURCES = \
++	win32/pidgin_exe_rc.rc \
++	win32/winpidgin.c
++
++libpidgin_la_SOURCES = \
++	$(common_SOURCES) \
++	win32/MinimizeToTray.c \
++	win32/gtkdocklet-win32.c \
++	win32/gtkwin32dep.c \
++	win32/untar.c \
++	win32/wspell.c \
++	win32/pidgin_dll_rc.rc
++
++libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
++libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
++
++pidgin_LDFLAGS = -mwindows
++pidgin_LDADD =
++	
++.rc.o:
++	$(WINDRES) $^ -o $@
++%.o : %.rc
++	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -i $< -o $@
++
++else
++pidgin_SOURCES = \
++	$(common_SOURCES) \
++	gtkdocklet-gtk.c
++
++pidgin_CFLAGS = $(AM_CFLAGS)
++pidgin_LDFLAGS = -export-dynamic
++
++pidgin_LDADD = $(common_LDADD)
++endif
++
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
+-	-DLIBDIR=\"$(libdir)/pidgin/\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-DPIDGIN_LIBDIR=\"$(libdir)/pidgin/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+ 	-DSYSCONFDIR=\"$(sysconfdir)\" \
+ 	-I$(top_builddir)/libpurple \
+@@ -177,6 +245,14 @@
+ 	$(LIBXML_CFLAGS) \
+ 	$(INTGG_CFLAGS)
+ 
++	
++if OS_WIN32
++AM_CPPFLAGS += \
++	-DUSE_FHS \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++	
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = data/pidgin.pc
+ 
+diff -aurN 000/source/pidgin/pidginstock.c 001/source/pidgin/pidginstock.c
+--- 000/source/pidgin/pidginstock.c
++++ 001/source/pidgin/pidginstock.c
+@@ -241,7 +241,7 @@
+ 			return filename;
+ 		g_free(filename);
+ 	}
+-	filename = g_build_filename(DATADIR, name, NULL);
++	filename = g_build_filename(PURPLE_DATADIR, name, NULL);
+ 	if (g_file_test(filename, G_FILE_TEST_EXISTS))
+ 		return filename;
+ 	g_free(filename);
+diff -aurN 000/source/pidgin/plugins/cap/Makefile.am 001/source/pidgin/plugins/cap/Makefile.am
+--- 000/source/pidgin/plugins/cap/Makefile.am
++++ 001/source/pidgin/plugins/cap/Makefile.am
+@@ -18,7 +18,7 @@
+ cap_la_LIBADD = $(GTK_LIBS) $(SQLITE3_LIBS)
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+diff -aurN 000/source/pidgin/plugins/disco/gtkdisco.c 001/source/pidgin/plugins/disco/gtkdisco.c
+--- 000/source/pidgin/plugins/disco/gtkdisco.c
++++ 001/source/pidgin/plugins/disco/gtkdisco.c
+@@ -119,14 +119,14 @@
+ 
+ 	if (service->type == XMPP_DISCO_SERVICE_TYPE_GATEWAY && service->gateway_type) {
+ 		char *tmp = g_strconcat(service->gateway_type, ".png", NULL);
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "protocols", size, tmp, NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "protocols", size, tmp, NULL);
+ 		g_free(tmp);
+ #if 0
+ 	} else if (service->type == XMPP_DISCO_SERVICE_TYPE_USER) {
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "status", size, "person.png", NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "status", size, "person.png", NULL);
+ #endif
+ 	} else if (service->type == XMPP_DISCO_SERVICE_TYPE_CHAT)
+-		filename = g_build_filename(DATADIR, "pixmaps", "pidgin", "status", size, "chat.png", NULL);
++		filename = g_build_filename(PURPLE_DATADIR, "pixmaps", "pidgin", "status", size, "chat.png", NULL);
+ 
+ 	if (filename) {
+ 		pixbuf = gdk_pixbuf_new_from_file(filename, NULL);
+diff -aurN 000/source/pidgin/plugins/disco/Makefile.am 001/source/pidgin/plugins/disco/Makefile.am
+--- 000/source/pidgin/plugins/disco/Makefile.am
++++ 001/source/pidgin/plugins/disco/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-xmppdisco_la_LDFLAGS = -module -avoid-version
++xmppdisco_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ EXTRA_DIST = \
+         Makefile.mingw
+@@ -15,14 +19,21 @@
+ 	xmppdisco.c \
+ 	xmppdisco.h
+ 
+-xmppdisco_la_LIBADD = $(GTK_LIBS)
++xmppdisco_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++
+diff -aurN 000/source/pidgin/plugins/gestures/Makefile.am 001/source/pidgin/plugins/gestures/Makefile.am
+--- 000/source/pidgin/plugins/gestures/Makefile.am
++++ 001/source/pidgin/plugins/gestures/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-gestures_la_LDFLAGS = -module -avoid-version
++gestures_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -13,14 +17,20 @@
+ 	stroke.c \
+ 	stroke-draw.c
+ 
+-gestures_la_LIBADD = $(GTK_LIBS)
++gestures_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS) $(GLIB_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+\ No newline at end of file
+diff -aurN 000/source/pidgin/plugins/gevolution/Makefile.am 001/source/pidgin/plugins/gevolution/Makefile.am
+--- 000/source/pidgin/plugins/gevolution/Makefile.am
++++ 001/source/pidgin/plugins/gevolution/Makefile.am
+@@ -1,6 +1,10 @@
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-gevolution_la_LDFLAGS = -module -avoid-version
++gevolution_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -15,15 +19,22 @@
+ 	new_person_dialog.c \
+ 	eds-utils.c
+ 
+-gevolution_la_LIBADD = $(EVOLUTION_ADDRESSBOOK_LIBS) $(GTK_LIBS)
++gevolution_la_LIBADD = $(EVOLUTION_ADDRESSBOOK_LIBS) $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS) $(GLIB_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(EVOLUTION_ADDRESSBOOK_CFLAGS) \
++	$(GLIB_CFLAGS) \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/Makefile.am 001/source/pidgin/plugins/Makefile.am
+--- 000/source/pidgin/plugins/Makefile.am
++++ 001/source/pidgin/plugins/Makefile.am
+@@ -1,4 +1,4 @@
+-DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker
++DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker win32
+ 
+ if BUILD_GEVOLUTION
+ GEVOLUTION_DIR = gevolution
+@@ -143,6 +143,12 @@
+ 	$(GSTREAMER_CFLAGS) \
+ 	$(PLUGIN_CFLAGS)
+ 
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
++
+ #
+ # This part allows people to build their own plugins in here.
+ # Yes, it's a mess.
+@@ -150,7 +156,7 @@
+ SUFFIXES = .c .so
+ .c.so:
+ 	$(LIBTOOL) --mode=compile $(CC) -DHAVE_CONFIG_H -I$(top_builddir) $(AM_CPPFLAGS) $(CFLAGS) -c $< -o tmp$@.lo $(PLUGIN_CFLAGS)
+-	$(LIBTOOL) --mode=link    $(CC) $(CFLAGS) -o libtmp$@.la -rpath $(plugindir) tmp$@.lo $(LIBS) $(LDFLAGS) -module -avoid-version $(PLUGIN_LIBS)
++	$(LIBTOOL) --mode=link    $(CC) $(CFLAGS) -o libtmp$@.la -rpath $(plugindir) tmp$@.lo $(LIBS) $(LDFLAGS) -module -avoid-version $(NO_UNDEFINED) $(PLUGIN_LIBS)
+ 	@rm -f tmp$@.lo tmp$@.o libtmp$@.la
+ 	@cp .libs/libtmp$@*.so $@
+ 	@rm -rf .libs/libtmp$@.*
+diff -aurN 000/source/pidgin/plugins/musicmessaging/Makefile.am 001/source/pidgin/plugins/musicmessaging/Makefile.am
+--- 000/source/pidgin/plugins/musicmessaging/Makefile.am
++++ 001/source/pidgin/plugins/musicmessaging/Makefile.am
+@@ -1,7 +1,11 @@
+ EXTRA_DIST = \
+ 	music.png
+ 
++if OS_WIN32
++musicmessagingdir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ musicmessagingdir = $(libdir)/pidgin
++endif
+ 
+ musicmessaging_la_LDFLAGS = -module -avoid-version
+ 
+@@ -16,7 +20,7 @@
+ musicmessaging_la_SOURCES = \
+ 	musicmessaging.c
+ 
+-musicmessaging_la_LIBADD = $(GTK_LIBS) $(DBUS_LIBS)
++musicmessaging_la_LIBADD = $(GTK_LIBS) $(DBUS_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ CLEANFILES              = music-messaging-bindings.c
+ 
+@@ -35,10 +39,16 @@
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS) \
+ 	$(DBUS_CFLAGS)
++	
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/musicmessaging/musicmessaging.c 001/source/pidgin/plugins/musicmessaging/musicmessaging.c
+--- 000/source/pidgin/plugins/musicmessaging/musicmessaging.c
++++ 001/source/pidgin/plugins/musicmessaging/musicmessaging.c
+@@ -548,11 +548,13 @@
+ 
+ static void kill_editor (MMConversation *mmconv)
+ {
++#ifndef _WIN32
+ 	if (mmconv->pid)
+ 	{
+ 		kill(mmconv->pid, SIGINT);
+ 		mmconv->pid = 0;
+ 	}
++#endif
+ }
+ 
+ static void init_conversation (PurpleConversation *conv)
+@@ -595,7 +597,7 @@
+ 
+ 	g_signal_connect(G_OBJECT(button), "toggled", G_CALLBACK(music_button_toggled), mmconv);
+ 
+-	file_path = g_build_filename(DATADIR, "pixmaps", "purple", "buttons",
++	file_path = g_build_filename(PURPLE_DATADIR, "pixmaps", "purple", "buttons",
+ 										"music.png", NULL);
+ 	image = gtk_image_new_from_file(file_path);
+ 	g_free(file_path);
+diff -aurN 000/source/pidgin/plugins/ticker/Makefile.am 001/source/pidgin/plugins/ticker/Makefile.am
+--- 000/source/pidgin/plugins/ticker/Makefile.am
++++ 001/source/pidgin/plugins/ticker/Makefile.am
+@@ -1,9 +1,13 @@
+ EXTRA_DIST = \
+ 		Makefile.mingw
+ 
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-ticker_la_LDFLAGS = -module -avoid-version
++ticker_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -14,14 +18,20 @@
+ 	gtkticker.h \
+ 	ticker.c
+ 
+-ticker_la_LIBADD = $(GTK_LIBS)
++ticker_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
+ 
+ endif
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+ 	$(DEBUG_CFLAGS) \
+ 	$(GTK_CFLAGS)
++
++if OS_WIN32
++AM_CPPFLAGS += \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32
++endif
+diff -aurN 000/source/pidgin/plugins/win32/Makefile.am 001/source/pidgin/plugins/win32/Makefile.am
+--- 000/source/pidgin/plugins/win32/Makefile.am
++++ 001/source/pidgin/plugins/win32/Makefile.am
+@@ -0,0 +1,9 @@
++DIST_SUBDIRS = transparency winprefs
++
++if OS_WIN32
++SUBDIRS = $(DIST_SUBDIRS)
++endif
++
++EXTRA_DIST = \
++	Makefile.mingw
++
+diff -aurN 000/source/pidgin/plugins/win32/transparency/Makefile.am 001/source/pidgin/plugins/win32/transparency/Makefile.am
+--- 000/source/pidgin/plugins/win32/transparency/Makefile.am
++++ 001/source/pidgin/plugins/win32/transparency/Makefile.am
+@@ -0,0 +1,31 @@
++EXTRA_DIST = \
++	Makefile.mingw \
++	win2ktrans.c
++
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++
++win2ktrans_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++
++if PLUGINS
++
++plugin_LTLIBRARIES = win2ktrans.la
++
++win2ktrans_la_SOURCES = \
++	win2ktrans.c
++
++win2ktrans_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
++
++endif
++
++AM_CPPFLAGS = \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-I$(top_srcdir)/libpurple \
++	-I$(top_builddir)/libpurple \
++	-I$(top_srcdir)/pidgin \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32 \
++	$(DEBUG_CFLAGS) \
++	$(GTK_CFLAGS)
++
++endif
+diff -aurN 000/source/pidgin/plugins/win32/winprefs/gtkappbar.c 001/source/pidgin/plugins/win32/winprefs/gtkappbar.c
+--- 000/source/pidgin/plugins/win32/winprefs/gtkappbar.c
++++ 001/source/pidgin/plugins/win32/winprefs/gtkappbar.c
+@@ -27,6 +27,7 @@
+  *  - Move 'App on top' feature from Trans plugin to here
+  *  - Bug: Multiple Show/Hide Desktop calls causes client area to disappear
+  */
++#define WINVER 0x500
+ #include <windows.h>
+ #include <winver.h>
+ #include <stdio.h>
+diff -aurN 000/source/pidgin/plugins/win32/winprefs/Makefile.am 001/source/pidgin/plugins/win32/winprefs/Makefile.am
+--- 000/source/pidgin/plugins/win32/winprefs/Makefile.am
++++ 001/source/pidgin/plugins/win32/winprefs/Makefile.am
+@@ -0,0 +1,35 @@
++EXTRA_DIST = \
++	gtkappbar.c \
++	gtkappbar.h \
++	winprefs.c \
++	Makefile.mingw
++
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++
++winprefs_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++
++if PLUGINS
++
++plugin_LTLIBRARIES = winprefs.la
++
++winprefs_la_SOURCES = \
++	gtkappbar.c \
++	gtkappbar.h \
++	winprefs.c
++
++winprefs_la_LIBADD = $(GTK_LIBS) $(PURPLE_LIBS) $(PIDGIN_LIBS)
++
++endif
++
++AM_CPPFLAGS = \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
++	-I$(top_srcdir)/libpurple \
++	-I$(top_builddir)/libpurple \
++	-I$(top_srcdir)/pidgin \
++	-I$(top_srcdir)/libpurple/win32 \
++	-I$(top_srcdir)/pidgin/win32 \
++	$(DEBUG_CFLAGS) \
++	$(GTK_CFLAGS)
++
++endif
+diff -aurN 000/source/pidgin/win32/gtkwin32dep.h 001/source/pidgin/win32/gtkwin32dep.h
+--- 000/source/pidgin/win32/gtkwin32dep.h
++++ 001/source/pidgin/win32/gtkwin32dep.h
+@@ -25,6 +25,10 @@
+ #include <windows.h>
+ #include <gtk/gtk.h>
+ #include "conversation.h"
++#include "win32dep.h"
++
++#undef PIDGIN_LIBDIR
++#define PIDGIN_LIBDIR PURPLE_LIBDIR
+ 
+ HINSTANCE winpidgin_dll_hinstance(void);
+ HINSTANCE winpidgin_exe_hinstance(void);
+diff -aurN 000/source/pidgin/win32/MinimizeToTray.c 001/source/pidgin/win32/MinimizeToTray.c
+--- 000/source/pidgin/win32/MinimizeToTray.c
++++ 001/source/pidgin/win32/MinimizeToTray.c
+@@ -14,7 +14,7 @@
+  *
+  * Copyright 2000 Matthew Ellis <m.t.ellis@bigfoot.com>
+  */
+-#define _WIN32_WINNT 0x0500
++#define _WIN32_WINNT 0x0501
+ #include <windows.h>
+ #include "MinimizeToTray.h"
+ 
+diff -aurN 000/source/pidgin/win32/pidgin_exe_rc.rc.in 001/source/pidgin/win32/pidgin_exe_rc.rc.in
+--- 000/source/pidgin/win32/pidgin_exe_rc.rc.in
++++ 001/source/pidgin/win32/pidgin_exe_rc.rc.in
+@@ -7,8 +7,8 @@
+ CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "pidgin.manifest.xml"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32
+diff -aurN 000/source/pidgin/win32/winpidgin.c 001/source/pidgin/win32/winpidgin.c
+--- 000/source/pidgin/win32/winpidgin.c
++++ 001/source/pidgin/win32/winpidgin.c
+@@ -321,11 +321,19 @@
+ 					posix = L"sr@Latn"; break;
+ 				case SUBLANG_SERBIAN_CYRILLIC:
+ 					posix = L"sr"; break;
++/* for some reason mingw-w64 doesn't have these definitions yet */
++#ifdef SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_CYRILLIC
+ 				case SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_CYRILLIC:
++					posix = L"bs"; break;
++#endif
++#ifdef SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_LATIN
+ 				case SUBLANG_BOSNIAN_BOSNIA_HERZEGOVINA_LATIN:
+ 					posix = L"bs"; break;
++#endif
++#ifdef SUBLANG_CROATIAN_BOSNIA_HERZEGOVINA_LATIN
+ 				case SUBLANG_CROATIAN_BOSNIA_HERZEGOVINA_LATIN:
+ 					posix = L"hr"; break;
++#endif
+ 			}
+ 			break;
+ 		case LANG_SWEDISH: posix = L"sv"; break;
+@@ -734,7 +742,7 @@
+ 			return 0;
+ 
+ 	/* Now we are ready for Pidgin .. */
+-	wcscat(pidgin_dir, L"\\pidgin.dll");
++	wcscat(pidgin_dir, L"\\libpidgin.dll");
+ 	if ((hmod = LoadLibraryW(pidgin_dir)))
+ 		pidgin_main = (LPFNPIDGINMAIN) GetProcAddress(hmod, "pidgin_main");
+ 
+@@ -747,7 +755,7 @@
+ 		BOOL mod_not_found = (dw == ERROR_MOD_NOT_FOUND || dw == ERROR_DLL_NOT_FOUND);
+ 		const wchar_t *err_msg = get_win32_error_message(dw);
+ 
+-		_snwprintf(errbuf, 512, L"Error loading pidgin.dll.\nError: (%u) %s%s%s",
++		_snwprintf(errbuf, 512, L"Error loading libpidgin.dll.\nError: (%u) %s%s%s",
+ 			(UINT) dw, err_msg,
+ 			mod_not_found ? L"\n" : L"",
+ 			mod_not_found ? L"This probably means that GTK+ can't be found." : L"");

--- a/mingw-w64-pidgin++/002-autotools-and-fhs-pidgin++.patch
+++ b/mingw-w64-pidgin++/002-autotools-and-fhs-pidgin++.patch
@@ -1,0 +1,189 @@
+diff -aurN 001/source/finch/finch.c 002/source/finch/finch.c
+--- 001/source/finch/finch.c
++++ 002/source/finch/finch.c
+@@ -377,7 +377,7 @@
+ 	purple_idle_set_ui_ops(finch_idle_get_ui_ops());
+ 
+ 	plugin_search_path_add_user_directories();
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(FINCH_LIBDIR);
+ 
+ 	if (!purple_core_init(FINCH_UI))
+ 	{
+diff -aurN 001/source/pidgin/gtkmain.c 002/source/pidgin/gtkmain.c
+--- 001/source/pidgin/gtkmain.c
++++ 002/source/pidgin/gtkmain.c
+@@ -807,7 +807,7 @@
+ 	 * in user's home directory.
+ 	 */
+ 	plugin_search_path_add_user_directories();
+-	purple_plugins_add_search_path(LIBDIR);
++	purple_plugins_add_search_path(PIDGIN_LIBDIR);
+ 
+ 	if (!purple_core_init(PIDGIN_UI)) {
+ 		fprintf(stderr,
+diff -aurN 001/source/pidgin/Makefile.am 002/source/pidgin/Makefile.am
+--- 001/source/pidgin/Makefile.am
++++ 002/source/pidgin/Makefile.am
+@@ -7,19 +7,8 @@
+ 		data/pidgin.desktop.in \
+ 		data/pidgin.pc.in \
+ 		data/pidgin-uninstalled.pc.in \
+-		win32/MinimizeToTray.h \
+-		win32/MinimizeToTray.c \
+ 		win32/pidgin_dll_rc.rc.in \
+ 		win32/pidgin_exe_rc.rc.in \
+-		win32/gtkdocklet-win32.c \
+-		win32/gtkwin32dep.c \
+-		win32/gtkwin32dep.h \
+-		win32/resource.h \
+-		win32/untar.c \
+-		win32/untar.h \
+-		win32/winpidgin.c \
+-		win32/wspell.c \
+-		win32/wspell.h \
+ 		win32/nsis/integrate_gtk.sh \
+ 		win32/nsis/rpm2zip.sh \
+ 		win32/nsis/pixmaps/pidgin-header.bmp \
+diff -aurN 001/source/pidgin/plugins/Makefile.am 002/source/pidgin/plugins/Makefile.am
+--- 001/source/pidgin/plugins/Makefile.am
++++ 002/source/pidgin/plugins/Makefile.am
+@@ -27,28 +27,33 @@
+ 	$(MUSICMESSAGING_DIR) \
+ 	$(PERL_DIR) \
+ 	disco \
+-	ticker
++	ticker \
++	win32
+ 
++if OS_WIN32
++plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
++else
+ plugindir = $(libdir)/pidgin
++endif
+ 
+-convcolors_la_LDFLAGS       = -module -avoid-version
+-contact_priority_la_LDFLAGS = -module -avoid-version
+-extplacement_la_LDFLAGS     = -module -avoid-version
+-gtk_signals_test_la_LDFLAGS = -module -avoid-version
+-gtkbuddynote_la_LDFLAGS     = -module -avoid-version
+-history_la_LDFLAGS          = -module -avoid-version
+-iconaway_la_LDFLAGS         = -module -avoid-version
+-markerline_la_LDFLAGS       = -module -avoid-version
+-notify_la_LDFLAGS           = -module -avoid-version
+-pidginrc_la_LDFLAGS         = -module -avoid-version
+-sendbutton_la_LDFLAGS       = -module -avoid-version
+-spellchk_la_LDFLAGS         = -module -avoid-version
+-themeedit_la_LDFLAGS        = -module -avoid-version
+-timestamp_la_LDFLAGS        = -module -avoid-version
+-timestamp_format_la_LDFLAGS = -module -avoid-version
+-unity_la_LDFLAGS            = -module -avoid-version
+-vvconfig_la_LDFLAGS         = -module -avoid-version
+-xmppconsole_la_LDFLAGS      = -module -avoid-version
++convcolors_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++contact_priority_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++extplacement_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
++gtk_signals_test_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++gtkbuddynote_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
++history_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
++iconaway_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++markerline_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++notify_la_LDFLAGS           = -module -avoid-version $(NO_UNDEFINED)
++pidginrc_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++sendbutton_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
++spellchk_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++themeedit_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++timestamp_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
++timestamp_format_la_LDFLAGS = -module -avoid-version $(NO_UNDEFINED)
++unity_la_LDFLAGS            = -module -avoid-version $(NO_UNDEFINED)
++vvconfig_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++xmppconsole_la_LDFLAGS      = -module -avoid-version $(NO_UNDEFINED)
+ 
+ if PLUGINS
+ 
+@@ -99,41 +104,34 @@
+ vvconfig_la_SOURCES         = vvconfig.c
+ xmppconsole_la_SOURCES      = xmppconsole.c
+ 
+-convcolors_la_LIBADD        = $(GTK_LIBS)
+-contact_priority_la_LIBADD  = $(GTK_LIBS)
+-extplacement_la_LIBADD      = $(GTK_LIBS)
+-gtk_signals_test_la_LIBADD  = $(GTK_LIBS)
+-gtkbuddynote_la_LIBADD      = $(GTK_LIBS)
+-history_la_LIBADD           = $(GTK_LIBS)
+-iconaway_la_LIBADD          = $(GTK_LIBS)
+-markerline_la_LIBADD        = $(GTK_LIBS)
+-notify_la_LIBADD            = $(GTK_LIBS)
+-pidginrc_la_LIBADD          = $(GTK_LIBS)
+-sendbutton_la_LIBADD        = $(GTK_LIBS)
+-spellchk_la_LIBADD          = $(GTK_LIBS)
+-themeedit_la_LIBADD         = $(GTK_LIBS)
+-timestamp_la_LIBADD         = $(GTK_LIBS)
+-timestamp_format_la_LIBADD  = $(GTK_LIBS)
+-unity_la_LIBADD             = $(GTK_LIBS) $(UNITY_LIBS)
+-vvconfig_la_LIBADD          = $(GTK_LIBS) $(GSTREAMER_LIBS)
+-xmppconsole_la_LIBADD       = $(GTK_LIBS)
++convcolors_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++contact_priority_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++extplacement_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
++gtk_signals_test_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++gtkbuddynote_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
++history_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
++iconaway_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++markerline_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++notify_la_LIBADD            = $(GTK_LIBS) $(PIDGIN_LIBS)
++pidginrc_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++sendbutton_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
++spellchk_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++themeedit_la_LIBADD         = $(GTK_LIBS) $(PIDGIN_LIBS)
++timestamp_la_LIBADD         = $(GTK_LIBS) $(PIDGIN_LIBS)
++timestamp_format_la_LIBADD  = $(GTK_LIBS) $(PIDGIN_LIBS)
++unity_la_LIBADD             = $(GTK_LIBS) $(UNITY_LIBS) $(PIDGIN_LIBS)
++vvconfig_la_LIBADD          = $(GTK_LIBS) $(GSTREAMER_LIBS) $(PIDGIN_LIBS)
++xmppconsole_la_LIBADD       = $(GTK_LIBS) $(PIDGIN_LIBS)
+ 
+ endif # PLUGINS
+ 
+ EXTRA_DIST = \
+-	Makefile.mingw \
+ 	mailchk.c \
+ 	pidgininc.c \
+-	raw.c \
+-	win32/transparency/Makefile.mingw \
+-	win32/transparency/win2ktrans.c \
+-	win32/winprefs/gtkappbar.c \
+-	win32/winprefs/gtkappbar.h \
+-	win32/winprefs/Makefile.mingw \
+-	win32/winprefs/winprefs.c
++	raw.c
+ 
+ AM_CPPFLAGS = \
+-	-DDATADIR=\"$(datadir)\" \
++	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-I$(top_builddir)/libpurple \
+ 	-I$(top_srcdir)/libpurple \
+ 	-I$(top_srcdir)/pidgin \
+diff -aurN 001/source/pidgin/win32/gtkdocklet-win32.c 002/source/pidgin/win32/gtkdocklet-win32.c
+--- 001/source/pidgin/win32/gtkdocklet-win32.c
++++ 002/source/pidgin/win32/gtkdocklet-win32.c
+@@ -21,7 +21,7 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  * 02111-1301, USA.
+  */
+-#define _WIN32_IE 0x0500
++#define _WIN32_IE 0x0501
+ #include "internal.h"
+ #include <windows.h>
+ #include <gdk/gdkwin32.h>
+diff -aurN 001/source/pidgin/win32/pidgin_exe_rc.rc.in 002/source/pidgin/win32/pidgin_exe_rc.rc.in
+--- 001/source/pidgin/win32/pidgin_exe_rc.rc.in
++++ 002/source/pidgin/win32/pidgin_exe_rc.rc.in
+@@ -24,7 +24,7 @@
+         VALUE "FileVersion", "@APPLICATION_VERSION@"
+         VALUE "InternalName", "pidgin"
+         VALUE "LegalCopyright", "Copyright (C) 1998-2015 The @APPLICATION_NAME@ developer community"
+-        VALUE "OriginalFilename", "@ORIGINAL_FILENAME@"
++        VALUE "OriginalFilename", "pidgin.exe"
+         VALUE "ProductName", "@APPLICATION_NAME@"
+         VALUE "ProductVersion", "@DISPLAY_VERSION_FULL@"
+       END

--- a/mingw-w64-pidgin++/003-autotools-and-fhs-adaptation.patch
+++ b/mingw-w64-pidgin++/003-autotools-and-fhs-adaptation.patch
@@ -1,0 +1,140 @@
+diff -aurN 002/source/configure.ac 003/source/configure.ac
+--- 002/source/configure.ac
++++ 003/source/configure.ac
+@@ -82,6 +82,8 @@
+ PURPLE_MINOR_VERSION=purple_minor_version
+ PURPLE_MICRO_VERSION=purple_micro_version
+ PURPLE_VERSION=[purple_display_version]
++APPLICATION_VERSION=purple_display_version
++AC_SUBST(APPLICATION_VERSION)
+ AC_SUBST(PURPLE_MAJOR_VERSION)
+ AC_SUBST(PURPLE_MINOR_VERSION)
+ AC_SUBST(PURPLE_MICRO_VERSION)
+@@ -406,10 +408,17 @@
+ 						   [extra version number to be displayed in Help->About and --help (for packagers)]),
+ 						   EXTRA_VERSION=$withval)
+ 
++DISPLAY_VERSION_FULL='purple_version_suffix'
++DISPLAY_VERSION_FULL="${DISPLAY_VERSION_FULL#-}"
++DISPLAY_VERSION="${DISPLAY_VERSION_FULL%.0}"
++AC_SUBST(DISPLAY_VERSION_FULL)
++
+ if test x"$EXTRA_VERSION" != "x" ; then
+-	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$VERSION-$EXTRA_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$DISPLAY_VERSION-$EXTRA_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION_FULL, "$DISPLAY_VERSION_FULL-$EXTRA_VERSION", [display version info])
+ else
+-	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION, "$DISPLAY_VERSION", [display version info])
++	AC_DEFINE_UNQUOTED(DISPLAY_VERSION_FULL, "$DISPLAY_VERSION_FULL", [display version info])
+ fi
+ 
+ AC_ARG_ENABLE(missing-dependencies, [AC_HELP_STRING([--disable-missing-dependencies],
+diff -aurN 002/source/libpurple/plugins/Makefile.am 003/source/libpurple/plugins/Makefile.am
+--- 002/source/libpurple/plugins/Makefile.am
++++ 003/source/libpurple/plugins/Makefile.am
+@@ -31,6 +31,7 @@
+ debug_example_la_LDFLAGS    = -module -avoid-version $(NO_UNDEFINED)
+ helloworld_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ idle_la_LDFLAGS             = -module -avoid-version $(NO_UNDEFINED)
++irchelper_la_LDFLAGS        = -module -avoid-version $(NO_UNDEFINED)
+ joinpart_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
+ log_reader_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ newline_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+@@ -52,6 +53,7 @@
+ 	autoaccept.la       \
+ 	buddynote.la        \
+ 	idle.la             \
++	irchelper.la        \
+ 	joinpart.la         \
+ 	log_reader.la       \
+ 	newline.la          \
+@@ -78,6 +80,7 @@
+ debug_example_la_SOURCES = debug_example.c
+ helloworld_la_SOURCES       = helloworld.c
+ idle_la_SOURCES             = idle.c
++irchelper_la_SOURCES        = irchelper.c
+ joinpart_la_SOURCES         = joinpart.c
+ log_reader_la_SOURCES       = log_reader.c
+ newline_la_SOURCES          = newline.c
+@@ -96,6 +99,7 @@
+ ciphertest_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
+ codeinline_la_LIBADD		= $(GLIB_LIBS) $(PURPLE_LIBS)
+ idle_la_LIBADD              = $(GLIB_LIBS) $(PURPLE_LIBS)
++irchelper_la_LIBADD         = $(GLIB_LIBS) $(PURPLE_LIBS)
+ joinpart_la_LIBADD          = $(GLIB_LIBS) $(PURPLE_LIBS)
+ log_reader_la_LIBADD        = $(GLIB_LIBS) $(PURPLE_LIBS)
+ newline_la_LIBADD           = $(GLIB_LIBS) $(PURPLE_LIBS)
+diff -aurN 002/source/pidgin/Makefile.am 003/source/pidgin/Makefile.am
+--- 002/source/pidgin/Makefile.am
++++ 003/source/pidgin/Makefile.am
+@@ -176,7 +176,10 @@
+ 	$(GTKSPELL_LIBS) \
+ 	$(LIBXML_LIBS) \
+ 	$(GTK_LIBS) \
+-	$(top_builddir)/libpurple/libpurple.la
++	$(top_builddir)/libpurple/libpurple.la \
++	-lwinsparkle \
++	-lcomctl32 \
++	-lexchndl
+ 
+ if OS_WIN32
+ lib_LTLIBRARIES = libpidgin.la
+@@ -198,12 +201,12 @@
+ libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
+ 
+ pidgin_LDFLAGS = -mwindows
+-pidgin_LDADD =
++pidgin_LDADD = -lexchndl
+ 	
+ .rc.o:
+ 	$(WINDRES) $^ -o $@
+ %.o : %.rc
+-	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -i $< -o $@
++	$(WINDRES) -I$(top_srcdir)/pidgin -I$(top_srcdir)/pidgin/win32 -I$(top_srcdir)/libpurple -I$(top_srcdir)/libpurple/win32 $(shell pkg-config --cflags-only-I gtk+-2.0) -i $< -o $@
+ 
+ else
+ pidgin_SOURCES = \
+@@ -217,6 +220,7 @@
+ endif
+ 
+ AM_CPPFLAGS = \
++	-DBUILD_DATE=\"$(shell date +%Y%m%d)\" \
+ 	-DPURPLE_DATADIR=\"$(datadir)\" \
+ 	-DPIDGIN_LIBDIR=\"$(libdir)/pidgin/\" \
+ 	-DLOCALEDIR=\"$(datadir)/locale\" \
+diff -aurN 002/source/pidgin/plugins/Makefile.am 003/source/pidgin/plugins/Makefile.am
+--- 002/source/pidgin/plugins/Makefile.am
++++ 003/source/pidgin/plugins/Makefile.am
+@@ -43,6 +43,7 @@
+ gtkbuddynote_la_LDFLAGS     = -module -avoid-version $(NO_UNDEFINED)
+ history_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+ iconaway_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
++ircaway_la_LDFLAGS          = -module -avoid-version $(NO_UNDEFINED)
+ markerline_la_LDFLAGS       = -module -avoid-version $(NO_UNDEFINED)
+ notify_la_LDFLAGS           = -module -avoid-version $(NO_UNDEFINED)
+ pidginrc_la_LDFLAGS         = -module -avoid-version $(NO_UNDEFINED)
+@@ -63,6 +64,7 @@
+ 	gtkbuddynote.la     \
+ 	history.la          \
+ 	iconaway.la         \
++	ircaway.la          \
+ 	markerline.la       \
+ 	notify.la           \
+ 	pidginrc.la         \
+@@ -92,6 +94,7 @@
+ gtkbuddynote_la_SOURCES     = gtkbuddynote.c
+ history_la_SOURCES          = history.c
+ iconaway_la_SOURCES         = iconaway.c
++ircaway_la_SOURCES          = ircaway.c
+ markerline_la_SOURCES       = markerline.c
+ notify_la_SOURCES           = notify.c
+ pidginrc_la_SOURCES         = pidginrc.c
+@@ -111,6 +114,7 @@
+ gtkbuddynote_la_LIBADD      = $(GTK_LIBS) $(PIDGIN_LIBS)
+ history_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
+ iconaway_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)
++ircaway_la_LIBADD           = $(GTK_LIBS) $(PIDGIN_LIBS)
+ markerline_la_LIBADD        = $(GTK_LIBS) $(PIDGIN_LIBS)
+ notify_la_LIBADD            = $(GTK_LIBS) $(PIDGIN_LIBS)
+ pidginrc_la_LIBADD          = $(GTK_LIBS) $(PIDGIN_LIBS)

--- a/mingw-w64-pidgin++/004-build-fixes.patch
+++ b/mingw-w64-pidgin++/004-build-fixes.patch
@@ -1,0 +1,82 @@
+diff -aurN 003/source/configure.ac 004/source/configure.ac
+--- 003/source/configure.ac
++++ 004/source/configure.ac
+@@ -703,7 +703,7 @@
+ 	if test "x$enable_consoleui" = "xyes"; then
+ 		dnl # Some distros put the headers in ncursesw/, some don't
+ 		found_ncurses_h=no
+-		for location in $ac_ncurses_includes $NCURSES_HEADERS /usr/include/ncursesw /usr/include
++		for location in $ac_ncurses_includes $NCURSES_HEADERS ${prefix}/include/ncursesw ${prefix}/include
+ 		do
+ 			f="$location/ncurses.h"
+ 			orig_CFLAGS="$CFLAGS"
+@@ -809,11 +809,11 @@
+ 	[AC_HELP_STRING([--disable-gstreamer], [compile without GStreamer audio support])],
+ 	enable_gst="$enableval", enable_gst="yes")
+ if test "x$enable_gst" != "xno"; then
+-	PKG_CHECK_MODULES(GSTREAMER, [gstreamer-0.10], [
++	PKG_CHECK_MODULES(GSTREAMER, [gstreamer-1.0], [
+ 		AC_DEFINE(USE_GSTREAMER, 1, [Use GStreamer for playing sounds])
+ 		AC_SUBST(GSTREAMER_CFLAGS)
+ 		AC_SUBST(GSTREAMER_LIBS)
+-		AC_CHECK_LIB(gstreamer-0.10, gst_registry_fork_set_enabled,
++		AC_CHECK_LIB(gstreamer-1.0, gst_registry_fork_set_enabled,
+ 			[ AC_DEFINE(GST_CAN_DISABLE_FORKING, [],
+ 			  [Define if gst_registry_fork_set_enabled exists])],
+ 			[], [$GSTREAMER_LIBS])
+diff -aurN 003/source/libpurple/dbus-server.h 004/source/libpurple/dbus-server.h
+--- 003/source/libpurple/dbus-server.h
++++ 004/source/libpurple/dbus-server.h
+@@ -199,7 +199,9 @@
+ 
+  */
+ 
++#ifndef HAVE_DBUS
+ #define DBUS_EXPORT
++#endif
+ 
+ /*
+    Here we include the list of #PURPLE_DBUS_DECLARE_TYPE statements for
+diff -aurN 003/source/pidgin/Makefile.am 004/source/pidgin/Makefile.am
+--- 003/source/pidgin/Makefile.am
++++ 004/source/pidgin/Makefile.am
+@@ -194,10 +194,10 @@
+ 	win32/gtkdocklet-win32.c \
+ 	win32/gtkwin32dep.c \
+ 	win32/untar.c \
+-	win32/wspell.c \
+-	win32/pidgin_dll_rc.rc
++	win32/wspell.c
+ 
+-libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
++libpidgin_la_DEPENDENCIES = win32/pidgin_dll_rc.o
++libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED) -Wl,win32/pidgin_dll_rc.o
+ libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
+ 
+ pidgin_LDFLAGS = -mwindows
+diff -aurN 003/source/pidgin/plugins/musicmessaging/Makefile.am 004/source/pidgin/plugins/musicmessaging/Makefile.am
+--- 003/source/pidgin/plugins/musicmessaging/Makefile.am
++++ 004/source/pidgin/plugins/musicmessaging/Makefile.am
+@@ -7,7 +7,7 @@
+ musicmessagingdir = $(libdir)/pidgin
+ endif
+ 
+-musicmessaging_la_LDFLAGS = -module -avoid-version
++musicmessaging_la_LDFLAGS = -module -avoid-version -no-undefined
+ 
+ if PLUGINS
+ if ENABLE_DBUS
+diff -aurN 003/source/pidgin/win32/pidgin_dll_rc.rc.in 004/source/pidgin/win32/pidgin_dll_rc.rc.in
+--- 003/source/pidgin/win32/pidgin_dll_rc.rc.in
++++ 004/source/pidgin/win32/pidgin_dll_rc.rc.in
+@@ -4,8 +4,8 @@
+ #include "pidgin.h"
+ 
+ VS_VERSION_INFO VERSIONINFO
+-  FILEVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
+-  PRODUCTVERSION PURPLE_MAJOR_VERSION,PURPLE_MINOR_VERSION,PURPLE_MICRO_VERSION,0
++  FILEVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
++  PRODUCTVERSION @PURPLE_MAJOR_VERSION@,@PURPLE_MINOR_VERSION@,@PURPLE_MICRO_VERSION@,0
+   FILEFLAGSMASK 0
+   FILEFLAGS 0
+   FILEOS VOS__WINDOWS32

--- a/mingw-w64-pidgin++/005-fix-save-suffix.patch
+++ b/mingw-w64-pidgin++/005-fix-save-suffix.patch
@@ -1,0 +1,12 @@
+diff -aurN 004/source/libpurple/util.c 005/source/libpurple/util.c
+--- 004/source/libpurple/util.c
++++ 005/source/libpurple/util.c
+@@ -2719,7 +2719,7 @@
+ 		g_free(filename_temp);
+ 		return FALSE;
+ 	}
+-#ifndef __COVERITY__
++#if !defined(__COVERITY__) && !defined(_WIN32)
+ 	/* Use stat to be absolutely sure.
+ 	 * It causes TOCTOU coverity warning (against g_rename below),
+ 	 * but it's not a threat for us.

--- a/mingw-w64-pidgin++/006-gtk-customizations.patch
+++ b/mingw-w64-pidgin++/006-gtk-customizations.patch
@@ -1,0 +1,22 @@
+diff -aurN 005/source/pidgin/win32/gtkwin32dep.c 006/source/pidgin/win32/gtkwin32dep.c
+--- 005/source/pidgin/win32/gtkwin32dep.c
++++ 006/source/pidgin/win32/gtkwin32dep.c
+@@ -393,6 +393,7 @@
+ void winpidgin_init(HINSTANCE hint) {
+ 	gchar *debug_dir, *locale_debug_dir;
+ 	INITCOMMONCONTROLSEX icc;
++	GtkSettings *settings;
+ 
+ 	purple_debug_info("winpidgin", "winpidgin_init start\n");
+ 
+@@ -401,6 +402,10 @@
+ 	icc.dwICC = ICC_STANDARD_CLASSES;
+ 	InitCommonControlsEx(&icc);
+ 
++	/* Set GTK+ theme */
++	settings = gtk_settings_get_default();
++	gtk_settings_set_string_property(settings, "gtk-theme-name", APPLICATION_NAME, NULL);
++
+ 	exe_hInstance = hint;
+ 	debug_dir = g_build_filename(purple_user_dir(), "pidgin.rpt", NULL);
+ 	locale_debug_dir = g_locale_from_utf8(debug_dir, -1, NULL, NULL, NULL);

--- a/mingw-w64-pidgin++/PKGBUILD
+++ b/mingw-w64-pidgin++/PKGBUILD
@@ -1,152 +1,152 @@
-# $Id$
-# MSYS2:
-# Maintainer: Ray Donnelly <mingw.android@gmail.com>
-# Arch Linux:
-# Maintainer: Evangelos Foutras <evangelos@foutrelis.com>
-# Contributor: Ionut Biru <ibiru@archlinux.org>
-# Contributor: Andrea Scarpino <andrea@archlinux.org>
-# Contributor: Alexander Fehr <pizzapunk gmail com>
-# Contributor: Lucien Immink <l.immink@student.fnt.hvu.nl>
+# Maintainer: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Zach Bacon <11doctorwhocanada@gmail.com>
 
-_realname=pidgin++
-pkgbase=mingw-w64-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
-         "${MINGW_PACKAGE_PREFIX}-libpurple"
-         "${MINGW_PACKAGE_PREFIX}-finch")
-pkgver=73
-pkgrel=2
+_realname='pidgin++'
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=15.1
+pkgrel=1
+pkgdesc='An improved version of Pidgin (mingw-w64)'
+url='http://pidgin.renatosilva.net'
+license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
 arch=('any')
-url="https://code.launchpad.net/pidgin++/"
-license=('GPL')
 
-makedepends=('python2'
-             "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
-             "ca-certificates"
-             'intltool')
-# source=(https://downloads.sourceforge.net/project/$pkgname/Pidgin/$pkgver/$pkgname-$pkgver.tar.bz2{,.asc})
-source=(~renatosilva-${pkgname}-trunk-${pkgver}.tgz::https://bazaar.launchpad.net/~renatosilva/pidgin++/trunk/tarball/${pkgver})
-sha256sums=('SKIP')
+options=(!libtool strip staticlibs)
+source=(${_realname}_${pkgver}.zip::"https://launchpad.net/${_realname}/trunk/${pkgver}/+download/Pidgin++%20${pkgver}%20Source.zip"
+        001-autotools-and-fhs-pidgin.patch
+        002-autotools-and-fhs-pidgin++.patch
+        003-autotools-and-fhs-adaptation.patch
+        004-build-fixes.patch
+        005-fix-save-suffix.patch
+        006-gtk-customizations.patch)
+sha256sums=('9c19ffbbc3d31c7bb33cc765b734bf58b3a8a0e0b97f9750358e0ccc0fa730e9'
+            'f73f7df412985b2d759f0efbbd817b02f2a283c350be9e22d0f5c9b6ee4593c1'
+            '2af6a6267db17a4d4b9b72da1ed345848c85d3822c984cc3e3b0d3c2a2af82b6'
+            '350f60efa7b09c6f2a97b21d24fb3e40531022e2c3739657fead7ff9fdec4260'
+            '020e5ade9001da1df5e62330dd49e02de011497552636faf6b626de8ed2f0ff6'
+            'bf587810750a4f0c54a692994f5eff369cd0afd026a6f7efbda7595f64a63de6'
+            '2545720a791ec20ca4e49a24a6771fa58d8170b6c33a22b35fb4fcc9ce73ec1b')
+
+conflicts=(${MINGW_PACKAGE_PREFIX}-pidgin)
+provides=(${MINGW_PACKAGE_PREFIX}-pidgin
+          ${MINGW_PACKAGE_PREFIX}-libpurple)
+depends=(${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme
+         ${MINGW_PACKAGE_PREFIX}-ca-certificates
+         #${MINGW_PACKAGE_PREFIX}-cyrus-sasl
+         #${MINGW_PACKAGE_PREFIX}-dbus
+         ${MINGW_PACKAGE_PREFIX}-drmingw
+         #${MINGW_PACKAGE_PREFIX}-farstream
+         ${MINGW_PACKAGE_PREFIX}-freetype
+         ${MINGW_PACKAGE_PREFIX}-fontconfig
+         ${MINGW_PACKAGE_PREFIX}-gettext
+         ${MINGW_PACKAGE_PREFIX}-gnutls
+         ${MINGW_PACKAGE_PREFIX}-gsasl
+         ${MINGW_PACKAGE_PREFIX}-gst-plugins-base
+         ${MINGW_PACKAGE_PREFIX}-gst-plugins-good
+         ${MINGW_PACKAGE_PREFIX}-gtk2
+         ${MINGW_PACKAGE_PREFIX}-gtkspell
+         ${MINGW_PACKAGE_PREFIX}-libgadu
+         ${MINGW_PACKAGE_PREFIX}-libidn
+         #${MINGW_PACKAGE_PREFIX}-libxml2
+         ${MINGW_PACKAGE_PREFIX}-meanwhile
+         #${MINGW_PACKAGE_PREFIX}-nspr
+         ${MINGW_PACKAGE_PREFIX}-nss
+         ${MINGW_PACKAGE_PREFIX}-ncurses
+         ${MINGW_PACKAGE_PREFIX}-silc-toolkit
+         ${MINGW_PACKAGE_PREFIX}-winsparkle
+         ${MINGW_PACKAGE_PREFIX}-zlib)
+makedepends=(gtk-doc rsync easyoptions
+             #${MINGW_PACKAGE_PREFIX}-dbus-glib
+             ${MINGW_PACKAGE_PREFIX}-doxygen
+             ${MINGW_PACKAGE_PREFIX}-gcc
+             ${MINGW_PACKAGE_PREFIX}-pkg-config
+             ${MINGW_PACKAGE_PREFIX}-python2
+             ${MINGW_PACKAGE_PREFIX}-xmlstarlet)
+
+_get_string_macro() {
+    local -n nameref_macro="${2}"
+    nameref_macro="$(grep --extended-regexp "#define\s+${2}\s" ${1})"
+    nameref_macro="${nameref_macro#*\"}"
+    nameref_macro="${nameref_macro%\"*}"
+}
+
 prepare() {
-  [ -d "${srcdir}"/${_realname}-${pkgver}-${CARCH} ] && rm -rf "${srcdir}"/${_realname}-${pkgver}-${CARCH}
-  mv "${srcdir}"/~renatosilva/pidgin++/trunk/source "${srcdir}"/${_realname}-${pkgver}-${CARCH}
-  cd "${srcdir}"/${_realname}-${pkgver}-${CARCH}
+    cd "${srcdir}/${_realname}_${pkgver}"
 
-  # Use Python 2
-  sed -i 's/env python$/&2/' */plugins/*.py \
-    libpurple/purple-{remote,notifications-example,url-handler}
+    # From https://build.opensuse.org/package/view_file/windows:mingw:win32/mingw32-pidgin/pidgin-2.10.11-autotools.patch
+    rm -f source/pidgin/plugins/win32/Makefile.am
+    rm -f source/pidgin/plugins/win32/transparency/Makefile.am
+    rm -f source/pidgin/plugins/win32/winprefs/Makefile.am
+    patch -p1 < "${srcdir}/001-autotools-and-fhs-pidgin.patch"
+    patch -p1 < "${srcdir}/002-autotools-and-fhs-pidgin++.patch"
+
+    patch -p1 < "${srcdir}/003-autotools-and-fhs-adaptation.patch"
+    patch -p1 < "${srcdir}/004-build-fixes.patch"
+    patch -p1 < "${srcdir}/005-fix-save-suffix.patch"
+    patch -p1 < "${srcdir}/006-gtk-customizations.patch"
+
+    cd source
+    libtoolize --force --copy --install
+    autoreconf -f -i
 }
 
 build() {
-  cd "${srcdir}"/${_realname}-${pkgver}-${CARCH}
-# Need to patch
-#  ../configure \
-#    --prefix=${MINGW_PREFIX} \
-#    --sysconfdir=/etc \
-#    --disable-schemas-install \
-#    --disable-meanwhile \
-#    --disable-gnutls \
-#    --enable-cyrus-sasl \
-#    --disable-doxygen \
-#    --enable-nm \
-#    --with-python=/usr/bin/python2 \
-#    --with-system-ssl-certs=/etc/ssl/certs
-  GTK_TOP=${MINGW_PREFIX} DATADIR=${MINGW_PREFIX}/share LIBXML2_TOP=${MINGW_PREFIX} make -f Makefile.mingw
+    msg2 'Synchronizing build directory'
+    rsync --recursive --times "${srcdir}/${_realname}_${pkgver}/source"/* "${srcdir}/${_realname}_${pkgver}.build.${CARCH}"
+    cd "${srcdir}/${_realname}_${pkgver}.build.${CARCH}"
+
+    case "${CARCH}" in
+        x86_64) APPLICATION_BITNESS='64' ;;
+        i686)   APPLICATION_BITNESS='32' ;;
+        *)      APPLICATION_BITNESS='BITNESS'
+    esac
+    _get_string_macro 'libpurple/internal.h' APPLICATION_NAME
+    _get_string_macro 'libpurple/internal.h' APPLICATION_WEBSITE
+
+    sed -i "s#env python#env python2#" */plugins/*.py
+    sed -i "s#env python#env python2#" libpurple/purple-{remote,notifications-example,url-handler}
+    sed -i "s/@APPLICATION_BITNESS@/${APPLICATION_BITNESS:-bitness}/g" */win32/*.rc.in
+    sed -i "s/@APPLICATION_WEBSITE@/${APPLICATION_WEBSITE//\//\\\/}/g" */win32/*.rc.in
+    sed -i "s/@APPLICATION_NAME@/${APPLICATION_NAME}/g" */win32/*.rc.in
+
+    CPPFLAGS+=' -DENABLE_UPDATE_CHECK'
+    CPPFLAGS+=' -D_WIN32_WINNT=0x501 -DHAVE_GETADDRINFO' # Enable IPv6
+
+    INTLTOOL_PERL=/usr/bin/perl ./configure \
+        --prefix=${MINGW_PREFIX} \
+        --build=${MINGW_CHOST} \
+        --host=${MINGW_CHOST} \
+        --sysconfdir=${MINGW_PREFIX}/etc \
+        --with-python=${MINGW_PREFIX}/bin/python2 \
+        --with-system-ssl-certs=${MINGW_PREFIX}/ssl/certs \
+        --without-x \
+        --disable-avahi \
+        --disable-schemas-install \
+        --disable-screensaver \
+        --disable-perl \
+        --disable-tcl \
+        --disable-tk \
+        --disable-sm \
+        --disable-nm \
+        --disable-vv \
+        --disable-dbus \
+        #--enable-cyrus-sasl
+
+    make
 }
 
-package_pidgin++(){
-  pkgdesc="Multi-protocol instant messaging client"
-  depends=("${MINGW_PACKAGE_PREFIX}-libpurple=$pkgver-$pkgrel"
-           "${MINGW_PACKAGE_PREFIX}-gtkspell"
-           "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme")
-  optdepends=('aspell: for spelling correction')
-  install=pidgin.install
+package() {
+    cd "${srcdir}/${_realname}_${pkgver}.build.${CARCH}"
+    make DESTDIR="${pkgdir}" install
+    install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 
-  cd "${srcdir}"/${_realname}-${pkgver}-${CARCH}
+    # GTK+ customizations
+    cp -r "${srcdir}/${_realname}_${pkgver}/source/pidgin/win32/gtk"/* "${pkgdir}${MINGW_PREFIX}"
+    cd "${pkgdir}${MINGW_PREFIX}/share/themes"
+    mv MS-Windows "${APPLICATION_NAME}"
 
-  # For linking
-  make -C libpurple DESTDIR="$pkgdir" install-libLTLIBRARIES
-
-  make -C pidgin DESTDIR="$pkgdir" install
-  make -C doc DESTDIR="$pkgdir" install
-
-  # Remove files that are packaged in libpurle
-  make -C libpurple DESTDIR="$pkgdir" uninstall-libLTLIBRARIES
-
-  install -Dm644 pidgin.desktop "$pkgdir"/usr/share/applications/pidgin.desktop
-
-  rm "$pkgdir/usr/share/man/man1/finch.1"
+    # Changelog
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+    cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+    "${srcdir}/${_realname}_${pkgver}/build/changelog.sh" --html --screenshot-prefix '../../' --output 'CHANGELOG.html'
 }
-
-package_libpurple(){
-  pkgdesc="IM library extracted from Pidgin"
-  depends=("${MINGW_PACKAGE_PREFIX}-gsasl"
-           "${MINGW_PACKAGE_PREFIX}-libidn"
-           "${MINGW_PACKAGE_PREFIX}-dbus-glib"
-           "${MINGW_PACKAGE_PREFIX}-nss")
-  optdepends=('avahi: Bonjour protocol support'
-              'ca-certificates: SSL CA certificates'
-              'python2-dbus: for purple-remote and purple-url-handler'
-              '${MINGW_PACKAGE_PREFIX}-tk: Tcl/Tk scripting support')
-
-  cd "${srcdir}"/${_realname}-${pkgver}-${CARCH}
-
-  for _dir in libpurple share/sounds share/ca-certs m4macros po; do
-    make -C "$_dir" DESTDIR="$pkgdir" install
-  done
-
-  # Remove GConf schema file
-  rm "$pkgdir/etc/gconf/schemas/purple.schemas"
-  rmdir "$pkgdir"/etc{/gconf{/schemas,},}
-}
-
-package_finch(){
-  pkgdesc="A ncurses-based messaging client"
-  depends=("${MINGW_PACKAGE_PREFIX}-libpurple=$pkgver-$pkgrel"
-           "${MINGW_PACKAGE_PREFIX}-ncurses"
-           "${MINGW_PACKAGE_PREFIX}-python2")
-
-  cd "${srcdir}"/${_realname}-${pkgver}-${CARCH}
-
-  # For linking
-  make -C libpurple DESTDIR="$pkgdir" install-libLTLIBRARIES
-
-  make -C finch DESTDIR="$pkgdir" install
-  make -C doc DESTDIR="$pkgdir" install
-
-  # Remove files that are packaged in libpurle
-  make -C libpurple DESTDIR="$pkgdir" uninstall-libLTLIBRARIES
-
-  rm "$pkgdir"/${MINGW_PREFIX}/share/man/man1/pidgin.1
-}
-
-package_mingw-w64-x86_64-pidgin++ ()
-{
-  package_pidgin++
-}
-
-package_mingw-w64-i686-pidgin++ ()
-{
-  package_pidgin
-}
-
-package_mingw-w64-x86_64-libpurple ()
-{
-package_libpurple
-}
-
-package_mingw-w64-i686-libpurple ()
-{
-  package_libpurple
-}
-
-package_mingw-w64-x86_64-finch ()
-{
-  package_finch
-}
-
-package_mingw-w64-i686-finch ()
-{
-  package_finch
-}
-
-# vim:set ts=2 sw=2 et:

--- a/mingw-w64-pidgin-hg/001-build-fixes.patch
+++ b/mingw-w64-pidgin-hg/001-build-fixes.patch
@@ -1,6 +1,7 @@
---- ./libpurple/Makefile.am.orig	2015-05-17 21:54:49.202429500 +0200
-+++ ./libpurple/Makefile.am	2015-05-17 23:06:31.848670500 +0200
-@@ -463,6 +463,7 @@
+diff -aurN 000/libpurple/Makefile.am 001/libpurple/Makefile.am
+--- 000/libpurple/Makefile.am
++++ 001/libpurple/Makefile.am
+@@ -467,6 +467,7 @@
  INTROSPECTION_GIRS =
  INTROSPECTION_SCANNER_ARGS = --add-include-path=$(prefix)/share/gir-1.0 --warn-all
  INTROSPECTION_COMPILER_ARGS = --includedir=$(prefix)/share/gir-1.0
@@ -8,7 +9,7 @@
  
  if HAVE_INTROSPECTION
  introspection_sources = \
-@@ -480,7 +481,7 @@
+@@ -484,7 +485,7 @@
  endif
  
  Purple_3_0_gir_CFLAGS = \
@@ -17,7 +18,7 @@
  	$(INCLUDES) \
  	-DDATADIR=\"$(datadir)\" \
  	-DLIBDIR=\"$(libdir)/purple-$(PURPLE_MAJOR_VERSION)/\" \
-@@ -506,10 +507,10 @@
+@@ -510,10 +511,10 @@
  Purple_3_0_gir_FILES = $(introspection_sources)
  INTROSPECTION_GIRS += Purple-$(PURPLE_MAJOR_VERSION).$(PURPLE_MINOR_VERSION).gir
  
@@ -30,8 +31,25 @@
  typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
  
  CLEANFILES += $(gir_DATA) $(typelib_DATA)
---- ./pidgin/Makefile.am.orig	2015-05-17 21:54:49.224430000 +0200
-+++ ./pidgin/Makefile.am	2015-05-17 23:07:16.130585900 +0200
+diff -aurN 000/pidgin/libpidgin.c 001/pidgin/libpidgin.c
+--- 000/pidgin/libpidgin.c
++++ 001/pidgin/libpidgin.c
+@@ -441,11 +441,11 @@
+ 	GIOChannel *signal_channel;
+ 	GIOStatus signal_status;
+ 	guint signal_channel_watcher;
+-	GError *error;
+ #ifndef DEBUG
+ 	char *segfault_message_tmp;
+ #endif /* DEBUG */
+ #endif /* HAVE_SIGNAL_N */
++	GError *error;
+ 	int opt;
+ 	gboolean gui_check;
+ 	gboolean debug_enabled, debug_colored;
+diff -aurN 000/pidgin/Makefile.am 001/pidgin/Makefile.am
+--- 000/pidgin/Makefile.am
++++ 001/pidgin/Makefile.am
 @@ -266,6 +266,7 @@
  INTROSPECTION_GIRS =
  INTROSPECTION_SCANNER_ARGS = --warn-all --add-include-path=$(top_builddir)/libpurple --add-include-path=$(prefix)/share/gir-1.0

--- a/mingw-w64-pidgin-hg/002-finch-fixes.patch
+++ b/mingw-w64-pidgin-hg/002-finch-fixes.patch
@@ -1,0 +1,25 @@
+diff -aurN 001/configure.ac 002/configure.ac
+--- 001/configure.ac
++++ 002/configure.ac
+@@ -828,7 +828,7 @@
+ 	    [enable_consoleui=no], [$GNT_LIBS])
+ 
+ 	if test "x$is_win32" = "xyes" ; then
+-		ncurses_sys_prefix="/usr/$host/sys-root/mingw"
++		ncurses_sys_prefix="$(cygpath --mixed $prefix)"
+ 	else
+ 		ncurses_sys_prefix="/usr"
+ 	fi
+diff -aurN 001/finch/libgnt/Makefile.am 002/finch/libgnt/Makefile.am
+--- 001/finch/libgnt/Makefile.am
++++ 002/finch/libgnt/Makefile.am
+@@ -90,7 +90,8 @@
+ 	$(GNT_LIBS) \
+ 	$(LIBXML_LIBS) \
+ 	$(INTROSPECTION_LIBS) \
+-	$(PY_LIBS)
++	$(PY_LIBS) \
++	-lncursesw
+ 
+ if IS_WIN32
+ 

--- a/mingw-w64-pidgin-hg/PKGBUILD
+++ b/mingw-w64-pidgin-hg/PKGBUILD
@@ -1,16 +1,21 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
+# Contributor: Renato Silva <br.renatosilva@gmail.com>
 
 _realname=pidgin
 pkgbase=mingw-w64-${_realname}-hg
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-hg"
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=r37207.e666f49a3e86
+provides=(${MINGW_PACKAGE_PREFIX}-${_realname}
+          ${MINGW_PACKAGE_PREFIX}-libpurple
+          ${MINGW_PACKAGE_PREFIX}-finch)
+conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname}
+          ${MINGW_PACKAGE_PREFIX}-libpurple
+          ${MINGW_PACKAGE_PREFIX}-finch)
+pkgver=r37643+.90e4018f26ea+
 pkgrel=1
 pkgdesc="Multi-protocol instant messaging client (mingw-w64)"
 arch=('any')
 url="http://pidgin.im/"
-license=("GPL")
+license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
 makedepends=("${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
@@ -37,9 +42,11 @@ options=(!libtool strip staticlibs)
 
 source=(${_realname}::"hg+https://hg.pidgin.im/pidgin/main"
         #"https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.bz2"
-        001-win.patch)
+        001-build-fixes.patch
+        002-finch-fixes.patch)
 sha256sums=('SKIP'
-            '65bc5f9e8dab874c483e08745a324c6c0e958e9ef3004f1cd8bf574fd7fe3712')
+            '9b23f36083330994637f286da6206020e5771164bfa4565c28285ae995a93685'
+            '0f4a19b31e8a947c57aa648e2bba0724bbef019fad46fd9345d1a6280c5e6ae0')
 
 pkgver() {
   cd "${_realname}"
@@ -49,7 +56,8 @@ pkgver() {
 prepare() {
   cd ${_realname}
 
-  patch -b -V simple -p1 -i ${srcdir}/001-win.patch
+  patch -b -V simple -p1 -i ${srcdir}/001-build-fixes.patch
+  patch -b -V simple -p1 -i ${srcdir}/002-finch-fixes.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }
@@ -58,7 +66,7 @@ build() {
   cd "${srcdir}/${_realname}"
   sed -i "s#env python#env python2#" */plugins/*.py
   sed -i "s#env python#env python2#" libpurple/purple-{remote,notifications-example,url-handler}
-  ./configure \
+  INTLTOOL_PERL=/usr/bin/perl ./configure \
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
@@ -68,9 +76,11 @@ build() {
       --disable-screensaver \
       --disable-sm \
       --disable-nm \
+      --disable-dbus \
       --with-python=${MINGW_PREFIX}/bin/python2 \
       --with-system-ssl-certs=${MINGW_PREFIX}/ssl/certs \
       --with-win32-dirs=fhs \
+      --enable-consoleui \
       #--enable-cyrus-sasl
 
   make

--- a/mingw-w64-pidgin/001-autotools-and-fhs.patch
+++ b/mingw-w64-pidgin/001-autotools-and-fhs.patch
@@ -1,6 +1,6 @@
 diff -aurN 000/configure.ac 001/configure.ac
---- 000/configure.ac	2015-12-31 21:19:40.000000000 -0200
-+++ 001/configure.ac	2016-02-05 15:36:24.296853500 -0200
+--- 000/configure.ac
++++ 001/configure.ac
 @@ -120,10 +120,44 @@
  dnl Check for Sun compiler
  AC_CHECK_DECL([__SUNPRO_C], [SUNCC="yes"], [SUNCC="no"])
@@ -141,8 +141,8 @@ diff -aurN 000/configure.ac 001/configure.ac
  		   share/ca-certs/Makefile
  		   finch/finch.pc
 diff -aurN 000/finch/finch.c 001/finch/finch.c
---- 000/finch/finch.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/finch/finch.c	2016-02-05 15:36:24.312475100 -0200
+--- 000/finch/finch.c
++++ 001/finch/finch.c
 @@ -383,7 +383,7 @@
  	purple_plugins_add_search_path(path);
  	g_free(path);
@@ -153,8 +153,8 @@ diff -aurN 000/finch/finch.c 001/finch/finch.c
  	if (!purple_core_init(FINCH_UI))
  	{
 diff -aurN 000/finch/gntsound.c 001/finch/gntsound.c
---- 000/finch/gntsound.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/finch/gntsound.c	2016-02-05 15:36:24.312475100 -0200
+--- 000/finch/gntsound.c
++++ 001/finch/gntsound.c
 @@ -616,7 +616,7 @@
  		if (!filename || !strlen(filename)) {
  			g_free(filename);
@@ -165,8 +165,8 @@ diff -aurN 000/finch/gntsound.c 001/finch/gntsound.c
  
  		purple_sound_play_file(filename, NULL);
 diff -aurN 000/finch/libgnt/wms/Makefile.am 001/finch/libgnt/wms/Makefile.am
---- 000/finch/libgnt/wms/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/finch/libgnt/wms/Makefile.am	2016-02-05 15:36:24.328099700 -0200
+--- 000/finch/libgnt/wms/Makefile.am
++++ 001/finch/libgnt/wms/Makefile.am
 @@ -29,7 +29,7 @@
  EXTRA_DIST = 
  
@@ -177,8 +177,8 @@ diff -aurN 000/finch/libgnt/wms/Makefile.am 001/finch/libgnt/wms/Makefile.am
  	-I$(top_srcdir)/finch \
  	-I$(top_srcdir)/finch/libgnt \
 diff -aurN 000/finch/Makefile.am 001/finch/Makefile.am
---- 000/finch/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/finch/Makefile.am	2016-02-05 15:36:24.328099700 -0200
+--- 000/finch/Makefile.am
++++ 001/finch/Makefile.am
 @@ -78,11 +78,11 @@
  	$(top_builddir)/libpurple/libpurple.la
  
@@ -195,8 +195,8 @@ diff -aurN 000/finch/Makefile.am 001/finch/Makefile.am
  	-I$(top_srcdir) \
  	-I$(srcdir)/libgnt/ \
 diff -aurN 000/finch/plugins/Makefile.am 001/finch/plugins/Makefile.am
---- 000/finch/plugins/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/finch/plugins/Makefile.am	2016-02-05 15:36:24.343729500 -0200
+--- 000/finch/plugins/Makefile.am
++++ 001/finch/plugins/Makefile.am
 @@ -39,7 +39,7 @@
  EXTRA_DIST = pietray.py
  
@@ -207,8 +207,8 @@ diff -aurN 000/finch/plugins/Makefile.am 001/finch/plugins/Makefile.am
  	-I$(top_srcdir)/libpurple \
  	-I$(top_srcdir) \
 diff -aurN 000/libpurple/certificate.c 001/libpurple/certificate.c
---- 000/libpurple/certificate.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/certificate.c	2016-02-05 15:36:24.359350100 -0200
+--- 000/libpurple/certificate.c
++++ 001/libpurple/certificate.c
 @@ -856,15 +856,15 @@
  {
  	/* Attempt to point at the appropriate system path */
@@ -229,8 +229,8 @@ diff -aurN 000/libpurple/certificate.c 001/libpurple/certificate.c
  	}
  
 diff -aurN 000/libpurple/data/purple.pc.in 001/libpurple/data/purple.pc.in
---- 000/libpurple/data/purple.pc.in	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/data/purple.pc.in	2016-02-05 15:36:24.359350100 -0200
+--- 000/libpurple/data/purple.pc.in
++++ 001/libpurple/data/purple.pc.in
 @@ -13,5 +13,5 @@
  Description: libpurple is a GLib-based instant messenger library.
  Version: @VERSION@
@@ -239,8 +239,8 @@ diff -aurN 000/libpurple/data/purple.pc.in 001/libpurple/data/purple.pc.in
 +Cflags: -I${includedir}/libpurple -I${includedir}/libpurple/win32
  Libs: -L${libdir} -lpurple
 diff -aurN 000/libpurple/dnsquery.c 001/libpurple/dnsquery.c
---- 000/libpurple/dnsquery.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/dnsquery.c	2016-02-05 15:36:24.374975100 -0200
+--- 000/libpurple/dnsquery.c
++++ 001/libpurple/dnsquery.c
 @@ -744,7 +744,8 @@
  
  	query_data = data;
@@ -252,8 +252,8 @@ diff -aurN 000/libpurple/dnsquery.c 001/libpurple/dnsquery.c
  		rc = purple_network_convert_idn_to_ascii(query_data->hostname, &hostname);
  		if (rc != 0) {
 diff -aurN 000/libpurple/example/Makefile.am 001/libpurple/example/Makefile.am
---- 000/libpurple/example/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/example/Makefile.am	2016-02-05 15:36:24.374975100 -0200
+--- 000/libpurple/example/Makefile.am
++++ 001/libpurple/example/Makefile.am
 @@ -12,11 +12,9 @@
  	$(top_builddir)/libpurple/libpurple.la
  
@@ -268,8 +268,8 @@ diff -aurN 000/libpurple/example/Makefile.am 001/libpurple/example/Makefile.am
  	-I$(top_srcdir)/libpurple \
  	-I$(top_srcdir) \
 diff -aurN 000/libpurple/example/nullclient.c 001/libpurple/example/nullclient.c
---- 000/libpurple/example/nullclient.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/example/nullclient.c	2016-02-05 15:36:24.390600400 -0200
+--- 000/libpurple/example/nullclient.c
++++ 001/libpurple/example/nullclient.c
 @@ -308,7 +308,11 @@
  	account = purple_account_new(name, prpl);
  
@@ -283,8 +283,8 @@ diff -aurN 000/libpurple/example/nullclient.c 001/libpurple/example/nullclient.c
  
  	/* It's necessary to enable the account first. */
 diff -aurN 000/libpurple/Makefile.am 001/libpurple/Makefile.am
---- 000/libpurple/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/Makefile.am	2016-02-05 15:36:24.406226800 -0200
+--- 000/libpurple/Makefile.am
++++ 001/libpurple/Makefile.am
 @@ -15,21 +15,25 @@
  		data/purple-uninstalled.pc.in \
  		win32/global.mak \
@@ -401,8 +401,8 @@ diff -aurN 000/libpurple/Makefile.am 001/libpurple/Makefile.am
  # We want to use SSL_CERTIFICATES_DIR when it's not empty.
  if ! INSTALL_SSL_CERTIFICATES
 diff -aurN 000/libpurple/plugin.c 001/libpurple/plugin.c
---- 000/libpurple/plugin.c	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/plugin.c	2016-02-05 15:36:24.406226800 -0200
+--- 000/libpurple/plugin.c
++++ 001/libpurple/plugin.c
 @@ -1179,7 +1179,7 @@
  purple_plugins_init(void) {
  	void *handle = purple_plugins_get_handle();
@@ -413,8 +413,8 @@ diff -aurN 000/libpurple/plugin.c 001/libpurple/plugin.c
  	purple_signal_register(handle, "plugin-load",
  						 purple_marshal_VOID__POINTER,
 diff -aurN 000/libpurple/plugins/Makefile.am 001/libpurple/plugins/Makefile.am
---- 000/libpurple/plugins/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/plugins/Makefile.am	2016-02-05 15:36:24.421850700 -0200
+--- 000/libpurple/plugins/Makefile.am
++++ 001/libpurple/plugins/Makefile.am
 @@ -24,27 +24,27 @@
  
  plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
@@ -532,8 +532,8 @@ diff -aurN 000/libpurple/plugins/Makefile.am 001/libpurple/plugins/Makefile.am
  # This part allows people to build their own plugins in here.
  # Yes, it's a mess.
 diff -aurN 000/libpurple/plugins/perl/Makefile.am 001/libpurple/plugins/perl/Makefile.am
---- 000/libpurple/plugins/perl/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/plugins/perl/Makefile.am	2016-02-05 15:36:24.421850700 -0200
+--- 000/libpurple/plugins/perl/Makefile.am
++++ 001/libpurple/plugins/perl/Makefile.am
 @@ -165,7 +165,6 @@
  	-I$(top_srcdir) \
  	-I$(top_srcdir)/libpurple \
@@ -543,8 +543,8 @@ diff -aurN 000/libpurple/plugins/perl/Makefile.am 001/libpurple/plugins/perl/Mak
  	$(GLIB_CFLAGS) \
  	$(PLUGIN_CFLAGS) \
 diff -aurN 000/libpurple/plugins/ssl/Makefile.am 001/libpurple/plugins/ssl/Makefile.am
---- 000/libpurple/plugins/ssl/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/plugins/ssl/Makefile.am	2016-02-05 15:36:24.437476400 -0200
+--- 000/libpurple/plugins/ssl/Makefile.am
++++ 001/libpurple/plugins/ssl/Makefile.am
 @@ -3,10 +3,10 @@
  
  plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
@@ -595,8 +595,8 @@ diff -aurN 000/libpurple/plugins/ssl/Makefile.am 001/libpurple/plugins/ssl/Makef
  ssl_nss_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
  nss_prefs_la_CFLAGS = $(AM_CPPFLAGS) $(NSS_CFLAGS)
 diff -aurN 000/libpurple/plugins/tcl/Makefile.am 001/libpurple/plugins/tcl/Makefile.am
---- 000/libpurple/plugins/tcl/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/plugins/tcl/Makefile.am	2016-02-05 15:36:24.437476400 -0200
+--- 000/libpurple/plugins/tcl/Makefile.am
++++ 001/libpurple/plugins/tcl/Makefile.am
 @@ -1,13 +1,13 @@
  plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
  
@@ -624,8 +624,8 @@ diff -aurN 000/libpurple/plugins/tcl/Makefile.am 001/libpurple/plugins/tcl/Makef
 +endif
 \ No newline at end of file
 diff -aurN 000/libpurple/protocols/bonjour/Makefile.am 001/libpurple/protocols/bonjour/Makefile.am
---- 000/libpurple/protocols/bonjour/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/protocols/bonjour/Makefile.am	2016-02-05 15:36:24.453101100 -0200
+--- 000/libpurple/protocols/bonjour/Makefile.am
++++ 001/libpurple/protocols/bonjour/Makefile.am
 @@ -40,7 +40,7 @@
  st =
  pkg_LTLIBRARIES       = libbonjour.la
@@ -636,8 +636,8 @@ diff -aurN 000/libpurple/protocols/bonjour/Makefile.am 001/libpurple/protocols/b
  endif
  
 diff -aurN 000/libpurple/protocols/gg/Makefile.am 001/libpurple/protocols/gg/Makefile.am
---- 000/libpurple/protocols/gg/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/protocols/gg/Makefile.am	2016-02-05 15:36:24.453101100 -0200
+--- 000/libpurple/protocols/gg/Makefile.am
++++ 001/libpurple/protocols/gg/Makefile.am
 @@ -96,6 +96,10 @@
  	$(GNUTLS_CFLAGS) \
  	-DGG_IGNORE_DEPRECATED
@@ -684,8 +684,8 @@ diff -aurN 000/libpurple/protocols/gg/Makefile.am 001/libpurple/protocols/gg/Mak
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/irc/Makefile.am 001/libpurple/protocols/irc/Makefile.am
---- 000/libpurple/protocols/irc/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/protocols/irc/Makefile.am	2016-02-05 15:36:24.468726700 -0200
+--- 000/libpurple/protocols/irc/Makefile.am
++++ 001/libpurple/protocols/irc/Makefile.am
 @@ -13,7 +13,7 @@
  
  AM_CFLAGS = $(st)
@@ -714,8 +714,8 @@ diff -aurN 000/libpurple/protocols/irc/Makefile.am 001/libpurple/protocols/irc/M
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/jabber/Makefile.am 001/libpurple/protocols/jabber/Makefile.am
---- 000/libpurple/protocols/jabber/Makefile.am	2015-12-31 21:19:40.000000000 -0200
-+++ 001/libpurple/protocols/jabber/Makefile.am	2016-02-05 15:36:24.468726700 -0200
+--- 000/libpurple/protocols/jabber/Makefile.am
++++ 001/libpurple/protocols/jabber/Makefile.am
 @@ -95,7 +95,8 @@
  
  AM_CFLAGS = $(st)
@@ -761,8 +761,8 @@ diff -aurN 000/libpurple/protocols/jabber/Makefile.am 001/libpurple/protocols/ja
 +endif
 +
 diff -aurN 000/libpurple/protocols/msn/Makefile.am 001/libpurple/protocols/msn/Makefile.am
---- 000/libpurple/protocols/msn/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/msn/Makefile.am	2016-02-05 15:36:24.484351400 -0200
+--- 000/libpurple/protocols/msn/Makefile.am
++++ 001/libpurple/protocols/msn/Makefile.am
 @@ -77,7 +77,7 @@
  
  AM_CFLAGS = $(st)
@@ -791,8 +791,8 @@ diff -aurN 000/libpurple/protocols/msn/Makefile.am 001/libpurple/protocols/msn/M
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/mxit/Makefile.am 001/libpurple/protocols/mxit/Makefile.am
---- 000/libpurple/protocols/mxit/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/mxit/Makefile.am	2016-02-05 15:36:24.484351400 -0200
+--- 000/libpurple/protocols/mxit/Makefile.am
++++ 001/libpurple/protocols/mxit/Makefile.am
 @@ -40,7 +40,7 @@
  
  AM_CFLAGS = $(st)
@@ -821,8 +821,8 @@ diff -aurN 000/libpurple/protocols/mxit/Makefile.am 001/libpurple/protocols/mxit
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/mxit/markup.c 001/libpurple/protocols/mxit/markup.c
---- 000/libpurple/protocols/mxit/markup.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/mxit/markup.c	2016-02-05 15:36:24.499976000 -0200
+--- 000/libpurple/protocols/mxit/markup.c
++++ 001/libpurple/protocols/mxit/markup.c
 @@ -230,7 +230,7 @@
  		return -1;
  	}
@@ -833,8 +833,8 @@ diff -aurN 000/libpurple/protocols/mxit/markup.c 001/libpurple/protocols/mxit/ma
  		/* not enough bytes left in data! */
  		return -1;
 diff -aurN 000/libpurple/protocols/myspace/Makefile.am 001/libpurple/protocols/myspace/Makefile.am
---- 000/libpurple/protocols/myspace/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/myspace/Makefile.am	2016-02-05 15:36:24.499976000 -0200
+--- 000/libpurple/protocols/myspace/Makefile.am
++++ 001/libpurple/protocols/myspace/Makefile.am
 @@ -19,7 +19,7 @@
  
  AM_CFLAGS = $(st)
@@ -863,8 +863,8 @@ diff -aurN 000/libpurple/protocols/myspace/Makefile.am 001/libpurple/protocols/m
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/novell/Makefile.am 001/libpurple/protocols/novell/Makefile.am
---- 000/libpurple/protocols/novell/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/novell/Makefile.am	2016-02-05 15:36:24.515601700 -0200
+--- 000/libpurple/protocols/novell/Makefile.am
++++ 001/libpurple/protocols/novell/Makefile.am
 @@ -28,7 +28,7 @@
  
  AM_CFLAGS = $(st)
@@ -893,8 +893,8 @@ diff -aurN 000/libpurple/protocols/novell/Makefile.am 001/libpurple/protocols/no
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/null/Makefile.am 001/libpurple/protocols/null/Makefile.am
---- 000/libpurple/protocols/null/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/null/Makefile.am	2016-02-05 15:36:24.515601700 -0200
+--- 000/libpurple/protocols/null/Makefile.am
++++ 001/libpurple/protocols/null/Makefile.am
 @@ -14,10 +14,15 @@
  st =
  pkg_LTLIBRARIES    = libnull.la
@@ -913,8 +913,8 @@ diff -aurN 000/libpurple/protocols/null/Makefile.am 001/libpurple/protocols/null
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/oscar/Makefile.am 001/libpurple/protocols/oscar/Makefile.am
---- 000/libpurple/protocols/oscar/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/oscar/Makefile.am	2016-02-05 15:36:24.515601700 -0200
+--- 000/libpurple/protocols/oscar/Makefile.am
++++ 001/libpurple/protocols/oscar/Makefile.am
 @@ -50,8 +50,9 @@
  
  AM_CFLAGS = $(st)
@@ -956,8 +956,8 @@ diff -aurN 000/libpurple/protocols/oscar/Makefile.am 001/libpurple/protocols/osc
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/sametime/Makefile.am 001/libpurple/protocols/sametime/Makefile.am
---- 000/libpurple/protocols/sametime/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/sametime/Makefile.am	2016-02-05 15:36:24.531226000 -0200
+--- 000/libpurple/protocols/sametime/Makefile.am
++++ 001/libpurple/protocols/sametime/Makefile.am
 @@ -24,8 +24,8 @@
  endif
  
@@ -978,8 +978,8 @@ diff -aurN 000/libpurple/protocols/sametime/Makefile.am 001/libpurple/protocols/
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/silc/Makefile.am 001/libpurple/protocols/silc/Makefile.am
---- 000/libpurple/protocols/silc/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/silc/Makefile.am	2016-02-05 15:36:24.546851000 -0200
+--- 000/libpurple/protocols/silc/Makefile.am
++++ 001/libpurple/protocols/silc/Makefile.am
 @@ -19,7 +19,7 @@
  
  AM_CFLAGS = $(st)
@@ -1008,8 +1008,8 @@ diff -aurN 000/libpurple/protocols/silc/Makefile.am 001/libpurple/protocols/silc
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/simple/Makefile.am 001/libpurple/protocols/simple/Makefile.am
---- 000/libpurple/protocols/simple/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/simple/Makefile.am	2016-02-05 15:36:24.546851000 -0200
+--- 000/libpurple/protocols/simple/Makefile.am
++++ 001/libpurple/protocols/simple/Makefile.am
 @@ -11,7 +11,7 @@
  
  AM_CFLAGS = $(st)
@@ -1038,8 +1038,8 @@ diff -aurN 000/libpurple/protocols/simple/Makefile.am 001/libpurple/protocols/si
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/protocols/yahoo/Makefile.am 001/libpurple/protocols/yahoo/Makefile.am
---- 000/libpurple/protocols/yahoo/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/protocols/yahoo/Makefile.am	2016-02-05 15:36:24.546851000 -0200
+--- 000/libpurple/protocols/yahoo/Makefile.am
++++ 001/libpurple/protocols/yahoo/Makefile.am
 @@ -27,8 +27,9 @@
  
  AM_CFLAGS = $(st)
@@ -1081,8 +1081,8 @@ diff -aurN 000/libpurple/protocols/yahoo/Makefile.am 001/libpurple/protocols/yah
 +	-I$(top_srcdir)/libpurple/win32
 +endif
 diff -aurN 000/libpurple/win32/libc_interface.h 001/libpurple/win32/libc_interface.h
---- 000/libpurple/win32/libc_interface.h	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/win32/libc_interface.h	2016-02-05 15:36:24.562474700 -0200
+--- 000/libpurple/win32/libc_interface.h
++++ 001/libpurple/win32/libc_interface.h
 @@ -23,6 +23,7 @@
  #ifndef _LIBC_INTERFACE_H_
  #define _LIBC_INTERFACE_H_
@@ -1092,8 +1092,8 @@ diff -aurN 000/libpurple/win32/libc_interface.h 001/libpurple/win32/libc_interfa
  #include <io.h>
  #include <errno.h>
 diff -aurN 000/libpurple/win32/libpurplerc.rc.in 001/libpurple/win32/libpurplerc.rc.in
---- 000/libpurple/win32/libpurplerc.rc.in	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/win32/libpurplerc.rc.in	2016-02-05 15:36:24.562474700 -0200
+--- 000/libpurple/win32/libpurplerc.rc.in
++++ 001/libpurple/win32/libpurplerc.rc.in
 @@ -2,8 +2,8 @@
  #include "version.h"
  
@@ -1106,8 +1106,8 @@ diff -aurN 000/libpurple/win32/libpurplerc.rc.in 001/libpurple/win32/libpurplerc
    FILEFLAGS 0
    FILEOS VOS__WINDOWS32
 diff -aurN 000/libpurple/win32/win32dep.c 001/libpurple/win32/win32dep.c
---- 000/libpurple/win32/win32dep.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/win32/win32dep.c	2016-02-05 15:36:24.578100700 -0200
+--- 000/libpurple/win32/win32dep.c
++++ 001/libpurple/win32/win32dep.c
 @@ -28,12 +28,18 @@
  
  #include "debug.h"
@@ -1192,8 +1192,8 @@ diff -aurN 000/libpurple/win32/win32dep.c 001/libpurple/win32/win32dep.c
  }
  
 diff -aurN 000/libpurple/win32/win32dep.h 001/libpurple/win32/win32dep.h
---- 000/libpurple/win32/win32dep.h	2015-12-31 21:19:41.000000000 -0200
-+++ 001/libpurple/win32/win32dep.h	2016-02-05 15:36:24.593725000 -0200
+--- 000/libpurple/win32/win32dep.h
++++ 001/libpurple/win32/win32dep.h
 @@ -65,6 +65,7 @@
  const char *wpurple_install_dir(void);
  const char *wpurple_lib_dir(void);
@@ -1220,8 +1220,8 @@ diff -aurN 000/libpurple/win32/win32dep.h 001/libpurple/win32/win32dep.h
  #ifdef __cplusplus
  }
 diff -aurN 000/pidgin/data/pidgin.pc.in 001/pidgin/data/pidgin.pc.in
---- 000/pidgin/data/pidgin.pc.in	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/data/pidgin.pc.in	2016-02-05 15:36:24.640601300 -0200
+--- 000/pidgin/data/pidgin.pc.in
++++ 001/pidgin/data/pidgin.pc.in
 @@ -12,5 +12,6 @@
  Description: Pidgin is a GTK2-based instant messenger application.
  Version: @VERSION@
@@ -1231,16 +1231,16 @@ diff -aurN 000/pidgin/data/pidgin.pc.in 001/pidgin/data/pidgin.pc.in
 +Libs: -L${libdir} -lpidgin
  
 diff -aurN 000/pidgin/data/pidgin-2.pc.in 001/pidgin/data/pidgin-2.pc.in
---- 000/pidgin/data/pidgin-2.pc.in	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/data/pidgin-2.pc.in	2016-02-05 15:36:24.656234200 -0200
+--- 000/pidgin/data/pidgin-2.pc.in
++++ 001/pidgin/data/pidgin-2.pc.in
 @@ -13,3 +13,4 @@
  Version: @VERSION@
  Requires: gtk+-2.0 purple
  Cflags: -I${includedir}
 +Libs: -L${libdir} -lpidgin
 diff -aurN 000/pidgin/gtkblist.c 001/pidgin/gtkblist.c
---- 000/pidgin/gtkblist.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkblist.c	2016-02-05 15:36:24.671858500 -0200
+--- 000/pidgin/gtkblist.c
++++ 001/pidgin/gtkblist.c
 @@ -3332,14 +3332,14 @@
  	char *path;
  
@@ -1318,8 +1318,8 @@ diff -aurN 000/pidgin/gtkblist.c 001/pidgin/gtkblist.c
  	}
  
 diff -aurN 000/pidgin/gtkdialogs.c 001/pidgin/gtkdialogs.c
---- 000/pidgin/gtkdialogs.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkdialogs.c	2016-02-05 15:36:24.671858500 -0200
+--- 000/pidgin/gtkdialogs.c
++++ 001/pidgin/gtkdialogs.c
 @@ -466,7 +466,7 @@
  	gtk_window_set_default_size(GTK_WINDOW(win), 450, 450);
  
@@ -1330,8 +1330,8 @@ diff -aurN 000/pidgin/gtkdialogs.c 001/pidgin/gtkdialogs.c
  	g_free(filename);
  
 diff -aurN 000/pidgin/gtkdnd-hints.c 001/pidgin/gtkdnd-hints.c
---- 000/pidgin/gtkdnd-hints.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkdnd-hints.c	2016-02-05 15:36:24.718774200 -0200
+--- 000/pidgin/gtkdnd-hints.c
++++ 001/pidgin/gtkdnd-hints.c
 @@ -121,7 +121,7 @@
  	for (i = 0; hint_windows[i].filename != NULL; i++) {
  		gchar *fname;
@@ -1342,8 +1342,8 @@ diff -aurN 000/pidgin/gtkdnd-hints.c 001/pidgin/gtkdnd-hints.c
  
  		hint_windows[i].widget = dnd_hints_init_window(fname);
 diff -aurN 000/pidgin/gtkdocklet-gtk.c 001/pidgin/gtkdocklet-gtk.c
---- 000/pidgin/gtkdocklet-gtk.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkdocklet-gtk.c	2016-02-05 15:36:24.734356400 -0200
+--- 000/pidgin/gtkdocklet-gtk.c
++++ 001/pidgin/gtkdocklet-gtk.c
 @@ -291,6 +291,6 @@
  	}
  
@@ -1353,8 +1353,8 @@ diff -aurN 000/pidgin/gtkdocklet-gtk.c 001/pidgin/gtkdocklet-gtk.c
  }
  
 diff -aurN 000/pidgin/gtkmain.c 001/pidgin/gtkmain.c
---- 000/pidgin/gtkmain.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkmain.c	2016-02-05 15:36:24.734356400 -0200
+--- 000/pidgin/gtkmain.c
++++ 001/pidgin/gtkmain.c
 @@ -269,7 +269,7 @@
  #ifndef _WIN32
  	/* use the nice PNG icon for all the windows */
@@ -1374,8 +1374,8 @@ diff -aurN 000/pidgin/gtkmain.c 001/pidgin/gtkmain.c
  	if (!purple_core_init(PIDGIN_UI)) {
  		fprintf(stderr,
 diff -aurN 000/pidgin/gtkprefs.c 001/pidgin/gtkprefs.c
---- 000/pidgin/gtkprefs.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkprefs.c	2016-02-05 15:36:24.749975300 -0200
+--- 000/pidgin/gtkprefs.c
++++ 001/pidgin/gtkprefs.c
 @@ -528,7 +528,7 @@
  	/* refresh the list of themes in the manager */
  	purple_theme_manager_refresh();
@@ -1386,8 +1386,8 @@ diff -aurN 000/pidgin/gtkprefs.c 001/pidgin/gtkprefs.c
  	g_free(tmp);
  
 diff -aurN 000/pidgin/gtksound.c 001/pidgin/gtksound.c
---- 000/pidgin/gtksound.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtksound.c	2016-02-05 15:36:24.765601300 -0200
+--- 000/pidgin/gtksound.c
++++ 001/pidgin/gtksound.c
 @@ -614,7 +614,7 @@
  			g_free(filename);
  
@@ -1398,8 +1398,8 @@ diff -aurN 000/pidgin/gtksound.c 001/pidgin/gtksound.c
  
  		purple_sound_play_file(filename, NULL);
 diff -aurN 000/pidgin/gtkthemes.c 001/pidgin/gtkthemes.c
---- 000/pidgin/gtkthemes.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkthemes.c	2016-02-05 15:36:24.765601300 -0200
+--- 000/pidgin/gtkthemes.c
++++ 001/pidgin/gtkthemes.c
 @@ -389,7 +389,7 @@
  
  	pidgin_smiley_themes_remove_non_existing();
@@ -1410,8 +1410,8 @@ diff -aurN 000/pidgin/gtkthemes.c 001/pidgin/gtkthemes.c
  	probedirs[2] = 0;
  	for (l=0; probedirs[l]; l++) {
 diff -aurN 000/pidgin/gtkutils.c 001/pidgin/gtkutils.c
---- 000/pidgin/gtkutils.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/gtkutils.c	2016-02-05 15:36:24.781227300 -0200
+--- 000/pidgin/gtkutils.c
++++ 001/pidgin/gtkutils.c
 @@ -607,7 +607,7 @@
  	 */
  	tmp = g_strconcat(protoname, ".png", NULL);
@@ -1440,8 +1440,8 @@ diff -aurN 000/pidgin/gtkutils.c 001/pidgin/gtkutils.c
  			GtkWidget *item;
  
 diff -aurN 000/pidgin/Makefile.am 001/pidgin/Makefile.am
---- 000/pidgin/Makefile.am	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/Makefile.am	2016-02-05 15:36:24.781227300 -0200
+--- 000/pidgin/Makefile.am
++++ 001/pidgin/Makefile.am
 @@ -7,19 +7,8 @@
  		data/pidgin.desktop.in \
  		data/pidgin.pc.in \
@@ -1600,8 +1600,8 @@ diff -aurN 000/pidgin/Makefile.am 001/pidgin/Makefile.am
  pkgconfig_DATA = data/pidgin.pc
  
 diff -aurN 000/pidgin/pidginstock.c 001/pidgin/pidginstock.c
---- 000/pidgin/pidginstock.c	2015-12-31 21:19:41.000000000 -0200
-+++ 001/pidgin/pidginstock.c	2016-02-05 15:36:24.796850900 -0200
+--- 000/pidgin/pidginstock.c
++++ 001/pidgin/pidginstock.c
 @@ -241,7 +241,7 @@
  			return filename;
  		g_free(filename);
@@ -1612,8 +1612,8 @@ diff -aurN 000/pidgin/pidginstock.c 001/pidgin/pidginstock.c
  		return filename;
  	g_free(filename);
 diff -aurN 000/pidgin/plugins/cap/Makefile.am 001/pidgin/plugins/cap/Makefile.am
---- 000/pidgin/plugins/cap/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/cap/Makefile.am	2016-02-05 15:36:24.812476300 -0200
+--- 000/pidgin/plugins/cap/Makefile.am
++++ 001/pidgin/plugins/cap/Makefile.am
 @@ -18,7 +18,7 @@
  cap_la_LIBADD = $(GTK_LIBS) $(SQLITE3_LIBS)
  
@@ -1624,8 +1624,8 @@ diff -aurN 000/pidgin/plugins/cap/Makefile.am 001/pidgin/plugins/cap/Makefile.am
  	-I$(top_builddir)/libpurple \
  	-I$(top_srcdir)/pidgin \
 diff -aurN 000/pidgin/plugins/disco/gtkdisco.c 001/pidgin/plugins/disco/gtkdisco.c
---- 000/pidgin/plugins/disco/gtkdisco.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/disco/gtkdisco.c	2016-02-05 15:36:24.812476300 -0200
+--- 000/pidgin/plugins/disco/gtkdisco.c
++++ 001/pidgin/plugins/disco/gtkdisco.c
 @@ -119,14 +119,14 @@
  
  	if (service->type == XMPP_DISCO_SERVICE_TYPE_GATEWAY && service->gateway_type) {
@@ -1645,8 +1645,8 @@ diff -aurN 000/pidgin/plugins/disco/gtkdisco.c 001/pidgin/plugins/disco/gtkdisco
  	if (filename) {
  		pixbuf = gdk_pixbuf_new_from_file(filename, NULL);
 diff -aurN 000/pidgin/plugins/disco/Makefile.am 001/pidgin/plugins/disco/Makefile.am
---- 000/pidgin/plugins/disco/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/disco/Makefile.am	2016-02-05 15:36:24.828102000 -0200
+--- 000/pidgin/plugins/disco/Makefile.am
++++ 001/pidgin/plugins/disco/Makefile.am
 @@ -1,6 +1,10 @@
 +if OS_WIN32
 +plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
@@ -1684,8 +1684,8 @@ diff -aurN 000/pidgin/plugins/disco/Makefile.am 001/pidgin/plugins/disco/Makefil
 +endif
 +
 diff -aurN 000/pidgin/plugins/gestures/Makefile.am 001/pidgin/plugins/gestures/Makefile.am
---- 000/pidgin/plugins/gestures/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/gestures/Makefile.am	2016-02-05 15:36:24.828102000 -0200
+--- 000/pidgin/plugins/gestures/Makefile.am
++++ 001/pidgin/plugins/gestures/Makefile.am
 @@ -1,6 +1,10 @@
 +if OS_WIN32
 +plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
@@ -1723,8 +1723,8 @@ diff -aurN 000/pidgin/plugins/gestures/Makefile.am 001/pidgin/plugins/gestures/M
 +endif
 \ No newline at end of file
 diff -aurN 000/pidgin/plugins/gevolution/Makefile.am 001/pidgin/plugins/gevolution/Makefile.am
---- 000/pidgin/plugins/gevolution/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/gevolution/Makefile.am	2016-02-05 15:36:24.828102000 -0200
+--- 000/pidgin/plugins/gevolution/Makefile.am
++++ 001/pidgin/plugins/gevolution/Makefile.am
 @@ -1,6 +1,10 @@
 +if OS_WIN32
 +plugindir = $(libdir)/purple-$(PURPLE_MAJOR_VERSION)
@@ -1763,8 +1763,8 @@ diff -aurN 000/pidgin/plugins/gevolution/Makefile.am 001/pidgin/plugins/gevoluti
 +	-I$(top_srcdir)/pidgin/win32
 +endif
 diff -aurN 000/pidgin/plugins/Makefile.am 001/pidgin/plugins/Makefile.am
---- 000/pidgin/plugins/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/Makefile.am	2016-02-05 15:36:24.843725600 -0200
+--- 000/pidgin/plugins/Makefile.am
++++ 001/pidgin/plugins/Makefile.am
 @@ -1,4 +1,4 @@
 -DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker
 +DIST_SUBDIRS = cap disco gestures gevolution musicmessaging perl ticker win32
@@ -1913,8 +1913,8 @@ diff -aurN 000/pidgin/plugins/Makefile.am 001/pidgin/plugins/Makefile.am
  	@cp .libs/libtmp$@*.so $@
  	@rm -rf .libs/libtmp$@.*
 diff -aurN 000/pidgin/plugins/musicmessaging/Makefile.am 001/pidgin/plugins/musicmessaging/Makefile.am
---- 000/pidgin/plugins/musicmessaging/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/musicmessaging/Makefile.am	2016-02-05 15:36:24.859359500 -0200
+--- 000/pidgin/plugins/musicmessaging/Makefile.am
++++ 001/pidgin/plugins/musicmessaging/Makefile.am
 @@ -1,7 +1,11 @@
  EXTRA_DIST = \
  	music.png
@@ -1955,8 +1955,8 @@ diff -aurN 000/pidgin/plugins/musicmessaging/Makefile.am 001/pidgin/plugins/musi
 +	-I$(top_srcdir)/pidgin/win32
 +endif
 diff -aurN 000/pidgin/plugins/musicmessaging/musicmessaging.c 001/pidgin/plugins/musicmessaging/musicmessaging.c
---- 000/pidgin/plugins/musicmessaging/musicmessaging.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/musicmessaging/musicmessaging.c	2016-02-05 15:36:24.874976900 -0200
+--- 000/pidgin/plugins/musicmessaging/musicmessaging.c
++++ 001/pidgin/plugins/musicmessaging/musicmessaging.c
 @@ -548,11 +548,13 @@
  
  static void kill_editor (MMConversation *mmconv)
@@ -1981,8 +1981,8 @@ diff -aurN 000/pidgin/plugins/musicmessaging/musicmessaging.c 001/pidgin/plugins
  	image = gtk_image_new_from_file(file_path);
  	g_free(file_path);
 diff -aurN 000/pidgin/plugins/ticker/Makefile.am 001/pidgin/plugins/ticker/Makefile.am
---- 000/pidgin/plugins/ticker/Makefile.am	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/ticker/Makefile.am	2016-02-05 15:36:24.874976900 -0200
+--- 000/pidgin/plugins/ticker/Makefile.am
++++ 001/pidgin/plugins/ticker/Makefile.am
 @@ -1,9 +1,13 @@
  EXTRA_DIST = \
  		Makefile.mingw
@@ -2022,8 +2022,8 @@ diff -aurN 000/pidgin/plugins/ticker/Makefile.am 001/pidgin/plugins/ticker/Makef
 +	-I$(top_srcdir)/pidgin/win32
 +endif
 diff -aurN 000/pidgin/plugins/win32/Makefile.am 001/pidgin/plugins/win32/Makefile.am
---- 000/pidgin/plugins/win32/Makefile.am	1969-12-31 21:00:00.000000000 -0300
-+++ 001/pidgin/plugins/win32/Makefile.am	2016-02-05 15:36:24.890602300 -0200
+--- 000/pidgin/plugins/win32/Makefile.am
++++ 001/pidgin/plugins/win32/Makefile.am
 @@ -0,0 +1,9 @@
 +DIST_SUBDIRS = transparency winprefs
 +
@@ -2035,8 +2035,8 @@ diff -aurN 000/pidgin/plugins/win32/Makefile.am 001/pidgin/plugins/win32/Makefil
 +	Makefile.mingw
 +
 diff -aurN 000/pidgin/plugins/win32/transparency/Makefile.am 001/pidgin/plugins/win32/transparency/Makefile.am
---- 000/pidgin/plugins/win32/transparency/Makefile.am	1969-12-31 21:00:00.000000000 -0300
-+++ 001/pidgin/plugins/win32/transparency/Makefile.am	2016-02-05 15:36:24.906233100 -0200
+--- 000/pidgin/plugins/win32/transparency/Makefile.am
++++ 001/pidgin/plugins/win32/transparency/Makefile.am
 @@ -0,0 +1,31 @@
 +EXTRA_DIST = \
 +	Makefile.mingw \
@@ -2070,8 +2070,8 @@ diff -aurN 000/pidgin/plugins/win32/transparency/Makefile.am 001/pidgin/plugins/
 +
 +endif
 diff -aurN 000/pidgin/plugins/win32/winprefs/gtkappbar.c 001/pidgin/plugins/win32/winprefs/gtkappbar.c
---- 000/pidgin/plugins/win32/winprefs/gtkappbar.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/plugins/win32/winprefs/gtkappbar.c	2016-02-05 15:36:24.906233100 -0200
+--- 000/pidgin/plugins/win32/winprefs/gtkappbar.c
++++ 001/pidgin/plugins/win32/winprefs/gtkappbar.c
 @@ -27,6 +27,7 @@
   *  - Move 'App on top' feature from Trans plugin to here
   *  - Bug: Multiple Show/Hide Desktop calls causes client area to disappear
@@ -2081,8 +2081,8 @@ diff -aurN 000/pidgin/plugins/win32/winprefs/gtkappbar.c 001/pidgin/plugins/win3
  #include <winver.h>
  #include <stdio.h>
 diff -aurN 000/pidgin/plugins/win32/winprefs/Makefile.am 001/pidgin/plugins/win32/winprefs/Makefile.am
---- 000/pidgin/plugins/win32/winprefs/Makefile.am	1969-12-31 21:00:00.000000000 -0300
-+++ 001/pidgin/plugins/win32/winprefs/Makefile.am	2016-02-05 15:36:24.921852600 -0200
+--- 000/pidgin/plugins/win32/winprefs/Makefile.am
++++ 001/pidgin/plugins/win32/winprefs/Makefile.am
 @@ -0,0 +1,35 @@
 +EXTRA_DIST = \
 +	gtkappbar.c \
@@ -2120,8 +2120,8 @@ diff -aurN 000/pidgin/plugins/win32/winprefs/Makefile.am 001/pidgin/plugins/win3
 +
 +endif
 diff -aurN 000/pidgin/win32/gtkdocklet-win32.c 001/pidgin/win32/gtkdocklet-win32.c
---- 000/pidgin/win32/gtkdocklet-win32.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/win32/gtkdocklet-win32.c	2016-02-05 15:36:24.937483100 -0200
+--- 000/pidgin/win32/gtkdocklet-win32.c
++++ 001/pidgin/win32/gtkdocklet-win32.c
 @@ -21,7 +21,7 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
   * 02111-1301, USA.
@@ -2132,8 +2132,8 @@ diff -aurN 000/pidgin/win32/gtkdocklet-win32.c 001/pidgin/win32/gtkdocklet-win32
  #include <gdk/gdkwin32.h>
  #include <gdk/gdk.h>
 diff -aurN 000/pidgin/win32/gtkwin32dep.h 001/pidgin/win32/gtkwin32dep.h
---- 000/pidgin/win32/gtkwin32dep.h	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/win32/gtkwin32dep.h	2016-02-05 15:36:24.953102600 -0200
+--- 000/pidgin/win32/gtkwin32dep.h
++++ 001/pidgin/win32/gtkwin32dep.h
 @@ -25,6 +25,10 @@
  #include <windows.h>
  #include <gtk/gtk.h>
@@ -2146,8 +2146,8 @@ diff -aurN 000/pidgin/win32/gtkwin32dep.h 001/pidgin/win32/gtkwin32dep.h
  HINSTANCE winpidgin_dll_hinstance(void);
  HINSTANCE winpidgin_exe_hinstance(void);
 diff -aurN 000/pidgin/win32/MinimizeToTray.c 001/pidgin/win32/MinimizeToTray.c
---- 000/pidgin/win32/MinimizeToTray.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/win32/MinimizeToTray.c	2016-02-05 15:36:24.968727900 -0200
+--- 000/pidgin/win32/MinimizeToTray.c
++++ 001/pidgin/win32/MinimizeToTray.c
 @@ -14,7 +14,7 @@
   *
   * Copyright 2000 Matthew Ellis <m.t.ellis@bigfoot.com>
@@ -2158,8 +2158,8 @@ diff -aurN 000/pidgin/win32/MinimizeToTray.c 001/pidgin/win32/MinimizeToTray.c
  #include "MinimizeToTray.h"
  
 diff -aurN 000/pidgin/win32/pidgin_exe_rc.rc.in 001/pidgin/win32/pidgin_exe_rc.rc.in
---- 000/pidgin/win32/pidgin_exe_rc.rc.in	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/win32/pidgin_exe_rc.rc.in	2016-02-05 15:36:24.984353300 -0200
+--- 000/pidgin/win32/pidgin_exe_rc.rc.in
++++ 001/pidgin/win32/pidgin_exe_rc.rc.in
 @@ -3,8 +3,8 @@
  #include "version.h"
  
@@ -2181,8 +2181,8 @@ diff -aurN 000/pidgin/win32/pidgin_exe_rc.rc.in 001/pidgin/win32/pidgin_exe_rc.r
          VALUE "ProductVersion", "@PIDGIN_VERSION@"
        END
 diff -aurN 000/pidgin/win32/winpidgin.c 001/pidgin/win32/winpidgin.c
---- 000/pidgin/win32/winpidgin.c	2015-12-31 21:19:42.000000000 -0200
-+++ 001/pidgin/win32/winpidgin.c	2016-02-05 15:36:24.984353300 -0200
+--- 000/pidgin/win32/winpidgin.c
++++ 001/pidgin/win32/winpidgin.c
 @@ -320,11 +320,19 @@
  					posix = L"sr@Latn"; break;
  				case SUBLANG_SERBIAN_CYRILLIC:

--- a/mingw-w64-pidgin/002-build-fixes.patch
+++ b/mingw-w64-pidgin/002-build-fixes.patch
@@ -1,6 +1,29 @@
+diff -aurN 001/configure.ac 002/configure.ac
+--- 001/configure.ac
++++ 002/configure.ac
+@@ -81,7 +81,9 @@
+ PURPLE_MAJOR_VERSION=purple_major_version
+ PURPLE_MINOR_VERSION=purple_minor_version
+ PURPLE_MICRO_VERSION=purple_micro_version
+-PURPLE_VERSION=[purple_display_version]
++PURPLE_VERSION=purple_display_version
++PIDGIN_VERSION=purple_display_version
++AC_SUBST(PIDGIN_VERSION)
+ AC_SUBST(PURPLE_MAJOR_VERSION)
+ AC_SUBST(PURPLE_MINOR_VERSION)
+ AC_SUBST(PURPLE_MICRO_VERSION)
+@@ -694,7 +696,7 @@
+ 	if test "x$enable_consoleui" = "xyes"; then
+ 		dnl # Some distros put the headers in ncursesw/, some don't
+ 		found_ncurses_h=no
+-		for location in $ac_ncurses_includes $NCURSES_HEADERS /usr/include/ncursesw /usr/include
++		for location in $ac_ncurses_includes $NCURSES_HEADERS ${prefix}/include/ncursesw ${prefix}/include
+ 		do
+ 			f="$location/ncurses.h"
+ 			orig_CFLAGS="$CFLAGS"
 diff -aurN 001/libpurple/dbus-server.h 002/libpurple/dbus-server.h
---- 001/libpurple/dbus-server.h	2016-02-05 14:45:10.800241700 -0200
-+++ 002/libpurple/dbus-server.h	2016-02-05 15:36:56.859415900 -0200
+--- 001/libpurple/dbus-server.h
++++ 002/libpurple/dbus-server.h
 @@ -199,7 +199,9 @@
  
   */
@@ -11,9 +34,26 @@ diff -aurN 001/libpurple/dbus-server.h 002/libpurple/dbus-server.h
  
  /*
     Here we include the list of #PURPLE_DBUS_DECLARE_TYPE statements for
+diff -aurN 001/pidgin/Makefile.am 002/pidgin/Makefile.am
+--- 001/pidgin/Makefile.am
++++ 002/pidgin/Makefile.am
+@@ -192,10 +192,10 @@
+ 	win32/gtkdocklet-win32.c \
+ 	win32/gtkwin32dep.c \
+ 	win32/untar.c \
+-	win32/wspell.c \
+-	win32/pidgin_dll_rc.rc
++	win32/wspell.c
+ 
+-libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED)
++libpidgin_la_DEPENDENCIES = win32/pidgin_dll_rc.o
++libpidgin_la_LDFLAGS = $(AVOID_VERSION) $(NO_UNDEFINED) -Wl,win32/pidgin_dll_rc.o
+ libpidgin_la_LIBADD = $(common_LDADD) -lz -lwinmm -lgdi32
+ 
+ pidgin_LDFLAGS = -mwindows
 diff -aurN 001/pidgin/plugins/musicmessaging/Makefile.am 002/pidgin/plugins/musicmessaging/Makefile.am
---- 001/pidgin/plugins/musicmessaging/Makefile.am	2016-02-05 15:36:24.859359500 -0200
-+++ 002/pidgin/plugins/musicmessaging/Makefile.am	2016-02-05 15:36:56.859415900 -0200
+--- 001/pidgin/plugins/musicmessaging/Makefile.am
++++ 002/pidgin/plugins/musicmessaging/Makefile.am
 @@ -7,7 +7,7 @@
  musicmessagingdir = $(libdir)/pidgin
  endif

--- a/mingw-w64-pidgin/PKGBUILD
+++ b/mingw-w64-pidgin/PKGBUILD
@@ -8,7 +8,7 @@ pkgver=2.10.12
 pkgrel=1
 pkgdesc='Multi-protocol instant messaging client (mingw-w64)'
 url='https://pidgin.im'
-license=(GPL2+)
+license=(GPL2 partial:'GPL2+') # GPL2+, but Novell and SILC are GPL2-only
 arch=('any')
 
 options=(!libtool strip staticlibs)
@@ -16,8 +16,10 @@ source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.t
         001-autotools-and-fhs.patch
         002-build-fixes.patch)
 sha256sums=('2c7523f0fefe89749c03b2b738ab9f7bd186da435be4762f1487eee31e77ffdd'
-            'f34f45c0c1cb1f17ff16baec0311db6236503e34e28e75f538261de36c8be35f'
-            'b3a6afac33d7fc147e32e854638307467d1af4f1dfcc3799d79dbfd8584c34e3')
+            '2c40e0ec1cf38c7445ad0d206e1bf69bfbc30fddca5379c386f9c4db841f51cc'
+            '2e6cdf921bbf09e0952d26cca2e1f1d502d72714419c723ca1ebacfbbbf6fa24')
+
+provides=(${MINGW_PACKAGE_PREFIX}-libpurple)
 depends=(${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme
          ${MINGW_PACKAGE_PREFIX}-ca-certificates
          #${MINGW_PACKAGE_PREFIX}-cyrus-sasl
@@ -42,7 +44,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme
          ${MINGW_PACKAGE_PREFIX}-silc-toolkit
          ${MINGW_PACKAGE_PREFIX}-zlib)
 makedepends=(gtk-doc rsync
-             ${MINGW_PACKAGE_PREFIX}-dbus-glib
+             #${MINGW_PACKAGE_PREFIX}-dbus-glib
              ${MINGW_PACKAGE_PREFIX}-doxygen
              ${MINGW_PACKAGE_PREFIX}-gcc
              ${MINGW_PACKAGE_PREFIX}-pkg-config
@@ -85,6 +87,7 @@ build() {
         --disable-tk \
         --disable-sm \
         --disable-nm \
+        --disable-dbus \
         #--enable-cyrus-sasl
 
     make


### PR DESCRIPTION
The command-line Finch client is now built for the 3.x series of Pidgin. The Pidgin++ package has been reimplemented and is now buildable, also the development version has been added. Other improvements are mentioned in commits. Requires [MSYS2-packages#96](https://github.com/Alexpux/MSYS2-packages/pull/96).