### PR TITLE
evince: add nss as dependency

### DIFF
--- a/mingw-w64-evince/PKGBUILD
+++ b/mingw-w64-evince/PKGBUILD
@@ -4,7 +4,7 @@ _realname=evince
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.20.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="Document (PostScript, PDF) viewer (mingw-w64)"
 license=("GPL 2")
@@ -18,7 +18,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-libgxps"
          "${MINGW_PACKAGE_PREFIX}-libspectre"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
-         "${MINGW_PACKAGE_PREFIX}-poppler")
+         "${MINGW_PACKAGE_PREFIX}-poppler"
+         "${MINGW_PACKAGE_PREFIX}-nss")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"


### PR DESCRIPTION
Evince is missing nss as dependency.

Fixes https://github.com/Alexpux/MINGW-packages/issues/1310