### PR TITLE
ccache: add shortcuts for gcc

### DIFF
--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('any')
 url="https://ccache.samba.org/"
@@ -23,9 +23,9 @@ sha256sums=('ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e'
 prepare() {
   cd ${_realname}-${pkgver}
   #./autogen.sh
-  
+
   #backported patch from git; fixed in unreleased 3.3
-  patch -p1 -i "${srcdir}"/MinGW-add-ifdeds.patch
+  patch -p1 -i ${srcdir}/MinGW-add-ifdeds.patch
 }
 
 build() {
@@ -42,4 +42,12 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
+
+  # hack: use bash scripts as shortcuts since we cannot use symlinks
+  install -d ${pkgdir}${MINGW_PREFIX}/lib/ccache/bin
+  cd ${pkgdir}${MINGW_PREFIX}/lib/ccache/bin
+  scripts=(c++ cc cpp gcc g++ ${MINGW_CHOST}-g++ ${MINGW_CHOST}-c++ ${MINGW_CHOST}-gcc)
+  for fn in ${scripts[*]}; do
+    echo -e '#!/bin/bash\n\nccache '${MINGW_PREFIX}'/bin/'$fn' "$@"' > $fn
+  done
 }


### PR DESCRIPTION
Add shortcuts for gcc.
makepkg-mingw doesn't use it after changing `ccache` flag in `makepkg_mingw32.conf` and `makepkg_mingw64.conf`. I suppose it is makepkg-mingw bug and I'll further investigate it.
Manual compilation after exporting `export PATH="/mingw32/lib/ccache/bin/:$PATH"` for 32-bits or `export PATH="/mingw64/lib/ccache/bin/:$PATH"` for 64-bits works fine.