### PR TITLE
Adjustment in development version of Pidgin++

### DIFF
--- a/mingw-w64-pidgin++-bzr/PKGBUILD
+++ b/mingw-w64-pidgin++-bzr/PKGBUILD
@@ -147,6 +147,11 @@ package() {
     make DESTDIR="${pkgdir}" install
     install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 
+    # GTK+ customizations
+    cp -r "${srcdir}/${_realname}/source/pidgin/win32/gtk"/* "${pkgdir}${MINGW_PREFIX}"
+    cd "${pkgdir}${MINGW_PREFIX}/share/themes"
+    mv MS-Windows "${APPLICATION_NAME}"
+
     # Changelog
     mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
     cd "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"


### PR DESCRIPTION
Install the GTK+ customizations like already implemented in release-based version.