### PR TITLE
jsoncpp: Fix ${MINGW_PREFIX} getting hard-coded into the CMake package files

### DIFF
--- a/mingw-w64-jsoncpp/PKGBUILD
+++ b/mingw-w64-jsoncpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jsoncpp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A C++ library for interacting with JSON (mingw-w64)"
 arch=('any')
 url="https://github.com/open-source-parsers/jsoncpp"
@@ -36,4 +36,9 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
+
+  pushd "${pkgdir}${MINGW_PREFIX}" > /dev/null
+  find "lib/cmake/${_realname}" -name '*.cmake' -exec \
+    sed -s "s|${MINGW_PREFIX}|\${_IMPORT_PREFIX}|g" -i {} \;
+  popd > /dev/null
 }


### PR DESCRIPTION
Upstream CMake deficiencies are to blame, I think, in this case, since I'm pretty sure I worked around this in my branch of the repo, but this is just a simple sed post-install that can fix up consuming jsoncpp by CMake-using packages.

First time contributing to msys2 - wasn't sure if I needed to bump any of the versions, etc. or do any other special things with the commit, so be kind and let me know if I messed this one up, thanks!