### PR TITLE
opus: Only use dllexport for the dll

### DIFF
--- a/mingw-w64-opus/0002-win32-only-use-dllexport-when-building-dll.patch
+++ b/mingw-w64-opus/0002-win32-only-use-dllexport-when-building-dll.patch
@@ -1,0 +1,31 @@
+From 6e9617371f7cf3f669a60d9540723a01f1128fc8 Mon Sep 17 00:00:00 2001
+From: Daniel Verkamp <daniel@drv.nu>
+Date: Wed, 21 Oct 2015 17:24:41 -0700
+Subject: [PATCH] win32: only use dllexport when building DLL
+
+If building a static library, marking symbols as dllexport causes them
+to be exported from the final executable. For example, run
+objdump -x opus_demo.exe on a --disabled-shared build and look for the
+export table; there should not be one in a normal Win32 .exe file, but
+when linking static libopus, the exe exports all of the opus_* public
+functions.
+
+Use the libtool-defined DLL_EXPORT flag to determine whether we are
+building a DLL and only specify __declspec(dllexport) in that case.
+---
+ include/opus_defines.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/opus_defines.h b/include/opus_defines.h
+index 647ed5d..315412d 100644
+--- a/include/opus_defines.h
++++ b/include/opus_defines.h
+@@ -65,7 +65,7 @@ extern "C" {
+ 
+ #ifndef OPUS_EXPORT
+ # if defined(WIN32)
+-#  ifdef OPUS_BUILD
++#  if defined(OPUS_BUILD) && defined(DLL_EXPORT)
+ #   define OPUS_EXPORT __declspec(dllexport)
+ #  else
+ #   define OPUS_EXPORT

--- a/mingw-w64-opus/PKGBUILD
+++ b/mingw-w64-opus/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Codec designed for interactive speech and audio transmission over the Internet (mingw-w64)"
 arch=('any')
 url="https://www.opus-codec.org/"
@@ -12,13 +12,16 @@ license=("BSD")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' 'staticlibs')
 source=("http://downloads.xiph.org/releases/${_realname}/${_realname}-${pkgver}.tar.gz"
-        0001-correctly-detect-alloca.mingw.patch)
+        0001-correctly-detect-alloca.mingw.patch
+        0002-win32-only-use-dllexport-when-building-dll.patch)
 sha256sums=('0e290078e31211baa7b5886bcc8ab6bc048b9fc83882532da4a1a45e58e907fd'
-            'e4c6fdfa0b9f46f5a836fae01d02c9d6964be9cfa9a38a2071deb91d15c2659e')
+            'e4c6fdfa0b9f46f5a836fae01d02c9d6964be9cfa9a38a2071deb91d15c2659e'
+            'ae116fc9b6979c1eda5e5527ceb9548ae61a4d357119a4a75a948a00cd277265')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-correctly-detect-alloca.mingw.patch"
+  patch -p1 -i "${srcdir}/0002-win32-only-use-dllexport-when-building-dll.patch"
   autoreconf -fi
 }
 


### PR DESCRIPTION
Fixes compilation with shared FFmpeg, when trying to use opus static library.

Chromium and Firefox instead define an empty OPUS_EXPORT when building, which disables dllexport for both shared and static libs, but it's only a problem for the static library, not the shared.

~~Patch from http://lists.xiph.org/pipermail/opus/2015-October/003175.html~~
~~Can't tell why it wasn't committed.~~
Patch was applied upstream in git, so it can be removed when next release is out.