### PR TITLE
Adjustment in winpthreads-git

### DIFF
--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-pkgver=5.0.0.4634.1a9aeb9
+pkgver=5.0.0.4651.7666854
 pkgrel=1
 pkgdesc="MinGW-w64 winpthreads library"
 url="http://mingw-w64.sourceforge.net"
@@ -36,7 +36,7 @@ pkgver() {
 
 prepare() {
   cd "${srcdir}/mingw-w64"
-  git am "${srcdir}"/0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch
+  patch -p1 < "${srcdir}"/0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch
   cd "${srcdir}"/mingw-w64/mingw-w64-libraries/winpthreads
   autoreconf -vfi
 }


### PR DESCRIPTION
The patches are now applied with patch instead of git, so:

* Mismatching package versions between architectures are avoided.
* The same source package is generated for both architectures as intended by Alexey.
* The real commit hash is present in package version.