### PR TITLE
Catch: Update to 1.5.0.

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=catch
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.0
+pkgver=1.5.0
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
@@ -12,7 +12,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-gcc"
               "${MINGW_PACKAGE_PREFIX}-cmake")
 license=('custom')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/philsquared/Catch/archive/v${pkgver}.tar.gz)
-sha256sums=('b225e9828291636745db75e42cd604b8d755dcad0c5235fc90d7c725c4b49fb1')
+sha256sums=('2c668ed9fec133517035f9e7384da8c7cc80f1aa737d777783ff2a44e19d3ad8')
 
 check() {
   rm -rf "${srcdir}/test-${MINGW_CHOST}"


### PR DESCRIPTION
I tested this and it builds fine on my machine.

By the way, I don't have an urgent desire to use this latest version of Catch.  The old one worked fine for my purposes.  But I just feel like I am doing my part to keep MSYS2 up-to-date which is generally good for all users.