### PR TITLE
qt5: deactivate patch 0037

### DIFF
--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -100,7 +100,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -340,7 +340,9 @@ prepare() {
 
   # Patches so that qt5-static can be used with cmake.
   patch -p1 -i ${srcdir}/0036-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
-  patch -p1 -i ${srcdir}/0037-qt-5.4.0-Improve-cmake-plugin-detection-as-not-all-are-suffixed-Plugin.patch
+  # patch 0037 breaks 5.6.0 cmake integration
+  # the patch causes Qml extra factories to be added twice (correctly as factories and wrongly as plugins)
+  ###patch -p1 -i ${srcdir}/0037-qt-5.4.0-Improve-cmake-plugin-detection-as-not-all-are-suffixed-Plugin.patch
 
   pushd qtbase > /dev/null
     patch -p1 -i ${srcdir}/0038-qt-5.5.0-cmake-Rearrange-STATIC-vs-INTERFACE-targets.patch


### PR DESCRIPTION
patch 0037 breaks cmake integration
patch file: 0037-qt-5.4.0-Improve-cmake-plugin-detection-as-not-all-are-suffixed-Plugin.patch

with the patch, a `find_package(Qt5Quick REQUIRED)` will fail with :

```
CMake Error at C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5Qml_QLocalClientConnectionFactory.cmake:2 (add_library):
  add_library cannot create imported target
  "Qt5::QLocalClientConnectionFactory" because another target with the same
  name already exists.
Call Stack (most recent call first):
  C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5QmlConfigExtras.cmake:4 (include)
  C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5QmlConfig.cmake:176 (include)
  C:/msys64/mingw64/lib/cmake/Qt5Quick/Qt5QuickConfig.cmake:96 (find_package)
  CMakeLists.txt:84 (find_package)

CMake Error at C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5Qml_QQmlDebuggerServiceFactory.cmake:2 (add_library):
  add_library cannot create imported target "Qt5::QQmlDebuggerServiceFactory"
  because another target with the same name already exists.
Call Stack (most recent call first):
  C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5QmlConfigExtras.cmake:4 (include)
  C:/msys64/mingw64/lib/cmake/Qt5Qml/Qt5QmlConfig.cmake:176 (include)
  C:/msys64/mingw64/lib/cmake/Qt5Quick/Qt5QuickConfig.cmake:96 (find_package)
  CMakeLists.txt:84 (find_package)

  ...
```

I have traced the source of the error to the patch.
Undoing its effect in my local environment addresses the issue.

I have not rebuilt qt5 but it should build fine.  