### PR TITLE
gtk3-git: need gtk-doc in makedepends

### DIFF
--- a/mingw-w64-gtk3-git/PKGBUILD
+++ b/mingw-w64-gtk3-git/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.19.5.365.g10cc354
+pkgver=3.21.1.29.g71c1e86
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (git) (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 # python2 is required to run gdbus-codegen
-makedepends+=("autoconf" "automake" "libtool")
+makedepends+=("autoconf" "automake" "libtool" "gtk-doc" "git")
 # autotools are required because several Makefile.am are modified
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"


### PR DESCRIPTION
Builds from the git package fail when `gtk-doc` is not installed, dues to the presence of the following line in `prepare()`. The fix is simple: depend on `gtk-doc`.

```sh
  [[ -f gtk-doc.make ]] || cp /usr/share/gtk-doc/data/gtk-doc.make .
```