### PR TITLE
Fixes for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,14 @@ environment:
     BUILD_URL: https://ci.appveyor.com/project/$(APPVEYOR_ACCOUNT_NAME)/$(APPVEYOR_PROJECT_NAME)/build/$(APPVEYOR_BUILD_VERSION)
 
 build_script:
-    # TODO: implement update-core --noconfirm and replace the below command line
-    - C:\msys64\usr\bin\pacman --sync --refresh --refresh --needed --noconfirm msys2-runtime msys2-runtime-devel bash pacman pacman-mirrors
+    # TODO: remove the line below once the AppVeyor installation includes a
+    # newer version of pacman that can perform core updates
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh pacman
+
+    # Git is required but currently not part of AppVeyor installation
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh git
+
+    - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 
 artifacts:

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -22,7 +22,7 @@ define_build_order || failure 'Could not determine build order'
 
 # Build
 message 'Building packages' "${packages[@]}"
-execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade
+execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade --sysupgrade
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource --config '/etc/makepkg_mingw64.conf'


### PR DESCRIPTION
Fix for the incomplete system update in AppVeyor after new pacman extended the core package list and the explicit references became outdated. This was causing the core update to be completed only in ci-build script, and the regular update to be left behind. For example, [MSYS2-packages#575](https://github.com/Alexpux/MSYS2-packages/pull/575) seems to have reproduced the problem.

Package downgrades are now enabled for regular updates and for AppVeyor core updates, so removed versions are properly detected. Git is now explicitly installed in AppVeyor since the external one is not anymore visible after minimal path has been implemented.