### PR TITLE
Add unibilium

### DIFF
--- a/mingw-w64-unibilium/0001-unibilium-msys-makefile.patch
+++ b/mingw-w64-unibilium/0001-unibilium-msys-makefile.patch
@@ -1,0 +1,35 @@
+diff --git a/Makefile b/Makefile
+index 35741ac..bb56037 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,9 @@
+ ifneq ($(wildcard .git),)
+-  -include maint.mk
++  ifeq ($(OS),Windows_NT)
++    -include maint_windows.mk
++  else
++    -include maint.mk
++  endif
+ endif
+ 
+ ifeq ($(shell uname),Darwin)
+@@ -32,7 +36,11 @@ INCDIR=$(PREFIX)/include
+ MANDIR=$(PREFIX)/share/man
+ MAN3DIR=$(MANDIR)/man3
+ 
+-TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
++ifneq ($(OS),Windows_NT)
++  TERMINFO_DIRS="/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/usr/local/lib/terminfo"
++else
++  TERMINFO_DIRS=""
++endif
+ 
+ POD2MAN=pod2man
+ POD2MAN_OPTS=-c "$(PACKAGE)" -s3 -r "$(PACKAGE)-$(PKG_VERSION)"
+diff --git a/maint_windows.mk b/maint_windows.mk
+new file mode 100644
+index 0000000..6088278
+--- /dev/null
++++ b/maint_windows.mk
+@@ -0,0 +1 @@
++CFLAGS=-std=gnu99 -pedantic -Wall -Wextra -Wundef -Wshadow -Wbad-function-cast -Wcast-align -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wdisabled-optimization -O2 -pipe

--- a/mingw-w64-unibilium/PKGBUILD
+++ b/mingw-w64-unibilium/PKGBUILD
@@ -1,0 +1,32 @@
+_realname=unibilium
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.2.0
+pkgrel=1
+pkgdesc='A terminfo parsing library (mingw-w64)'
+arch=('any')
+url='https://github.com/mauke/unibilium/'
+license=(LGPL3)
+source=("$_realname-$pkgver.tar.gz::https://github.com/mauke/unibilium/archive/v$pkgver.tar.gz"
+	"0001-unibilium-msys-makefile.patch")
+sha1sums=("ed5150071bef1d1504fddbbe1c842ab47c1cbaec"
+	"4852cc0e4e3174e5b60d6d1e1d74d8d234a4ebf3")
+
+prepare() {
+  cd "${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/0001-unibilium-msys-makefile.patch"
+}
+
+build() {
+  cd $_realname-$pkgver
+  make PREFIX=${MINGW_PREFIX}
+}
+
+check() {
+  cd $_realname-$pkgver
+  make test
+}
+
+package() {
+  cd $_realname-$pkgver
+  make install PREFIX=${MINGW_PREFIX} DESTDIR="$pkgdir"
+}


### PR DESCRIPTION
Recipe for the unibilium library. The patch disables asan CFLAGS and removes the default terminfo paths.