### PR TITLE
Fix for continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+    MSYSTEM: MSYS
     DEPLOY_PROVIDER: bintray
     BINTRAY_ACCOUNT: alexpux
     BINTRAY_REPOSITORY: msys2

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -26,7 +26,7 @@ execute 'Upgrading the system' pacman --noconfirm --noprogressbar --sync --refre
 for package in "${packages[@]}"; do
     execute 'Building binary' makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --rmdeps --cleanbuild
     execute 'Building source' makepkg --noconfirm --noprogressbar --skippgpcheck --allsource --config '/etc/makepkg_mingw64.conf'
-    yes|execute 'Installing' pacman --noprogressbar --upgrade *.pkg.tar.xz
+    execute 'Installing' yes:pacman --noprogressbar --upgrade *.pkg.tar.xz
     deploy_enabled && mv "${package}"/*.pkg.tar.xz artifacts
     deploy_enabled && mv "${package}"/*.src.tar.gz artifacts
     unset package

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -118,10 +118,14 @@ git_config() {
 # Run command with status
 execute(){
     local status="${1}"
-    local command=("${@:2}")
+    local command="${2}"
+    local arguments=("${@:3}")
     cd "${package:-.}"
     message "${status}"
-    ${command[@]} || failure "${status} failed"
+    if [[ "${command}" != *:* ]]
+        then ${command} ${arguments[@]}
+        else ${command%%:*} | ${command#*:} ${arguments[@]}
+    fi || failure "${status} failed"
     cd - > /dev/null
 }
 


### PR DESCRIPTION
* Proper detection of package installation failures, avoiding false positives such as #1376.
* Explicitly set a default shell in AppVeyor, avoiding failures like reproduced by [MSYS2-packages#587](https://github.com/Alexpux/MSYS2-packages/pull/587).