### PR TITLE
mingw-w64-libmariadbclient - upgrade to 2.2.3

### DIFF
--- a/mingw-w64-libmariadbclient/001-2.2.3-fix-libnames-mingw.patch
+++ b/mingw-w64-libmariadbclient/001-2.2.3-fix-libnames-mingw.patch
@@ -1,27 +1,27 @@
---- mariadb-connector-c-2.2.0-src/libmariadb/CMakeLists.txt.orig	2015-09-29 22:21:13.000000000 +0300
-+++ mariadb-connector-c-2.2.0-src/libmariadb/CMakeLists.txt	2015-10-30 12:42:38.140347000 +0300
-@@ -375,27 +375,26 @@
-   SET(EMPTY_FILE ${CMAKE_SOURCE_DIR}/libmariadb/empty.c)
- ENDIF()
- 
--ADD_LIBRARY(mariadbclient STATIC $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE} ${EXPORT_LINK})
-+ADD_LIBRARY(mariadbclient STATIC $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE})
+--- mariadb-connector-c-2.2.3-src/libmariadb/CMakeLists.txt.orig	2016-04-12 06:34:11 -0400
++++ mariadb-connector-c-2.2.3-src/libmariadb/CMakeLists.txt	2016-05-03 17:44:58 -0400
+@@ -384,23 +384,23 @@
+ ADD_LIBRARY(mariadbclient STATIC ${mariadbclient_RC} $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE} ${EXPORT_LINK})
  TARGET_LINK_LIBRARIES(mariadbclient ${SYSTEM_LIBS})
  
--ADD_LIBRARY(libmariadb SHARED $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE} ${EXPORT_LINK})
+-ADD_LIBRARY(libmariadb SHARED ${libmariadb_RC} $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE} ${EXPORT_LINK})
 -TARGET_LINK_LIBRARIES(libmariadb ${SYSTEM_LIBS})
-+ADD_LIBRARY(mariadb SHARED $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE})
++ADD_LIBRARY(mariadb SHARED ${libmariadb_RC} $<TARGET_OBJECTS:mariadb_obj> ${EMPTY_FILE} ${EXPORT_LINK})
 +TARGET_LINK_LIBRARIES(mariadb ${SYSTEM_LIBS})
  IF(UNIX)
-   SET_TARGET_PROPERTIES(libmariadb PROPERTIES COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
+-  SET_TARGET_PROPERTIES(libmariadb PROPERTIES COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
++  SET_TARGET_PROPERTIES(mariadb PROPERTIES COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
  ENDIF()
+-SIGN_TARGET(libmariadb)
++SIGN_TARGET(mariadb)
  
  IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
 -  TARGET_LINK_LIBRARIES (libmariadb "-Wl,--no-undefined")
 -  TARGET_LINK_LIBRARIES (libmariadb "-Wl,--version-script=${EXPORT_FILE}")
 +  TARGET_LINK_LIBRARIES (mariadb "-Wl,--no-undefined")
++  TARGET_LINK_LIBRARIES (mariadb "-Wl,--version-script=${EXPORT_FILE}")
    TARGET_LINK_LIBRARIES (mariadbclient "-Wl,--no-undefined")
--  TARGET_LINK_LIBRARIES (mariadbclient "-Wl,--version-script=${EXPORT_FILE}")
+   TARGET_LINK_LIBRARIES (mariadbclient "-Wl,--version-script=${EXPORT_FILE}")
  ENDIF()
  
 -SET_TARGET_PROPERTIES(libmariadb PROPERTIES PREFIX "")
@@ -30,22 +30,14 @@
 -SET_TARGET_PROPERTIES(libmariadb PROPERTIES VERSION 
 +SET_TARGET_PROPERTIES(mariadb PROPERTIES VERSION 
     ${CPACK_PACKAGE_VERSION_MAJOR}
--   SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR})
-+   SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
-+   RUNTIME_OUTPUT_NAME libmariadb)
+    SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR})
  
- #
- # Installation
-@@ -408,20 +409,20 @@
- # There are still several projects which don't make use
- # of the config program. To make sure these programs can
+@@ -415,18 +415,18 @@
  # use mariadb client library we provide libmysql symlinks
--IF(NOT WIN32 AND WITH_MYSQLCOMPAT)
--  SET(INSTALL_PATH ${LIB_INSTALL_DIR}/${SUFFIX_INSTALL_DIR})
+ IF(NOT WIN32 AND WITH_MYSQLCOMPAT)
+   SET(INSTALL_PATH ${LIB_INSTALL_DIR}/${SUFFIX_INSTALL_DIR})
 -  create_symlink(libmysqlclient${CMAKE_SHARED_LIBRARY_SUFFIX} libmariadb ${INSTALL_PATH})
 -  create_symlink(libmysqlclient_r${CMAKE_SHARED_LIBRARY_SUFFIX} libmariadb ${INSTALL_PATH})
-+IF(WITH_MYSQLCOMPAT)
-+  SET(INSTALL_PATH ${BIN_INSTALL_DIR})
 +  create_symlink(libmysqlclient${CMAKE_SHARED_LIBRARY_SUFFIX} mariadb ${INSTALL_PATH})
 +  create_symlink(libmysqlclient_r${CMAKE_SHARED_LIBRARY_SUFFIX} mariadb ${INSTALL_PATH})
    create_symlink(libmysqlclient${CMAKE_STATIC_LIBRARY_SUFFIX} mariadbclient ${INSTALL_PATH})

--- a/mingw-w64-libmariadbclient/PKGBUILD
+++ b/mingw-w64-libmariadbclient/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libmariadbclient
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.0
-pkgrel=2
+pkgver=2.2.3
+pkgrel=1
 pkgdesc="MariaDB client libraries (mingw-w64)"
 arch=('any')
 url="http://mariadb.org"
@@ -17,20 +17,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('!strip' 'staticlibs')
 source=(#"https://downloads.mariadb.org/interstitial/connector-c-${pkgver}/source-tgz/mariadb-connector-c-${pkgver}-src.tar.gz"
         http://mirror.mephi.ru/mariadb/connector-c-${pkgver}/mariadb-connector-c-${pkgver}-src.tar.gz{,.asc}
-        'fix-libnames-mingw.patch'
+        '001-2.2.3-fix-libnames-mingw.patch'
         'use_fopen_for_xp_compatibility.patch'
         'fix-size-t-defined.patch'
         'fix-redefinitions.patch')
-sha256sums=('3825b068d38bc19d6ad1eaecdd74bcd49d6ddd9d00559fb150e4e851a55bbbd4'
+validpgpkeys=("199369E5404BD5FC7D2FE43BCBCB082A1BB943DB") #MariaDB Package Signing Key <package-signing-key@mariadb.org>
+sha256sums=('cd01ce2c418382f90fd0b21c3c756b89643880efe3447507bf740569b9d08eed'
             'SKIP'
-            '2872bbfef721ebcdfa970ea57ad81888a4f29a6f55fed140c38b53f52b2b5d78'
+            '1e0d1aa9cbae0cd5dcac40faf3b7309ed20e2727645f05ec5559baad598937a0'
             '8069bc0c7f4204fe2b1ea54c610c27aebd0c54d7a21ecf6352c9bdd9cf1c4062'
             'e84d3ac9b2e716dc1581d82c34001d8561bb0d09750d1d57d4b448a8cc259ff0'
             'ddb20e474ba1a63f65f28ee76bb74074316b15cc90ecdae6d2aa1febf0803d72')
 
 prepare() {
   cd ${srcdir}/mariadb-connector-c-${pkgver}-src
-  patch -p1 -i ${srcdir}/fix-libnames-mingw.patch
+  patch -p1 -i ${srcdir}/001-2.2.3-fix-libnames-mingw.patch
   patch -p1 -i ${srcdir}/use_fopen_for_xp_compatibility.patch
   patch -p1 -i ${srcdir}/fix-size-t-defined.patch
   patch -p1 -i ${srcdir}/fix-redefinitions.patch


### PR DESCRIPTION
Upgrade to version 2.2.3 and adjust libname patch for new version.