### PR TITLE
mingw-w64-libmaxminddb - upgrade to 1.2.0

### DIFF
--- a/mingw-w64-libmaxminddb/0001-libmaxminddb-1.2.0-mingw-no-undefined.patch
+++ b/mingw-w64-libmaxminddb/0001-libmaxminddb-1.2.0-mingw-no-undefined.patch
@@ -1,0 +1,11 @@
+--- libmaxminddb-1.2.0/src/Makefile.am.orig	2016-05-04 18:55:39 -0400
++++ libmaxminddb-1.2.0/src/Makefile.am	2016-05-04 18:58:11 -0400
+@@ -3,7 +3,7 @@
+ lib_LTLIBRARIES = libmaxminddb.la
+ 
+ libmaxminddb_la_SOURCES = maxminddb.c maxminddb-compat-util.h
+-libmaxminddb_la_LDFLAGS = -version-info 0:7:0
++libmaxminddb_la_LDFLAGS = -no-undefined -version-info 0:7:0
+ include_HEADERS = $(top_srcdir)/include/maxminddb.h
+ 
+ pkgconfig_DATA = libmaxminddb.pc

--- a/mingw-w64-libmaxminddb/PKGBUILD
+++ b/mingw-w64-libmaxminddb/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libmaxminddb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.4
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="C library for reading MaxMind DB files, including the GeoIP2 databases from MaxMind (mingw-w64)"
 arch=('any')
@@ -19,18 +19,18 @@ options=('!emptydirs')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/maxmind/${_realname}/archive/${pkgver}.tar.gz
         "MaxMind-DB"::git+https://github.com/maxmind/MaxMind-DB.git
         libtap::git+https://github.com/zorgnax/libtap.git
-        mingw-no-undefined.patch)
-sha256sums=('39ccc2c296bcc989c86513967a8cc9cb7e4efe0153ef61f07a3d7d1e931e3d02'
+        0001-libmaxminddb-1.2.0-mingw-no-undefined.patch)
+sha256sums=('4147241d4e3103bd843167ae5a0d5cf176632b6898cb1cca6223d2d58cc53ef5'
             'SKIP'
             'SKIP'
-            'f3246d235bd6dfcb6fd8e89fa63de95b0384283fce12a0ebef56e1b2fe9bd248')
+            'd8215ab43c8abea0017b64cd407e831816c527927fa943a4c817d0c07420f997')
 
 prepare() {
   cp -rf ${srcdir}/libtap ${srcdir}/${_realname}-${pkgver}/t/
   cp -rf ${srcdir}/MaxMind-DB ${srcdir}/${_realname}-${pkgver}/t/
   cd "${srcdir}/${_realname}-${pkgver}"
-  patch -p1 -i ${srcdir}/mingw-no-undefined.patch
-  autoreconf -fiv
+  patch -p1 -i "${srcdir}/0001-libmaxminddb-1.2.0-mingw-no-undefined.patch"
+  ./bootstrap
 }
 
 build() {

--- a/mingw-w64-libmaxminddb/mingw-no-undefined.patch
+++ b/mingw-w64-libmaxminddb/mingw-no-undefined.patch
@@ -1,9 +1,0 @@
---- libmaxminddb-1.0.3/src/Makefile.am.orig	2015-01-03 00:36:04.463200000 +0300
-+++ libmaxminddb-1.0.3/src/Makefile.am	2015-01-03 00:36:14.915200000 +0300
-@@ -3,5 +3,5 @@
- lib_LTLIBRARIES = libmaxminddb.la
- 
- libmaxminddb_la_SOURCES = maxminddb.c
--libmaxminddb_la_LDFLAGS = -version-info 0:7:0
-+libmaxminddb_la_LDFLAGS = -no-undefined -version-info 0:7:0
- include_HEADERS = $(top_srcdir)/include/maxminddb.h


### PR DESCRIPTION
Upgrade to 1.2.0 and adjust mingw-no-undefined patch for new ver.