### PR TITLE
mingw-w64-harfbuzz - 1.2.7 - Upgrade to new version

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=harfbuzz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.2.6
-pkgrel=2
+pkgver=1.2.7
+pkgrel=1
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -22,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
 options=('strip' 'staticlibs')
 optdepends=("${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support")
 source=("https://www.freedesktop.org/software/harfbuzz/release/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('7537bacccb3524df0cd2a4d5bc7e168bcc10e8171e0324f3cd522583868192c1')
+sha256sums=('bba0600ae08b84384e6d2d7175bea10b5fc246c4583dc841498d01894d479026')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
mingw-w64-harfbuzz - upgrade to version 1.2.7.