### PR TITLE
mingw-w64-iso-codes:: 3.68 - update to latest version

### DIFF
--- a/mingw-w64-iso-codes/PKGBUILD
+++ b/mingw-w64-iso-codes/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=iso-codes
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.67
+pkgver=3.68
 pkgrel=1
 pkgdesc="Lists of the country, language, and currency names (mingw-w64)"
 arch=('any')
 license=('LGPL')
 url="https://pkg-isocodes.alioth.debian.org/"
 source=(https://pkg-isocodes.alioth.debian.org/downloads/${_realname}-${pkgver}.tar.xz{,.sig})
-sha256sums=('603f51e0b5ebd762b66d9aa3bd0d9a33af1aaedae88caaaf196fcc5bb4abf00c'
+sha256sums=('5881cf7caa5adfffb14ade99138949324c28a277babe8d07dafbff521acef9d1'
             'SKIP')
 validpgpkeys=('D1CB8F39BC5DED24C5D2C78C1302F1F036EBEB19' #Dr. Tobias Quathamer <t.quathamer@mailbox.org>
    '1302F1F036EBEB19' #Dr. Tobias Quathamer <t.quathamer@mailbox.org>


### PR DESCRIPTION
mingw-w64-iso-codes:: 3.68 - update to latest version