### PR TITLE
qt5[-static]: update cmake patch 0042 - exclude Qt5Qml factory plugins

### DIFF
--- a/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,6 +1,6 @@
-diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.5.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
---- qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
-+++ qt-everywhere-opensource-src-5.5.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
+diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+--- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
++++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
 @@ -64,14 +64,17 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
@@ -63,7 +63,7 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  !!ELSE
      add_library(Qt5::$${CMAKE_MODULE_NAME} SHARED IMPORTED)
  !!ENDIF
-@@ -276,6 +294,48 @@
+@@ -276,6 +294,53 @@
      set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} PROPERTY
        INTERFACE_COMPILE_DEFINITIONS $${MODULE_DEFINE})
  
@@ -71,6 +71,11 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
 +    unset(pluginTargets)
 +    if (pluginTargetsMaybe)
 +        foreach(pluginTarget ${pluginTargetsMaybe})
++            # exclude Qt5Qml factory plugins as they will be included later by Qt5QmlConfigExtras
++            string(REGEX MATCH Qt5Qml_.*Factory.cmake excluded ${pluginTarget})
++            if (excluded)
++                continue()
++            endif()
 +            file(STRINGS ${pluginTarget} matched REGEX Qt5$${CMAKE_MODULE_NAME}_PLUGINS)
 +            if (matched)
 +                list(APPEND pluginTargets ${pluginTarget})
@@ -112,7 +117,7 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  !!IF !equals(TEMPLATE, aux)
  !!IF !isEmpty(CMAKE_RELEASE_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
-@@ -356,37 +416,6 @@
+@@ -356,37 +421,6 @@
      )
  !!ENDIF // TEMPLATE != aux
  
@@ -150,4 +155,3 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  
  !!IF !isEmpty(CMAKE_MODULE_EXTRAS)
      include(\"${CMAKE_CURRENT_LIST_DIR}/Qt5$${CMAKE_MODULE_NAME}ConfigExtras.cmake\")
-

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -100,7 +100,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -725,7 +725,7 @@ sha256sums=('76a95cf6c1503290f75a641aa25079cd0c5a8fcd7cff07ddebff80a955b07de7'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            '9eb9366d81179883e09e180bcd6bba3452661879f993a7e48e4c86d8bb4720e6'
+            'f5454bc38d57a734e5b36f6c54310576339628298d810628443f0a58a46e7477'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'

--- a/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,6 +1,6 @@
-diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.5.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
---- qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
-+++ qt-everywhere-opensource-src-5.5.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
+diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
+--- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
++++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
 @@ -64,14 +64,17 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
@@ -63,7 +63,7 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  !!ELSE
      add_library(Qt5::$${CMAKE_MODULE_NAME} SHARED IMPORTED)
  !!ENDIF
-@@ -276,6 +294,48 @@
+@@ -276,6 +294,53 @@
      set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} PROPERTY
        INTERFACE_COMPILE_DEFINITIONS $${MODULE_DEFINE})
  
@@ -71,6 +71,11 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
 +    unset(pluginTargets)
 +    if (pluginTargetsMaybe)
 +        foreach(pluginTarget ${pluginTargetsMaybe})
++            # exclude Qt5Qml factory plugins as they will be included later by Qt5QmlConfigExtras
++            string(REGEX MATCH Qt5Qml_.*Factory.cmake excluded ${pluginTarget})
++            if (excluded)
++                continue()
++            endif()
 +            file(STRINGS ${pluginTarget} matched REGEX Qt5$${CMAKE_MODULE_NAME}_PLUGINS)
 +            if (matched)
 +                list(APPEND pluginTargets ${pluginTarget})
@@ -112,7 +117,7 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  !!IF !equals(TEMPLATE, aux)
  !!IF !isEmpty(CMAKE_RELEASE_TYPE)
  !!IF !isEmpty(CMAKE_STATIC_WINDOWS_BUILD)
-@@ -356,37 +416,6 @@
+@@ -356,37 +421,6 @@
      )
  !!ENDIF // TEMPLATE != aux
  
@@ -150,4 +155,3 @@ diff -urN qt-everywhere-opensource-src-5.5.0.orig/qtbase/mkspecs/features/data/c
  
  !!IF !isEmpty(CMAKE_MODULE_EXTRAS)
      include(\"${CMAKE_CURRENT_LIST_DIR}/Qt5$${CMAKE_MODULE_NAME}ConfigExtras.cmake\")
-

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -100,7 +100,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -726,7 +726,7 @@ sha256sums=('76a95cf6c1503290f75a641aa25079cd0c5a8fcd7cff07ddebff80a955b07de7'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            '9eb9366d81179883e09e180bcd6bba3452661879f993a7e48e4c86d8bb4720e6'
+            'f5454bc38d57a734e5b36f6c54310576339628298d810628443f0a58a46e7477'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'


### PR DESCRIPTION
 update cmake patch 0042 to exclude Qt5Qml factory plugins from the fix and avoid duplicate includes later in Qt5QmlConfigExtras.cmake

see https://github.com/Alexpux/MINGW-packages/issues/1364