### PR TITLE
devcon-git: Disable wildcard globbing.

### DIFF
--- a/mingw-w64-devcon-git/PKGBUILD
+++ b/mingw-w64-devcon-git/PKGBUILD
@@ -5,9 +5,9 @@
 _realname=devcon
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-provides="${MINGW_PACKAGE_PREFIX}-${_realname}"
-conflicts="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=r35.818f6ee
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=r45.6e1115d
 pkgrel=1
 pkgdesc='Search for and manipulate devices (mingw-w64)'
 arch=('any')
@@ -44,6 +44,10 @@ prepare() {
 
   # SetupScanFileQueue expects its callback to be stdcall.
   patch -p1 -i "${srcdir}/03-stdcall-callback.patch"
+
+  # We don't want MinGW to expand wildcards; we need to be able to
+  # run commands like "devcon hwids *" to search for all devices.
+  echo "int _dowildcard = 0;" > wildcard.cpp
 
   windmc msg.mc
 }


### PR DESCRIPTION
Our mingw-w64 crt globs wildcards it sees on `argv` by default because it was configured with `--enable-wildcard`.  That prevents us from running commands like `devcon hwids *`, which is the correct way to list the hardware IDs of all the devices on the system.  This pull request disables wildcard globbing for devcon.

Note that to run that command in Bash, you would actually have to type:

    devcon hwids \*