### PR TITLE
mingw-w64-libssh: 0.7.3: Update to latest version and rekey mingw-as-unix patch

### DIFF
--- a/mingw-w64-libssh/PKGBUILD
+++ b/mingw-w64-libssh/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libssh
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.7.0
-pkgrel=2
+pkgver=0.7.3
+pkgrel=1
 pkgdesc="Library for accessing ssh client services through C libraries (mingw-w64)"
 arch=('any')
 url="http://www.libssh.org/"
@@ -17,14 +17,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 validpgpkeys=('8DFF53E18F2ABC8D8F3C92237EE0FC4DCC014E3D') # Andreas Schneider <asn@cryptomilk.org>
-source=(https://red.libssh.org/attachments/download/140/${_realname}-${pkgver}.tar.xz
-        https://red.libssh.org/attachments/download/139/${_realname}-${pkgver}.tar.asc
+source=(https://red.libssh.org/attachments/download/195/${_realname}-${pkgver}.tar.xz
+        https://red.libssh.org/attachments/download/194/${_realname}-${pkgver}.tar.asc
         mingw-as-unix.patch
         mingw-DATADIR-conflict.patch
         fix-threads-libraryname-in-config.patch)
-sha256sums=('0551bc341f33641ddc349b31730b3010870ad26a4dbfad3d090a1738fe3e402b'
+sha256sums=('26ef46be555da21112c01e4b9f5e3abba9194485c8822ab55ba3d6496222af98'
             'SKIP'
-            'a771e3a0f7e7230404ca75a3a9ea6e9cdb7fdd0a4029e440485cc13fe4de8a70'
+            'd0790ab4e47d90b7fa5a15a2b08430b65db72a8d88fac8f5883e48a7fdc6d6c4'
             '444a66b1926f49c54df844c22263496c2d86e124c8bcdbd194c4581d06140c1b'
             'a69b444d4a9b1861991661d5f3ca8d2ab705fac1f5766a79730328b0bdd86691')
 

--- a/mingw-w64-libssh/mingw-as-unix.patch
+++ b/mingw-w64-libssh/mingw-as-unix.patch
@@ -7,20 +7,28 @@ diff -Naur libssh-0.6.4-orig/cmake/Modules/DefineInstallationPaths.cmake libssh-
    IF (NOT APPLICATION_NAME)
      MESSAGE(STATUS "${PROJECT_NAME} is used as APPLICATION_NAME")
      SET(APPLICATION_NAME ${PROJECT_NAME})
-diff -Naur libssh-0.6.4-orig/CMakeLists.txt libssh-0.6.4/CMakeLists.txt
---- libssh-0.6.4-orig/CMakeLists.txt	2014-12-19 11:11:27.000000000 +0300
-+++ libssh-0.6.4/CMakeLists.txt	2014-12-25 12:41:43.298000000 +0300
-@@ -84,8 +84,8 @@
- add_subdirectory(src)
- 
+diff -aur libssh-0.7.3/CMakeLists.txt.orig libssh-0.7.3/CMakeLists.txt
+--- libssh-0.7.3/CMakeLists.txt.orig    2016-05-14 09:35:49 -0400
++++ libssh-0.7.3/CMakeLists.txt 2016-05-14 09:44:29 -0400
+@@ -85,7 +85,7 @@
+
  # pkg-config file
+ if (UNIX)
 -configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc)
--configure_file(libssh_threads.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh_threads.pc)
 +configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc @ONLY)
-+configure_file(libssh_threads.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh_threads.pc @ONLY)
  install(
    FILES
      ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc
+@@ -97,7 +97,7 @@
+ )
+
+     if (LIBSSH_THREADS)
+-        configure_file(libssh_threads.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh_threads.pc)
++        configure_file(libssh_threads.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh_threads.pc @ONLY)
+         install(
+           FILES
+             ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc
+
 diff -Naur libssh-0.6.4-orig/libssh.pc.cmake libssh-0.6.4/libssh.pc.cmake
 --- libssh-0.6.4-orig/libssh.pc.cmake	2013-02-07 22:23:14.000000000 +0400
 +++ libssh-0.6.4/libssh.pc.cmake	2014-12-25 12:44:04.023000000 +0300


### PR DESCRIPTION
mingw-w64-libssh: 0.7.3: Update to latest version and rekey
mingw-as-unix patch