### PR TITLE
Add mingw-w64-libmypaint-git

### DIFF
--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -1,0 +1,68 @@
+# Maintainer: Andrew Chadwick <a.t.chadwick@gmail.com>
+
+_realname=libmypaint
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=(
+    "${MINGW_PACKAGE_PREFIX}-${_realname}"
+    "mypaint<1.3.0alpha"
+)
+pkgver=1.3.0alpha.0
+pkgrel=1
+pkgdesc="Brush engine used by MyPaint (git) (mingw-w64)"
+arch=('any')
+url="http://mypaint.org"
+license=("ISC")
+makedepends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc"
+    "${MINGW_PACKAGE_PREFIX}-pkg-config"
+    "${MINGW_PACKAGE_PREFIX}-json-c"
+    "${MINGW_PACKAGE_PREFIX}-glib2"
+)
+makedepends+=("autoconf" "automake" "libtool" "git")
+# autotools are required because several Makefile.am are modified
+depends=(
+    "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+    "${MINGW_PACKAGE_PREFIX}-glib2"
+)
+options=('!strip' 'debug')
+source=("${_realname}::git+https://github.com/mypaint/libmypaint.git")
+sha256sums=('SKIP')
+
+# Not yet. Need some proper version tags upsteam first.
+# Note that when we do that, MyPaint tends to use vA.B.C notation.
+#pkgver() {
+#  cd "${srcdir}"/${_realname}
+#  git describe --tags | sed 's|-|.|g'
+#}
+
+prepare() {
+  cd "${srcdir}"/${_realname}
+  #./autogen.sh --help
+  for f in README ChangeLog NEWS AUTHORS; do
+    if ! test -f "$f"; then
+      echo "Creating $f"
+      echo "missing" > "$f"
+    fi
+  done
+  autoreconf -vfi
+  intltoolize --automake || exit $?
+}
+
+build() {
+  #export GI_SCANNER_DEBUG="save-temps"
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  cp -rf libmypaint build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/share/pkgconfig" \
+  ./configure --prefix=${MINGW_PREFIX}
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${MINGW_CHOST}
+  make -j1 DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}"/${_realname}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+}


### PR DESCRIPTION
libmypaint is splitting off from MyPaint fully now.

Build for this lib is now a simple autotools thing. I've tested that it works properly from MSYS2 using makepkg-mingw for both MINGW64 and MINGW32.