### PR TITLE
Put back LibXML++ 2.6

### DIFF
--- a/mingw-w64-libxml++2.6/PKGBUILD
+++ b/mingw-w64-libxml++2.6/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=libxml++
+pkgbase=mingw-w64-${_realname}2.6
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2.6"
+pkgver=2.40.0
+pkgrel=1
+arch=('any')
+pkgdesc="C++ wrapper for the libxml2 XML parser library (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-glibmm")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+license=('LGPL')
+url="http://libxmlplusplus.sourceforge.net/"
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
+sha256sums=('a7b9703203696972cae50436e150979ef187d9b03c95519bdd89623b4068162a')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build="${MINGW_CHOST}" \
+    --disable-static \
+    --enable-shared
+
+  # Hack for mingw python
+  local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
+  find . -type f -name "Makefile" -exec sed -i "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" {} \;
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
Version 2.6 and 3.0 can be installed in parallel
for smoother transition.

This commit just reverts the old PKGBUILD into a separate directory.
The availability of the 2.6 version should close #1343.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alexpux/mingw-packages/1417)
<!-- Reviewable:end -->
