### PR TITLE
libssh: repackage missing pkg-config files

### DIFF
--- a/mingw-w64-libssh/PKGBUILD
+++ b/mingw-w64-libssh/PKGBUILD
@@ -24,7 +24,7 @@ source=(https://red.libssh.org/attachments/download/195/${_realname}-${pkgver}.t
         fix-threads-libraryname-in-config.patch)
 sha256sums=('26ef46be555da21112c01e4b9f5e3abba9194485c8822ab55ba3d6496222af98'
             'SKIP'
-            'd0790ab4e47d90b7fa5a15a2b08430b65db72a8d88fac8f5883e48a7fdc6d6c4'
+            '3e95048aa0acf0a639120cb732dcce14ea1e51a7ed59b18a25e05001ebabd241'
             '444a66b1926f49c54df844c22263496c2d86e124c8bcdbd194c4581d06140c1b'
             'a69b444d4a9b1861991661d5f3ca8d2ab705fac1f5766a79730328b0bdd86691')
 

--- a/mingw-w64-libssh/mingw-as-unix.patch
+++ b/mingw-w64-libssh/mingw-as-unix.patch
@@ -13,7 +13,8 @@ diff -aur libssh-0.7.3/CMakeLists.txt.orig libssh-0.7.3/CMakeLists.txt
 @@ -85,7 +85,7 @@
 
  # pkg-config file
- if (UNIX)
+-if (UNIX)
++if (UNIX OR MINGW)
 -configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc)
 +configure_file(libssh.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc @ONLY)
  install(
@@ -28,6 +29,15 @@ diff -aur libssh-0.7.3/CMakeLists.txt.orig libssh-0.7.3/CMakeLists.txt
          install(
            FILES
              ${CMAKE_CURRENT_BINARY_DIR}/libssh.pc
+@@ -108,7 +108,7 @@
+             pkgconfig
+         )
+     endif (LIBSSH_THREADS)
+-endif (UNIX)
++endif (UNIX OR MINGW)
+
+ # cmake config files
+ set(LIBSSH_LIBRARY_NAME ${CMAKE_SHARED_LIBRARY_PREFIX}ssh${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 diff -Naur libssh-0.6.4-orig/libssh.pc.cmake libssh-0.6.4/libssh.pc.cmake
 --- libssh-0.6.4-orig/libssh.pc.cmake	2013-02-07 22:23:14.000000000 +0400


### PR DESCRIPTION
Previous update stopped including pkg-config files which are needed for ex. FFmpeg.