### PR TITLE
Continuous Integration: Enable 64 bit build.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,8 @@
 build:
-  image: teaci/msys32
+  image: teaci/msys$$arch
   pull: true
-  shell: msys32
+  shell: msys$$arch
   commands:
-    - export RUNTEST=$$runtest
     - ./ci-build.sh
 
 notify:
@@ -16,7 +15,7 @@ notify:
       port: 6667
 
 matrix:
-  runtest:
-    - false
-# Temprorary disable matrix build to workaround irc plugin bug on wine-ci.org, see https://github.com/drone/drone/issues/1459
-#    - true # allow failures
+  arch:
+    - 64
+    - 32
+#FIXME: When a matrix build is done, only the build status of the last job in a matrix is sent to notification plugins, this confuses our irc plugin, see https://github.com/drone/drone/issues/1459. Github pull request Web UI status and Tea CI Web UI status works fine with matrix build.


### PR DESCRIPTION
Now we bring 64 bit support to Tea CI, next step is adding package uploading script so users can have a convenient way to download testing packages. 