### PR TITLE
libzip: updated to version 1.1.2 and fixed bug

### DIFF
--- a/mingw-w64-libzip/PKGBUILD
+++ b/mingw-w64-libzip/PKGBUILD
@@ -1,23 +1,29 @@
 # Maintainer: Jianfeng Liu <liujianfeng1994@gmail.com>
+# Contributor: Olivier Michel <Olivier.Michel@cyberbotics.com>
 
 _realname=libzip
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.1
-pkgrel=2
+pkgver=1.1.2
+pkgrel=1
 pkgdesc="A C library for reading, creating, and modifying zip archives (mingw-w64)"
 url="http://www.nih.at/libzip/index.html"
 license=('BSD')
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-dlfcn")
 options=('staticlibs' '!libtool')
-source=("http://www.nih.at/${_realname}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('f948d597afbb471de8d528d0e35ed977de85b2f4d76fdd74abbb985550e5d840')
+source=("http://www.nih.at/${_realname}/${_realname}-${pkgver}.tar.xz"
+        'configure.patch')
+sha256sums=('a921b45b5d840e998ff2544197eba4c3593dccb8ad0ee938630c2227c2c59fb3'
+            '58fe10fe7867abdad71d2c632009a353b62076feaa7b174ee595498d977534d8')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
+  
+  patch -p1 -i ${srcdir}/configure.patch
+  
   autoreconf -fi
 }
 

--- a/mingw-w64-libzip/configure.patch
+++ b/mingw-w64-libzip/configure.patch
@@ -1,0 +1,46 @@
+--- a/configure.ac	Thu Apr 07 14:13:07 2016 +0200
++++ b/configure.ac	Wed Apr 13 13:25:32 2016 +0200
+@@ -65,6 +65,13 @@
+     AC_DEFINE([HAVE___PROGNAME], [1], [Define if libc defines __progname])
+ fi
+
++AC_CACHE_CHECK([whether we are building for a Win32 host], [ac_cv_win32_host],
++	       AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#ifdef _WIN32
++ choke me
++#endif
++ ]])],
++ [ac_cv_win32_host=no], [ac_cv_win32_host=yes]))
++AM_CONDITIONAL([WIN32_HOST], [test "x$ac_cv_win32_host" = "xyes"])
+
+ AC_CHECK_HEADERS([fts.h stdbool.h strings.h unistd.h])
+
+--- a/lib/Makefile.am	Thu Apr 07 14:13:07 2016 +0200
++++ b/lib/Makefile.am	Wed Apr 13 13:25:32 2016 +0200
+@@ -10,7 +10,19 @@
+ libzip_la_LDFLAGS=-no-undefined -version-info 4:0:0
+ libzip_la_LIBADD=@LTLIBOBJS@
+
++if WIN32_HOST
++IO_SOURCES=\
++	zip_source_win32a.c \
++	zip_source_win32handle.c \
++	zip_source_win32utf8.c \
++	zip_source_win32w.c
++else
++IO_SOURCES=\
++	zip_source_file.c
++endif
++
+ libzip_la_SOURCES=\
++	${IO_SOURCES} \
+	zip_add.c \
+	zip_add_dir.c \
+	zip_add_entry.c \
+@@ -80,7 +92,6 @@
+	zip_source_crc.c \
+	zip_source_deflate.c \
+	zip_source_error.c \
+-	zip_source_file.c \
+	zip_source_filep.c \
+	zip_source_free.c \
+	zip_source_function.c \


### PR DESCRIPTION
Fixes #1418.

This fixes a bug found in the current libzip package preventing the user from adding a new file to an existing archive.