### PR TITLE
mingw-w64-curl: 7.49.0 Update to latest version

### DIFF
--- a/mingw-w64-curl/0001-curl-relocation.patch
+++ b/mingw-w64-curl/0001-curl-relocation.patch
@@ -1,7 +1,7 @@
-diff -urN curl-7.37.1.orig/configure.ac curl-7.37.1/configure.ac
---- curl-7.37.1.orig/configure.ac	2014-07-14 19:49:18.000000000 +0100
-+++ curl-7.37.1/configure.ac	2014-08-28 21:39:53.352497100 +0100
-@@ -2940,6 +2940,7 @@
+diff -aur curl-7.49.0/configure.ac.orig curl-7.49.0/configure.ac
+--- curl-7.49.0/configure.ac.orig	2016-05-16 03:23:33 -0400
++++ curl-7.49.0/configure.ac	2016-05-23 10:38:16 -0400
+@@ -3191,6 +3191,7 @@
    ])
  fi
  
@@ -9,10 +9,10 @@ diff -urN curl-7.37.1.orig/configure.ac curl-7.37.1/configure.ac
  
  # check for ssize_t
  AC_CHECK_TYPE(ssize_t, ,
-diff -urN curl-7.37.1.orig/lib/curl_config.h.in curl-7.37.1/lib/curl_config.h.in
---- curl-7.37.1.orig/lib/curl_config.h.in	2014-07-14 19:50:33.000000000 +0100
-+++ curl-7.37.1/lib/curl_config.h.in	2014-08-28 21:34:05.997388600 +0100
-@@ -6,6 +6,9 @@
+diff -aur curl-7.49.0/lib/curl_config.h.in.orig curl-7.49.0/lib/curl_config.h.in > patch
+--- curl-7.49.0/lib/curl_config.h.in.orig	2016-05-16 03:24:14 -0400
++++ curl-7.49.0/lib/curl_config.h.in	2016-05-23 11:21:50 -0400
+@@ -9,6 +9,9 @@
  /* Location of default ca path */
  #undef CURL_CA_PATH
  
@@ -22,22 +22,22 @@ diff -urN curl-7.37.1.orig/lib/curl_config.h.in curl-7.37.1/lib/curl_config.h.in
  /* to disable cookies support */
  #undef CURL_DISABLE_COOKIES
  
-diff --git a/lib/Makefile.inc b/lib/Makefile.inc
---- a/lib/Makefile.inc
-+++ b/lib/Makefile.inc
-@@ -46,7 +46,7 @@ LIB_CFILES = file.c timeval.c base64.c hostip.c progress.c formdata.c   \
-   curl_ntlm_core.c curl_ntlm_msgs.c curl_sasl.c curl_multibyte.c        \
-   hostcheck.c bundles.c conncache.c pipeline.c dotdot.c x509asn1.c      \
-   http2.c curl_sasl_sspi.c smb.c curl_sasl_gssapi.c curl_endian.c       \
--  curl_des.c
-+  curl_des.c pathtools.c
+diff -aur curl-7.49.0/lib/Makefile.inc.orig curl-7.49.0/lib/Makefile.inc > patch
+--- curl-7.49.0/lib/Makefile.inc.orig	2016-05-23 11:24:30 -0400
++++ curl-7.49.0/lib/Makefile.inc	2016-05-23 11:30:00 -0400
+@@ -53,7 +53,7 @@
+   http_proxy.c non-ascii.c asyn-ares.c asyn-thread.c curl_gssapi.c      \
+   http_ntlm.c curl_ntlm_wb.c curl_ntlm_core.c curl_sasl.c               \
+   curl_multibyte.c hostcheck.c conncache.c pipeline.c dotdot.c          \
+-  x509asn1.c http2.c smb.c curl_endian.c curl_des.c
++  x509asn1.c http2.c smb.c curl_endian.c curl_des.c pathtools.c
  
  LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
    formdata.h cookie.h http.h sendf.h ftp.h url.h dict.h if2ip.h         \
-@@ -65,7 +65,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
-   curl_ntlm_msgs.h curl_sasl.h curl_multibyte.h hostcheck.h bundles.h   \
-   conncache.h curl_setup_once.h multihandle.h setup-vms.h pipeline.h    \
-   dotdot.h x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h  \
+@@ -72,7 +72,7 @@
+   curl_sasl.h curl_multibyte.h hostcheck.h conncache.h                  \
+   curl_setup_once.h multihandle.h setup-vms.h pipeline.h dotdot.h       \
+   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \
 -  curl_printf.h
 +  curl_printf.h pathtools.h
  
@@ -599,22 +599,20 @@ diff -urN curl-7.37.1.orig/lib/pathtools.h curl-7.37.1/lib/pathtools.h
 +char * get_relocated_path_list(char const * from, char const * to_path_list);
 +
 +#endif /* PATHTOOLS_H */
-diff -urN curl-7.37.1.orig/lib/url.c curl-7.37.1/lib/url.c
---- curl-7.37.1.orig/lib/url.c	2014-07-15 22:49:55.000000000 +0100
-+++ curl-7.37.1/lib/url.c	2014-08-28 21:47:00.370221400 +0100
-@@ -130,6 +130,11 @@
- #include <curl/mprintf.h>
- 
- #include "curl_memory.h"
-+
+diff -aur curl-7.49.0/lib/url.c.orig curl-7.49.0/lib/url.c
+--- curl-7.49.0/lib/url.c.orig	2016-05-16 03:23:43 -0400
++++ curl-7.49.0/lib/url.c	2016-05-23 11:39:21 -0400
+@@ -130,6 +130,9 @@
+ #include "pipeline.h"
+ #include "dotdot.h"
+ #include "strdup.h"
 +#if defined(__MINGW32__)
 +#include "pathtools.h"
 +#endif
-+
- /* The last #include file should be: */
- #include "memdebug.h"
- 
-@@ -585,7 +591,20 @@
+ /* The last 3 #include files should be in this order */
+ #include "curl_printf.h"
+ #include "curl_memory.h"
+@@ -581,7 +584,20 @@
  
    /* This is our preferred CA cert bundle/path since install time */
  #if defined(CURL_CA_BUNDLE)

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.48.0
+pkgver=7.49.0
 pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
@@ -32,11 +32,13 @@ options=('staticlibs')
 source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0004-cURL-Get-relocatable-base-from-dll.patch")
-sha256sums=('864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753'
+sha256sums=('14f44ed7b5207fea769ddb2c31bd9e720d37312e1c02315def67923a4a636078'
             'SKIP'
-            '99327833b310a2a05197bf48d43e5a8bb89b8ec3f7315d6b1adba327d4bf8074'
+            '3302d6fb38e3ba9e335e892df6d8e7e01bd18b926cd51ff7b871cb656412c430'
             'e21fb106ebda8559ba2d34633a9d7d94be541de02de01982f92d67048bb9854b')
-validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91')  # Daniel Stenberg
+validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
+              '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
+              '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
 
 prepare() {
   cd "${_realname}-${pkgver}"


### PR DESCRIPTION
mingw-w64-culr: 7.49.0 Update to latest version
rekey relocation patch
Add all valid pgp keys.