### PR TITLE
Averted the relocation bug.

### DIFF
--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -140,7 +140,6 @@ build() {
     --target=${MINGW_CHOST} \
     --with-native-system-header-dir=${MINGW_PREFIX}/${MINGW_CHOST}/include \
     --libexecdir=${MINGW_PREFIX}/lib \
-    --with-gxx-include-dir=${MINGW_PREFIX}/include/c++/${_realpkgver} \
     --enable-bootstrap \
     --with-arch=${_arch} \
     --with-tune=generic \
@@ -153,7 +152,6 @@ build() {
     --enable-libstdcxx-time=yes \
     --disable-libstdcxx-pch \
     --disable-libstdcxx-debug \
-    --enable-version-specific-runtime-libs \
     --disable-isl-version-check \
     --enable-lto \
     --enable-libgomp \
@@ -173,6 +171,8 @@ build() {
     ${_conf}
     #--enable-libitm
     #--enable-objc-gc
+    #--with-gxx-include-dir=${MINGW_PREFIX}/include/c++/${_realpkgver} \
+    #--enable-version-specific-runtime-libs \
 
   # While we're debugging -fopenmp problems at least.
   # .. we may as well not strip anything.


### PR DESCRIPTION
According to <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70936>, GCC's '--with-gxx-include-dir' configure option is causing a relocation bug, We'd better remove it.
The newly added standard-conforming <cstdlib> and <cmath> C++ headers since GCC 6 suffer from this bug. A relocated GCC will complain about inability to find <stdlib.h> and <math.h>, respectively.
In addition, removal of this option changes the paths where GCC searches for libstdc++ headers. We make GCC search for them in the default directories by removing '--enable-version-specific-runtime-libs' as well.


---
Here is an abridged IRC log in #gcc on OFTC today:

> [16:12:21] \<lh_mouse> The #include_next bug. it hasn't been fixed.
> [16:12:25] \<jwakely> lh_mouse: your problems were on mingw though, right?
> [16:12:54] \<drako> anyways, my target version is 4.9.3, so it's good :-)
> [16:12:56] \<lh_mouse> jwakely, another person reported the same bug on Linux.
> [16:13:01] \<lh_mouse> jwakely, https://gcc.gnu.org/ml/gcc/2016-05/msg00092.html
> [16:13:02] \<jwakely> lh_mouse: link?
> [16:13:10] \<jwakely> that's not a bug report, is it in bugzilla?
> ...
> [16:16:06] \<lh_mouse> jwakely, https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70936
> ...
> [16:47:30] \<lh_mouse> jwakely, 70936 updated with 'gcc -v' output and a minimal testcase.
> [16:47:47] \<jwakely> thanks
> [16:48:32] \<lh_mouse> Well the testcase consists of only a line of command:  echo '#include \<cstdlib>' | g++ -v -x c++ -
> [16:49:02] \<jwakely> it's still useful
> ...
> [17:00:11] \<jwakely> I suspect --with-gxx-include-dir is the problem
> [17:01:13] \<lh_mouse> So what should I do? remove it?
> [17:01:42] \<jwakely> be patient
> [17:01:59] \<lh_mouse> >_<
> [17:01:59] \<jwakely> but yes, you could try removing it from the build and see if it makes any difference
> [17:04:05] * davidlt (~davidlt@pb-d-128-141-241-251.cern.ch) has joined
> [17:04:45] \<lh_mouse> Removed. I am going to rebuild GCC which would take more than an hour with bootstrap disabled.
> ...
> [17:27:11] \<jwakely> lh_mouse: --with-gxx-include-dir is definitely the problem
> [17:27:23] \<jwakely> I just tested it on linux and reproduced the path re-ordering
> ...
> [17:30:24] \<jwakely> lh_mouse: if you'd provided the 'gcc -v' output in the first place it might have been easier to find the problem. that's why you're asked to read https://gcc.gnu.org/bugs/ before you create a bug report
> [17:30:30] \<jwakely> but nobody reads it ;-(
> ...
> [18:07:28] \<lh_mouse> jwakely, now it can't find any C++ headers.
> [18:07:57] \<lh_mouse> one moment.
> [18:07:59] \<jwakely> lh_mouse: that makes no sense
> [18:08:17] \<jwakely> lh_mouse: the default for --with-gxx-include-dir should be fine
> [18:08:40] \<lh_mouse> I copied the C++ headers and the relocation bug didn't take place any more.
> [18:10:32] \<lh_mouse> jwakely, http://paste.ubuntu.com/16728438/   This is what 'gcc -v' outputs.
> [18:10:52] \<lh_mouse> The directory 'C:/newdir/MSYS2/mingw32/bin/../lib/gcc/i686-w64-mingw32/6.1.1/include/c++' doesn't exist.
> [18:11:05] * lh_mouse goes look at the package.
> [18:13:11] \<lh_mouse> The C++ headers are installed in 'C:/newdir/MSYS2/mingw32/include/c++/6.1.1'.
> [18:14:33] \<lh_mouse> The wrong path is 'C:/newdir/MSYS2/mingw32/lib/gcc/i686-w64-mingw32/6.1.1/include/c++'.
> [18:15:17] \<jwakely> possibly related to --enable-version-specific-runtime-libs ... not sure
> [18:18:55] \<lh_mouse> Rebuilding.
> [18:19:42] \<lh_mouse> ... isn't that option supposed to affect 'runtime libs' only?
> [18:20:34] \<jwakely> I don't remember if it moves headers too (they're already in version-specific dirs, so maybe not)
> [18:20:55] \<jwakely> libstdc++ is a runtime lib though, so its headers might be affected. it wouldn't be insane for that to happen
> [18:21:10] * iains uses  --enable-version-specific-runtime-libs quite a bit on darwin, and would expect to see the headers installed in lib/gcc/<target>/<version>/include/c++  with that option enabled (at least it works for me, including Ada and Java)
> [18:21:34] \<jwakely> iains: thanks, that's what I thought
> [18:22:32] \<jwakely> so that explains why lh_mouse's compiler is expecting to find the headers in C:/newdir/MSYS2/mingw32/lib/gcc/i686-w64-mingw32/6.1.1/include/c++
> [18:22:40] \<jwakely> but doesn't explain why they're installed somewhere else
> [18:22:59] * cp- has quit (Quit: Disappears in a puff of smoke)
> [18:23:07] \<jwakely> too many options! I wish people would start with a minimal set of configure options and add them to get a working config
> [18:23:17] \<jwakely> starting with every possible option and removing them to get a working config is a PITA
> [18:24:12] \<lh_mouse> jwakely, if '--with-gxx-include-dir' is the cause of the bug I am about to remove it as well as '--enable-version-specific-runtime-libs' from the build script.
> [18:24:25] \<jwakely> yes
> [18:24:34] \<lh_mouse> Is this stil a driver bug?
> [18:24:38] \<lh_mouse> s/stil/still/
> [18:24:45] \<iains> I’d expect those two to conflict - one or the other seems reasonable
> [18:25:04] \<jwakely> lh_mouse: yes, definitely a driver bug
> [18:28:36] \<iains> (JFTR, the headers are installed in the expected place on my last gcc-6.1.0-based --enable-version-specific-runtime-libs build)
> [18:28:50] \<segher> jwakely: you want that eh?  well i want a pony!  :-)
> [18:28:56] \<lh_mouse> Then I would leave the bug report alone. Later I would send a patch for the build script to the MSYS2 team. In order to tell people how the bug is caused I may have to copy part of today's log from this channel. Would you mind that? jwakely iains
> [18:29:12] \<jwakely> np
> [18:29:17] \<lh_mouse> I appreciate your help. :>
> [18:29:17] \<iains> ok by me
