### PR TITLE
angle: Update to 2.1.r5785

### DIFF
--- a/mingw-w64-angleproject-git/PKGBUILD
+++ b/mingw-w64-angleproject-git/PKGBUILD
@@ -4,11 +4,11 @@
 _realname=angleproject
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=2.1.r5684
+pkgver=2.1.r5785
 pkgrel=1
 pkgdesc='ANGLE project built from git source (mingw-w64)'
 arch=('any')
-url='https://code.google.com/p/angleproject/'
+url='https://chromium.googlesource.com/angle/angle'
 license=('LGPLv2+')
 depends=()
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" 'gyp-git' 'git')
@@ -64,8 +64,7 @@ build() {
   #export CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4"
   #export CXXFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4"
 
-  sed -i -e 's_python _python2 _g' -e 's_"python"_"python2"_g' -e "s_'python'_'python2'_g" -e 's_/usr/bin/python_/usr/bin/python2_g' $(find -type f)
-  sed -i -e 's|vsprintf_s|vsprintf|g' $(find . \( -name '*.h' -or -name '*.cpp' \) -and -type f)
+  sed -i -e 's_python _python2 _g' -e 's_"python"_"python2"_g' -e "s_'python'_'python2'_g" -e 's_/usr/bin/python_/usr/bin/python2_g' $(find -not \( -path "./.git*" -prune \) -type f)
 
   if [[ "${MINGW_CHOST}" == "i686-w64-mingw32" ]]; then
     _target="win32"
@@ -73,7 +72,7 @@ build() {
     _target="win64"
   fi
 
-  gyp -D OS=win -D MSVS_VERSION="" -D TARGET=${_target} --format make --depth . -I build/common.gypi src/angle.gyp
+  gyp -D use_ozone=0 -D OS=win -D MSVS_VERSION="" -D TARGET=${_target} --format make --depth . -I build/common.gypi src/angle.gyp
 
   # Make sure the correct libraries are linked in
   #sed -i s@'^LIBS :='@'LIBS := -ld3d9 -ldxguid'@ ../src/libGLESv2.target.mk
@@ -90,7 +89,6 @@ package() {
 
   install out/Debug/lib.target/libGLESv2.dll "${pkgdir}${MINGW_PREFIX}"/bin/libGLESv2.dll
   install out/Debug/lib.target/libEGL.dll "${pkgdir}${MINGW_PREFIX}"/bin/libEGL.dll
-
   ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}${MINGW_PREFIX}"/bin/*.dll
 
   #install libGLESv2.a "${pkgdir}${MINGW_PREFIX}"/lib/


### PR DESCRIPTION
- vsprintf doesn't exist anywhere in the source; remove sed
- don't run sed on .git files and dir (fixes indexv2 errors)
- add missing define to gyp
- use official url