### PR TITLE
Fixed packaging stuff.

### DIFF
--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-fortran-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada-git"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc-git")
-pkgver=r145684.bbf9535
+pkgver=r145817.32dc90f
 pkgrel=1
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
@@ -183,6 +183,8 @@ build() {
 
   make all
 
+  rm -rf ${srcdir}${MINGW_PREFIX}
+
   make -j1 DESTDIR=${srcdir} install
   mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
 }
@@ -218,7 +220,7 @@ ENDFILE
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
 
   cd ${srcdir}${MINGW_PREFIX}
-  cp bin/{libatomic*,libgcc*,libgomp*,libquadmath*,libssp*,libstdc*,libvtv*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  cp bin/{libatomic*,libgcc*,libgomp*,libitm*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
 }
 
 package_mingw-w64-gcc-git() {
@@ -256,7 +258,7 @@ package_mingw-w64-gcc-git() {
   cp bin/${MINGW_CHOST}-gcc-nm.exe                      ${pkgdir}${MINGW_PREFIX}/bin/
   cp bin/${MINGW_CHOST}-gcc-ranlib.exe                  ${pkgdir}${MINGW_PREFIX}/bin/
 
-  #cp bin/{libgcc*,libgomp*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
+  #cp bin/{libatomic*,libgcc*,libgomp*,libitm*,libquadmath*,libssp*,libstdc*}.dll ${pkgdir}${MINGW_PREFIX}/bin/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/*.h        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/
   cp -r lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/ssp     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/
@@ -266,24 +268,27 @@ package_mingw-w64-gcc-git() {
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/collect2.exe       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/crt*.o             ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/liblto*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libatomic*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libatomic*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgcc*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgcov*           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgomp*           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libquadmath*       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libssp*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libvtv*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgomp*           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libquadmath*       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libssp*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libvtv*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/lto*.exe           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
 
   #mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib
-  cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   #cp lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/
+  cp ${srcdir}${MINGW_PREFIX}/lib/libgcc* ${pkgdir}${MINGW_PREFIX}/lib/
+  cp ${srcdir}${MINGW_PREFIX}/lib/libstdc++* ${pkgdir}${MINGW_PREFIX}/lib/
+  cp ${srcdir}${MINGW_PREFIX}/lib/libsupc++* ${pkgdir}${MINGW_PREFIX}/lib/
 
   #cp -r lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/c++ ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/
   cp -r include/c++ ${pkgdir}${MINGW_PREFIX}/include/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/cc1plus.exe        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libstdc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libsupc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libstdc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libsupc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
 
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/{doc,info,locale,man}
   #cp -r share/doc/gcc-${_realpkgver} ${pkgdir}${MINGW_PREFIX}/share/doc/
@@ -338,7 +343,7 @@ package_mingw-w64-gcc-fortran-git() {
   cp -r lib/gcc/${MINGW_CHOST}/${_realpkgver}/finclude       ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/f951.exe          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libcaf_single.a   ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgfortran*      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libgfortran*      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/man/man1
   cp share/man/man1/gfortran.1*                         ${pkgdir}${MINGW_PREFIX}/share/man/man1/
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/info
@@ -383,7 +388,7 @@ package_mingw-w64-gcc-objc-git() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include
   cp -r lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/objc    ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/cc1obj.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libobjc.*          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  #cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/libobjc.*          ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/cc1objplus.exe     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
 }
 


### PR DESCRIPTION
This a general patch for gcc-5-branch and gcc-6-branch that fixes issues mentioned in #1374 and #1437.

* In #1374:

The relocation bug mentioned in #1374 is a [GCC bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70936) and has been averted.
libvtv*.dll is now excluded from packaging, though the reason why it isn't built is still unknown.

* In #1437:

Modification of the library path introduces problems when packaging DLLs. Libraries are known to be subject to this bug are `libatomic*`, `libgomp*`, `libquadmath*`, `libssp*`, `libobjc*` and `libgfortan*`.

The `build()` function now removes the destination directory before it invokes `make install` so missing libraries are now reported as errors. Otherwise, if a successful package has been created already, `makepkg` might be happy with existent files.

Two bootstraps with all languages enabled from scratch that had all indeterminate and installed files removed and targeted x86_64 and i686 were made to verify the script. 

@BrisingrAerowing @mati865 @tkelman 
Please test whether this script works.
