### PR TITLE
gdb-git: Fix patch

### DIFF
--- a/mingw-w64-gdb-git/0003-MinGW-w64-Use-gnu-printf.patch
+++ b/mingw-w64-gdb-git/0003-MinGW-w64-Use-gnu-printf.patch
@@ -99,12 +99,12 @@ index e23fe17..2cf64c7 100644
               around bugs in the Solaris 8 implementation of printf.  */
  	  printf ("  [%6tx]  ", data - start);
 diff --git a/gas/read.c b/gas/read.c
-index e992534..a163914 100644
+index a940ff3..e8cb26c 100644
 --- a/gas/read.c
 +++ b/gas/read.c
-@@ -4413,7 +4413,7 @@ emit_expr_with_reloc (expressionS *exp,
- 	      || (get & hibit) == 0))
- 	{		/* Leading bits contain both 0s & 1s.  */
+@@ -4415,7 +4415,7 @@ emit_expr_with_reloc (expressionS *exp,
+ 	{
+ 	  /* Leading bits contain both 0s & 1s.  */
  #if defined (BFD64) && BFD_HOST_64BIT_LONG_LONG
 -#ifndef __MSVCRT__
 +#if !defined(__MSVCRT__) || defined(__USE_MINGW_ANSI_STDIO)

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gdb
 _gcc_ver=5.3.0
 pkgbase=mingw-w64-${_realname}
 _base_ver=7.11
-pkgver=7.11.r86530.2d8dcb8
+pkgver=7.11.r87497.834bb58
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -35,7 +35,7 @@ sha256sums=('SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
             'c88dcddafcb217a1f933b786a01fb6261adae7841aaddac1c2d96bdc259f00b6'
             'c92183a52f53d82cb5ffddf2a18f5bddd350ccc0db01eff1e5918d98467ee8e3'
-            'e250112adafd5f098334406357e99ab33ad796a348a646feb90fbc68bca91f1b'
+            'c8aab67618e05c31e3b60b59319d8fa3eeb7ca9dbf8de937a07c99533557dd5f'
             '4ddb55be45625efd1b2c82d2e344f4ebc9f17e362642489f21eb19fa9ec8d94b')
 
 pkgver() {


### PR DESCRIPTION
`makepkg` previously failed with:
```
[...]
==> Starting prepare()...
Applying: MinGW-w64: Two fixes for 'unusual' files.
Applying: MinGW-w64: Fix libibery configure
Applying: MinGW-w64: Use gnu-printf
error: patch failed: gas/read.c:4413
error: gas/read.c: patch does not apply
Patch failed at 0001 MinGW-w64: Use gnu-printf
[...]
```