### PR TITLE
Use strtok_r() under mingw-w64 to support winxp

### DIFF
--- a/mingw-w64-libvpx/0009-use-strtok_r.mingw.patch
+++ b/mingw-w64-libvpx/0009-use-strtok_r.mingw.patch
@@ -1,0 +1,17 @@
+--- libvpx-1.5.0/vpx/src/svc_encodeframe.c.orig	2015-11-10 06:12:38.000000000 +0800
++++ libvpx-1.5.0/vpx/src/svc_encodeframe.c	2016-06-04 21:59:01.192496000 +0800
+@@ -28,14 +28,6 @@
+ #include "vpx_mem/vpx_mem.h"
+ #include "vp9/common/vp9_onyxc_int.h"
+ 
+-#ifdef __MINGW32__
+-#define strtok_r strtok_s
+-#ifndef MINGW_HAS_SECURE_API
+-// proto from /usr/x86_64-w64-mingw32/include/sec_api/string_s.h
+-_CRTIMP char *__cdecl strtok_s(char *str, const char *delim, char **context);
+-#endif  /* MINGW_HAS_SECURE_API */
+-#endif  /* __MINGW32__ */
+-
+ #ifdef _MSC_VER
+ #define strdup _strdup
+ #define strtok_r strtok_s

--- a/mingw-w64-libvpx/PKGBUILD
+++ b/mingw-w64-libvpx/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libvpx
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The VP8 Codec SDK (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -14,13 +14,16 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/webmproject/libvpx/arc
         0001-enable-shared-on.mingw.patch
         0002-no-pthreads.mingw.patch
         0003-cross-with-native-binutils.mingw.patch
-        0005-fix-exports.mingw.patch)
+        0005-fix-exports.mingw.patch
+        0009-use-strtok_r.mingw.patch)
 options=('strip' 'staticlibs')
 sha256sums=('f199b03b67042e8d94a3ae8bc841fb82b6a8430bdf3965aeeaafe8245bcfa699'
             'f7bb395aa92b43cdee829cb796bf6ef0d62af6ad74ad37c9ed2b2c2ad40365a3'
             '00e645af59161c2d750af7d2adda13e5486825b7b4dbb3ed870d8fd1e431a6e2'
             'b855c8bbee071dfac267797723ea4ffbb7ebc66d159bc0bb6a64bfee0c08da00'
-            '7c511b5df935278da2cba32b03b90582f360ab6786a5e32028bc82025193fabd')
+            '7c511b5df935278da2cba32b03b90582f360ab6786a5e32028bc82025193fabd'
+	    'd8b602fc6ad9ef7bbd3c239f91c60930b90efee0acab795441051cba4a9bbba4')
+
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -29,6 +32,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/0002-no-pthreads.mingw.patch
   patch -Np1 -i ${srcdir}/0003-cross-with-native-binutils.mingw.patch
   patch -Np1 -i ${srcdir}/0005-fix-exports.mingw.patch
+  patch -Np1 -i ${srcdir}/0009-use-strtok_r.mingw.patch
 }
 
 build() {


### PR DESCRIPTION
mingw-w64 provides strtok_r(), defined in "string.h", so there is no need to use strtok_s().  This has the added benefit that libvpx will work under Windows XP.