### PR TITLE
Make x265 support winxp

### DIFF
--- a/mingw-w64-x265/0001-winxp-condition-var.mingw.patch
+++ b/mingw-w64-x265/0001-winxp-condition-var.mingw.patch
@@ -1,0 +1,41 @@
+--- a/source/common/winxp.h.orig	2016-01-25 16:16:50.000000000 +1100
++++ b/source/common/winxp.h	2016-06-05 15:55:35.994089600 +1000
+@@ -24,7 +24,7 @@
+ #ifndef X265_WINXP_H
+ #define X265_WINXP_H
+ 
+-#if defined(_WIN32) && (_WIN32_WINNT < 0x0600) // _WIN32_WINNT_VISTA
++#if defined(_WIN32) && !defined(__x86_64__) // 32-bit Windows
+ 
+ #ifdef _MSC_VER
+ #include <intrin.h> // _InterlockedCompareExchange64
+@@ -58,10 +58,10 @@
+ 
+ } // namespace X265_NS
+ 
+-#else // if defined(_WIN32) && (_WIN32_WINNT < 0x0600)
++#else // if defined(_WIN32) && !defined(__x86_64__)
+ 
+ #define XP_CONDITION_VAR_FREE(x)
+ 
+-#endif // _WIN32_WINNT <= _WIN32_WINNT_WINXP
++#endif // 32-bit Windows
+ 
+ #endif // ifndef X265_WINXP_H
+--- a/source/common/winxp.cpp.orig	2016-01-25 16:16:50.000000000 +1100
++++ b/source/common/winxp.cpp	2016-06-05 15:54:16.730113600 +1000
+@@ -23,7 +23,7 @@
+ 
+ #include "threading.h"
+ 
+-#if defined(_WIN32) && (_WIN32_WINNT < 0x0600) // _WIN32_WINNT_VISTA
++#if defined(_WIN32) && !defined(__x86_64__) // 32-bit Windows
+ 
+ namespace X265_NS {
+ /* Mimic CONDITION_VARIABLE functions only supported on Vista+ */
+@@ -127,4 +127,4 @@
+ 
+ namespace { int _avoid_linker_warnings = 0; }
+ 
+-#endif // _WIN32_WINNT <= _WIN32_WINNT_WINXP
++#endif // 32-bit Windows

--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -45,8 +45,8 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
-    -DWINXP_SUPPORT:BOOL=${_WINXP_SUPPORT} \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
     ../../../source
   make
 
@@ -61,7 +61,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DWINXP_SUPPORT:BOOL=${_WINXP_SUPPORT} \
+    -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
     -DHIGH_BIT_DEPTH=ON \
     -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
     -DENABLE_CLI=OFF \

--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -5,7 +5,7 @@ _realname=x265
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.9
-pkgrel=1
+pkgrel=2
 pkgdesc='Open Source H265/HEVC video encoder (mingw-w64)'
 arch=('any')
 license=('GPL')
@@ -13,10 +13,27 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=('yasm' "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip')
 url='https://bitbucket.org/multicoreware/x265'
-source=("${_realname}-${pkgver}.tar.bz2"::"${url}/get/${pkgver}.tar.bz2")
-sha256sums=('e1e4de6ead44e21c15378675e09c39ef192f2b7c844dd369d2ba1e979aca1ebb')
+source=("${_realname}-${pkgver}.tar.bz2"::"${url}/get/${pkgver}.tar.bz2"
+        "0001-winxp-condition-var.mingw.patch")
+sha256sums=('e1e4de6ead44e21c15378675e09c39ef192f2b7c844dd369d2ba1e979aca1ebb'
+            'c71016ca51eb6d8916de9ef48f14048412569ae89e149f3d372158af6378e0e4')
+
+
+prepare() {
+  cd "${srcdir}"/multicoreware-x265-*
+  patch -Np1 -i ${srcdir}/0001-winxp-condition-var.mingw.patch
+}
+
 
 build() {
+  if [ "${CARCH}" = 'i686' ]; then
+    _ENABLE_ASM=OFF
+    _WINXP_SUPPORT=TRUE
+  else
+    _ENABLE_ASM=ON
+    _WINXP_SUPPORT=FALSE
+  fi
+
   # Build 8 bit-depth lib and exe.
   cd "${srcdir}"/multicoreware-x265-*/build/msys
   if [ -d 8bit ]; then
@@ -28,6 +45,7 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
+    -DWINXP_SUPPORT:BOOL=${_WINXP_SUPPORT} \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ../../../source
   make
@@ -39,16 +57,11 @@ build() {
   mkdir -p ../10bit
   cd ../10bit
 
-  if [ "${CARCH}" = 'i686' ]; then
-    _ENABLE_ASM=OFF
-  else
-    _ENABLE_ASM=ON
-  fi
-
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DWINXP_SUPPORT:BOOL=${_WINXP_SUPPORT} \
     -DHIGH_BIT_DEPTH=ON \
     -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
     -DENABLE_CLI=OFF \


### PR DESCRIPTION
Instead of using _WIN32_WINNT to determine whether Windows XP support code in "winxp.cpp" and "winxp.h" is needed, enable it for 32-bit builds.

Also, pass -DWINXP_SUPPORT:BOOL=TRUE to cmake under 32-bit builds to enable Windows XP support.