### PR TITLE
mingw-w64-glew - 1:13.0 - build 32-bit and 64-bit binaries in separate dirs

### DIFF
--- a/mingw-w64-glew/PKGBUILD
+++ b/mingw-w64-glew/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glew
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.13.0
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="GLEW, The OpenGL Extension Wrangler Library (mingw-w64)"
 depends=()
@@ -23,11 +23,12 @@ prepare() {
 }
 
 build() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MINGW_CHOST}" && cd "build-${CARCH}"
   MSYSTEM=MINGW make GLEW_PREFIX=${MINGW_PREFIX}
 }
 
 package () {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}/build-${CARCH}"
   MSYSTEM=MINGW make GLEW_PREFIX=${MINGW_PREFIX} DESTDIR="${pkgdir}" install.all
 }


### PR DESCRIPTION
mingw-w64-glew - 1:13.0 - build 32-bit and 64-bit binaries in separate dirs