### PR TITLE
KDEF5 fixes for build process

### DIFF
--- a/mingw-w64-attica-qt5/PKGBUILD
+++ b/mingw-w64-attica-qt5/PKGBUILD
@@ -32,12 +32,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-karchive-qt5/PKGBUILD
+++ b/mingw-w64-karchive-qt5/PKGBUILD
@@ -32,12 +32,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcodecs-qt5/PKGBUILD
+++ b/mingw-w64-kcodecs-qt5/PKGBUILD
@@ -32,12 +32,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kconfig-qt5/PKGBUILD
+++ b/mingw-w64-kconfig-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcoreaddons-qt5/PKGBUILD
+++ b/mingw-w64-kcoreaddons-qt5/PKGBUILD
@@ -32,12 +32,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcrash-qt5/PKGBUILD
+++ b/mingw-w64-kcrash-qt5/PKGBUILD
@@ -33,12 +33,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kdbusaddons-qt5/PKGBUILD
+++ b/mingw-w64-kdbusaddons-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kglobalaccel-qt5/PKGBUILD
+++ b/mingw-w64-kglobalaccel-qt5/PKGBUILD
@@ -30,15 +30,15 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
-      -DKF5Config_DIR=${MINGW_PREFIX}/lib/cmake/KF5Config \
+      -DKF5Config_DIR=${QT5_PREFIX}/lib/cmake/KF5Config \
       "${extra_config[@]}" \
       -G'MSYS Makefiles'
   make

--- a/mingw-w64-kguiaddons-qt5/PKGBUILD
+++ b/mingw-w64-kguiaddons-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-ki18n-qt5/PKGBUILD
+++ b/mingw-w64-ki18n-qt5/PKGBUILD
@@ -34,12 +34,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kidletime-qt5/PKGBUILD
+++ b/mingw-w64-kidletime-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kimageformats-qt5/PKGBUILD
+++ b/mingw-w64-kimageformats-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kitemmodels-qt5/PKGBUILD
+++ b/mingw-w64-kitemmodels-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kitemviews-qt5/PKGBUILD
+++ b/mingw-w64-kitemviews-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kjs-qt5/PKGBUILD
+++ b/mingw-w64-kjs-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kplotting-qt5/PKGBUILD
+++ b/mingw-w64-kplotting-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
+++ b/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kwindowsystem-qt5/PKGBUILD
+++ b/mingw-w64-kwindowsystem-qt5/PKGBUILD
@@ -30,12 +30,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-solid-qt5/PKGBUILD
+++ b/mingw-w64-solid-qt5/PKGBUILD
@@ -33,12 +33,12 @@ build() {
     QT5_PREFIX=${MINGW_PREFIX}
   fi
 
-  MSYS2_ARG_CONV_EXCL=-DCMAKE_INSTALL_PREFIX= \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
     cmake ../${_basename}-${pkgver} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
-      -DLIB_INSTALL_DIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
       -DQt5_DIR=${QT5_PREFIX}/lib/cmake/Qt5 \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \


### PR DESCRIPTION
1. add -DECM_MKSPECS_INSTALL_DIR= to MSYS2_ARG_CONV_EXCL so mkspecs files are placed in /mingw{32,64} instead of /msys{32,64}/mingw{32,64}
2. change deprecated LIB_INSTALL_DIR with KDE_INSTALL_LIBDIR
3. place mkspecs files in ${QT5_PREFIX}/share/qt5/mkspecs (Qt5 mkspecs dir) instead of ${QT5_PREFIX} which points to root /mingw{32,64}

Since @mingwandroid maintains KDEF5 he should decide about this PR.