### PR TITLE
python-{cx_freeze,nuitka,pillow,rst2pdf}: fix shebang

### DIFF
--- a/mingw-w64-python-cx_Freeze/PKGBUILD
+++ b/mingw-w64-python-cx_Freeze/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-cx_Freeze"
          "${MINGW_PACKAGE_PREFIX}-python3-cx_Freeze")
 pkgver=4.3.3
-pkgrel=6
+pkgrel=7
 pkgdesc="Python package for freezing scripts into executables (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -46,6 +46,8 @@ package_python2-cx_Freeze() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
            "${MINGW_PACKAGE_PREFIX}-python2-six")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+
   cd python2-cx_Freeze-${pkgver}-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
@@ -54,16 +56,32 @@ package_python2-cx_Freeze() {
   mv ${pkgdir}${MINGW_PREFIX}/bin/cxfreeze{,2}
   mv ${pkgdir}${MINGW_PREFIX}/bin/cxfreeze-postinstall{,2}
   mv ${pkgdir}${MINGW_PREFIX}/bin/cxfreeze-quickstart{,2}
+  
+  # fix python command in files
+  pushd "${pkgdir}${MINGW_PREFIX}"/bin > /dev/null
+  for filename in cxfreeze2 cxfreeze-quickstart2; do
+    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${filename}
+  done
+  popd > /dev/null
 }
 
 package_python3-cx_Freeze() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-six")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+		   
   cd python3-cx_Freeze-${pkgver}-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1
+	
+  # fix python command in files
+  pushd "${pkgdir}${MINGW_PREFIX}"/bin > /dev/null
+  for filename in cxfreeze cxfreeze-quickstart; do
+    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${filename}
+  done
+  popd > /dev/null
 }
 
 package_mingw-w64-i686-python2-cx_Freeze() {

--- a/mingw-w64-python-nuitka/PKGBUILD
+++ b/mingw-w64-python-nuitka/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nuitka
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.5.14.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Python to native compiler (mingw-w64)"
 arch=('any')
 license=('APACHE')
@@ -33,6 +33,8 @@ build() {
 package_python3-nuitka() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  
   cd "${srcdir}/python3-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
@@ -40,7 +42,8 @@ package_python3-nuitka() {
   pushd "${pkgdir}${MINGW_PREFIX}"/bin > /dev/null
   for filename in nuitka nuitka-run; do
     sed -e "s|...\python|python3|g" \
-        -i "${pkgdir}${MINGW_PREFIX}"/bin/${filename}.bat
+        -i ${filename}.bat
+    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${filename}
   done
   popd > /dev/null
 
@@ -48,6 +51,8 @@ package_python3-nuitka() {
 
 package_python2-nuitka() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+  
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
   cd "${srcdir}/python2-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -57,7 +62,8 @@ package_python2-nuitka() {
   for filename in nuitka nuitka-run; do
     sed -e "s|...\python|python2|g" \
         -e "s|${filename}|${filename}2|g" \
-        -i "${pkgdir}${MINGW_PREFIX}"/bin/${filename}.bat
+        -i ${filename}.bat
+    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${filename}
     mv "${pkgdir}${MINGW_PREFIX}"/bin/${filename} "${pkgdir}${MINGW_PREFIX}"/bin/${filename}2
     mv "${pkgdir}${MINGW_PREFIX}"/bin/${filename}.bat "${pkgdir}${MINGW_PREFIX}"/bin/${filename}2.bat
   done

--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-python2-pillow" "${MINGW_PACKAGE_PREFIX}-pytho
 pkgver=3.2.0
 _py2basever=2.7
 _py3basever=3.5m
-pkgrel=1
+pkgrel=2
 arch=('any')
 license=('custom')
 url="https://github.com/python-pillow/Pillow/"
@@ -42,6 +42,8 @@ package_python3-pillow() {
   conflicts=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
   optdepends=("${MINGW_PACKAGE_PREFIX}-tk: for the ImageTK module")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}/" --optimize=0
@@ -53,6 +55,7 @@ package_python3-pillow() {
   # clean up bins
   cd "${pkgdir}${MINGW_PREFIX}/bin"
   for f in *.py; do
+  	sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${f}
     mv "$f" "${f%.py}"
   done
 }
@@ -64,6 +67,8 @@ package_python2-pillow() {
   replaces=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
   conflicts=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
   optdepends=("${MINGW_PACKAGE_PREFIX}-tk: for the ImageTK module")
+  
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -80,6 +85,7 @@ package_python2-pillow() {
   # clean up bins
   cd "${pkgdir}${MINGW_PREFIX}/bin"
   for f in *.py; do
+	  sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${f}
     mv "${f}" "${f%.py}2"
   done
 }

--- a/mingw-w64-python-rst2pdf/PKGBUILD
+++ b/mingw-w64-python-rst2pdf/PKGBUILD
@@ -3,7 +3,7 @@ _realname=rst2pdf
 pkgbase=mingw-w64-python2-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.93
-pkgrel=1
+pkgrel=2
 pkgdesc="Create PDFs from simple text markup, no LaTeX required (mingw-w64)"
 arch=('any')
 url='https://github.com/ralsina/rst2pdf'
@@ -52,12 +52,18 @@ package_python3-rst2pdf() {
   # just in case some package wants to use the rst2pdf executable. 
   provides=("${MINGW_PACKAGE_PREFIX}-rst2pdf")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  
   cd "${srcdir}/python3-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1
 
   install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE.txt"
+
+  # fix python command in files
+  cd "${pkgdir}${MINGW_PREFIX}/bin"
+  sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i rst2pdf-script.py
 }
 
 package_python2-rst2pdf() {
@@ -71,12 +77,18 @@ package_python2-rst2pdf() {
   # just in case some package wants to use the rst2pdf executable. 
   provides=("${MINGW_PACKAGE_PREFIX}-rst2pdf")
 
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  
   cd "${srcdir}/python2-build"
   
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1
   install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE.txt"
+  
+  # fix python command in files
+  cd "${pkgdir}${MINGW_PREFIX}/bin"
+  sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i rst2pdf-script.py
 }
 
 package_mingw-w64-i686-python2-rst2pdf() {


### PR DESCRIPTION
Fixes #1492 

Based on python-sphinx package.

There are some files containing `C:/building/msys64/mingw{32
,64}` left in /mingw{32,64}/bin:
```
croco-0.6-config
curl-config
python-config.sh
python2-pyuic5.bat
python3-config
python3.5-config
python3.5m-config
pyuic5.bat
xml2-config
xslt-config
```