### PR TITLE
qt5: fix windeployqt

### DIFF
--- a/mingw-w64-qt5/0125-qt5-windeployqt-fixes.patch
+++ b/mingw-w64-qt5/0125-qt5-windeployqt-fixes.patch
@@ -1,0 +1,74 @@
+From fccfcf6e3b023ef392e1a199a14459ae30a6b44f Mon Sep 17 00:00:00 2001
+From: James Duley <jagduley@gmail.com>
+Date: Mon, 20 Jun 2016 15:10:09 +0100
+Subject: [PATCH] Fix windeployqt for MSYS2
+
+Note this breaks normal MinGW deployment
+---
+ src/windeployqt/main.cpp | 36 +-----------------------------------
+ 1 file changed, 1 insertion(+), 35 deletions(-)
+
+diff --git a/src/windeployqt/main.cpp b/src/windeployqt/main.cpp
+index 6c78353..3ac75d8 100644
+--- a/src/windeployqt/main.cpp
++++ b/src/windeployqt/main.cpp
+@@ -1010,7 +1010,7 @@ static QStringList compilerRunTimeLibs(Platform platform, bool isDebug, unsigned
+     QStringList result;
+     switch (platform) {
+     case WindowsMinGW: { // MinGW: Add runtime libraries
+-        static const char *minGwRuntimes[] = {"*gcc_", "*stdc++", "*winpthread"};
++        static const char *minGwRuntimes[] = {"*gcc_s_", "*stdc++", "*winpthread"};
+         const QString gcc = findInPath(QStringLiteral("g++.exe"));
+         if (gcc.isEmpty()) {
+             std::wcerr << "Warning: Cannot find GCC installation directory. g++.exe must be in the path.\n";
+@@ -1194,38 +1194,6 @@ static DeployResult deploy(const Options &options,
+         return result;
+     }
+ 
+-    // Some Windows-specific checks: Qt5Core depends on ICU when configured with "-icu". Other than
+-    // that, Qt5WebKit has a hard dependency on ICU.
+-    if (options.platform & WindowsBased)  {
+-        const QStringList qtLibs = dependentQtLibs.filter(QStringLiteral("Qt5Core"), Qt::CaseInsensitive)
+-            + dependentQtLibs.filter(QStringLiteral("Qt5WebKit"), Qt::CaseInsensitive);
+-        foreach (const QString &qtLib, qtLibs) {
+-            QStringList icuLibs = findDependentLibraries(qtLib, options.platform, errorMessage).filter(QStringLiteral("ICU"), Qt::CaseInsensitive);
+-            if (!icuLibs.isEmpty()) {
+-                // Find out the ICU version to add the data library icudtXX.dll, which does not show
+-                // as a dependency.
+-                QRegExp numberExpression(QStringLiteral("\\d+"));
+-                Q_ASSERT(numberExpression.isValid());
+-                const int index = numberExpression.indexIn(icuLibs.front());
+-                if (index >= 0)  {
+-                    const QString icuVersion = icuLibs.front().mid(index, numberExpression.matchedLength());
+-                    if (optVerboseLevel > 1)
+-                        std::wcout << "Adding ICU version " << icuVersion << '\n';
+-                    icuLibs.push_back(QStringLiteral("icudt") + icuVersion + QLatin1String(windowsSharedLibrarySuffix));
+-                }
+-                foreach (const QString &icuLib, icuLibs) {
+-                    const QString icuPath = findInPath(icuLib);
+-                    if (icuPath.isEmpty()) {
+-                        *errorMessage = QStringLiteral("Unable to locate ICU library ") + icuLib;
+-                        return result;
+-                    }
+-                    dependentQtLibs.push_back(icuPath);
+-                } // foreach icuLib
+-                break;
+-            } // !icuLibs.isEmpty()
+-        } // Qt5Core/Qt5WebKit
+-    } // Windows
+-
+     // Scan Quick2 imports
+     QmlImportScanResult qmlScanResult;
+     if (options.quickImports && usesQml2) {
+@@ -1522,8 +1490,6 @@ int main(int argc, char **argv)
+     const QMap<QString, QString> qmakeVariables = queryQMakeAll(&errorMessage);
+     const QString xSpec = qmakeVariables.value(QStringLiteral("QMAKE_XSPEC"));
+     options.platform = platformFromMkSpec(xSpec);
+-    if (options.platform == WindowsMinGW || options.platform == Windows)
+-        options.compilerRunTime = true;
+ 
+     {   // Command line
+         QCommandLineParser parser;
+-- 
+2.8.2
+

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -100,7 +100,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -225,7 +225,8 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0052-qt5-qtwebkit-mfence-mingw.patch
         0121-qt5-qtwebkit-dont-depend-on-icu.patch
         0122-revert-qt4-unicode-removal.patch
-        0124-qt5-qtwebkit-disambiguate-append.patch)
+        0124-qt5-qtwebkit-disambiguate-append.patch
+        0125-qt5-windeployqt-fixes.patch)
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -377,6 +378,10 @@ prepare() {
     popd > /dev/null
     patch -p1 -i ${srcdir}/0124-qt5-qtwebkit-disambiguate-append.patch
   fi
+
+  pushd qttools > /dev/null
+    patch -p1 -i ${srcdir}/0125-qt5-windeployqt-fixes.patch
+  popd
 
   # See: https://bugreports.qt-project.org/browse/QTBUG-37902
   # _ver_num=${_ver_base%%-*}
@@ -740,4 +745,5 @@ sha256sums=('0d3cc75d2368ad988c9ec6bcbed6362dbaa8e03fdfd04e679284f4b9af91e565'
             'f7fe9ce6d2832b4e220d209ba08a1fbfb1adeb5abea1531240a1d5a96d2540e5'
             'e412e0715597331d69d2672f072b4578ed4c0d7a3b8f959bce216f6998c74922'
             'd9e3928ded3adf98bc6c57f0c40126be29679d767701bdb5d161cc5d85ce81ee'
-            '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900')
+            '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900'
+            'e868da7e8716fd3f09d448d003796feda77e59b38d194cab7c8a99fabbdb78af')


### PR DESCRIPTION
This makes it actually possible to run. It doesn't actually get all the lib dependencies because of the extra ones we link to, but it useful for deploying plugins.