### PR TITLE
mpv: update to 0.18.0

### DIFF
--- a/mingw-w64-angleproject-git/PKGBUILD
+++ b/mingw-w64-angleproject-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=angleproject
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=2.1.r5785
+pkgver=2.1.r5864
 pkgrel=1
 pkgdesc='ANGLE project built from git source (mingw-w64)'
 arch=('any')

--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.17.0
+pkgver=0.18.0
 pkgrel=1
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="http://mpv.io"
@@ -32,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "pkg-config"
              "python")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mpv-player/${_realname}/archive/v${pkgver}.tar.gz)
-sha256sums=('602cd2b0f5fc7e43473234fbb96e3f7bbb6418f15eb8fa720d9433cce31eba6e')
+sha256sums=('b656638d4f6bce2621baaacb60d8be384aa492fcd86dfd43996aaa2c16fee02b')
 
 # strip doesn't work well with the mpv.com wrapper, so strip manually instead
 options=(!strip !emptydirs)
@@ -63,7 +63,6 @@ build() {
     --enable-dvdread \
     --enable-egl-angle \
     --enable-enca \
-    --enable-gpl3 \
     --enable-jpeg \
     --enable-lcms2 \
     --enable-libarchive \


### PR DESCRIPTION
### TL;DR Mostly working, there seem to be bug with backend choosing.

With both old and updated angle there is issue with 32 bit `LIBEGL.DLL`.
Without angle update 64 bit mpv was throwing warnings/error when playing certain video files.

I do NOT recommend using 32 bit mpv (64 bit seems to be fine) with mesa package installed:
```
[vo/opengl] Initializing OpenGL backend 'angle'
[vo/opengl] Failed to load LIBEGL.DLL
[vo/opengl] Initializing OpenGL backend 'angle-es2'
[vo/opengl] Not using this by default.
[vo/opengl] Initializing OpenGL backend 'win'
[vo/opengl] GL_VERSION='3.0 Mesa 11.2.0 (git-aa91c51)'
[vo/opengl] Detected desktop OpenGL 3.0.
[vo/opengl] GL_VENDOR='VMware, Inc.'
[vo/opengl] GL_RENDERER='Gallium 0.4 on llvmpipe (LLVM 3.8, 128 bits)'
[vo/opengl] GL_SHADING_LANGUAGE_VERSION='1.30'
[vo/opengl] Loaded extension GL_ARB_sync.
[vo/opengl] Loaded extension GL_ARB_timer_query.
[vo/opengl] Loaded extension GL_ARB_debug_output.
[vo/opengl] Detected suspected software renderer.
[vo/opengl] WGL_EXT_swap_control missing.
[vo/opengl] Suspected software renderer or indirect context.
[vo/opengl/win32] uninit
[vo/opengl] Initializing OpenGL backend 'dxinterop'
[vo/opengl] GL_VERSION='3.0 Mesa 11.2.0 (git-aa91c51)'
[vo/opengl] Detected desktop OpenGL 3.0.
[vo/opengl] GL_VENDOR='VMware, Inc.'
[vo/opengl] GL_RENDERER='Gallium 0.4 on llvmpipe (LLVM 3.8, 128 bits)'
[vo/opengl] GL_SHADING_LANGUAGE_VERSION='1.30'
[vo/opengl] Loaded extension GL_ARB_sync.
[vo/opengl] Loaded extension GL_ARB_timer_query.
[vo/opengl] Loaded extension GL_ARB_debug_output.
[vo/opengl] Detected suspected software renderer.
[vo/opengl] WGL_NV_DX_interop is not supported
```

Hardware playback (`--hwdec auto`) was broken since 32 bit mpv preferred mesa over Nvidia driver. After removing mesa it choose Nvidia driver properly:
```
[vo/opengl] Initializing OpenGL backend 'angle'
[vo/opengl] Failed to load LIBEGL.DLL
[vo/opengl] Initializing OpenGL backend 'angle-es2'
[vo/opengl] Not using this by default.
[vo/opengl] Initializing OpenGL backend 'win'
[vo/opengl] GL_VERSION='3.3.0'
[vo/opengl] Detected desktop OpenGL 3.3.
[vo/opengl] GL_VENDOR='NVIDIA Corporation'
[vo/opengl] GL_RENDERER='GeForce 8600 GT/PCIe/SSE2'
[vo/opengl] GL_SHADING_LANGUAGE_VERSION='3.30 NVIDIA via Cg compiler'
[vo/opengl] Loaded extension WGL_EXT_swap_control.
[vo/opengl] Loaded extension GL_ARB_debug_output.
```

64 bit mpv with and without mesa is the same since priority is ANGLE>MESA>NVIDIA and 64 bit angle is working:
```
[vo/opengl] Initializing OpenGL backend 'angle'
[vo/opengl] Rendering flipped.
[vo/opengl] Using DirectComposition.
[vo/opengl] GL_VERSION='OpenGL ES 3.0 (ANGLE 2.1.0.41db2245556b)'
[vo/opengl] Detected GLES 3.0.
[vo/opengl] GL_VENDOR='Google Inc.'
[vo/opengl] GL_RENDERER='ANGLE (NVIDIA GeForce 8600 GT  Direct3D11 vs_4_0 ps_4_0
)'
[vo/opengl] GL_SHADING_LANGUAGE_VERSION='OpenGL ES GLSL ES 3.00 (ANGLE 2.1.0.41d
b2245556b)'
[vo/opengl] Loaded extension GL_EXT_texture_norm16.
[vo/opengl] Loaded extension GL_EXT_color_buffer_half_float.
[vo/opengl] Loaded extension GL_EXT_disjoint_timer_query.
[vo/opengl] Loaded extension GL_ANGLE_translated_shader_source.
[vo/opengl] swap_control extension missing.
```