### PR TITLE
Fixes for continuous integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,8 @@ build:
   pull: true
   shell: msys$$arch
   commands:
+    # TODO: remove this option when not anymore needed
+    - if [ $$arch = 32 ]; then export DISABLE_QUALITY_CHECK=true; fi
     - ./ci-build.sh
 
 notify:

--- a/ci-library.sh
+++ b/ci-library.sh
@@ -133,6 +133,7 @@ execute(){
 update_system() {
     repman add ci.msys 'https://dl.bintray.com/alexpux/msys2' || return 1
     pacman --noconfirm --noprogressbar --sync --refresh --refresh --sysupgrade --sysupgrade || return 1
+    test -n "${DISABLE_QUALITY_CHECK}" && return 0 # TODO: remove this option when not anymore needed
     pacman --noconfirm --noprogressbar --sync ci.msys/pactoys
 }
 
@@ -191,6 +192,11 @@ list_packages() {
 
 # Recipe quality
 check_recipe_quality() {
+    # TODO: remove this option when not anymore needed
+    if test -n "${DISABLE_QUALITY_CHECK}"; then
+        echo 'This feature is disabled.'
+        return 0
+    fi
     saneman --format='\t%l:%c %p:%c %m' --verbose --no-terminal "${packages[@]}"
 }
 


### PR DESCRIPTION
Drone uses a 32-bit installation of MSYS2 for building both MINGW and MSYS packages for this architecture. Installing latest saneman from repository ci.msys fails because it has been generated by the AppVeyor installation, which is 64-bit.

One possible solution is using only a 64-bit installation in Drone, or generating one additional 32-bit MSYS repository as suggested by @fracting. For now, recipe check has been disabled for Drone 32-bit, thus avoiding installation of saneman.