### PR TITLE
ffmpeg: update to 3.1

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.0.2
+pkgver=3.1
 pkgrel=1
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
@@ -13,7 +13,6 @@ options=('staticlibs' 'strip')
 depends=(
         "${MINGW_PACKAGE_PREFIX}-bzip2"
         "${MINGW_PACKAGE_PREFIX}-celt"
-        "${MINGW_PACKAGE_PREFIX}-dcadec"
         "${MINGW_PACKAGE_PREFIX}-fontconfig"
         "${MINGW_PACKAGE_PREFIX}-gnutls"
         "${MINGW_PACKAGE_PREFIX}-gsm"
@@ -43,7 +42,7 @@ depends=(
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-yasm")
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.bz2{,.asc})
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('30e3c77c2f4c358ed087869455a7496cbd7753a5e1b98d20ba49c1004009fd36'
+sha256sums=('2100fca81627e6cbe937fd6a071ae89277c02350538944b2b0c3c2cc71d9402a'
             'SKIP')
 
 prepare() {
@@ -76,7 +75,6 @@ build() {
     --enable-libbluray \
     --enable-libcaca \
     --enable-libcelt \
-    --enable-libdcadec \
     --enable-libfreetype \
     --enable-libgsm \
     --enable-libmodplug \
@@ -112,6 +110,8 @@ build() {
 
 check() {
   cd "${srcdir}/build-${MINGW_CHOST}"
+  # workaround for conflict with SDL main(), use it if you have SDL installed
+  #make check CC_C="-c -Umain"
   make check
 }
 


### PR DESCRIPTION
libdcadec removed upstream https://ffmpeg.org/pipermail/ffmpeg-cvslog/2016-March/098996.html

There are references to `$(cygpath -m /)` inside /lib/pkgconfig/*.pc files and someone more experienced should take a look at it.