### PR TITLE
Update PKGBUILD for mingw-w64-nlopt

### DIFF
--- a/mingw-w64-nlopt/PKGBUILD
+++ b/mingw-w64-nlopt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=nlopt
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.4.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A library for nonlinear optimization (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-swig")
@@ -50,6 +50,10 @@ build() {
   # build system is a bit racy around the swig scm and scm.in file.
   make -j1
   cp "${srcdir}"/build-${CARCH}/.libs/libnlopt_cxx.a "${srcdir}"/build-${CARCH}/libnlopt_cxx.a
+  
+  # without this call, the resulting libraries do not contain the functions
+  # pertaining to the Fortran API
+  make distclean
 
   # Build static and shared C libraries.
   ../${_realname}-${pkgver}/configure \


### PR DESCRIPTION
Issues with the build system resulted in the generation of libraries with absent/non-functioning Fortran API. The build system does weird things to generate the C++ library, and then goes back and redoes everything to generate the normal C library. After some discussion and investigation with people in the Freenode `##fortran` community, we were able to build working packages if a `make distclean` statement is placed inbetween those two build stages. I still have some suspicions about whether some Fortran related packages need to be in the build dependencies, but that depends on what is considered "standard" to be installed on the machine generating the packages for the repository.