### PR TITLE
Updated SQLite3 to latest release and enabled usage of _msize function.

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_amalgamationver=3120100
-pkgver=3.12.1
+_amalgamationver=3130000
+pkgver=3.13.0
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -18,14 +18,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=("https://www.sqlite.org/2016/sqlite-autoconf-${_amalgamationver}.tar.gz"
         LICENSE)
-sha256sums=('1c038519862b3983b0475f3ed3143ce4bbfcd21bfbd0741192f415838c831a7c'
+sha256sums=('e2797026b3310c9d08bd472f6d430058c6dd139ff9d4e30289884ccd9744086b'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('!strip' 'staticlibs' '!buildflags')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
-  CFLAGS+=" -fexceptions -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_ENABLE_RTREE=1 -fno-strict-aliasing"
+  CFLAGS+=" -fexceptions -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_USE_MALLOC_H=1 -DSQLITE_USE_MSIZE=1 -DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_ENABLE_RTREE=1 -fno-strict-aliasing"
   ../sqlite-autoconf-${_amalgamationver}/configure \
     --prefix=${MINGW_PREFIX} \
     --host=${MINGW_CHOST} \


### PR DESCRIPTION
_msize is the Win32 version of malloc_usable_size, but SQLite doesn't use
it on MinGW for some reason. This commit fixes that, as _msize is more
optimized than SQLite's homegrown implementation (according to the documentation).