### PR TITLE
glfw: change args of install() for find_package

### DIFF
--- a/mingw-w64-glfw/003-3.2-cmake-install.patch
+++ b/mingw-w64-glfw/003-3.2-cmake-install.patch
@@ -1,0 +1,13 @@
+--- glfw-3.2/src/CMakeLists.txt.orig	2016-07-04 04:04:17.899541500 +0900
++++ glfw-3.2/src/CMakeLists.txt	2016-07-04 04:05:27.672026700 +0900
+@@ -115,6 +115,9 @@ if (MSVC)
+ endif()
+ 
+ if (GLFW_INSTALL)
+-    install(TARGETS glfw EXPORT glfwTargets DESTINATION lib${LIB_SUFFIX})
++    install(TARGETS glfw EXPORT glfwTargets
++        RUNTIME DESTINATION bin${LIB_SUFFIX}
++        ARCHIVE DESTINATION lib${LIB_SUFFIX}
++        LIBRARY DESTINATION lib${LIB_SUFFIX})
+ endif()
+ 

--- a/mingw-w64-glfw/PKGBUILD
+++ b/mingw-w64-glfw/PKGBUILD
@@ -4,7 +4,7 @@ _realname=glfw
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A free, open source, portable framework for OpenGL application development (mingw-w64)"
 arch=('any')
 url="http://www.glfw.org/"
@@ -15,15 +15,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('staticlibs' 'strip')
 source=(https://downloads.sourceforge.net/project/glfw/glfw/${pkgver}/${_realname}-${pkgver}.tar.gz
         001-3.2-cmake-suffix.patch
-        002-3.2-vulkan_test.patch)
+        002-3.2-vulkan_test.patch
+        003-3.2-cmake-install.patch)
 sha256sums=('6dfd1f2753aec8fd54c5f24d1be9b530fc86eb3e608bee3bc7f493e8bb22b8f7'
             '3ee710c0628e4fa5b46099bcd90c9bc1b40dcf937611428a97a02e402cbfafca'
-            'fb03a7c00bdb80d56945264c695e6fdefeda5fe95b2b0537364d97904ae5eeb0')
+            'fb03a7c00bdb80d56945264c695e6fdefeda5fe95b2b0537364d97904ae5eeb0'
+            'a15b6d2b5550d404b107eeb12ad15abe83fb340df70fd57939c9439e26b4d578')
 
 prepare() {
   cd "${srcdir}/glfw-${pkgver}"
   patch -Np1 -i ${srcdir}/001-3.2-cmake-suffix.patch
   patch -Np1 -i ${srcdir}/002-3.2-vulkan_test.patch
+  patch -Np1 -i ${srcdir}/003-3.2-cmake-install.patch
 }
 
 build() {
@@ -64,11 +67,6 @@ package() {
 
   cd "${srcdir}/shared-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
-
-#  mv ${pkgdir}${MINGW_PREFIX}/lib/glfw3dll.a ${pkgdir}${MINGW_PREFIX}/lib/libglfw3.dll.a
-
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
-  mv ${pkgdir}${MINGW_PREFIX}/lib/*.dll ${pkgdir}${MINGW_PREFIX}/bin/
 
   #copy license file
   mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"


### PR DESCRIPTION
allow CMake to find_package(glfw3) without symbolic links.

In CMakeLists.txt of other projects, `find_package(glfw3)` had failed because `/mingw64/lib/cmake/glfw3/glfw3Targets-noconfig.cmake` required glfw3.dll at `${_IMPORT_PREFIX}/lib/` but the DLL was moved into `${_IMPORT_PREFIX}/bin/`.

After this commit, the `glfw3Targets-noconfig.cmake` requires `${_IMPORT_PREFIX}/bin/glfw3.dll`.