### PR TITLE
ffmpeg: update to 3.1.1

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.1
+pkgver=3.1.1
 pkgrel=1
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ depends=(
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-yasm")
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.bz2{,.asc})
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('2100fca81627e6cbe937fd6a071ae89277c02350538944b2b0c3c2cc71d9402a'
+sha256sums=('a5bca50a90a37b983eaa17c483a387189175f37ca678ae7e51d43e7610b4b3b4'
             'SKIP')
 
 prepare() {


### PR DESCRIPTION
This is ABI bugfix release, should replace 3.1 ASAP