### PR TITLE
emacs-git: remove unnecessary options

### DIFF
--- a/mingw-w64-emacs-git/PKGBUILD
+++ b/mingw-w64-emacs-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname='emacs'
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r121448.a314016
+pkgver=r126276.66d5c75
 pkgrel=1
 pkgdesc="The extensible, customizable, self-documenting, real-time display editor (mingw-w64)"
 url="https://www.gnu.org/software/${_realname}/"
@@ -26,6 +26,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-giflib"
             "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "patch"
              "git")
 options=('strip')
 source=("${_realname}"::"git://git.savannah.gnu.org/${_realname}.git"
@@ -52,25 +53,9 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "build-${MINGW_CHOST}"
 
-  local with_wide_int='no'
-
-  if test "${CARCH}" == 'x86_64'; then
-    with_wide_int='yes'
-  fi
-
-  CPPFLAGS="-DNDEBUG -isystem ${MINGW_PREFIX}/include"
-  CFLAGS="-pipe -O3 -fomit-frame-pointer -funroll-loops"
-  LDFLAGS="-s -Wl,-s"
   "${srcdir}/${_realname}/configure" \
     --prefix="${MINGW_PREFIX}" \
-    --build="${MINGW_CHOST}" \
-    --with-wide-int="${with_wide_int}" \
-    --with-sound="yes" \
-    --with-file-notification="yes" \
-    --without-gpm \
-    --without-gconf \
-    --without-gsettings \
-    --without-selinux
+    --build="${MINGW_CHOST}"
 
   make
 }


### PR DESCRIPTION
This makes the build more similar to what the defaults used by stock
emacs and makepkg-mingw. Most of the removed options either didn't apply
to Windows or the selected value was the same as the default.