### PR TITLE
unvanquished: new package, 0.50.0 version

### DIFF
--- a/mingw-w64-unvanquished-data/PKGBUILD
+++ b/mingw-w64-unvanquished-data/PKGBUILD
@@ -1,0 +1,65 @@
+# ArchLinux (AUR):
+# Maintainer: Viech <viech unvanquished net>
+# MSYS2:
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+_realname=unvanquished-data
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.50.0
+pkgrel=1
+
+_gitver="archlinux/${pkgver}-${pkgrel}"
+
+pkgdesc='Game assets for Unvanquished.'
+arch=('any')
+url='http://www.unvanquished.net'
+license=('GPL3')
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-aria2>=1.18.7-2"
+             'sed') # XXX dependency on sed for workaround below
+source=("https://github.com/Unvanquished/Unvanquished/raw/${_gitver}/download-pk3-torrent.sh"
+        "copy-instead-of-symlink.patch")
+
+# disable package compression since assets are already compressed
+PKGEXT='.pkg.tar'
+
+prepare() {
+  cd ${srcdir}
+
+  patch -p1 -i ${srcdir}/copy-instead-of-symlink.patch
+}
+
+package() {
+	# create installation directory
+	install -dm755 "${pkgdir}${MINGW_PREFIX}/share/unvanquished/pkg/"
+
+	# use package source directory as the cache for the download script
+	if [ ! -d "${srcdir}/cache" ]; then
+		mkdir "${srcdir}/cache"
+	fi
+
+	# attempt to copy existing assets from the system, so they aren't redownloaded
+	if [ -d ${MINGW_PREFIX}/share/unvanquished/pkg ]; then
+		echo "Copying existing assets from the system..."
+		cp -r ${MINGW_PREFIX}/share/unvanquished/pkg/*.pk3 "${pkgdir}${MINGW_PREFIX}/share/unvanquished/pkg/" || true
+	fi
+
+	# make the download script aware of copied assets, so it will remove unneeded ones
+	ls -c1 "${pkgdir}${MINGW_PREFIX}/share/unvanquished/pkg/" > "${srcdir}/cache/last-assets.txt"
+
+	# remove old aria2 progress files in case the torrent itself was updated
+	rm -f "${srcdir}/cache/"*".aria2"
+
+	# XXX work around a bug in aria2/GnuTLS https handling by using http for now
+	sed -i 's,https,http,' download-pk3-torrent.sh
+
+  # MSYS cannot use directory links (junctions)
+  sed -ie '/rm -f "$path\/pkg"/,+2d' download-pk3-torrent.sh
+
+	# download new or modified assets
+	./download-pk3-torrent.sh "${pkgdir}${MINGW_PREFIX}/share/unvanquished/pkg/" "${srcdir}/cache" "${pkgver}"
+}
+
+sha256sums=('4990c5271272a008e103a36868e1a26559c77d3056e3bb4a1504588acffb06ac'
+            'db93d928e94b9840f2b441c06abf38615c3d4c7ce3868bf5601d53137d5567af')

--- a/mingw-w64-unvanquished-data/copy-instead-of-symlink.patch
+++ b/mingw-w64-unvanquished-data/copy-instead-of-symlink.patch
@@ -1,0 +1,24 @@
+--- src/download-pk3-torrent.sh.orig	2016-07-11 17:16:32.900233700 +0200
++++ src/download-pk3-torrent.sh	2016-07-12 10:50:11.056602400 +0200
+@@ -69,11 +69,11 @@
+ done
+
+ # symlink the extraction path to the target so the files land in the right place
++# MSYS2 cannot use symlinks so just create directories and copy files later
+ if [ ! -d "$path" ]; then
+     mkdir "$path" || exit
+ fi
+-rm -f "$path/pkg"
+-ln -s "$target_dir" "$path/pkg"
++[ ! -d "$path/pkg" ] && mkdir "$path/pkg"
+
+ # build a comma seperated list of assets and their ids
+ asset_lst=$(aria2c -S "$torrent_file"|grep '.*/pkg/.*\.pk3'|awk -F'|' '{print $2}'|grep -o '[^/]*$')
+@@ -105,3 +105,7 @@
+ # save list of downloaded assets
+ echo "$assets_lst" > "$last_assets_file"
+
++# Copy files to the target directory
++echo "Copying files to target directory..."
++cp -a "$path/pkg/." "$target_dir"
++echo

--- a/mingw-w64-unvanquished/PKGBUILD
+++ b/mingw-w64-unvanquished/PKGBUILD
@@ -1,0 +1,153 @@
+# ArchLinux (AUR):
+# Maintainer: Viech <viech unvanquished net>
+# Contributor: Gereon Schomber
+# Contributor: Martin F. Schumann
+# MSYS2:
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+_realname=unvanquished
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.50.0
+pkgrel=1
+
+_gitver="archlinux/${pkgver}-${pkgrel}"
+_unvanquished="${_realname/u/U}-${_gitver/\//-}"
+
+_naclsdkver="4"
+if test "$CARCH" == "x86_64"; then
+	_naclsdkname=mingw64
+else
+	_naclsdkname=mingw32
+fi
+_naclsdk="${_naclsdkname}-${_naclsdkver}"
+
+pkgdesc='A team-based, fast-paced, fps/rts hybrid game which pits aliens against humans. Monthly alpha release. (mingw-w64)'
+arch=('any')
+url='http://www.unvanquished.net'
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-unvanquished-data>=${pkgver}"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-geoip"
+         "${MINGW_PACKAGE_PREFIX}-glew"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libogg"
+         "${MINGW_PACKAGE_PREFIX}-libpng"
+         "${MINGW_PACKAGE_PREFIX}-libtheora"
+         "${MINGW_PACKAGE_PREFIX}-libvorbis"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
+         "${MINGW_PACKAGE_PREFIX}-nettle"
+         "${MINGW_PACKAGE_PREFIX}-openal"
+         "${MINGW_PACKAGE_PREFIX}-opus"
+         "${MINGW_PACKAGE_PREFIX}-opusfile"
+         "${MINGW_PACKAGE_PREFIX}-SDL2"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+provides=('unvanquished')
+conflicts=('unvanquished-git')
+options=('emptydirs' '!strip')
+backup=("${MINGW_PREFIX:1}/etc/conf.d/unvanquished.conf"
+        "${MINGW_PREFIX:1}/etc/unvanquished/server.cfg"
+        "${MINGW_PREFIX:1}/etc/unvanquished/maprotation.cfg")
+install="${_realname}-${CARCH}.install"
+source=("https://github.com/Unvanquished/Unvanquished/archive/${_gitver}.tar.gz"
+        'unvanquished-i686.install'
+				'unvanquished-x86_64.install'
+				"https://dl.unvanquished.net/deps/${_naclsdk}.zip")
+
+prepare() {
+	cd "${srcdir}"
+
+  # Use MSYS2 libs
+  rm -rf "${_naclsdk}/bin" "${_naclsdk}/include" "${_naclsdk}/lib"
+
+  [[ -d "${_unvanquished}/daemon/external_deps/${_naclsdkname}" ]] \
+    && rm -rf "${_unvanquished}/daemon/external_deps/${_naclsdkname}"
+	ln -sfr "${_naclsdk}" -t "${_unvanquished}/daemon/external_deps"
+
+	# Use /mingw{32,64} paths
+	for file in "${srcdir}/${_unvanquished}"/archlinux/*.{conf,sh}; do
+		sed -e "s/\/usr/\\${MINGW_PREFIX}/g" \
+				-e "s/\/var/\\${MINGW_PREFIX}\/var/g" \
+				-i $file
+	done
+}
+
+build() {
+	cd "${srcdir}/${_unvanquished}"
+
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DBUILD_CGAME=OFF \
+      -DBUILD_SGAME=OFF \
+      ../${_unvanquished}
+	make
+}
+
+package() {
+	# create installation directories
+
+	install -dm 755 "${pkgdir}${MINGW_PREFIX}"/etc/conf.d \
+                  "${pkgdir}${MINGW_PREFIX}"/etc/unvanquished \
+                  "${pkgdir}${MINGW_PREFIX}"/bin \
+                  "${pkgdir}${MINGW_PREFIX}"/lib/systemd/system \
+                  "${pkgdir}${MINGW_PREFIX}"/lib/unvanquished \
+                  "${pkgdir}${MINGW_PREFIX}"/share/applications \
+                  "${pkgdir}${MINGW_PREFIX}"/share/icons/hicolor/128x128/apps \
+                  "${pkgdir}${MINGW_PREFIX}"/share/licenses/unvanquished \
+                  "${pkgdir}${MINGW_PREFIX}"/share/unvanquished/pkg \
+                  "${pkgdir}${MINGW_PREFIX}"/var/lib/unvanquished-server/config \
+                  "${pkgdir}${MINGW_PREFIX}"/var/lib/unvanquished-server/game
+
+	# install content
+	cd "${srcdir}/${_unvanquished}"
+
+	install -m 644 debian/unvanquished.png "${pkgdir}${MINGW_PREFIX}/share/icons/hicolor/128x128/apps/"
+	install -m 644 COPYING.txt             "${pkgdir}${MINGW_PREFIX}/share/licenses/unvanquished/"
+
+	cd "${srcdir}"/build-${CARCH}
+
+	install -m 755 daemon                  "${pkgdir}${MINGW_PREFIX}/lib/unvanquished/"
+	install -m 755 daemonded               "${pkgdir}${MINGW_PREFIX}/lib/unvanquished/"
+	install -m 755 daemon-tty              "${pkgdir}${MINGW_PREFIX}/lib/unvanquished/"
+	install -m 755 irt_core-x86*.nexe      "${pkgdir}${MINGW_PREFIX}/lib/unvanquished/"
+	# install -m 755 nacl_helper_bootstrap   "${pkgdir}/${MINGW_PREFIX}/lib/unvanquished/"
+	install -m 755 nacl_loader             "${pkgdir}${MINGW_PREFIX}/lib/unvanquished/"
+
+	# install starters and dedicated server config
+	cd "${srcdir}/${_unvanquished}/archlinux"
+
+	install -m 755 unvanquished.sh         "${pkgdir}${MINGW_PREFIX}/bin/unvanquished"
+	install -m 755 unvanquished-tty.sh     "${pkgdir}${MINGW_PREFIX}/bin/unvanquished-tty"
+	install -m 644 unvanquished.conf       "${pkgdir}${MINGW_PREFIX}/etc/conf.d/"
+	# install -m 644 unvanquished.service    "${pkgdir}/usr/lib/systemd/system/"
+	# install -m 644 unvanquished.desktop    "${pkgdir}/usr/share/applications/"
+	install -m 644 configs/maprotation.cfg "${pkgdir}${MINGW_PREFIX}/etc/unvanquished/"
+	install -m 644 configs/server.cfg      "${pkgdir}${MINGW_PREFIX}/etc/unvanquished/"
+
+	# setup server home directory
+	# moved to install file
+	# cd "${pkgdir}${MINGW_PREFIX}/var/lib/unvanquished-server/config"
+	#
+	# MSYS='winsymlinks:lnk' ln -s ../../../..${MINGW_PREFIX}/etc/unvanquished/server.cfg .
+	#
+	# cd "${pkgdir}${MINGW_PREFIX}/var/lib/unvanquished-server/game"
+	#
+	# MSYS='winsymlinks:lnk' ln -s ../../../..${MINGW_PREFIX}/etc/unvanquished/maprotation.cfg .
+}
+
+sha256sums=('a4bd28ff55fe481d9e22f6209ef6ae647642bbcaca6653f6968172ec2fc2fcdf'
+            'c65a44f13e5d757cc280ce35d723d56f27c34256ff8569143cbbc0d17c3dc464'
+						'78cba91d087f5ca2ce2bda3fbe8cfdd13ce53ca404b1057b7c16063d59d4fe27')
+if test "$CARCH" == "x86_64"; then
+	sha256sums+=('507918feff75dd22894fb60750fd8112446d537d33bf5173353d351e2256e32b')
+else
+	sha256sums+=('85595e3b6ebdd936c711ab9c892a3f442e58412dbc7e4937a26aeba631f3bf9f')
+fi

--- a/mingw-w64-unvanquished/unvanquished-i686.install
+++ b/mingw-w64-unvanquished/unvanquished-i686.install
@@ -1,0 +1,70 @@
+_update_desktop_environment() {
+	# update icon cache
+	xdg-icon-resource forceupdate --theme hicolor &> /dev/null
+
+	# install unv:// protocol handler
+	update-desktop-database -q
+	update-mime-database /usr/share/mime >/dev/null
+}
+
+_add_server_user() {
+	if ! getent passwd unvanquished >/dev/null; then
+		useradd -rM -d /var/lib/unvanquished-server -c "Unvanquished dedicated server" -s /bin/false unvanquished
+	fi
+}
+
+_delete_server_user() {
+	if getent passwd unvanquished >/dev/null; then
+		userdel unvanquished
+		groupdel unvanquished
+	fi
+}
+
+_chown_server_home() {
+	chown -R unvanquished:unvanquished /var/lib/unvanquished-server
+}
+
+_migrate() {
+	# delete pre unvanquished-data assets
+	if [ -d /var/lib/unvanquished ] && ! pacman -Qo /var/lib/unvanquished >/dev/null 2>&1; then
+		echo "Deleting old asset directory..."
+
+		if [ -d /var/lib/unvanquished/main ]; then
+			rm -f /var/lib/unvanquished/main/*.pk3
+			rmdir /var/lib/unvanquished/main
+		fi
+
+		if [ -d /var/lib/unvanquished/pkg ]; then
+			rm -f /var/lib/unvanquished/pkg/*.pk3
+			rmdir /var/lib/unvanquished/pkg
+		fi
+
+		rmdir /var/lib/unvanquished
+	fi
+	if [ -d /var/cache/unvanquished ] && ! pacman -Qo /var/cache/unvanquished >/dev/null 2>&1; then
+		echo "Deleting old asset update cache..."
+		rm -r /var/cache/unvanquished
+	fi
+}
+
+post_install() {
+	#_add_server_user
+	#_chown_server_home
+	#_update_desktop_environment
+	MSYS='winsymlinks:lnk' ln -s /mingw32/etc/unvanquished/server.cfg /mingw32/var/lib/unvanquished-server/config/.
+	MSYS='winsymlinks:lnk' ln -s /mingw32/etc/unvanquished/maprotation.cfg /mingw32/var/lib/unvanquished-server/game/.
+}
+
+post_upgrade() {
+	_migrate
+}
+
+pre_remove() {
+	true
+}
+
+post_remove() {
+	#_delete_server_user
+	#_update_desktop_environment
+	true
+}

--- a/mingw-w64-unvanquished/unvanquished-x86_64.install
+++ b/mingw-w64-unvanquished/unvanquished-x86_64.install
@@ -1,0 +1,70 @@
+_update_desktop_environment() {
+	# update icon cache
+	xdg-icon-resource forceupdate --theme hicolor &> /dev/null
+
+	# install unv:// protocol handler
+	update-desktop-database -q
+	update-mime-database /usr/share/mime >/dev/null
+}
+
+_add_server_user() {
+	if ! getent passwd unvanquished >/dev/null; then
+		useradd -rM -d /var/lib/unvanquished-server -c "Unvanquished dedicated server" -s /bin/false unvanquished
+	fi
+}
+
+_delete_server_user() {
+	if getent passwd unvanquished >/dev/null; then
+		userdel unvanquished
+		groupdel unvanquished
+	fi
+}
+
+_chown_server_home() {
+	chown -R unvanquished:unvanquished /var/lib/unvanquished-server
+}
+
+_migrate() {
+	# delete pre unvanquished-data assets
+	if [ -d /var/lib/unvanquished ] && ! pacman -Qo /var/lib/unvanquished >/dev/null 2>&1; then
+		echo "Deleting old asset directory..."
+
+		if [ -d /var/lib/unvanquished/main ]; then
+			rm -f /var/lib/unvanquished/main/*.pk3
+			rmdir /var/lib/unvanquished/main
+		fi
+
+		if [ -d /var/lib/unvanquished/pkg ]; then
+			rm -f /var/lib/unvanquished/pkg/*.pk3
+			rmdir /var/lib/unvanquished/pkg
+		fi
+
+		rmdir /var/lib/unvanquished
+	fi
+	if [ -d /var/cache/unvanquished ] && ! pacman -Qo /var/cache/unvanquished >/dev/null 2>&1; then
+		echo "Deleting old asset update cache..."
+		rm -r /var/cache/unvanquished
+	fi
+}
+
+post_install() {
+	#_add_server_user
+	#_chown_server_home
+	#_update_desktop_environment
+	MSYS='winsymlinks:lnk' ln -s /mingw64/etc/unvanquished/server.cfg /mingw64/var/lib/unvanquished-server/config/.
+	MSYS='winsymlinks:lnk' ln -s /mingw64/etc/unvanquished/maprotation.cfg /mingw64/var/lib/unvanquished-server/game/.
+}
+
+post_upgrade() {
+	_migrate
+}
+
+pre_remove() {
+	true
+}
+
+post_remove() {
+	#_delete_server_user
+	#_update_desktop_environment
+	true
+}


### PR DESCRIPTION
Depends on https://github.com/Alexpux/MINGW-packages/pull/1547.
Based on https://aur.archlinux.org/packages/unvanquished/

Not meant to be added to pacman yet as 32-bit version crashes with no console output (debug doesn't help either, probably NaCl have to be recompiled).
64-bit version is fine.

I'm going to holidays so I'll put it here if someone wants to help. After return I'll prepare git package.