### PR TITLE
fontconfig: allow to disable auto font-cache update

### DIFF
--- a/mingw-w64-fontconfig/fontconfig-i686.install
+++ b/mingw-w64-fontconfig/fontconfig-i686.install
@@ -6,15 +6,23 @@ post_install() {
 
 _EOF
 
-  echo -n "updating font cache... "
-  mingw32/bin/fc-cache -f
-  echo "done."
+  if [ -n "${MSYS2_FC_CACHE_SKIP}" ]; then
+    echo "Warning: 'MSYS2_FC_CACHE_SKIP' set, skipping font cache update"
+  else
+    echo -n "updating font cache... "
+    mingw32/bin/fc-cache -f
+    echo "done."
+  fi
 }
 
 post_upgrade() {
-  echo -n "updating font cache... "
-  mingw32/bin/fc-cache -f
-  echo "done."
+  if [ -n "${MSYS2_FC_CACHE_SKIP}" ]; then
+    echo "Warning: 'MSYS2_FC_CACHE_SKIP' set, skipping font cache update"
+  else
+    echo -n "updating font cache... "
+    mingw32/bin/fc-cache -f
+    echo "done."
+  fi
 }
 
 post_remove() {

--- a/mingw-w64-fontconfig/fontconfig-x86_64.install
+++ b/mingw-w64-fontconfig/fontconfig-x86_64.install
@@ -6,15 +6,23 @@ post_install() {
 
 _EOF
 
-  echo -n "updating font cache... "
-  mingw64/bin/fc-cache -f
-  echo "done."
+  if [ -n "${MSYS2_FC_CACHE_SKIP}" ]; then
+    echo "Warning: 'MSYS2_FC_CACHE_SKIP' set, skipping font cache update"
+  else
+    echo -n "updating font cache... "
+    mingw64/bin/fc-cache -f
+    echo "done."
+  fi
 }
 
 post_upgrade() {
-  echo -n "updating font cache... "
-  mingw64/bin/fc-cache -f
-  echo "done."
+  if [ -n "${MSYS2_FC_CACHE_SKIP}" ]; then
+    echo "Warning: 'MSYS2_FC_CACHE_SKIP' set, skipping font cache update"
+  else
+    echo -n "updating font cache... "
+    mingw64/bin/fc-cache -f
+    echo "done."
+  fi
 }
 
 post_remove() {


### PR DESCRIPTION
Each time fontconfig is installed or updated, a lengthy
process of font cache update is started automatically.
In certain use-cases, f.e. when one if its dependents
is used for automated build purposes, this causes an
unnecessary and unwanted delay in the process. On
AppVeyor CI free-tier in particular, this process takes
about 5 minutes.

This patch adds the ability to disable this automatic
font cache update, by setting the environment variable
`MSYS2_FC_CACHE_SKIP` to any non-empty value, prior
to lauching `pacman`.