### PR TITLE
Possibly improve pyzmq build

### DIFF
--- a/mingw-w64-python-pyzmq/001-mingw-python.patch
+++ b/mingw-w64-python-pyzmq/001-mingw-python.patch
@@ -1,14 +1,49 @@
---- pyzmq-15.2.0.orig/setup.py	2016-01-12 14:31:19.000000000 +0000
-+++ pyzmq-15.2.0/setup.py	2016-07-19 15:51:01.966344700 +0100
-@@ -449,7 +449,10 @@
+--- src/py2zmq-15.2.0/setup.py	2016-07-19 16:31:03.100214900 +0100
++++ src/pyzmq-15.2.0/setup.py	2016-07-19 16:38:12.475410600 +0100
+@@ -120,7 +120,7 @@
+     # is this necessary?
+     if sys.platform.startswith('freebsd'):
+         settings['libraries'].append('pthread')
+-    elif sys.platform.startswith('win'):
++    elif sys.platform.startswith('win') and 'MSYSTEM' not in os.environ:
+         # link against libzmq in build dir:
+         plat = distutils.util.get_platform()
+         temp = 'temp.%s-%i.%i' % (plat, sys.version_info[0], sys.version_info[1])
+@@ -351,7 +351,7 @@
+     def create_tempdir(self):
+         self.erase_tempdir()
+         os.makedirs(self.tempdir)
+-        if sys.platform.startswith('win'):
++        if sys.platform.startswith('win') and 'MSYSTEM' not in os.environ:
+             # fetch libzmq.dll into local dir
+             local_dll = pjoin(self.tempdir, 'libzmq.dll')
+             if not self.config['zmq_prefix'] and not os.path.exists(local_dll):
+@@ -394,7 +394,7 @@
+         """
+         if 'bundle_libzmq_dylib' in self.config:
+             return self.config['bundle_libzmq_dylib']
+-        elif (sys.platform.startswith('win') or self.cross_compiling) \
++        elif ((sys.platform.startswith('win') and 'MSYSTEM' not in os.environ) or self.cross_compiling) \
+                 and not self.config['libzmq_extension']:
+             # always bundle libzmq on Windows and cross-compilation
+             return True
+@@ -443,9 +443,9 @@
+             warn("Detected ZMQ version: %s. Some new features in libzmq may not be exposed by pyzmq." % vs)
+             line()
+ 
+-        if sys.platform.startswith('win'):
++        if sys.platform.startswith('win') and 'MSYSTEM' not in os.environ:
+             # fetch libzmq.dll into local dir
+             local_dll = localpath('zmq','libzmq.dll')
              if not zmq_prefix and not os.path.exists(local_dll):
                  fatal("ZMQ directory must be specified on Windows via setup.cfg or 'python setup.py configure --zmq=/path/to/zeromq2'")
              try:
--                shutil.copy(pjoin(zmq_prefix, 'lib', 'libzmq.dll'), local_dll)
-+                if 'MSYSTEM' in os.environ:
-+                    shutil.copy(pjoin(zmq_prefix, 'bin', 'libzmq.dll'), local_dll)
-+                else:
-+                    shutil.copy(pjoin(zmq_prefix, 'lib', 'libzmq.dll'), local_dll)
-             except Exception:
-                 if not os.path.exists(local_dll):
-                     warn("Could not copy libzmq into zmq/, which is usually necessary on Windows."
+@@ -565,7 +565,7 @@
+             # this may not be sufficiently precise
+             libzmq.define_macros.append(('ZMQ_USE_POLL', 1))
+         
+-        if sys.platform.startswith('win'):
++        if sys.platform.startswith('win') and 'MSYSTEM' not in os.environ:
+             # include defines from zeromq msvc project:
+             libzmq.define_macros.append(('FD_SETSIZE', 1024))
+             libzmq.define_macros.append(('DLL_EXPORT', 1))

--- a/mingw-w64-python-pyzmq/PKGBUILD
+++ b/mingw-w64-python-pyzmq/PKGBUILD
@@ -15,10 +15,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
 source=("https://pypi.python.org/packages/source/p/pyzmq/pyzmq-$pkgver.tar.gz"
 				"001-mingw-python.patch")
 sha256sums=('2dafa322670a94e20283aba2a44b92134d425bd326419b68ad4db8d0831a26ec'
-						'4b2a1f3718a2711162d416d1e60b70e1cc8f90489c117178963dcae831c7b3e1')
+						'b9b642fc7939d53b456cca51195632109c711ebf173ff8fb418c84a05c1e7eac')
 prepare() {
 	cd "$srcdir"
-	patch -p0 -i 001-mingw-python.patch
+	patch -p1 -i 001-mingw-python.patch
   cp -a pyzmq-${pkgver} py2zmq-${pkgver}
 }
 
@@ -39,10 +39,6 @@ package_python3-pyzmq() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"
 					 "${MINGW_PACKAGE_PREFIX}-zeromq")
 	
-  cd "$srcdir"
-	mkdir -p lib
-	cp ${MINGW_PREFIX}/bin/libzmq.dll pyzmq-${pkgver}/zmq/
-	
   cd "${srcdir}/pyzmq-${pkgver}"
 	
 	sed -i 's|except socket.error, e:|except socket.error as e:|' zmq/eventloop/ioloop.py
@@ -55,10 +51,6 @@ package_python2-pyzmq() {
   local interpreter=python2
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
 					 "${MINGW_PACKAGE_PREFIX}-zeromq")
-					 
-  cd "$srcdir"
-	mkdir -p lib
-	cp ${MINGW_PREFIX}/bin/libzmq.dll pyzmq-${pkgver}/zmq/
 
   cd "${srcdir}/py2zmq-${pkgver}"
 	


### PR DESCRIPTION
I've patched setup.py to shortcut a lot of the platform == win hacks on MSYS. Perhaps this will make the CI build happier. It does get rid of a warning that it can't find libzmq when the build script tries to copy it for MSVC's sake.