### PR TITLE
Fix libffi 3.2.1 on 64-bit

### DIFF
--- a/mingw-w64-libffi/PKGBUILD
+++ b/mingw-w64-libffi/PKGBUILD
@@ -5,18 +5,21 @@ _realname=libffi
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A portable, high level programming interface to various calling conventions (mingw-w64)"
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 license=('MIT')
 url="https://sourceware.org/libffi"
-source=("ftp://sourceware.org/pub/libffi/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37')
+source=("ftp://sourceware.org/pub/libffi/${_realname}-${pkgver}.tar.gz"
+        "fix_return_size.patch")
+sha256sums=('d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37'
+            'f0b27e01eb2f7f6bfa52fc519a1e64b5c83e1f68476ffcc2f2fa808ba6ca4e0f')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -p2 -i ../fix_return_size.patch
 }
 
 build() {

--- a/mingw-w64-libffi/fix_return_size.patch
+++ b/mingw-w64-libffi/fix_return_size.patch
@@ -1,0 +1,50 @@
+--- src/libffi-3.2.1/src/x86/ffi.c.orig	2016-07-20 21:24:49.000771900 +0100
++++ src/libffi-3.2.1/src/x86/ffi.c	2016-07-20 21:25:09.918786700 +0100
+@@ -65,7 +65,8 @@
+   if ((ecif->cif->flags == FFI_TYPE_STRUCT
+        || ecif->cif->flags == FFI_TYPE_MS_STRUCT)
+ #ifdef X86_WIN64
+-      && ((ecif->cif->rtype->size & (1 | 2 | 4 | 8)) == 0)
++      && (ecif->cif->rtype->size != 1 && ecif->cif->rtype->size != 2
++          && ecif->cif->rtype->size != 4 && ecif->cif->rtype->size != 8)
+ #endif
+       )
+     {
+@@ -108,7 +109,7 @@
+ #ifdef X86_WIN64
+       if (z > FFI_SIZEOF_ARG
+           || ((*p_arg)->type == FFI_TYPE_STRUCT
+-              && (z & (1 | 2 | 4 | 8)) == 0)
++              && (z != 1 && z != 2 && z != 4 && z != 8))
+ #if FFI_TYPE_DOUBLE != FFI_TYPE_LONGDOUBLE
+           || ((*p_arg)->type == FFI_TYPE_LONGDOUBLE)
+ #endif
+@@ -360,7 +361,8 @@
+ #ifdef X86_WIN64
+   if (rvalue == NULL
+       && cif->flags == FFI_TYPE_STRUCT
+-      && ((cif->rtype->size & (1 | 2 | 4 | 8)) == 0))
++      && cif->rtype->size != 1 && cif->rtype->size != 2
++      && cif->rtype->size != 4 && cif->rtype->size != 8)
+     {
+       ecif.rvalue = alloca((cif->rtype->size + 0xF) & ~0xF);
+     }
+@@ -545,7 +547,8 @@
+   if ((cif->flags == FFI_TYPE_STRUCT
+        || cif->flags == FFI_TYPE_MS_STRUCT)
+ #ifdef X86_WIN64
+-      && ((cif->rtype->size & (1 | 2 | 4 | 8)) == 0)
++      && ((cif->rtype->size != 1 && cif->rtype->size != 2
++           && cif->rtype->size != 4 && cif->rtype->size != 8))
+ #endif
+       )
+     {
+@@ -608,7 +611,7 @@
+ #ifdef X86_WIN64
+       if (z > FFI_SIZEOF_ARG
+           || ((*p_arg)->type == FFI_TYPE_STRUCT
+-              && (z & (1 | 2 | 4 | 8)) == 0)
++              && (z != 1 && z != 2 && z != 4 && z != 8))
+ #if FFI_TYPE_DOUBLE != FFI_TYPE_LONGDOUBLE
+           || ((*p_arg)->type == FFI_TYPE_LONGDOUBLE)
+ #endif


### PR DESCRIPTION
libffi was broken on 64-bit, any c function returning a struct > 8 bytes and not a multiple of 16 will cause a segfault. This is because between 3.1 and 3.2 somebody changed (size != 1 || size != 2 || size != 4 || size != 8) into (size & (1 | 2 | 4 | 8) == 0), which is not the same.

As an alternative, downgrading to 3.1 or upgrading to git should also fix it.