### PR TITLE
Update wxWidgets build files for GCC 6

### DIFF
--- a/mingw-w64-wxwidgets/PKGBUILD
+++ b/mingw-w64-wxwidgets/PKGBUILD
@@ -7,7 +7,7 @@ _realname=wxWidgets
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase=mingw-w64-${_realname}
 pkgver=3.0.2
-pkgrel=13
+pkgrel=14
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
@@ -28,13 +28,15 @@ source=(https://downloads.sourceforge.net/wxwindows/wxWidgets-${pkgver}.tar.bz2
         "wxWidgets-3.0.2-msw-dc-orientation-fix.patch"
         "wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
         "wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
-        "wxWidgets-3.0.2-windows-version.patch")
+        "wxWidgets-3.0.2-windows-version.patch"
+        "wxWidgets-3.0.2-gcc6-abs.patch")
 sha256sums=('346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d'
             'd30e32efbb334ff473e8d8c37152281b19b78a36bd5c766ed9781c7581ee92c2'
             '12f9f474aceb39e5e978e5abbd4288a0ab62d1bcd2ea4a1899c0641fbee8abe1'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
             '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
-            'c73911b55371554f071b0c547630b6fa5b03eec8307e6fb0ae7587833ea96c0e')
+            'c73911b55371554f071b0c547630b6fa5b03eec8307e6fb0ae7587833ea96c0e'
+            '35baeefa14a4b3b60c580337c96887ea439bbfe052dae236bfce109cf43d1031')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -43,6 +45,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch
   patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
   patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-windows-version.patch
+  patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-gcc6-abs.patch
 }
 
 build() {

--- a/mingw-w64-wxwidgets/wxWidgets-3.0.2-gcc6-abs.patch
+++ b/mingw-w64-wxwidgets/wxWidgets-3.0.2-gcc6-abs.patch
@@ -1,0 +1,23 @@
+diff -uNr wxWidgets-3.0.2.orig/src/stc/scintilla/src/Editor.cxx wxWidgets-3.0.2.mod/src/stc/scintilla/src/Editor.cxx
+--- wxWidgets-3.0.2.orig/src/stc/scintilla/src/Editor.cxx	2016-07-22 11:35:57.000000000 +0500
++++ wxWidgets-3.0.2.mod/src/stc/scintilla/src/Editor.cxx	2016-07-22 11:30:51.000000000 +0500
+@@ -11,6 +11,7 @@
+ #include <ctype.h>
+ #include <assert.h>
+ 
++#include <cmath>
+ #include <string>
+ #include <vector>
+ #include <map>
+@@ -5841,9 +5842,9 @@
+ }
+ 
+ static bool Close(Point pt1, Point pt2) {
+-	if (abs(pt1.x - pt2.x) > 3)
++	if (std::abs(pt1.x - pt2.x) > 3)
+ 		return false;
+-	if (abs(pt1.y - pt2.y) > 3)
++	if (std::abs(pt1.y - pt2.y) > 3)
+ 		return false;
+ 	return true;
+ }


### PR DESCRIPTION
Fix for issue #1578 for the changed ABI in GCC 6.1.

Bumped pkgrel and added patch from upstream for wxWidgets issue 17147 to
fix compile errors regarding overloaded abs() function in the Scintilla editor component.

Referenced wxWidgets bug http://trac.wxwidgets.org/ticket/17147