### PR TITLE
gcc: disable weak refs in x86_64

### DIFF
--- a/mingw-w64-gcc/0017-disable-weak-refs.patch
+++ b/mingw-w64-gcc/0017-disable-weak-refs.patch
@@ -1,0 +1,10 @@
+--- gcc-6.1.0/libstdc++-v3/config/os/mingw32-w64/os_defines.h.orig	2016-01-04 14:30:49.999997000 +0000
++++ gcc-6.1.0/libstdc++-v3/config/os/mingw32-w64/os_defines.h	2016-07-24 20:45:37.352669700 +0100
+@@ -76,6 +76,7 @@
+ 
+ #ifdef __x86_64__
+ #define _GLIBCXX_LLP64 1
++#define _GLIBCXX_USE_WEAK_REF 0
+ #endif
+ 
+ // Enable use of GetModuleHandleEx (requires Windows XP/2003) in

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -51,6 +51,7 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}/${_realname}-${pkgve
         "0014-gcc-6-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch"
         "0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch"
         "0016-gcc-6-branch-PR-c-71092-ICE-with-array-and-constexpr.patch"
+        "0017-disable-weak-refs.patch"
         "0100-gcc-4.8-libstdc++export.patch"
         "0110-gcc-4.7-stdthreads.patch")
 sha256sums=('09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351'
@@ -70,6 +71,7 @@ sha256sums=('09c4c85cabebb971b1de732a0219609f93fc0af5f86f6e437fd8d7f832f1a351'
             '60a58ed41389691a68ef4b7d47a0328df4d28d26e6c680a6b06b31191481ca65'
             '262c6fb0f6c9951d69e4c2dcc27949aa8f2cca8e672faf66740a7dbba4a4cd2c'
             '2f422c1c3c90145072c8636cf5ee94419d4f7872741fcff913fa65b3a98df570'
+            '09f27e0dae8d962f2a46a33a9891f2d14303629bb40f91ed8c5824c90da653a9'
             '21191b4fd57ce5f230fcc97b4d9ae31bdc387d7c7c8e39436aa7e4268d278d3d'
             '5e0fc1437ce0b357e78d440692e3a30a7905a5f360a67928a95b14ec8d45365b')
 
@@ -93,6 +95,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0014-gcc-6-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
   patch -p1 -i ${srcdir}/0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch
   patch -p1 -i ${srcdir}/0016-gcc-6-branch-PR-c-71092-ICE-with-array-and-constexpr.patch
+  patch -p1 -i ${srcdir}/0017-disable-weak-refs.patch
 
   #patch -p1 -i ${srcdir}/0100-gcc-4.8-libstdc++export.patch
   #patch -p1 -i ${srcdir}/0110-gcc-4.7-stdthreads.patch

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
 pkgver=6.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"


### PR DESCRIPTION
Fixes relocation errors mentioned in #1580
Idea from https://github.com/gcc-mirror/gcc/commit/40c727c8722ab47a821e2fe371f1b6b96be0200d