### PR TITLE
cmake: update to 3.6.1

### DIFF
--- a/mingw-w64-cmake/0002-Implement-Qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/0002-Implement-Qt5-static-plugin-support.patch
@@ -33,9 +33,9 @@ diff -urN cmake-3.5.2/Source/cmGlobalGenerator.cxx cmake-3.5.2.new/Source/cmGlob
             !(*ti)->GetPropertyAsBool("AUTORCC")) ||
            (*ti)->IsImported()) {
          continue;
-diff -urN cmake-3.5.2/Source/cmQtAutoGeneratorInitializer.cxx cmake-3.5.2.new/Source/cmQtAutoGeneratorInitializer.cxx
---- cmake-3.5.2/Source/cmQtAutoGeneratorInitializer.cxx	2016-04-15 14:41:22.000000000 +0100
-+++ cmake-3.5.2.new/Source/cmQtAutoGeneratorInitializer.cxx	2016-06-03 00:52:18.607232400 +0100
+diff -urN cmake-3.6.1/Source/cmQtAutoGeneratorInitializer.cxx cmake-3.6.1.new/Source/cmQtAutoGeneratorInitializer.cxx
+--- cmake-3.6.1/Source/cmQtAutoGeneratorInitializer.cxx	2016-07-22 15:50:22.000000000 +0200
++++ cmake-3.6.1.new/Source/cmQtAutoGeneratorInitializer.cxx	2016-07-27 18:15:39.092290100 +0200
 @@ -20,6 +20,7 @@
  #include <sys/stat.h>
  
@@ -43,21 +43,12 @@ diff -urN cmake-3.5.2/Source/cmQtAutoGeneratorInitializer.cxx cmake-3.5.2.new/So
 +#include <cmGeneratedFileStream.h>
  
  #if defined(_WIN32) && !defined(__CYGWIN__)
- # include "cmGlobalVisualStudioGenerator.h"
-@@ -28,7 +28,7 @@
- static std::string GetAutogenTargetName(cmGeneratorTarget const* target)
- {
-   std::string autogenTargetName = target->GetName();
--  autogenTargetName += "_automoc";
-+  autogenTargetName += "_autogen";
-   return autogenTargetName;
- }
- 
-@@ -164,6 +165,65 @@
+ #include "cmGlobalVisualStudioGenerator.h"
+@@ -88,6 +89,65 @@
         fileIt != newRccFiles.end(); ++fileIt) {
      const_cast<cmGeneratorTarget*>(target)->AddSource(*fileIt);
    }
-+
++  
 +  /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake,
 +   * macro(_populate_Core_plugin_properties ..), we'd have:
 +   * set_property(TARGET PROPERTY AUTOSTATICPLUGINS True) // Not currently need
@@ -119,21 +110,29 @@ diff -urN cmake-3.5.2/Source/cmQtAutoGeneratorInitializer.cxx cmake-3.5.2.new/So
  }
  
  static void GetCompileDefinitionsAndDirectories(
-@@ -790,6 +850,13 @@
-     {
+@@ -368,7 +428,7 @@
+ std::string GetAutogenTargetName(cmGeneratorTarget const* target)
+ {
+   std::string autogenTargetName = target->GetName();
+-  autogenTargetName += "_automoc";
++  autogenTargetName += "_autogen";
+   return autogenTargetName;
+ }
+ 
+@@ -690,6 +750,12 @@
+   if (target->GetPropertyAsBool("AUTORCC")) {
      toolNames.push_back("rcc");
-     }
+   }
 +  /* AUTOSTATICPLUGINS .cpp files are created at cmake execution time,
 +   * and not at build time, so in that case it is possible to get here
 +   * with no toolNames. */
-+  if (!toolNames.size())
-+    {
++  if (!toolNames.size()) {
 +    return;
-+    }
++  }
  
    std::string tools = toolNames[0];
    toolNames.erase(toolNames.begin());
-@@ -920,7 +988,9 @@
+@@ -858,7 +924,9 @@
  
    if (target->GetPropertyAsBool("AUTOMOC") ||
        target->GetPropertyAsBool("AUTOUIC") ||

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.6.0
+pkgver=3.6.1
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -27,10 +27,10 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0002-Implement-Qt5-static-plugin-support.patch"
         "pkg-config-without-prefix.patch"
         "do-not-generate-import-library-for-executables.patch")
-sha256sums=('fd05ed40cc40ef9ef99fac7b0ece2e0b871858a82feade48546f5d2940147670'
+sha256sums=('28ee98ec40427d41a45673847db7a905b59ce9243bb866eaf59dce0f58aaef11'
             'ce17e87849e6d07cf69422bb39c0682640ed3a03ea07808395c235a84e22be97'
             'aa816b734bf91941403b25bc9d9fd1797675ce2b4a7311bdb6e3ecae38964c37'
-            'ee020a43a3fd6937760514ce5615edba675e80316e678cfba5942e6af3e347e8'
+            'd78e30b4e0e8c1fc449acff5ea910c4691edd1ca2be60141ad7d3dd9a11ce6b9'
             'aa807e20e4a2902a8e6f3f36e1cd7d4b043d0df12f4fb0f4e6bd27d9d6842c0f'
             '8503536bfc6606e147c62cd7bc28f984911a04b7bf8164264c345eacbf68dc5b')
 


### PR DESCRIPTION
Fixes #1577 
Part of 0002-Implement-Qt5-static-plugin-support.patch had to be recreated due to fuzz and miscompilation

@Optiligence could you test if resolves your issues?

Also it would be great if someone could test static plugins.