### PR TITLE
winpthreads-git: Align thread entry point stack

### DIFF
--- a/mingw-w64-winpthreads-git/0001-Align-thread-entry-point-stack.patch
+++ b/mingw-w64-winpthreads-git/0001-Align-thread-entry-point-stack.patch
@@ -1,0 +1,30 @@
+From 18d2e8eaf68c8b4dd53b1f27bd4add745765b19e Mon Sep 17 00:00:00 2001
+From: Aleksey Vasenev <margtu-fivt@ya.ru>
+Date: Thu, 28 Jul 2016 15:31:06 +0300
+Subject: [PATCH] Align thread entry point stack
+
+__attribute__((aligned)) don't work for stack variables in threads created
+with _beginthreadex without alignment.
+
+Signed-off-by: Aleksey Vasenev <margtu-fivt@ya.ru>
+---
+ mingw-w64-libraries/winpthreads/src/thread.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mingw-w64-libraries/winpthreads/src/thread.c b/mingw-w64-libraries/winpthreads/src/thread.c
+index ceea98e..9fa773a 100644
+--- a/mingw-w64-libraries/winpthreads/src/thread.c
++++ b/mingw-w64-libraries/winpthreads/src/thread.c
+@@ -1454,6 +1454,9 @@ pthread_setcanceltype (int type, int *oldtype)
+   return 0;
+ }
+ 
++#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)
++__attribute__((force_align_arg_pointer))
++#endif
+ int
+ pthread_create_wrapper (void *args)
+ {
+-- 
+2.9.1
+

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-pkgver=5.0.0.4670.00cda6f
+pkgver=5.0.0.4685.cfe1994
 pkgrel=1
 pkgdesc="MinGW-w64 winpthreads library"
 url="http://mingw-w64.sourceforge.net"
@@ -22,9 +22,11 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-headers-git")
 options=('strip' '!buildflags' 'staticlibs' '!emptydirs' '!debug')
 source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64"
-        "0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch")
+        "0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch"
+        "0001-Align-thread-entry-point-stack.patch")
 sha256sums=('SKIP'
-            'd9e8af81682d9bf70e3d87506f51156cec61260b810a234bce861cb2eb3a5919')
+            'd9e8af81682d9bf70e3d87506f51156cec61260b810a234bce861cb2eb3a5919'
+            '6255646140e4904aa36b698e430ff365530b6c1ef9946dca6f9ff1db1f52d496')
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -38,6 +40,7 @@ prepare() {
   cd "${srcdir}/mingw-w64"
   [[ -f mingw-w64-libraries/winpthreads/src/libgcc/dll_frame_info.c ]] && rm -rf mingw-w64-libraries/winpthreads/src/libgcc/dll_frame_info.c
   git am --committer-date-is-author-date "${srcdir}"/0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch
+  git am --committer-date-is-author-date "${srcdir}"/0001-Align-thread-entry-point-stack.patch
   cd "${srcdir}"/mingw-w64/mingw-w64-libraries/winpthreads
   autoreconf -vfi
 }


### PR DESCRIPTION
**attribute**((aligned)) don't work for stack variables in threads created
with _beginthreadex without alignment.
