### PR TITLE
Add libvterm-bzr

### DIFF
--- a/mingw-w64-libvterm-bzr/PKGBUILD
+++ b/mingw-w64-libvterm-bzr/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Rui Abreu Ferreira <raf-ep@gmx.com>
+
+_realname=libvterm
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-bzr"
+pkgver=r681
+pkgrel=1
+pkgdesc='Abstract library implementation of a VT220/xterm/ECMA-48 terminal emulator (mingw-w64)'
+arch=('any')
+url='http://www.leonerd.org.uk/code/libvterm'
+license=('MIT')
+makedepends=('bzr')
+source=("${pkgname}::bzr+http://bazaar.leonerd.org.uk/c/libvterm/")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${pkgname}"
+  printf "r%s" "$(bzr revno)"
+}
+
+package() {
+  cd "${pkgname}"
+  # Do not build binaries they only work in real UNIX
+  make install-inc install-lib PREFIX=${MINGW_PREFIX} DESTDIR="$pkgdir"
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
libvterm is an abstract terminal emulator library, used by Neovim to implement terminal support.