### PR TITLE
Add lua51-bitop

### DIFF
--- a/mingw-w64-lua-bitop/PKGBUILD
+++ b/mingw-w64-lua-bitop/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Rui Abreu Ferreira <raf-ep@gmx.com>
+
+_realname=bitop
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-lua51-${_realname}")
+pkgver=1.0.2
+pkgrel=1
+arch=('any')
+url='http://bitop.luajit.org'
+license=('MIT')
+pkgdesc='C extension adding bitwise operations on numbers for Lua (mingw-w64)'
+depends=("${MINGW_PACKAGE_PREFIX}-lua51")
+makedepends=("${MINGW_PACKAGE_PREFIX}-lua51"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+
+source=("http://bitop.luajit.org/download/LuaBitOp-${pkgver}.tar.gz")
+sha256sums=('1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99')
+
+build() {
+  cd LuaBitOp-${pkgver}
+  gcc -O2 -fPIC $(pkg-config --cflags lua5.1) -shared -o bit.dll bit.c $(pkg-config --libs lua5.1)
+}
+
+package_mingw-w64-lua51-bitop() {
+  cd LuaBitOp-${pkgver}
+  install -Dm755 bit.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/5.1/bit.dll"
+}
+
+package_mingw-w64-x86_64-lua51-bitop() {
+  package_mingw-w64-lua51-bitop
+}
+
+package_mingw-w64-i686-lua51-bitop() {
+  package_mingw-w64-lua51-bitop
+}


### PR DESCRIPTION
The bit module, from Luajit, for regular Lua.

Bitop is compatible with lua 5.2 but not 5.3, which is why I did not add a lua-bitop package as well.