### PR TITLE
Fixes for DllMain in glib2

### DIFF
--- a/mingw-w64-gdk-pixbuf2/0003-fix-dllmain.patch
+++ b/mingw-w64-gdk-pixbuf2/0003-fix-dllmain.patch
@@ -1,0 +1,29 @@
+--- gdk-pixbuf-2.35.1-orig/gdk-pixbuf/gdk-pixbuf-io.c	2016-04-26 21:34:17.000000000 +0200
++++ gdk-pixbuf-2.35.1/gdk-pixbuf/gdk-pixbuf-io.c	2016-08-02 17:27:21.952759200 +0200
+@@ -191,7 +191,7 @@
+         return file_formats;
+ }
+ 
+-#ifdef G_OS_WIN32
++#if defined (G_OS_WIN32) && defined (DLL_EXPORT)
+ 
+ /* DllMain function needed to tuck away the gdk-pixbuf DLL handle */
+ 
+@@ -221,7 +221,7 @@
+   static gchar *toplevel = NULL;
+ 
+   if (toplevel == NULL) {
+-#if defined(G_OS_WIN32)
++#if defined (G_OS_WIN32) && defined (DLL_EXPORT)
+     toplevel = g_win32_get_package_installation_directory_of_module (gdk_pixbuf_dll);
+ #elif defined(OS_DARWIN)
+     char pathbuf[PATH_MAX + 1];
+@@ -232,7 +232,7 @@
+     bin_dir = g_dirname(pathbuf);
+     toplevel = g_build_path (G_DIR_SEPARATOR_S, bin_dir, "..", NULL);
+     g_free (bin_dir);
+-#elif defined (OS_LINUX)
++#elif defined (OS_LINUX) || defined(__MINGW32__)
+     gchar *exe_path, *bin_dir;
+ 
+     exe_path = g_file_read_link ("/proc/self/exe", NULL);

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -24,15 +24,18 @@ options=('emptydirs')
 install=${_realname}-${CARCH}.install
 source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${pkgver}.tar.xz"
         0001-Use-a-regex-to-properly-export-the-symbols.patch
-        0002-gdk-pixbuf-introspection.patch)
+        0002-gdk-pixbuf-introspection.patch
+        0003-fix-dllmain.patch)
 sha256sums=('51eba2550262bc1f1ad3569b4420f55b9261d2fc477e33a8d9b34c7e7f0d5631'
             'e8d278e30c44e973e14e3c61e8ab195621d6a9a402e0da557db4616955ca4543'
-            'dd496d66f0a6b369410fb4039e116ac7d6c2808c97998932a1f8f70b58f88ce2')
+            'dd496d66f0a6b369410fb4039e116ac7d6c2808c97998932a1f8f70b58f88ce2'
+            '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e')
 
 prepare() {
   cd ${srcdir}/gdk-pixbuf-${pkgver}
   patch -p1 -i "${srcdir}"/0001-Use-a-regex-to-properly-export-the-symbols.patch
   patch -p1 -i "${srcdir}"/0002-gdk-pixbuf-introspection.patch
+  patch -p1 -i "${srcdir}"/0003-fix-dllmain.patch
 
   autoreconf -fi
 }

--- a/mingw-w64-glib2/0004-glib-prefer-constructors-over-DllMain.patch
+++ b/mingw-w64-glib2/0004-glib-prefer-constructors-over-DllMain.patch
@@ -1,7 +1,6 @@
-diff -Naur glib-2.46.0-orig/glib/glib-init.c glib-2.46.0/glib/glib-init.c
---- glib-2.46.0-orig/glib/glib-init.c	2015-09-12 18:13:45.000000000 +0300
-+++ glib-2.46.0/glib/glib-init.c	2015-09-22 09:09:00.512195800 +0300
-@@ -238,12 +238,14 @@
+--- glib-2.48.1-orig/glib/glib-init.c	2016-05-10 10:54:30.000000000 +0200
++++ glib-2.48.1/glib/glib-init.c	2016-08-02 15:34:00.453365600 +0200
+@@ -245,12 +245,14 @@
  
  #if defined (G_OS_WIN32)
  
@@ -18,7 +17,7 @@ diff -Naur glib-2.46.0-orig/glib/glib-init.c glib-2.46.0/glib/glib-init.c
  BOOL WINAPI
  DllMain (HINSTANCE hinstDLL,
           DWORD     fdwReason,
-@@ -253,11 +255,6 @@
+@@ -260,11 +262,6 @@
      {
      case DLL_PROCESS_ATTACH:
        glib_dll = hinstDLL;
@@ -30,7 +29,7 @@ diff -Naur glib-2.46.0-orig/glib/glib-init.c glib-2.46.0/glib/glib-init.c
        break;
  
      case DLL_THREAD_DETACH:
-@@ -274,7 +271,10 @@
+@@ -288,7 +285,10 @@
    return TRUE;
  }
  
@@ -42,7 +41,7 @@ diff -Naur glib-2.46.0-orig/glib/glib-init.c glib-2.46.0/glib/glib-init.c
  
  #ifdef G_DEFINE_CONSTRUCTOR_NEEDS_PRAGMA
  #pragma G_DEFINE_CONSTRUCTOR_PRAGMA_ARGS(glib_init_ctor)
-@@ -284,6 +284,12 @@
+@@ -298,6 +298,12 @@
  static void
  glib_init_ctor (void)
  {
@@ -55,3 +54,14 @@ diff -Naur glib-2.46.0-orig/glib/glib-init.c glib-2.46.0/glib/glib-init.c
    glib_init ();
  }
  
+--- glib-2.48.1-orig/gobject/gtype.c	2016-02-29 15:32:08.000000000 +0100
++++ glib-2.48.1/gobject/gtype.c	2016-08-02 15:34:05.794575300 +0200
+@@ -4459,7 +4459,7 @@
+   _g_signal_init ();
+ }
+ 
+-#if defined (G_OS_WIN32)
++#if defined (G_OS_WIN32) && defined (DLL_EXPORT)
+ 
+ BOOL WINAPI DllMain (HINSTANCE hinstDLL,
+                      DWORD     fdwReason,

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -33,7 +33,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
 sha256sums=('74411bff489cb2a3527bac743a51018841a56a4d896cc1e0d0d54f8166a14612'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '1b24cc928f69f73599f83269a7b3eb7bf7efbe114109251e6765053a1e1f4cd6'
-            '7b099af0c562f397458542482d6d1debe437f220762aa2ed94b2e6c4d43dd8a6'
+            '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'
             'd1d35bb7865527422e28635ed373731e800c30ff5732c7bf8c66be37158509fb'
             '5cb481295ff86c2802030984d8b2bf6a3b1dcd5e5fe7b0be68b22d9116305837'


### PR DESCRIPTION
This fixes part of the problem in https://github.com/Alexpux/MINGW-packages/issues/988.

The [current patch](https://github.com/Alexpux/MINGW-packages/blob/master/mingw-w64-glib2/0004-glib-prefer-constructors-over-DllMain.patch) to avoid `DllMain` is incomplete. If we statically link librsvg or cairo we get **multiple definition of DllMain** linking erros.

The current PR works around `DllMain` for static builds of `gobject.a` and `gdk-pixbuf.a` and only enables `DllMain` when building the shared library. 