### PR TITLE
Added python-ipykernel as dependency

### DIFF
--- a/mingw-w64-python-jupyter_client/PKGBUILD
+++ b/mingw-w64-python-jupyter_client/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jupyter_client
 pkgbase=mingw-w64-python-jupyter_client
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="The reference implementation of the Jupyter protocol. (mingw-w64)"
 arch=('any')
 url="http://jupyter.org/"
@@ -34,7 +34,7 @@ all_build() {
 
 package_python3-jupyter_client() {
   local interpreter=python3
-  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+  depends=("${MINGW_PACKAGE_PREFIX}-python3-ipykernel"
            "${MINGW_PACKAGE_PREFIX}-python3-pyzmq")
 
   all_build ${interpreter}
@@ -44,7 +44,7 @@ package_python3-jupyter_client() {
 
 package_python2-jupyter_client() {
   local interpreter=python2
-  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+  depends=("${MINGW_PACKAGE_PREFIX}-python2-ipykernel"
            "${MINGW_PACKAGE_PREFIX}-python2-pyzmq")
 
   all_build ${interpreter}


### PR DESCRIPTION
Make jupyter_client automatically pull ipykernel. Otherwise, jupyter-console won't work unless
the user manually install ipykernel:

λ python3 C:\msys64\mingw64\bin\jupyter-console
[ZMQTerminalIPythonApp] WARNING | Native kernel (python3) is not available
Traceback (most recent call last):
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\kernelspec.py", line 173, in get_kernel_spec
    resource_dir = d[kernel_name.lower()]
KeyError: 'python3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\msys64\mingw64\bin\jupyter-console", line 5, in <module>
    app.main()
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_core\application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\traitlets\config\application.py", line 595, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-114>", line 2, in initialize
  File "C:\msys64\mingw64\lib\python3.5\site-packages\traitlets\config\application.py", line 74, in catch_config_error
    return method(app, *args, **kwargs)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_console\app.py", line 137, in initialize
    self.init_shell()
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_console\app.py", line 105, in init_shell
    JupyterConsoleApp.initialize(self)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\consoleapp.py", line 334, in initialize
    self.init_kernel_manager()
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\consoleapp.py", line 288, in init_kernel_manager
    self.kernel_manager.start_kernel(**kwargs)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\manager.py", line 230, in start_kernel
    kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\manager.py", line 170, in format_kernel_cmd
    cmd = self.kernel_spec.argv + extra_arguments
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\manager.py", line 82, in kernel_spec
    self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
  File "C:\msys64\mingw64\lib\python3.5\site-packages\jupyter_client\kernelspec.py", line 175, in get_kernel_spec
    raise NoSuchKernel(kernel_name)
jupyter_client.kernelspec.NoSuchKernel: No such kernel named python3