### PR TITLE
[DO NOT MERGE][WIP] kdeapps: initial commit

### DIFF
--- a/mingw-w64-PKGBUILD-common/build-kde-applications
+++ b/mingw-w64-PKGBUILD-common/build-kde-applications
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "shared" ]]; then
+  echo "Building shared"
+elif [[ "$1" == "static" ]]; then
+  echo "Building static"
+else
+  echo "${0} :: Error :: Please pass static or shared"
+  exit 1
+fi
+
+THISDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Listed in tier-order
+declare -a pkgs=(
+baloo-widgets-qt5
+#doplhin-qt5  #FIXME: undefined reference to `_imp___*'
+kate-qt5
+)
+
+for pkg in "${pkgs[@]}"; do
+  pushd ${THISDIR}/../mingw-w64-${pkg}
+  export KF5_VARIANT=$1
+  rm -rf *pkg*xz src pkg
+  makepkg-mingw -siLf --noconfirm || exit 1
+  popd
+done

--- a/mingw-w64-baloo-widgets-qt5/PKGBUILD
+++ b/mingw-w64-baloo-widgets-qt5/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Ray Donnelly <mingw.android@gmail.com>
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "baloo-widgets"
+pkgver=16.04.3
+pkgrel=1
+arch=('any')
+pkgdesc="This package contains GUI widgets for baloo (mingw-w64-qt5${_namesuff})"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+depends=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+source=("http://download.kde.org/stable/applications/${pkgver%}/src/${_basename}-${pkgver}.tar.xz")
+sha256sums=('f717b88dc1510b530cdb2c1deea18bd22382906542e37d36c37868d6c864d11a')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DBUILD_TESTING=OFF \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-dolphin-qt5/PKGBUILD
+++ b/mingw-w64-dolphin-qt5/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "dolphin"
+pkgver=16.04.3
+pkgrel=1
+pkgdesc="Dolphin is a file manager focusing on usability. (mingw-w64)"
+arch=('any')
+license=('GPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules" "${MINGW_PACKAGE_PREFIX}-python3")
+source=("http://download.kde.org/stable/applications/${pkgver}/src/${_basename}-${pkgver}.tar.xz"
+        "fix-win-detection.patch")
+sha256sums=('201f42d2f709c359a2f7b0974b1e35b6f22034a165540fd2af12b146b1a58599'
+            '60b83416debeb8bc45cfd351f801097a7e6e32058234c8cb6f6a591b19ad12bc')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+  
+  cd ${srcdir}/${_basename}-${pkgver}
+  patch -p1 -i ${srcdir}/fix-win-detection.patch
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DBUILD_TESTING=OFF \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-dolphin-qt5/fix-win-detection.patch
+++ b/mingw-w64-dolphin-qt5/fix-win-detection.patch
@@ -1,0 +1,25 @@
+diff -urN dolphin-16.04.3.orig/src/kitemviews/private/kdirectorycontentscounterworker.cpp dolphin-16.04.3/src/kitemviews/private/kdirectorycontentscounterworker.cpp
+--- dolphin-16.04.3.orig/src/kitemviews/private/kdirectorycontentscounterworker.cpp	2016-08-04 23:33:45.015298900 +0200
++++ dolphin-16.04.3/src/kitemviews/private/kdirectorycontentscounterworker.cpp	2016-08-04 23:48:09.143457600 +0200
+@@ -18,10 +18,11 @@
+  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA            *
+  ***************************************************************************/
+ 
++#include <QtGlobal>
+ #include "kdirectorycontentscounterworker.h"
+ 
+ // Required includes for subItemsCount():
+-#ifdef Q_WS_WIN
++#ifdef Q_OS_WIN
+     #include <QDir>
+ #else
+     #include <dirent.h>
+@@ -39,7 +40,7 @@
+     const bool countHiddenFiles = options & CountHiddenFiles;
+     const bool countDirectoriesOnly = options & CountDirectoriesOnly;
+ 
+-#ifdef Q_WS_WIN
++#ifdef Q_OS_WIN
+     QDir dir(path);
+     QDir::Filters filters = QDir::NoDotAndDotDot | QDir::System;
+     if (countHiddenFiles) {

--- a/mingw-w64-kate-qt5/PKGBUILD
+++ b/mingw-w64-kate-qt5/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Mateusz Mikuła <mati865@gmail.com>
+
+_realname=kate
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=16.04.3
+pkgrel=1
+pkgdesc="Kate is a multi-document, multi-view text editor for KDE (mingw-w64)"
+url='https://kate-editor.org/'
+arch=('any')
+license=('GPL')
+depends=("${MINGW_PACKAGE_PREFIX}-kio-qt5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules" "${MINGW_PACKAGE_PREFIX}-python3")
+source=("http://download.kde.org/stable/applications/${pkgver}/src/${_realname}-${pkgver}.tar.xz")
+sha256sums=('8df0040326469361d1f163616810c9c1a89dad675a81144dc3b5d3ae3f3f15a9')
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+	  -G'MSYS Makefiles' \
+	  -DCMAKE_BUILD_TYPE=Release \
+	  -DBUILD_TESTING=OFF \
+	  -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+	  -DCMAKE_INSTALL_LIBDIR=lib \
+	  ../${_realname}-${pkgver}
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
Depends on: https://github.com/Alexpux/MINGW-packages/pull/1623#issuecomment-238090678

Kate is incomplete due to issue with `GenericDataLocation` in Frameworks. Dolphin doesn't build (undefined reference to `_imp___*').

TODO:
- kate doesn't exit completely after exiting (need to press Ctrl-C in console or kill from task manager; could be related to Framework bugs)
