### PR TITLE
qt5: add new functions better fit MSYS2 needs

### DIFF
--- a/mingw-w64-qt5/0200-create-writableLocationMsys-and-standardLocationsMsy.patch
+++ b/mingw-w64-qt5/0200-create-writableLocationMsys-and-standardLocationsMsy.patch
@@ -1,0 +1,401 @@
+From eb5aa8e9fbb9ae59f7167f5359facabb6e1b186d Mon Sep 17 00:00:00 2001
+From: mati865 <mati865@gmail.com>
+Date: Wed, 10 Aug 2016 16:03:23 +0200
+Subject: [PATCH] create writableLocationMsys and standardLocationsMsys
+
+Based on qstandardpaths_unix.cpp
+We need it to make porting of the KDE easier and improve it's quality.
+---
+ qtbase/src/corelib/io/io.pri                  |   1 +
+ qtbase/src/corelib/io/qstandardpaths.h        |   3 +
+ qtbase/src/corelib/io/qstandardpaths_msys.cpp | 351 ++++++++++++++++++++++++++
+ 3 files changed, 355 insertions(+)
+ create mode 100644 qtbase/src/corelib/io/qstandardpaths_msys.cpp
+
+diff --git a/qtbase/src/corelib/io/io.pri b/qtbase/src/corelib/io/io.pri
+index 8d9908c..538a30a 100644
+--- a/qtbase/src/corelib/io/io.pri
++++ b/qtbase/src/corelib/io/io.pri
+@@ -108,6 +108,7 @@ win32 {
+     !winrt {
+         SOURCES += io/qsettings_win.cpp
+         SOURCES += io/qstandardpaths_win.cpp
++        SOURCES += io/qstandardpaths_msys.cpp
+ 
+         wince* {
+             SOURCES += io/qprocess_wince.cpp \
+diff --git a/qtbase/src/corelib/io/qstandardpaths.h b/qtbase/src/corelib/io/qstandardpaths.h
+index 5c0e08b..998167a 100644
+--- a/qtbase/src/corelib/io/qstandardpaths.h
++++ b/qtbase/src/corelib/io/qstandardpaths.h
+@@ -70,6 +70,9 @@ public:
+ 
+     static QString writableLocation(StandardLocation type);
+     static QStringList standardLocations(StandardLocation type);
++    
++    static QString writableLocationMsys(StandardLocation type);
++    static QStringList standardLocationsMsys(StandardLocation type);
+ 
+     enum LocateOption {
+         LocateFile = 0x0,
+diff --git a/qtbase/src/corelib/io/qstandardpaths_msys.cpp b/qtbase/src/corelib/io/qstandardpaths_msys.cpp
+new file mode 100644
+index 0000000..a65abf3
+--- /dev/null
++++ b/qtbase/src/corelib/io/qstandardpaths_msys.cpp
+@@ -0,0 +1,351 @@
++/****************************************************************************
++**
++** Copyright (C) 2015 The Qt Company Ltd.
++** Contact: http://www.qt.io/licensing/
++**
++** This file is part of the QtCore module of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL21$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see http://www.qt.io/terms-conditions. For further
++** information use the contact form at http://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 2.1 or version 3 as published by the Free
++** Software Foundation and appearing in the file LICENSE.LGPLv21 and
++** LICENSE.LGPLv3 included in the packaging of this file. Please review the
++** following information to ensure the GNU Lesser General Public License
++** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
++** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
++**
++** As a special exception, The Qt Company gives you certain additional
++** rights. These rights are described in The Qt Company LGPL Exception
++** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#include "qstandardpaths.h"
++#include <qdir.h>
++#include <qfile.h>
++#include <qhash.h>
++#include <qtextstream.h>
++#include <private/qfilesystemengine_p.h>
++#include <errno.h>
++#include <stdlib.h>
++#include "qconfig.cpp"
++
++#ifndef QT_BOOTSTRAPPED
++#include <qcoreapplication.h>
++#endif
++
++#ifndef QT_NO_STANDARDPATHS
++
++QT_BEGIN_NAMESPACE
++
++static void appendOrganizationAndApp(QString &path)
++{
++#ifndef QT_BOOTSTRAPPED
++    const QString org = QCoreApplication::organizationName();
++    if (!org.isEmpty())
++        path += QLatin1Char('/') + org;
++    const QString appName = QCoreApplication::applicationName();
++    if (!appName.isEmpty())
++        path += QLatin1Char('/') + appName;
++#else
++    Q_UNUSED(path);
++#endif
++}
++
++QString QStandardPaths::writableLocationMsys(StandardLocation type)
++{
++    QDir homeDir;
++    QDir mingwDir;
++    QDir tempDir;
++#ifndef QT_BOOTSTRAPPED
++    homeDir.setPath(".");
++    mingwDir.setPath(QT_CONFIGURE_PREFIX_PATH;
++    tempDir.setPath(QT_CONFIGURE_PREFIX_PATH + QLatin1String("/../tmp"));
++#else
++    Q_UNUSED(homeDir);
++    Q_UNUSED(mingwDir);
++    Q_UNUSED(tempDir);
++#endif
++    
++    switch (type) {
++    case HomeLocation:
++        return homeDir.absolutePath();
++    case TempLocation:
++        return tempDir.absolutePath();
++    case CacheLocation:
++    case GenericCacheLocation:
++    {
++        // http://standards.freedesktop.org/basedir-spec/basedir-spec-0.6.html
++        QString xdgCacheHome = QFile::decodeName(qgetenv("XDG_CACHE_HOME"));
++        if (isTestModeEnabled())
++            xdgCacheHome = homeDir.absolutePath() + QLatin1String("/.qttest/cache");
++        if (xdgCacheHome.isEmpty())
++            xdgCacheHome = homeDir.absolutePath() + QLatin1String("/.cache");
++        if (type == QStandardPaths::CacheLocation)
++            appendOrganizationAndApp(xdgCacheHome);
++        return xdgCacheHome;
++    }
++    case AppDataLocation:
++    case AppLocalDataLocation:
++    case GenericDataLocation:
++    {
++        QString xdgDataHome = QFile::decodeName(qgetenv("XDG_DATA_HOME"));
++        if (isTestModeEnabled())
++            xdgDataHome = homeDir.absolutePath() + QLatin1String("/.qttest/share");
++        if (xdgDataHome.isEmpty())
++            xdgDataHome = homeDir.absolutePath() + QLatin1String("/.local/share");
++        if (type == AppDataLocation || type == AppLocalDataLocation)
++            appendOrganizationAndApp(xdgDataHome);
++        return xdgDataHome;
++    }
++    case ConfigLocation:
++    case GenericConfigLocation:
++    case AppConfigLocation:
++    {
++        // http://standards.freedesktop.org/basedir-spec/latest/
++        QString xdgConfigHome = QFile::decodeName(qgetenv("XDG_CONFIG_HOME"));
++        if (isTestModeEnabled())
++            xdgConfigHome = homeDir.absolutePath() + QLatin1String("/.qttest/config");
++        if (xdgConfigHome.isEmpty())
++            xdgConfigHome = homeDir.absolutePath() + QLatin1String("/.config");
++        if (type == AppConfigLocation)
++            appendOrganizationAndApp(xdgConfigHome);
++        return xdgConfigHome;
++    }
++    case RuntimeLocation:
++    {
++        // http://standards.freedesktop.org/basedir-spec/latest/
++        QFileInfo fileInfo;
++        QString xdgRuntimeDir = QFile::decodeName(qgetenv("XDG_RUNTIME_DIR"));
++        if (xdgRuntimeDir.isEmpty()) {
++            const QString userName = qgetenv("USER");
++            xdgRuntimeDir = tempDir.absolutePath() + QLatin1String("/runtime-") + userName;
++            fileInfo.setFile(xdgRuntimeDir);
++            if (!fileInfo.isDir()) {
++                if (!QDir().mkdir(xdgRuntimeDir)) {
++                    qWarning("QStandardPaths: error creating runtime directory %s: %s", qPrintable(xdgRuntimeDir), qPrintable(qt_error_string(errno)));
++                    return QString();
++                }
++            }
++            qWarning("QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '%s'", qPrintable(xdgRuntimeDir));
++        } else {
++            fileInfo.setFile(xdgRuntimeDir);
++            if (!fileInfo.exists()) {
++                qWarning("QStandardPaths: XDG_RUNTIME_DIR points to non-existing path '%s', "
++                         "please create it with 0700 permissions.", qPrintable(xdgRuntimeDir));
++                return QString();
++            }
++            if (!fileInfo.isDir()) {
++                qWarning("QStandardPaths: XDG_RUNTIME_DIR points to '%s' which is not a directory",
++                         qPrintable(xdgRuntimeDir));
++                return QString();
++            }
++        }
++        const QFile::Permissions wantedPerms = QFile::ReadUser | QFile::WriteUser | QFile::ExeUser
++                                               | QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner;
++        if (fileInfo.permissions() != wantedPerms) {
++            QFile file(xdgRuntimeDir);
++            if (!file.setPermissions(wantedPerms)) {
++                qWarning("QStandardPaths: could not set correct permissions on runtime directory %s: %s",
++                         qPrintable(xdgRuntimeDir), qPrintable(file.errorString()));
++                return QString();
++            }
++        }
++        return xdgRuntimeDir;
++    }
++    default:
++        break;
++    }
++
++#ifndef QT_BOOTSTRAPPED
++    // http://www.freedesktop.org/wiki/Software/xdg-user-dirs
++    QString xdgConfigHome = QFile::decodeName(qgetenv("XDG_CONFIG_HOME"));
++    if (xdgConfigHome.isEmpty())
++        xdgConfigHome = homeDir.absolutePath() + QLatin1String("/.config");
++    QFile file(xdgConfigHome + QLatin1String("/user-dirs.dirs"));
++    if (!isTestModeEnabled() && file.open(QIODevice::ReadOnly)) {
++        QHash<QString, QString> lines;
++        QTextStream stream(&file);
++        // Only look for lines like: XDG_DESKTOP_DIR="$HOME/Desktop"
++        QRegExp exp(QLatin1String("^XDG_(.*)_DIR=(.*)$"));
++        while (!stream.atEnd()) {
++            const QString &line = stream.readLine();
++            if (exp.indexIn(line) != -1) {
++                const QStringList lst = exp.capturedTexts();
++                const QString key = lst.at(1);
++                QString value = lst.at(2);
++                if (value.length() > 2
++                    && value.startsWith(QLatin1Char('\"'))
++                    && value.endsWith(QLatin1Char('\"')))
++                    value = value.mid(1, value.length() - 2);
++                // Store the key and value: "DESKTOP", "$HOME/Desktop"
++                lines[key] = value;
++            }
++        }
++
++        QString key;
++        switch (type) {
++        case DesktopLocation:
++            key = QLatin1String("DESKTOP");
++            break;
++        case DocumentsLocation:
++            key = QLatin1String("DOCUMENTS");
++            break;
++        case PicturesLocation:
++            key = QLatin1String("PICTURES");
++            break;
++        case MusicLocation:
++            key = QLatin1String("MUSIC");
++            break;
++        case MoviesLocation:
++            key = QLatin1String("VIDEOS");
++            break;
++        case DownloadLocation:
++            key = QLatin1String("DOWNLOAD");
++            break;
++        default:
++            break;
++        }
++        if (!key.isEmpty()) {
++            QString value = lines.value(key);
++            if (!value.isEmpty()) {
++                // value can start with $HOME
++                if (value.startsWith(QLatin1String("$HOME")))
++                    value = homeDir.absolutePath() + value.mid(5);
++                if (value.length() > 1 && value.endsWith(QLatin1Char('/')))
++                    value.chop(1);
++                return value;
++            }
++        }
++    }
++#endif
++
++    QString path;
++    switch (type) {
++    case DesktopLocation:
++        path = QDir::homePath() + QLatin1String("/Desktop");
++        break;
++    case DocumentsLocation:
++        path = QDir::homePath() + QLatin1String("/Documents");
++       break;
++    case PicturesLocation:
++        path = QDir::homePath() + QLatin1String("/Pictures");
++        break;
++
++    case FontsLocation:
++        path = homeDir.absolutePath() + QLatin1String("/.fonts");
++        break;
++
++    case MusicLocation:
++        path = QDir::homePath() + QLatin1String("/Music");
++        break;
++
++    case MoviesLocation:
++        path = QDir::homePath() + QLatin1String("/Videos");
++        break;
++    case DownloadLocation:
++        path = QDir::homePath() + QLatin1String("/Downloads");
++        break;
++    case ApplicationsLocation:
++        path = writableLocationMsys(GenericDataLocation) + QLatin1String("/applications");
++        break;
++
++    default:
++        break;
++    }
++
++    return path;
++}
++
++static QStringList xdgDataDirs()
++{
++    QStringList dirs;
++    // http://standards.freedesktop.org/basedir-spec/latest/
++    QString xdgDataDirsEnv = QFile::decodeName(qgetenv("XDG_DATA_DIRS"));
++    if (xdgDataDirsEnv.isEmpty()) {
++        dirs.append(QT_CONFIGURE_PREFIX_PATH + QString::fromLatin1("/local/share"));
++        dirs.append(QT_CONFIGURE_PREFIX_PATH + QString::fromLatin1("/share"));
++    } else {
++        dirs = xdgDataDirsEnv.split(QLatin1Char(':'), QString::SkipEmptyParts);
++
++        // Normalize paths, skip relative paths
++        QMutableListIterator<QString> it(dirs);
++        while (it.hasNext()) {
++            const QString dir = it.next();
++            if (!dir.startsWith(QLatin1Char('/')))
++                it.remove();
++            else
++                it.setValue(QDir::cleanPath(dir));
++        }
++
++        // Remove duplicates from the list, there's no use for duplicated
++        // paths in XDG_DATA_DIRS - if it's not found in the given
++        // directory the first time, it won't be there the second time.
++        // Plus duplicate paths causes problems for example for mimetypes,
++        // where duplicate paths here lead to duplicated mime types returned
++        // for a file, eg "text/plain,text/plain" instead of "text/plain"
++        dirs.removeDuplicates();
++    }
++    return dirs;
++}
++
++static QStringList xdgConfigDirs()
++{
++    QStringList dirs;
++    // http://standards.freedesktop.org/basedir-spec/latest/
++    const QString xdgConfigDirs = QFile::decodeName(qgetenv("XDG_CONFIG_DIRS"));
++    if (xdgConfigDirs.isEmpty())
++        dirs.append(QT_CONFIGURE_PREFIX_PATH + QString::fromLatin1("/etc/xdg"));
++    else
++        dirs = xdgConfigDirs.split(QLatin1Char(':'));
++    return dirs;
++}
++
++QStringList QStandardPaths::standardLocationsMsys(StandardLocation type)
++{
++    QStringList dirs;
++    switch (type) {
++    case ConfigLocation:
++    case GenericConfigLocation:
++        dirs = xdgConfigDirs();
++        break;
++    case AppConfigLocation:
++        dirs = xdgConfigDirs();
++        for (int i = 0; i < dirs.count(); ++i)
++            appendOrganizationAndApp(dirs[i]);
++        break;
++    case GenericDataLocation:
++        dirs = xdgDataDirs();
++        break;
++    case ApplicationsLocation:
++        dirs = xdgDataDirs();
++        for (int i = 0; i < dirs.count(); ++i)
++            dirs[i].append(QLatin1String("/applications"));
++        break;
++    case AppDataLocation:
++    case AppLocalDataLocation:
++        dirs = xdgDataDirs();
++        for (int i = 0; i < dirs.count(); ++i)
++            appendOrganizationAndApp(dirs[i]);
++        break;
++    default:
++        break;
++    }
++    const QString localDir = writableLocationMsys(type);
++    dirs.prepend(localDir);
++    return dirs;
++}
++
++QT_END_NAMESPACE
++
++#endif // QT_NO_STANDARDPATHS
+-- 
+2.9.1
+

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -100,7 +100,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -226,7 +226,8 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0121-qt5-qtwebkit-dont-depend-on-icu.patch
         0122-revert-qt4-unicode-removal.patch
         0124-qt5-qtwebkit-disambiguate-append.patch
-        0125-qt5-windeployqt-fixes.patch)
+        0125-qt5-windeployqt-fixes.patch
+        0200-create-writableLocationMsys-and-standardLocationsMsy.patch)
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -382,6 +383,8 @@ prepare() {
   pushd qttools > /dev/null
     patch -p1 -i ${srcdir}/0125-qt5-windeployqt-fixes.patch
   popd
+  
+  patch -p1 < ${srcdir}/0200-create-writableLocationMsys-and-standardLocationsMsy.patch
 
   # See: https://bugreports.qt-project.org/browse/QTBUG-37902
   # _ver_num=${_ver_base%%-*}
@@ -746,4 +749,5 @@ sha256sums=('0d3cc75d2368ad988c9ec6bcbed6362dbaa8e03fdfd04e679284f4b9af91e565'
             'e412e0715597331d69d2672f072b4578ed4c0d7a3b8f959bce216f6998c74922'
             'd9e3928ded3adf98bc6c57f0c40126be29679d767701bdb5d161cc5d85ce81ee'
             '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900'
-            'e868da7e8716fd3f09d448d003796feda77e59b38d194cab7c8a99fabbdb78af')
+            'e868da7e8716fd3f09d448d003796feda77e59b38d194cab7c8a99fabbdb78af'
+            '9ed1ab9cc70192323f84b8223cef536c15c8b1bcbcb6d82328e6c49de7f304bc')


### PR DESCRIPTION
Probably final version of patch.
new functions: `QStandardPaths::standardLocationsMsys()`, `QStandardPaths::writableLocationMsys()`
They don't collide with anything and can be used in everything that calls 'QStandardPaths::standardLocations()` or `QStandardPaths::writableLocation()` but should search MSYS2 paths (e.x. `/mingw{32,64}/etc`, `/mingw{32,64}/share`) instead of Windows (e.x. `%APPDATA%`, `%PROGRAMDATA%`).

KDE porting would greatly benefit from this change.
Support for XDG_* is also included https://wiki.archlinux.org/index.php/XDG_Base_Directory_support

https://doc.qt.io/qt-5/qstandardpaths.html#standardLocations

Example dirs:
```
$ test.exe
GenericDataLocation: D:/msys64/home/mati865/.local/share,D:/msys64/mingw64/local/share,D:/msys64/mingw64/share
TempLocation: D:/msys64/tmp
ApplicationsLocation: D:/msys64/home/mati865/.local/share/applications,D:/msys64/mingw64/local/share/applications,D:/msys64/mingw64/share/applications
AppDataLocation: D:/msys64/home/mati865/.local/share/test,D:/msys64/mingw64/local/share/test,D:/msys64/mingw64/share/test
GenericConfigLocation: D:/msys64/home/mati865/.config,D:/msys64/mingw64/etc/xdg
RuntimeLocation: D:/msys64/tmp/runtime-mati865
HomeLocation: D:/msys64/home/mati865
MusicLocation: C:/Users/mati865/Music
```