### PR TITLE
ngspice: Fix path for header files

### DIFF
--- a/mingw-w64-ngspice/PKGBUILD
+++ b/mingw-w64-ngspice/PKGBUILD
@@ -11,8 +11,8 @@ _realname=ngspice
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=26
-pkgrel=1
-pkgdesc='Mixed-level/Mixed-signal circuit simulator based on Spice3f5, Ciber1b1, and Xspice.'
+pkgrel=2
+pkgdesc='Mixed-level/Mixed-signal circuit simulator based on Spice3f5, Cider1b1, and Xspice.'
 url='http://ngspice.sourceforge.net'
 license=('BSD')
 arch=('any')
@@ -61,7 +61,11 @@ package() {
   install -D -m644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -D -m644  "${srcdir}/${_realname}-doc-${pkgver}/manual.pdf" "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}/manual.pdf"
 
-  cd "${srcdir}/build-shared-${CARCH}"
-  install -D -m755 "src/.libs/libngspice-0.dll" "${pkgdir}${MINGW_PREFIX}/bin"
+  # ngspice installs headers to /${PREFIX}/share/ngspice/include, which is not the usual location for *.h files
+  mv ${pkgdir}${MINGW_PREFIX}/share/ngspice/include ${pkgdir}${MINGW_PREFIX}
 
+  # library files have to be copied manually
+  cd "${srcdir}/build-shared-${CARCH}"
+  install -D -m755 src/.libs/libngspice-0.dll "${pkgdir}${MINGW_PREFIX}/bin"
+  install -D -m755 src/.libs/libngspice.dll.a "${pkgdir}${MINGW_PREFIX}/lib"
 }


### PR DESCRIPTION
Currently ngspice installs header files is ${MINGW_PREFIX}/share/ngspice/include, which is not usual.
This merge request changes the path to ${MINGW_PREFIX}/include to conform with commonly accepted standards.