### PR TITLE
Fixes boost 1.60.0 issue

### DIFF
--- a/mingw-w64-boost/PKGBUILD
+++ b/mingw-w64-boost/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.60.0
 _boostver=${pkgver//./_}
-pkgrel=3
+pkgrel=4
 pkgdesc="Free peer-reviewed portable C++ source libraries (mingw-w64)"
 arch=('any')
 url="https://www.boost.org/"
@@ -34,7 +34,8 @@ source=(https://downloads.sourceforge.net/sourceforge/boost/boost_${_boostver}.t
         boost-1.60.0-mingw-context.patch
         boost-include-intrin-h-on-mingw-w64.patch
         using-mingw-w64-python.patch
-        msys2-mingw-folders-bootstrap.patch)
+        msys2-mingw-folders-bootstrap.patch
+        boost-1.60.0-shared_ptr_registration.patch)
 sha256sums=('686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b'
             'c5eae6354693c6b4e6364d4cf6f06c6c3de4c28486bf812cbd291f4410126cf8'
             'f32d189cc661e9b843cf0a3c1528de41aaf4f1ea69d6150b5bcd0a2525d36424'
@@ -51,7 +52,8 @@ sha256sums=('686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b'
             'cb4b080b68f2d1176c7c9e6302dd9263b8a81e3226b323745765f73c3dfaba6f'
             '9a269375b8eb262b93fb18ea6b2ac8c97b16fb71b8bab900faa4c2df2816f2eb'
             '0dd6346d369850aad13bf8d9bc2f0abc16d4b0586e34d61fab11f65d3d7fa9d4'
-            'ff22cad312b49625cc54edf41b210f2fc697322403e074792c82b0b5f45c4060')
+            'ff22cad312b49625cc54edf41b210f2fc697322403e074792c82b0b5f45c4060'
+            'd673f2df169c5a86dda8036a34da1a3f5c5787a25009d7f45c8b4c3615fd0950')
 
 prepare() {
   cd "${srcdir}/boost_${_boostver}"
@@ -102,6 +104,9 @@ prepare() {
   patch -p1 -i ${srcdir}/using-mingw-w64-python.patch
 
   patch -p1 -i ${srcdir}/msys2-mingw-folders-bootstrap.patch
+  
+  # https://github.com/boostorg/python/issues/56
+  patch -p2 -i ${srcdir}/boost-1.60.0-shared_ptr_registration.patch
 }
 
 build() {

--- a/mingw-w64-boost/boost-1.60.0-shared_ptr_registration.patch
+++ b/mingw-w64-boost/boost-1.60.0-shared_ptr_registration.patch
@@ -1,0 +1,28 @@
+--- a/include/boost/python/object/class_metadata.hpp
++++ b/include/boost/python/object/class_metadata.hpp
+@@ -164,7 +164,7 @@ struct class_metadata
+     >::type held_type;
+ 
+     // Determine if the object will be held by value
+-    typedef is_convertible<held_type*,T*> use_value_holder;
++    typedef mpl::bool_<is_convertible<held_type*,T*>::value> use_value_holder;
+     
+     // Compute the "wrapped type", that is, if held_type is a smart
+     // pointer, we're talking about the pointee.
+@@ -175,10 +175,12 @@ struct class_metadata
+     >::type wrapped;
+ 
+     // Determine whether to use a "back-reference holder"
+-    typedef mpl::or_<
+-        has_back_reference<T>
+-      , is_same<held_type_arg,T>
+-      , is_base_and_derived<T,wrapped>
++    typedef mpl::bool_<
++        mpl::or_<
++            has_back_reference<T>
++          , is_same<held_type_arg,T>
++          , is_base_and_derived<T,wrapped>
++        >::value
+     > use_back_reference;
+ 
+     // Select the holder.


### PR DESCRIPTION
Fixes the boost-1.60.0 issue described here: https://github.com/boostorg/python/pull/59
and here: https://bodhi.fedoraproject.org/updates/FEDORA-2016-fff5d70162
I have rebuilt the MinGW Boost packages on my Windows machine with the patched recipe and they work fine.