### PR TITLE
gtk3: update to version 3.20.9

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.20.6
+pkgver=3.20.9
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -29,7 +29,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz")
-sha256sums=('3f8016563a96b1cfef4ac9e795647f6316deb2978ff939b19e4e4f8f936fa4b2')
+sha256sums=('83a609ba2f3424b5509e73967c49c67833af466d6f91081b24ee5c64fce6ac17')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"


### PR DESCRIPTION
Here is an update of GTK+ 3. It compiles and works fine for me.