### PR TITLE
dbus: update to 1.10.10 and enable check

### DIFF
--- a/mingw-w64-dbus/PKGBUILD
+++ b/mingw-w64-dbus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dbus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.8
+pkgver=1.10.10
 pkgrel=1
 arch=('any')
 pkgdesc="Freedesktop.org message bus system (mingw-w64)"
@@ -17,7 +17,7 @@ options=('strip' 'staticlibs')
 license=("BSD")
 url="https://www.freedesktop.org/wiki/Software/dbus"
 source=("https://dbus.freedesktop.org/releases/dbus/${_realname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('baf3d22baa26d3bdd9edc587736cd5562196ce67996d65b82103bedbe1f0c014'
+sha256sums=('9d8f1d069ab4d1a0255d7b400ea3bcef4430c42e729b1012abb2890e3f739a43'
             'SKIP')
 
 prepare() {
@@ -35,12 +35,15 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --enable-xml-docs \
     --disable-systemd \
-    --disable-tests \
-    --disable-Werror \
     --enable-shared \
     --enable-static
 
   make
+}
+
+check() {
+  cd build-${MINGW_CHOST}
+  make check
 }
 
 package() {


### PR DESCRIPTION
Seems to work fine.
Compiles successfully without `--disable-Werror` so removing it.