### PR TITLE
add lz4 dependency to libarchive

### DIFF
--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="library that can create and read several streaming archive formats (mingw-w64)"
 arch=('any')
 url="http://www.libarchive.org"
@@ -14,6 +14,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-bzip2
          ${MINGW_PACKAGE_PREFIX}-expat
          ${MINGW_PACKAGE_PREFIX}-libiconv
+         ${MINGW_PACKAGE_PREFIX}-lz4
          ${MINGW_PACKAGE_PREFIX}-lzo2
          ${MINGW_PACKAGE_PREFIX}-libsystre
          ${MINGW_PACKAGE_PREFIX}-nettle


### PR DESCRIPTION
https://bugs.archlinux.org/task/49888
fixes Alexpux/MINGW-packages#1663