### PR TITLE
curl: add missing dependancy of libcurl

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -7,7 +7,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.50.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
 url="https://curl.haxx.se"
@@ -18,6 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libidn"
          "${MINGW_PACKAGE_PREFIX}-libmetalink"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
+         "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-rtmpdump"
          $([[ "$_variant" == "-openssl" ]] && echo \


### PR DESCRIPTION
Fixes cmake not working if lz4 isn't installed.