### PR TITLE
 openscenegraph-git: put back release package DESTDIR

### DIFF
--- a/mingw-w64-openscenegraph-git/PKGBUILD
+++ b/mingw-w64-openscenegraph-git/PKGBUILD
@@ -91,7 +91,7 @@ package_release() {
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 
   cd Release-${MINGW_CHOST}
-  make -j1 install
+  make DESTDIR=${pkgdir} -j1 install
 }
 
 package_debug() {


### PR DESCRIPTION
was removed by mistake in last commit