### PR TITLE
qt5[-static]: upgrade to hot fix 5.6.1-1

### DIFF
--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -90,6 +90,8 @@ _realname=qt5${_namesuff}
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver_base=5.6.1
+# use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
+_hotfix=-1
 
 # qt5-static must be kept in its own prefix hierarchy
 # as otherwise it will conflict with qt5 itself
@@ -100,7 +102,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -163,9 +165,9 @@ makedepends=("bison"
 groups=("${MINGW_PACKAGE_PREFIX}-qt" "${MINGW_PACKAGE_PREFIX}-qt5")
 options=('!strip' 'staticlibs' 'ccache')
 _pkgfqn="qt-everywhere-opensource-src-${_ver_base}"
-noextract=(${_pkgfqn}.tar.xz)
+noextract=(${_pkgfqn}${_hotfix}.tar.xz)
 source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base//RC/rc}/single/${_pkgfqn}.tar.xz
-        https://download.qt.io/official_releases/qt/${pkgver%.*}/${_ver_base}/single/${_pkgfqn}.tar.xz
+        https://download.qt.io/official_releases/qt/${pkgver%.*}/${_ver_base}${_hotfix}/single/${_pkgfqn}${_hotfix}.tar.xz
         https://download.qt.io/community_releases/${pkgver%.*}/${_ver_base}/qtwebkit-opensource-src-${_ver_base}.tar.xz
         #https://download.qt.io/snapshots/qt/${pkgver%.*}/${_ver_base}/2014-05-07_85/src/qt-everywhere-opensource-src-${_ver_base}.tar.xz
         #"qt3d"::"git://gitorious.org/qt/qt3d.git"
@@ -253,7 +255,7 @@ pkg_config_qt5() {
 
 prepare() {
   [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
-  tar -xJf ${srcdir}/${_pkgfqn}.tar.xz -C ${srcdir} || true
+  tar -xJf ${srcdir}/${_pkgfqn}${_hotfix}.tar.xz -C ${srcdir} || true
 
   cd ${srcdir}
   rm -rf ${_pkgfqn}/qtwebkit
@@ -682,7 +684,7 @@ package() {
 # export PKG_CONFIG_PATH=/mingw32/lib/pkgconfig
 # E:/m2/repo/mingw-w64-qt5/src/i686/qtbase/bin/qmake.exe -o Makefile qml.pro
 
-sha256sums=('0d3cc75d2368ad988c9ec6bcbed6362dbaa8e03fdfd04e679284f4b9af91e565'
+sha256sums=('ce08a7eb54661705f55fb283d895a089b267c688fabe017062bd71b9231736db'
             'f5cfbfa5fad2b65a9be907d426f99694b86a04c3bb5a8814b21bd0ade4c672aa'
             '7363ae7695af2f5278e9d91f6e52b3533dea4139ef252284bb82abfd025630d9'
             '609ab74b93ef11f24ef4d7c1bd0a2e81c4280b07fa455dfcf003a2364ab72745'

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -90,6 +90,8 @@ _realname=qt5${_namesuff}
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver_base=5.6.1
+# use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
+_hotfix=-1
 
 # qt5-static must be kept in its own prefix hierarchy
 # as otherwise it will conflict with qt5 itself
@@ -100,7 +102,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -163,9 +165,9 @@ makedepends=("bison"
 groups=("${MINGW_PACKAGE_PREFIX}-qt" "${MINGW_PACKAGE_PREFIX}-qt5")
 options=('!strip' 'staticlibs' 'ccache')
 _pkgfqn="qt-everywhere-opensource-src-${_ver_base}"
-noextract=(${_pkgfqn}.tar.xz)
+noextract=(${_pkgfqn}${_hotfix}.tar.xz)
 source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base//RC/rc}/single/${_pkgfqn}.tar.xz
-        https://download.qt.io/official_releases/qt/${pkgver%.*}/${_ver_base}/single/${_pkgfqn}.tar.xz
+        https://download.qt.io/official_releases/qt/${pkgver%.*}/${_ver_base}${_hotfix}/single/${_pkgfqn}${_hotfix}.tar.xz
         https://download.qt.io/community_releases/${pkgver%.*}/${_ver_base}/qtwebkit-opensource-src-${_ver_base}.tar.xz
         #https://download.qt.io/snapshots/qt/${pkgver%.*}/${_ver_base}/2014-05-07_85/src/qt-everywhere-opensource-src-${_ver_base}.tar.xz
         #"qt3d"::"git://gitorious.org/qt/qt3d.git"
@@ -254,7 +256,7 @@ pkg_config_qt5() {
 
 prepare() {
   [[ -d ${srcdir}/${_pkgfqn} ]] && rm -rf ${srcdir}/${_pkgfqn}
-  tar -xJf ${srcdir}/${_pkgfqn}.tar.xz -C ${srcdir} || true
+  tar -xJf ${srcdir}/${_pkgfqn}${_hotfix}.tar.xz -C ${srcdir} || true
 
   cd ${srcdir}
   rm -rf ${_pkgfqn}/qtwebkit
@@ -687,7 +689,7 @@ package() {
 # export PKG_CONFIG_PATH=/mingw32/lib/pkgconfig
 # E:/m2/repo/mingw-w64-qt5/src/i686/qtbase/bin/qmake.exe -o Makefile qml.pro
 
-sha256sums=('0d3cc75d2368ad988c9ec6bcbed6362dbaa8e03fdfd04e679284f4b9af91e565'
+sha256sums=('ce08a7eb54661705f55fb283d895a089b267c688fabe017062bd71b9231736db'
             'f5cfbfa5fad2b65a9be907d426f99694b86a04c3bb5a8814b21bd0ade4c672aa'
             '7363ae7695af2f5278e9d91f6e52b3533dea4139ef252284bb82abfd025630d9'
             '609ab74b93ef11f24ef4d7c1bd0a2e81c4280b07fa455dfcf003a2364ab72745'


### PR DESCRIPTION
see https://blog.qt.io/blog/2016/06/08/qt-5-6-1-released/

compiles fine up until it hits https://github.com/Alexpux/MINGW-packages/issues/1689