### PR TITLE
jq: make it depend on oniguruma

### DIFF
--- a/mingw-w64-jq/PKGBUILD
+++ b/mingw-w64-jq/PKGBUILD
@@ -4,12 +4,13 @@ _realname=jq
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.5
-pkgrel=2
+pkgrel=3
 pkgdesc="Command-line JSON processor (mingw-w64)"
 arch=('any')
 url='https://stedolan.github.io/jq/'
 license=('MIT')
 makedepends=("autoconf" "automake" "bison" "flex" "python2")
+depends=("${MINGW_PACKAGE_PREFIX}-oniguruma")
 source=("https://github.com/stedolan/${_realname}/releases/download/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
         no-undefined.patch
         missing-library.patch)


### PR DESCRIPTION
Oniguruma is a required dependency since version 1.5