### PR TITLE
Add ghc 8.0.1

### DIFF
--- a/mingw-w64-ghc/0001-Add-Windows-import-library-support-to-the-Runtime-Li.patch
+++ b/mingw-w64-ghc/0001-Add-Windows-import-library-support-to-the-Runtime-Li.patch
@@ -1,0 +1,1009 @@
+From 97f2b16483aae28dc8fd60b6d2e1e283618f2390 Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar@zhox.com>
+Date: Sun, 17 Apr 2016 13:03:17 +0200
+Subject: [PATCH] Add Windows import library support to the Runtime Linker
+
+Summary:
+Import libraries are files ending in `.dll.a` and `.lib` depending on which
+compiler creates them (GCC, vs MSVC).
+
+Import Libraries are standard `archive` files that contain object files.
+These object files can have two different formats:
+
+1) The normal COFF Object format for object files
+    (contains all ascii data and very little program code, so do not
+     try to execute.)
+2) "short import" format which just contains a symbol name and
+   the dll in which the symbol can be found.
+
+Import Libraries are useful for two things:
+
+1) Allowing applications that don't support dynamic linking to
+   link against the import lib (non-short format) which then
+   makes calls into the DLL by loading it at runtime.
+
+2) Allow linking of mutually recursive dlls. if `A.DLL` requires
+   `B.DLL` and vice versa, import libs can be used to break the cycle
+   as they can be created from the expected exports of the DLLs.
+
+A side effect of having these two capabilities is that Import libs are often
+used to hide specific versions of DLLs behind a non-versioned import lib.
+
+e.g. GCC_S.a (non-conventional import lib) will point to the correct
+`libGCC` DLL. With this support Windows Haskell files can now just link
+to `-lGCC_S` and not have to worry about what the actual name of libGCC is.
+
+Also third party libraries such as `icuuc` use import libs to forward to
+versioned DLLs. e.g. `icuuc.lib` points to `icuuc51.dll` etc.
+
+Test Plan:
+./validate
+
+Two new tests added T11072gcc T11072msvc
+
+Two binary files have been added to the test folder because the "short"
+import library format doesn't seem to be creatable via `dlltool`
+and requires Microsoft's `lib.exe`.
+
+Reviewers: bgamari, RyanGlScott, erikd, goldfire, austin, hvr
+
+Reviewed By: RyanGlScott, erikd
+
+Subscribers: thomie
+
+Differential Revision: https://phabricator.haskell.org/D1696
+
+GHC Trac Issues: #11072
+---
+ compiler/ghci/Linker.hs                            |  50 ++-
+ rts/Linker.c                                       | 385 +++++++++++++--------
+ rts/LinkerInternals.h                              | 125 ++++++-
+ testsuite/tests/ghci/linking/dyn/Makefile          |  16 +
+ testsuite/tests/ghci/linking/dyn/T11072.hs         |   7 +
+ testsuite/tests/ghci/linking/dyn/T11072gcc.stdout  |   1 +
+ testsuite/tests/ghci/linking/dyn/T11072msvc.stdout |   1 +
+ testsuite/tests/ghci/linking/dyn/all.T             |  10 +
+ testsuite/tests/ghci/linking/dyn/i686/libAS.lib    | Bin 0 -> 1698 bytes
+ testsuite/tests/ghci/linking/dyn/libAS.def         |   3 +
+ testsuite/tests/ghci/linking/dyn/x86_64/libAS.lib  | Bin 0 -> 1700 bytes
+ 11 files changed, 445 insertions(+), 153 deletions(-)
+ create mode 100644 testsuite/tests/ghci/linking/dyn/T11072.hs
+ create mode 100644 testsuite/tests/ghci/linking/dyn/T11072gcc.stdout
+ create mode 100644 testsuite/tests/ghci/linking/dyn/T11072msvc.stdout
+ create mode 100644 testsuite/tests/ghci/linking/dyn/i686/libAS.lib
+ create mode 100644 testsuite/tests/ghci/linking/dyn/libAS.def
+ create mode 100644 testsuite/tests/ghci/linking/dyn/x86_64/libAS.lib
+
+diff --git a/compiler/ghci/Linker.hs b/compiler/ghci/Linker.hs
+index 4b8a322..5042136 100644
+--- a/compiler/ghci/Linker.hs
++++ b/compiler/ghci/Linker.hs
+@@ -1227,9 +1227,6 @@ linkPackage hsc_env pkg
+             mapM_ (load_dyn hsc_env)
+               (known_dlls ++ map (mkSOName platform) dlls)
+ 
+-        -- DLLs are loaded, reset the search paths
+-        mapM_ (removeLibrarySearchPath hsc_env) $ reverse pathCache
+-
+         -- After loading all the DLLs, we can load the static objects.
+         -- Ordering isn't important here, because we do one final link
+         -- step to resolve everything.
+@@ -1238,6 +1235,13 @@ linkPackage hsc_env pkg
+ 
+         maybePutStr dflags "linking ... "
+         ok <- resolveObjs hsc_env
++
++        -- DLLs are loaded, reset the search paths
++        -- Import libraries will be loaded via loadArchive so only
++        -- reset the DLL search path after all archives are loaded
++        -- as well.
++        mapM_ (removeLibrarySearchPath hsc_env) $ reverse pathCache
++
+         if succeeded ok
+            then maybePutStrLn dflags "done."
+            else let errmsg = "unable to load package `"
+@@ -1281,9 +1285,10 @@ locateLib hsc_env is_hs dirs lib
+     -- For non-Haskell libraries (e.g. gmp, iconv):
+     --   first look in library-dirs for a dynamic library (libfoo.so)
+     --   then  look in library-dirs for a static library (libfoo.a)
+-    --   first look in library-dirs and inplace GCC for a dynamic library (libfoo.so)
++    --   then look in library-dirs and inplace GCC for a dynamic library (libfoo.so)
+     --   then  check for system dynamic libraries (e.g. kernel32.dll on windows)
+     --   then  try "gcc --print-file-name" to search gcc's search path
++    --   then  try looking for import libraries on Windows (.dll.a, .lib)
+     --   then  look in library-dirs and inplace GCC for a static library (libfoo.a)
+     --       for a dynamic library (#5289)
+     --   otherwise, assume loadDLL can find it
+@@ -1291,6 +1296,7 @@ locateLib hsc_env is_hs dirs lib
+   = findDll     `orElse`
+     findSysDll  `orElse`
+     tryGcc      `orElse`
++    tryImpLib   `orElse`
+     findArchive `orElse`
+     assumeDll
+ 
+@@ -1321,31 +1327,43 @@ locateLib hsc_env is_hs dirs lib
+      loading_profiled_hs_libs = interpreterProfiled dflags
+      loading_dynamic_hs_libs  = interpreterDynamic dflags
+ 
++     import_libs  = [lib <.> "lib", "lib" ++ lib <.> "lib", "lib" ++ lib <.> "dll.a"]
++
+      hs_dyn_lib_name = lib ++ '-':programName dflags ++ projectVersion dflags
+      hs_dyn_lib_file = mkHsSOName platform hs_dyn_lib_name
+ 
+-     so_name = mkSOName platform lib
++     so_name     = mkSOName platform lib
+      lib_so_name = "lib" ++ so_name
+      dyn_lib_file = case (arch, os) of
+                              (ArchX86_64, OSSolaris2) -> "64" </> so_name
+                              _ -> so_name
+ 
+-     findObject     = liftM (fmap Object)  $ findFile dirs obj_file
+-     findDynObject  = liftM (fmap Object)  $ findFile dirs dyn_obj_file
+-     findArchive    = let local  = liftM (fmap Archive) $ findFile dirs arch_file
+-                          linked = liftM (fmap Archive) $ searchForLibUsingGcc dflags arch_file dirs
+-                      in liftM2 (<|>) local linked
+-     findHSDll      = liftM (fmap DLLPath) $ findFile dirs hs_dyn_lib_file
+-     findDll        = liftM (fmap DLLPath) $ findFile dirs dyn_lib_file
+-     findSysDll     = fmap (fmap $ DLL . takeFileName) $ findSystemLibrary hsc_env so_name
+-     tryGcc         = let short = liftM (fmap DLLPath) $ searchForLibUsingGcc dflags so_name     dirs
+-                          full  = liftM (fmap DLLPath) $ searchForLibUsingGcc dflags lib_so_name dirs
+-                      in liftM2 (<|>) short full
++     findObject    = liftM (fmap Object)  $ findFile dirs obj_file
++     findDynObject = liftM (fmap Object)  $ findFile dirs dyn_obj_file
++     findArchive   = let local  = liftM (fmap Archive) $ findFile dirs arch_file
++                         linked = liftM (fmap Archive) $ searchForLibUsingGcc dflags arch_file dirs
++                     in liftM2 (<|>) local linked
++     findHSDll     = liftM (fmap DLLPath) $ findFile dirs hs_dyn_lib_file
++     findDll       = liftM (fmap DLLPath) $ findFile dirs dyn_lib_file
++     findSysDll    = fmap (fmap $ DLL . takeFileName) $ findSystemLibrary hsc_env so_name
++     tryGcc        = let short = liftM (fmap DLLPath) $ searchForLibUsingGcc dflags so_name     dirs
++                         full  = liftM (fmap DLLPath) $ searchForLibUsingGcc dflags lib_so_name dirs
++                     in liftM2 (<|>) short full
++     tryImpLib     = case os of
++                       OSMinGW32 -> let check name = liftM (fmap Archive) $ searchForLibUsingGcc dflags name dirs
++                                    in apply (map check import_libs)
++                       _         -> return Nothing
+ 
+      assumeDll   = return (DLL lib)
+      infixr `orElse`
+      f `orElse` g = f >>= maybe g return
+ 
++     apply []     = return Nothing
++     apply (x:xs) = do x' <- x
++                       if isJust x'
++                          then return x'
++                          else apply xs
++
+      platform = targetPlatform dflags
+      arch = platformArch platform
+      os = platformOS platform
+diff --git a/rts/Linker.c b/rts/Linker.c
+index 50f438a..d670f1d 100644
+--- a/rts/Linker.c
++++ b/rts/Linker.c
+@@ -259,6 +259,9 @@ static ObjectCode* mkOc( pathchar *path, char *image, int imageSize,
+ #define struct_stat struct _stat
+ #define open wopen
+ #define WSTR(s) L##s
++#define pathprintf swprintf
++#define pathsplit _wsplitpath_s
++#define pathsize sizeof(wchar_t)
+ #else
+ #define pathcmp strcmp
+ #define pathlen strlen
+@@ -266,6 +269,9 @@ static ObjectCode* mkOc( pathchar *path, char *image, int imageSize,
+ #define pathstat stat
+ #define struct_stat struct stat
+ #define WSTR(s) s
++#define pathprintf snprintf
++#define pathsplit _splitpath_s
++#define pathsize sizeof(char)
+ #endif
+ 
+ static pathchar* pathdup(pathchar *path)
+@@ -290,7 +296,7 @@ static pathchar* mkPath(char* path)
+     {
+         barf("mkPath failed converting char* to wchar_t*");
+     }
+-
++    ret[required] = '\0';
+     return ret;
+ #else
+     return pathdup(path);
+@@ -349,6 +355,33 @@ static void machoInitSymbolsWithoutUnderscore( void );
+ #endif
+ 
+ #if defined(OBJFORMAT_PEi386)
++/* string utility function */
++static HsBool endsWithPath(pathchar* base, pathchar* str) {
++    int blen = pathlen(base);
++    int slen = pathlen(str);
++    return (blen >= slen) && (0 == pathcmp(base + blen - slen, str));
++}
++
++static int checkAndLoadImportLibrary(
++    pathchar* arch_name,
++    char* member_name,
++    FILE* f);
++
++static int findAndLoadImportLibrary(
++    ObjectCode* oc
++    );
++
++static UChar *myindex(
++    int scale,
++    void* base,
++    int index);
++static UChar *cstring_from_COFF_symbol_name(
++    UChar* name,
++    UChar* strtab);
++static char *cstring_from_section_name(
++    UChar* name,
++    UChar* strtab);
++
+ 
+ /* Add ld symbol for PE image base. */
+ #if defined(__GNUC__)
+@@ -1375,7 +1408,7 @@ static void* lookupSymbol_ (char *lbl)
+            See Note [runtime-linker-phases] */
+         if (oc && oc->status == OBJECT_LOADED) {
+             oc->status = OBJECT_NEEDED;
+-            IF_DEBUG(linker, debugBelch("lookupSymbol: on-demand loaded symbol '%s'\n", lbl));
++            IF_DEBUG(linker, debugBelch("lookupSymbol: on-demand loading symbol '%s'\n", lbl));
+             r = ocTryLoad(oc);
+ 
+             if (!r) {
+@@ -1942,10 +1975,11 @@ void freeObjectCode (ObjectCode *oc)
+ * Sets the initial status of a fresh ObjectCode
+ */
+ static void setOcInitialStatus(ObjectCode* oc) {
+-    if (oc->archiveMemberName == NULL) {
++    if (oc->isImportLib == HS_BOOL_TRUE) {
++        oc->status = OBJECT_DONT_RESOLVE;
++    } else if (oc->archiveMemberName == NULL) {
+         oc->status = OBJECT_NEEDED;
+-    }
+-    else {
++    } else {
+         oc->status = OBJECT_LOADED;
+     }
+ }
+@@ -2028,7 +2062,7 @@ static HsInt loadArchive_ (pathchar *path)
+     size_t thisFileNameSize;
+     char *fileName;
+     size_t fileNameSize;
+-    int isObject, isGnuIndex, isThin;
++    int isObject, isGnuIndex, isThin, isImportLib;
+     char tmp[20];
+     char *gnuFileIndex;
+     int gnuFileIndexSize;
+@@ -2075,10 +2109,11 @@ static HsInt loadArchive_ (pathchar *path)
+     fileName = stgMallocBytes(fileNameSize, "loadArchive(fileName)");
+ 
+     isThin = 0;
++    isImportLib = 0;
+ 
+     f = pathopen(path, WSTR("rb"));
+     if (!f)
+-        barf("loadObj: can't read `%s'", path);
++        barf("loadObj: can't read `%" PATH_FMT "'", path);
+ 
+     /* Check if this is an archive by looking for the magic "!<arch>\n"
+      * string.  Usually, if this fails, we barf and quit.  On Darwin however,
+@@ -2101,7 +2136,7 @@ static HsInt loadArchive_ (pathchar *path)
+ 
+     n = fread ( tmp, 1, 8, f );
+     if (n != 8)
+-        barf("loadArchive: Failed reading header from `%s'", path);
++        barf("loadArchive: Failed reading header from `%" PATH_FMT "'", path);
+     if (strncmp(tmp, "!<arch>\n", 8) == 0) {}
+ #if !defined(mingw32_HOST_OS)
+     /* See Note [thin archives on Windows] */
+@@ -2151,13 +2186,14 @@ static HsInt loadArchive_ (pathchar *path)
+     }
+ #else
+     else {
+-        barf("loadArchive: Not an archive: `%s'", path);
++        barf("loadArchive: Not an archive: `%" PATH_FMT "'", path);
+     }
+ #endif
+ 
+     IF_DEBUG(linker, debugBelch("loadArchive: loading archive contents\n"));
+ 
+-    while(1) {
++    while (1) {
++        IF_DEBUG(linker, debugBelch("loadArchive: reading at %ld\n", ftell(f)));
+         n = fread ( fileName, 1, 16, f );
+         if (n != 16) {
+             if (feof(f)) {
+@@ -2165,7 +2201,7 @@ static HsInt loadArchive_ (pathchar *path)
+                 break;
+             }
+             else {
+-                barf("loadArchive: Failed reading file name from `%s'", path);
++                barf("loadArchive: Failed reading file name from `%" PATH_FMT "'", path);
+             }
+         }
+ 
+@@ -2178,19 +2214,19 @@ static HsInt loadArchive_ (pathchar *path)
+ 
+         n = fread ( tmp, 1, 12, f );
+         if (n != 12)
+-            barf("loadArchive: Failed reading mod time from `%s'", path);
++            barf("loadArchive: Failed reading mod time from `%" PATH_FMT "'", path);
+         n = fread ( tmp, 1, 6, f );
+         if (n != 6)
+-            barf("loadArchive: Failed reading owner from `%s'", path);
++            barf("loadArchive: Failed reading owner from `%" PATH_FMT "'", path);
+         n = fread ( tmp, 1, 6, f );
+         if (n != 6)
+-            barf("loadArchive: Failed reading group from `%s'", path);
++            barf("loadArchive: Failed reading group from `%" PATH_FMT "'", path);
+         n = fread ( tmp, 1, 8, f );
+         if (n != 8)
+-            barf("loadArchive: Failed reading mode from `%s'", path);
++            barf("loadArchive: Failed reading mode from `%" PATH_FMT "'", path);
+         n = fread ( tmp, 1, 10, f );
+         if (n != 10)
+-            barf("loadArchive: Failed reading size from `%s'", path);
++            barf("loadArchive: Failed reading size from `%" PATH_FMT "'", path);
+         tmp[10] = '\0';
+         for (n = 0; isdigit(tmp[n]); n++);
+         tmp[n] = '\0';
+@@ -2199,9 +2235,9 @@ static HsInt loadArchive_ (pathchar *path)
+         IF_DEBUG(linker, debugBelch("loadArchive: size of this archive member is %d\n", memberSize));
+         n = fread ( tmp, 1, 2, f );
+         if (n != 2)
+-            barf("loadArchive: Failed reading magic from `%s'", path);
++            barf("loadArchive: Failed reading magic from `%" PATH_FMT "'", path);
+         if (strncmp(tmp, "\x60\x0A", 2) != 0)
+-            barf("loadArchive: Failed reading magic from `%s' at %ld. Got %c%c",
++            barf("loadArchive: Failed reading magic from `%" PATH_FMT "' at %ld. Got %c%c",
+                  path, ftell(f), tmp[0], tmp[1]);
+ 
+         isGnuIndex = 0;
+@@ -2221,7 +2257,7 @@ static HsInt loadArchive_ (pathchar *path)
+                 }
+                 n = fread ( fileName, 1, thisFileNameSize, f );
+                 if (n != (int)thisFileNameSize) {
+-                    barf("loadArchive: Failed reading filename from `%s'",
++                    barf("loadArchive: Failed reading filename from `%" PATH_FMT "'",
+                          path);
+                 }
+                 fileName[thisFileNameSize] = 0;
+@@ -2311,15 +2347,32 @@ static HsInt loadArchive_ (pathchar *path)
+         IF_DEBUG(linker,
+                  debugBelch("loadArchive: Found member file `%s'\n", fileName));
+ 
+-        isObject =
+-               (thisFileNameSize >= 2 &&
+-                fileName[thisFileNameSize - 2] == '.' &&
+-                fileName[thisFileNameSize - 1] == 'o')
+-            || (thisFileNameSize >= 4 &&
+-                fileName[thisFileNameSize - 4] == '.' &&
+-                fileName[thisFileNameSize - 3] == 'p' &&
+-                fileName[thisFileNameSize - 2] == '_' &&
+-                fileName[thisFileNameSize - 1] == 'o');
++        isObject = (thisFileNameSize >= 2 && strncmp(fileName + thisFileNameSize - 2, ".o"  , 2) == 0)
++                || (thisFileNameSize >= 4 && strncmp(fileName + thisFileNameSize - 4, ".p_o", 4) == 0);
++
++#if defined(OBJFORMAT_PEi386)
++        /*
++        * Note [MSVC import files (ext .lib)]
++        * MSVC compilers store the object files in
++        * the import libraries with extension .dll
++        * so on Windows we should look for those too.
++        * The PE COFF format doesn't specify any specific file name
++        * for sections. So on windows, just try to load it all.
++        *
++        * Linker members (e.g. filename / are skipped since they are not needed)
++        */
++        isImportLib = thisFileNameSize >= 4 && strncmp(fileName + thisFileNameSize - 4, ".dll", 4) == 0;
++
++        /*
++         * Note [GCC import files (ext .dll.a)]
++         * GCC stores import information in the same binary format
++         * as the object file normally has. The only difference is that
++         * all the information are put in .idata sections. The only real
++         * way to tell if we're dealing with an import lib is by looking
++         * at the file extension.
++         */
++        isImportLib = isImportLib || endsWithPath(path, WSTR(".dll.a"));
++#endif // windows
+ 
+         IF_DEBUG(linker, debugBelch("loadArchive: \tthisFileNameSize = %d\n", (int)thisFileNameSize));
+         IF_DEBUG(linker, debugBelch("loadArchive: \tisObject = %d\n", isObject));
+@@ -2330,8 +2383,8 @@ static HsInt loadArchive_ (pathchar *path)
+             IF_DEBUG(linker, debugBelch("loadArchive: Member is an object file...loading...\n"));
+ 
+ #if defined(mingw32_HOST_OS)
+-        // TODO: We would like to use allocateExec here, but allocateExec
+-        //       cannot currently allocate blocks large enough.
++            // TODO: We would like to use allocateExec here, but allocateExec
++            //       cannot currently allocate blocks large enough.
+             image = allocateImageAndTrampolines(path, fileName,
+ #if defined(x86_64_HOST_ARCH)
+                f,
+@@ -2395,7 +2448,7 @@ static HsInt loadArchive_ (pathchar *path)
+             {
+                 n = fread ( image, 1, memberSize, f );
+                 if (n != memberSize) {
+-                    barf("loadArchive: error whilst reading `%s'", path);
++                    barf("loadArchive: error whilst reading `%" PATH_FMT "'", path);
+                 }
+             }
+ 
+@@ -2414,8 +2467,20 @@ static HsInt loadArchive_ (pathchar *path)
+                 fclose(f);
+                 return 0;
+             } else {
+-                oc->next = objects;
+-                objects = oc;
++#if defined(OBJFORMAT_PEi386)
++                if (isImportLib)
++                {
++                    findAndLoadImportLibrary(oc);
++                    stgFree(oc);
++                    oc = NULL;
++                    break;
++                } else {
++#endif
++                    oc->next = objects;
++                    objects = oc;
++#if defined(OBJFORMAT_PEi386)
++                }
++#endif
+             }
+         }
+         else if (isGnuIndex) {
+@@ -2430,11 +2495,25 @@ static HsInt loadArchive_ (pathchar *path)
+ #endif
+             n = fread ( gnuFileIndex, 1, memberSize, f );
+             if (n != memberSize) {
+-                barf("loadArchive: error whilst reading `%s'", path);
++                barf("loadArchive: error whilst reading `%" PATH_FMT "'", path);
+             }
+             gnuFileIndex[memberSize] = '/';
+             gnuFileIndexSize = memberSize;
+         }
++        else if (isImportLib) {
++#if defined(OBJFORMAT_PEi386)
++            if (checkAndLoadImportLibrary(path, fileName, f)) {
++                IF_DEBUG(linker, debugBelch("loadArchive: Member is an import file section... Corresponding DLL has been loaded...\n"));
++            }
++            else {
++                IF_DEBUG(linker, debugBelch("loadArchive: Member is not a valid import file section... Skipping...\n"));
++                n = fseek(f, memberSize, SEEK_CUR);
++                if (n != 0)
++                    barf("loadArchive: error whilst seeking by %d in `%" PATH_FMT "'",
++                    memberSize, path);
++            }
++#endif
++        }
+         else {
+             IF_DEBUG(linker, debugBelch("loadArchive: '%s' does not appear to be an object file\n", fileName));
+             if (!isThin || thisFileNameSize == 0) {
+@@ -2455,7 +2534,7 @@ static HsInt loadArchive_ (pathchar *path)
+                     break;
+                 }
+                 else {
+-                    barf("loadArchive: Failed reading padding from `%s'", path);
++                    barf("loadArchive: Failed reading padding from `%" PATH_FMT "'", path);
+                 }
+             }
+             IF_DEBUG(linker, debugBelch("loadArchive: successfully read one pad byte\n"));
+@@ -3270,103 +3349,6 @@ ocFlushInstructionCache( ObjectCode *oc )
+ 
+ #if defined(OBJFORMAT_PEi386)
+ 
+-
+-
+-typedef unsigned char          UChar;
+-typedef unsigned short         UInt16;
+-typedef unsigned int           UInt32;
+-typedef          int           Int32;
+-typedef unsigned long long int UInt64;
+-
+-
+-typedef
+-   struct {
+-      UInt16 Machine;
+-      UInt16 NumberOfSections;
+-      UInt32 TimeDateStamp;
+-      UInt32 PointerToSymbolTable;
+-      UInt32 NumberOfSymbols;
+-      UInt16 SizeOfOptionalHeader;
+-      UInt16 Characteristics;
+-   }
+-   COFF_header;
+-
+-#define sizeof_COFF_header 20
+-
+-
+-typedef
+-   struct {
+-      UChar  Name[8];
+-      UInt32 VirtualSize;
+-      UInt32 VirtualAddress;
+-      UInt32 SizeOfRawData;
+-      UInt32 PointerToRawData;
+-      UInt32 PointerToRelocations;
+-      UInt32 PointerToLinenumbers;
+-      UInt16 NumberOfRelocations;
+-      UInt16 NumberOfLineNumbers;
+-      UInt32 Characteristics;
+-   }
+-   COFF_section;
+-
+-#define sizeof_COFF_section 40
+-
+-
+-typedef
+-   struct {
+-      UChar  Name[8];
+-      UInt32 Value;
+-      UInt16 SectionNumber;
+-      UInt16 Type;
+-      UChar  StorageClass;
+-      UChar  NumberOfAuxSymbols;
+-   }
+-   COFF_symbol;
+-
+-#define sizeof_COFF_symbol 18
+-
+-
+-typedef
+-   struct {
+-      UInt32 VirtualAddress;
+-      UInt32 SymbolTableIndex;
+-      UInt16 Type;
+-   }
+-   COFF_reloc;
+-
+-#define sizeof_COFF_reloc 10
+-
+-/* From PE spec doc, section 3.3.2 */
+-/* Note use of MYIMAGE_* since IMAGE_* are already defined in
+-   windows.h -- for the same purpose, but I want to know what I'm
+-   getting, here. */
+-#define MYIMAGE_FILE_RELOCS_STRIPPED        0x0001
+-#define MYIMAGE_FILE_EXECUTABLE_IMAGE       0x0002
+-#define MYIMAGE_FILE_DLL                    0x2000
+-#define MYIMAGE_FILE_SYSTEM                 0x1000
+-#define MYIMAGE_FILE_BYTES_REVERSED_HI      0x8000
+-#define MYIMAGE_FILE_BYTES_REVERSED_LO      0x0080
+-#define MYIMAGE_FILE_32BIT_MACHINE          0x0100
+-
+-/* From PE spec doc, section 5.4.2 and 5.4.4 */
+-#define MYIMAGE_SYM_CLASS_EXTERNAL          2
+-#define MYIMAGE_SYM_CLASS_STATIC            3
+-#define MYIMAGE_SYM_UNDEFINED               0
+-#define MYIMAGE_SYM_CLASS_WEAK_EXTERNAL     105
+-
+-/* From PE spec doc, section 3.1 */
+-#define MYIMAGE_SCN_CNT_CODE                0x00000020
+-#define MYIMAGE_SCN_CNT_INITIALIZED_DATA    0x00000040
+-#define MYIMAGE_SCN_CNT_UNINITIALIZED_DATA  0x00000080
+-#define MYIMAGE_SCN_LNK_COMDAT              0x00001000
+-#define MYIMAGE_SCN_LNK_NRELOC_OVFL         0x01000000
+-#define MYIMAGE_SCN_LNK_REMOVE              0x00000800
+-#define MYIMAGE_SCN_MEM_DISCARDABLE         0x02000000
+-
+-/* From PE spec doc, section 5.2.1 */
+-#define MYIMAGE_REL_I386_DIR32              0x0006
+-#define MYIMAGE_REL_I386_REL32              0x0014
+-
+ static int verifyCOFFHeader ( COFF_header *hdr, pathchar *filename);
+ 
+ /* We assume file pointer is right at the
+@@ -3424,6 +3406,134 @@ allocateImageAndTrampolines (
+    return image + PEi386_IMAGE_OFFSET;
+ }
+ 
++static int findAndLoadImportLibrary(ObjectCode* oc)
++{
++    int i;
++
++    COFF_header*  hdr;
++    COFF_section* sectab;
++    COFF_symbol*  symtab;
++    UChar*        strtab;
++
++    hdr = (COFF_header*)(oc->image);
++    sectab = (COFF_section*)(
++        ((UChar*)(oc->image))
++        + sizeof_COFF_header + hdr->SizeOfOptionalHeader
++        );
++
++    symtab = (COFF_symbol*)(
++        ((UChar*)(oc->image))
++        + hdr->PointerToSymbolTable
++        );
++
++    strtab = ((UChar*)symtab)
++        + hdr->NumberOfSymbols * sizeof_COFF_symbol;
++
++    for (i = 0; i < oc->n_sections; i++)
++    {
++        COFF_section* sectab_i
++            = (COFF_section*)myindex(sizeof_COFF_section, sectab, i);
++
++        char *secname = cstring_from_section_name(sectab_i->Name, strtab);
++
++        // Find the first entry containing a valid .idata$7 section.
++        if (strcmp(secname, ".idata$7") == 0) {
++            /* First load the containing DLL if not loaded. */
++            Section section = oc->sections[i];
++
++            pathchar* dirName = stgMallocBytes(pathsize * pathlen(oc->fileName), "findAndLoadImportLibrary(oc)");
++            pathsplit(oc->fileName, NULL, 0, dirName, pathsize * pathlen(oc->fileName), NULL, 0, NULL, 0);
++            HsPtr token = addLibrarySearchPath(dirName);
++            char* dllName = (char*)section.start;
++
++            if (strlen(dllName) == 0 || dllName[0] == ' ')
++            {
++                continue;
++            }
++
++            IF_DEBUG(linker, debugBelch("lookupSymbol: on-demand '%ls' => `%s'\n", oc->fileName, dllName));
++
++            pathchar* dll = mkPath(dllName);
++            removeLibrarySearchPath(token);
++
++            const char* result = addDLL(dll);
++            stgFree(dll);
++
++            if (result != NULL) {
++                errorBelch("Could not load `%s'. Reason: %s\n", (char*)dllName, result);
++                return 0;
++            }
++
++            break;
++        }
++
++        stgFree(secname);
++    }
++
++    return 1;
++}
++
++static int checkAndLoadImportLibrary( pathchar* arch_name, char* member_name, FILE* f)
++{
++    char* image;
++    static HsBool load_dll_warn = HS_BOOL_FALSE;
++
++    if (load_dll_warn) { return 0; }
++
++    /* Based on Import Library specification. PE Spec section 7.1 */
++
++    COFF_import_header hdr;
++    size_t n;
++
++    n = fread(&hdr, 1, sizeof_COFF_import_Header, f);
++    if (n != sizeof(COFF_header)) {
++        errorBelch("getNumberOfSymbols: error whilst reading `%s' header in `%" PATH_FMT "'\n",
++            member_name, arch_name);
++        return 0;
++    }
++
++    if (hdr.Sig1 != 0x0 || hdr.Sig2 != 0xFFFF) {
++        fseek(f, -sizeof_COFF_import_Header, SEEK_CUR);
++        IF_DEBUG(linker, debugBelch("loadArchive: Object `%s` is not an import lib. Skipping...\n", member_name));
++        return 0;
++    }
++
++    IF_DEBUG(linker, debugBelch("loadArchive: reading %d bytes at %ld\n", hdr.SizeOfData, ftell(f)));
++
++    image = malloc(hdr.SizeOfData);
++    n = fread(image, 1, hdr.SizeOfData, f);
++    if (n != hdr.SizeOfData) {
++        errorBelch("loadArchive: error whilst reading `%s' header in `%" PATH_FMT "'. Did not read enough bytes.\n",
++            member_name, arch_name);
++    }
++
++    char* symbol  = strtok(image, "\0");
++    int symLen    = strlen(symbol) + 1;
++    int nameLen   = n - symLen;
++    char* dllName = malloc(sizeof(char) * nameLen);
++    dllName       = strncpy(dllName, image + symLen, nameLen);
++    pathchar* dll = malloc(sizeof(wchar_t) * nameLen);
++    mbstowcs(dll, dllName, nameLen);
++    free(dllName);
++
++    IF_DEBUG(linker, debugBelch("loadArchive: read symbol %s from lib `%ls'\n", symbol, dll));
++    const char* result = addDLL(dll);
++
++    free(image);
++
++    if (result != NULL) {
++        errorBelch("Could not load `%ls'. Reason: %s\n", dll, result);
++        load_dll_warn = HS_BOOL_TRUE;
++
++        free(dll);
++        fseek(f, -(n + sizeof_COFF_import_Header), SEEK_CUR);
++        return 0;
++    }
++
++    free(dll);
++    return 1;
++}
++
+ /* We use myindex to calculate array addresses, rather than
+    simply doing the normal subscript thing.  That's because
+    some of the above structs have sizes which are not
+@@ -3967,7 +4077,8 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+        symtab_i = (COFF_symbol*)
+            myindex ( sizeof_COFF_symbol, symtab, i );
+        if (symtab_i->SectionNumber == MYIMAGE_SYM_UNDEFINED
+-           && symtab_i->Value > 0) {
++           && symtab_i->Value > 0
++           && symtab_i->StorageClass != MYIMAGE_SYM_CLASS_SECTION) {
+            globalBssSize += symtab_i->Value;
+        }
+        i += symtab_i->NumberOfAuxSymbols;
+@@ -3995,7 +4106,8 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+ 
+       addr  = NULL;
+       HsBool isWeak = HS_BOOL_FALSE;
+-      if (symtab_i->SectionNumber != MYIMAGE_SYM_UNDEFINED) {
++      if (   symtab_i->SectionNumber != MYIMAGE_SYM_UNDEFINED
++          && symtab_i->SectionNumber > 0) {
+          /* This symbol is global and defined, viz, exported */
+          /* for MYIMAGE_SYMCLASS_EXTERNAL
+                 && !MYIMAGE_SYM_UNDEFINED,
+@@ -4006,7 +4118,7 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+             = (COFF_section*) myindex ( sizeof_COFF_section,
+                                         sectab,
+                                         symtab_i->SectionNumber-1 );
+-         if (  symtab_i->StorageClass == MYIMAGE_SYM_CLASS_EXTERNAL
++         if (symtab_i->StorageClass == MYIMAGE_SYM_CLASS_EXTERNAL
+             || (   symtab_i->StorageClass == MYIMAGE_SYM_CLASS_STATIC
+                 && sectabent->Characteristics & MYIMAGE_SCN_LNK_COMDAT)
+             ) {
+@@ -4249,6 +4361,7 @@ ocResolve_PEi386 ( ObjectCode* oc )
+          switch (reltab_j->Type) {
+ #if defined(i386_HOST_ARCH)
+             case MYIMAGE_REL_I386_DIR32:
++            case MYIMAGE_REL_I386_DIR32NB:
+                *(UInt32 *)pP = ((UInt32)S) + A;
+                break;
+             case MYIMAGE_REL_I386_REL32:
+@@ -4327,7 +4440,7 @@ ocResolve_PEi386 ( ObjectCode* oc )
+                }
+ #endif
+             default:
+-               debugBelch("%" PATH_FMT ": unhandled PEi386 relocation type %d",
++               debugBelch("%" PATH_FMT ": unhandled PEi386 relocation type %d\n",
+                      oc->fileName, reltab_j->Type);
+                return 0;
+          }
+diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
+index a34e6f3..b311a8f 100644
+--- a/rts/LinkerInternals.h
++++ b/rts/LinkerInternals.h
+@@ -16,7 +16,8 @@ typedef enum {
+     OBJECT_LOADED,
+     OBJECT_NEEDED,
+     OBJECT_RESOLVED,
+-    OBJECT_UNLOADED
++    OBJECT_UNLOADED,
++    OBJECT_DONT_RESOLVE
+ } OStatus;
+ 
+ /* Indication of section kinds for loaded objects.  Needed by
+@@ -172,6 +173,11 @@ typedef struct _ObjectCode {
+ 
+     ForeignExportStablePtr *stable_ptrs;
+ 
++    /* Indicates whether if the .o file comes from
++       an import library. In which case we shouldn't
++       execute code from it. */
++    HsBool isImportLib;
++
+ } ObjectCode;
+ 
+ #define OC_INFORMATIVE_FILENAME(OC)             \
+@@ -192,4 +198,121 @@ void exitLinker( void );
+ 
+ void freeObjectCode (ObjectCode *oc);
+ 
++#if defined(mingw32_HOST_OS)
++
++typedef unsigned char          UChar;
++typedef unsigned short         UInt16;
++typedef short                  Int16;
++typedef unsigned int           UInt32;
++typedef          int           Int32;
++typedef unsigned long long int UInt64;
++
++
++typedef
++struct {
++    UInt16 Machine;
++    UInt16 NumberOfSections;
++    UInt32 TimeDateStamp;
++    UInt32 PointerToSymbolTable;
++    UInt32 NumberOfSymbols;
++    UInt16 SizeOfOptionalHeader;
++    UInt16 Characteristics;
++}
++COFF_header;
++
++#define sizeof_COFF_header 20
++
++/* Section 7.1 PE Specification */
++typedef
++struct {
++    UInt16 Sig1;
++    UInt16 Sig2;
++    UInt16 Version;
++    UInt16 Machine;
++    UInt32 TimeDateStamp;
++    UInt32 SizeOfData;
++    UInt16 Ordinal;
++    UInt16 Type_NameType_Reserved;
++}
++COFF_import_header;
++
++#define sizeof_COFF_import_Header 20
++
++typedef
++struct {
++    UChar  Name[8];
++    UInt32 VirtualSize;
++    UInt32 VirtualAddress;
++    UInt32 SizeOfRawData;
++    UInt32 PointerToRawData;
++    UInt32 PointerToRelocations;
++    UInt32 PointerToLinenumbers;
++    UInt16 NumberOfRelocations;
++    UInt16 NumberOfLineNumbers;
++    UInt32 Characteristics;
++}
++COFF_section;
++
++#define sizeof_COFF_section 40
++
++
++typedef
++struct {
++    UChar  Name[8];
++    UInt32 Value;
++    Int16  SectionNumber;
++    UInt16 Type;
++    UChar  StorageClass;
++    UChar  NumberOfAuxSymbols;
++}
++COFF_symbol;
++
++#define sizeof_COFF_symbol 18
++
++
++typedef
++struct {
++    UInt32 VirtualAddress;
++    UInt32 SymbolTableIndex;
++    UInt16 Type;
++}
++COFF_reloc;
++
++#define sizeof_COFF_reloc 10
++
++/* From PE spec doc, section 3.3.2 */
++/* Note use of MYIMAGE_* since IMAGE_* are already defined in
++windows.h -- for the same purpose, but I want to know what I'm
++getting, here. */
++#define MYIMAGE_FILE_RELOCS_STRIPPED        0x0001
++#define MYIMAGE_FILE_EXECUTABLE_IMAGE       0x0002
++#define MYIMAGE_FILE_DLL                    0x2000
++#define MYIMAGE_FILE_SYSTEM                 0x1000
++#define MYIMAGE_FILE_BYTES_REVERSED_HI      0x8000
++#define MYIMAGE_FILE_BYTES_REVERSED_LO      0x0080
++#define MYIMAGE_FILE_32BIT_MACHINE          0x0100
++
++/* From PE spec doc, section 5.4.2 and 5.4.4 */
++#define MYIMAGE_SYM_CLASS_EXTERNAL          2
++#define MYIMAGE_SYM_CLASS_STATIC            3
++#define MYIMAGE_SYM_UNDEFINED               0
++#define MYIMAGE_SYM_CLASS_SECTION           104
++#define MYIMAGE_SYM_CLASS_WEAK_EXTERNAL     105
++
++/* From PE spec doc, section 3.1 */
++#define MYIMAGE_SCN_CNT_CODE                0x00000020
++#define MYIMAGE_SCN_CNT_INITIALIZED_DATA    0x00000040
++#define MYIMAGE_SCN_CNT_UNINITIALIZED_DATA  0x00000080
++#define MYIMAGE_SCN_LNK_COMDAT              0x00001000
++#define MYIMAGE_SCN_LNK_NRELOC_OVFL         0x01000000
++#define MYIMAGE_SCN_LNK_REMOVE              0x00000800
++#define MYIMAGE_SCN_MEM_DISCARDABLE         0x02000000
++
++/* From PE spec doc, section 5.2.1 */
++#define MYIMAGE_REL_I386_DIR32              0x0006
++#define MYIMAGE_REL_I386_DIR32NB            0x0007
++#define MYIMAGE_REL_I386_REL32              0x0014
++
++#endif /* OBJFORMAT_PEi386 */
++
+ #endif /* LINKERINTERNALS_H */
+diff --git a/testsuite/tests/ghci/linking/dyn/Makefile b/testsuite/tests/ghci/linking/dyn/Makefile
+index 56e27b1..b37fdea 100644
+--- a/testsuite/tests/ghci/linking/dyn/Makefile
++++ b/testsuite/tests/ghci/linking/dyn/Makefile
+@@ -64,6 +64,22 @@ compile_libAB_dyn:
+ 	'$(TEST_HC)' $(TEST_HC_OPTS) -ignore-dot-ghci -v0 -o "bin_dyn/$(call EXE,T10955dyn)" -L./bin_dyn -lB -lA T10955dyn.hs -v0
+ 	LD_LIBRARY_PATH=./bin_dyn ./bin_dyn/$(call EXE,T10955dyn)
+ 
++.PHONY: compile_libAS_impl_gcc
++compile_libAS_impl_gcc:
++	rm -rf bin_impl_gcc
++	mkdir bin_impl_gcc
++	'$(TEST_HC)' $(MY_TEST_HC_OPTS) -odir "bin_impl_gcc" -shared A.c -o "bin_impl_gcc/$(call DLL,ASimpL)"
++	mv bin_impl_gcc/libASimpL.dll.a bin_impl_gcc/libASx.dll.a
++	echo "main" | '$(TEST_HC)' $(TEST_HC_OPTS) --interactive -ignore-dot-ghci -v0 T11072.hs -lASx -L./bin_impl_gcc
++
++.PHONY: compile_libAS_impl_msvc
++compile_libAS_impl_msvc:
++	rm -rf bin_impl_msvc
++	mkdir bin_impl_msvc
++	'$(TEST_HC)' $(MY_TEST_HC_OPTS) -odir "bin_impl_msvc" -shared A.c -o "bin_impl_msvc/$(call DLL,ASimpL)"
++	rm -f bin_impl_msvc/libAS*.a
++	echo "main" | '$(TEST_HC)' $(TEST_HC_OPTS) --interactive -ignore-dot-ghci -v0 T11072.hs -lAS -L./bin_impl_msvc -L"./$(shell uname -m)"
++
+ .PHONY: T1407
+ T1407:
+ 	cat T1407.script | LD_LIBRARY_PATH=. "$(TEST_HC)" $(TEST_HC_OPTS) -ignore-dot-ghci -v0 --interactive -L.
+diff --git a/testsuite/tests/ghci/linking/dyn/T11072.hs b/testsuite/tests/ghci/linking/dyn/T11072.hs
+new file mode 100644
+index 0000000..56636d8
+--- /dev/null
++++ b/testsuite/tests/ghci/linking/dyn/T11072.hs
+@@ -0,0 +1,7 @@
++module Main where
++
++import Foreign
++import Foreign.C.Types
++foreign import ccall "foo" dle :: IO CInt
++
++main = dle >>= print
+diff --git a/testsuite/tests/ghci/linking/dyn/T11072gcc.stdout b/testsuite/tests/ghci/linking/dyn/T11072gcc.stdout
+new file mode 100644
+index 0000000..78c6bae
+--- /dev/null
++++ b/testsuite/tests/ghci/linking/dyn/T11072gcc.stdout
+@@ -0,0 +1 @@
++2
+diff --git a/testsuite/tests/ghci/linking/dyn/T11072msvc.stdout b/testsuite/tests/ghci/linking/dyn/T11072msvc.stdout
+new file mode 100644
+index 0000000..78c6bae
+--- /dev/null
++++ b/testsuite/tests/ghci/linking/dyn/T11072msvc.stdout
+@@ -0,0 +1 @@
++2
+diff --git a/testsuite/tests/ghci/linking/dyn/all.T b/testsuite/tests/ghci/linking/dyn/all.T
+index e1e0fd2..d54c84e 100644
+--- a/testsuite/tests/ghci/linking/dyn/all.T
++++ b/testsuite/tests/ghci/linking/dyn/all.T
+@@ -34,3 +34,13 @@ test('T10458',
+      pre_cmd('$MAKE -s --no-print-directory compile_libT10458'),
+      extra_hc_opts('-L$PWD/T10458dir -lAS')],
+      ghci_script, ['T10458.script'])
++
++test('T11072gcc',
++     [unless(doing_ghci, skip), unless(opsys('mingw32'), skip), extra_clean(['bin_impl_gcc/*', 'bin_impl_gcc'])],
++     run_command,
++     ['$MAKE -s --no-print-directory compile_libAS_impl_gcc'])
++
++test('T11072msvc',
++     [unless(doing_ghci, skip), unless(opsys('mingw32'), skip), extra_clean(['bin_impl_msvc/*', 'bin_impl_msvc'])],
++     run_command,
++     ['$MAKE -s --no-print-directory compile_libAS_impl_msvc'])
+diff --git a/testsuite/tests/ghci/linking/dyn/libAS.def b/testsuite/tests/ghci/linking/dyn/libAS.def
+new file mode 100644
+index 0000000..4873b34
+--- /dev/null
++++ b/testsuite/tests/ghci/linking/dyn/libAS.def
+@@ -0,0 +1,3 @@
++LIBRARY libASimpL
++EXPORTS
++foo

--- a/mingw-w64-ghc/0001-Add-relocation-type-R_X86_64_REX_GOTPCRELX.patch
+++ b/mingw-w64-ghc/0001-Add-relocation-type-R_X86_64_REX_GOTPCRELX.patch
@@ -1,0 +1,50 @@
+From 0d963caf40da4391028a3beb95b5082c87985e7d Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar@zhox.com>
+Date: Sun, 5 Jun 2016 09:59:05 +0200
+Subject: [PATCH] Add relocation type R_X86_64_REX_GOTPCRELX
+
+Summary:
+Adding support for the `R_X86_64_REX_GOTPCRELX` relocation type.
+This relocation is treated by the linker the same as the `R_X86_64_GOTPCRELX` type
+`G + GOT + A - P` to generate relative offsets to the GOT.
+The `REX` prefix has no influence in this stage.
+
+This is based on https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-r252.pdf
+
+Test Plan: ./validate
+
+Reviewers: erikd, austin, bgamari, simonmar
+
+Reviewed By: erikd
+
+Subscribers: thomie, #ghc_windows_task_force
+
+Differential Revision: https://phabricator.haskell.org/D2303
+
+GHC Trac Issues: #12147
+---
+ rts/Linker.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/rts/Linker.c b/rts/Linker.c
+index 5a6a8c2..a1f72e5 100644
+--- a/rts/Linker.c
++++ b/rts/Linker.c
+@@ -5681,7 +5681,13 @@ do_Elf_Rela_relocations ( ObjectCode* oc, char* ehdrC,
+           *(Elf64_Sword *)P = (Elf64_Sword)value;
+ #endif
+           break;
+-
++/* These two relocations were introduced in glibc 2.23 and binutils 2.26.
++    But in order to use them the system which compiles the bindist for GHC needs
++    to have glibc >= 2.23. So only use them if they're defined. */
++#if defined(R_X86_64_REX_GOTPCRELX) && defined(R_X86_64_GOTPCRELX)
++      case R_X86_64_REX_GOTPCRELX:
++      case R_X86_64_GOTPCRELX:
++#endif
+       case R_X86_64_GOTPCREL:
+       {
+           StgInt64 gotAddress = (StgInt64) &makeSymbolExtra(oc, ELF_R_SYM(info), S)->addr;
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Enable-checkProddableBlock-on-x86_64.patch
+++ b/mingw-w64-ghc/0001-Enable-checkProddableBlock-on-x86_64.patch
@@ -1,0 +1,49 @@
+From da3c1ebb8a57e81f12c5be192e477f79158a2398 Mon Sep 17 00:00:00 2001
+From: Simon Marlow <marlowsd@gmail.com>
+Date: Sat, 21 May 2016 18:36:49 +0200
+Subject: [PATCH] Enable checkProddableBlock on x86_64
+
+We've been seeing some memory corruption after using the linker, and I
+want to enable this to see if it catches anything.
+
+Test Plan:
+* validate
+* modified the linker_unload test to remove the performGC calls to use
+  as a benchmark, saw no significant difference after this change.
+
+Reviewers: bgamari, erikd, austin
+
+Reviewed By: austin
+
+Subscribers: thomie
+
+Differential Revision: https://phabricator.haskell.org/D2245
+---
+ rts/Linker.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rts/Linker.c b/rts/Linker.c
+index 61b10d8..e867d04 100644
+--- a/rts/Linker.c
++++ b/rts/Linker.c
+@@ -4034,7 +4034,7 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+ 
+       if (kind != SECTIONKIND_OTHER && end >= start) {
+           addSection(&sections[i], kind, SECTION_NOMEM, start, sz, 0, 0, 0);
+-          addProddableBlock(oc, start, end - start + 1);
++          addProddableBlock(oc, start, sz);
+       }
+ 
+       stgFree(secname);
+@@ -5756,7 +5756,7 @@ do_Elf_Rela_relocations ( ObjectCode* oc, char* ehdrC,
+ 
+       IF_DEBUG(linker,debugBelch("Reloc: P = %p   S = %p   A = %p\n",
+                                         (void*)P, (void*)S, (void*)A ));
+-      /* checkProddableBlock ( oc, (void*)P ); */
++      checkProddableBlock(oc, (void*)P, sizeof(Elf_Word));
+ 
+ #if defined(sparc_HOST_ARCH) || defined(powerpc_HOST_ARCH) || defined(x86_64_HOST_ARCH)
+       value = S + A;
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Fix-configure-detection.patch
+++ b/mingw-w64-ghc/0001-Fix-configure-detection.patch
@@ -1,0 +1,75 @@
+From 18f06878ed5d8cb0cf366a876f2bfea29647e5f0 Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar@zhox.com>
+Date: Sat, 13 Aug 2016 16:27:30 +0100
+Subject: [PATCH] Fix configure detection.
+
+Summary:
+GHC's configure script seems to normalize the values returned from config.guess.
+So for Windows it turns x86_64-pc-mingw64 into x86_64-unknown-mingw32.
+These mangled names are stored in the values $BuildPlatform, $HostPlatform
+and $TargetPlatform.
+
+However further down the file when the comparison is done between the stage0
+compiler and the host the normalized versions are not used.
+So when normalization actually changes the triple this check will fail.
+
+Not sure why it's worked for all this time.. Nor if this is the right fix?
+Does it still work for cross compiling correctly?
+
+Test Plan: ./configure
+
+Reviewers: hvr, austin, thomie, bgamari, erikd
+
+Reviewed By: erikd
+
+Subscribers: erikd, #ghc_windows_task_force
+
+Differential Revision: https://phabricator.haskell.org/D2452
+
+GHC Trac Issues: #12487
+---
+ configure.ac | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index e9569e9..acd33cf 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -410,20 +410,20 @@ dnl ** Building a cross compiler?
+ dnl --------------------------------------------------------------
+ CrossCompiling=NO
+ # If 'host' and 'target' differ, then this means we are building a cross-compiler.
+-if test "$target" != "$host" ; then
++if test "$TargetPlatform" != "$HostPlatform" ; then
+     CrossCompiling=YES
+     cross_compiling=yes   # This tells configure that it can accept just 'target',
+                           # otherwise you get
+                           #   configure: error: cannot run C compiled programs.
+                           #   If you meant to cross compile, use `--host'.
+ fi
+-if test "$build" != "$host" ; then
++if test "$BuildPlatform" != "$host" ; then
+    AC_MSG_ERROR([
+ You've selected:
+ 
+-  BUILD:  $build   (the architecture we're building on)
+-  HOST:   $host    (the architecture the compiler we're building will execute on)
+-  TARGET: $target  (the architecture the compiler we're building will produce code for)
++  BUILD:  $BuildPlatform   (the architecture we're building on)
++  HOST:   $HostPlatform    (the architecture the compiler we're building will execute on)
++  TARGET: $TargetPlatform  (the architecture the compiler we're building will produce code for)
+ 
+ BUILD must equal HOST; that is, we do not support building GHC itself
+ with a cross-compiler.  To cross-compile GHC itself, set TARGET: stage
+@@ -437,7 +437,7 @@ then
+ else
+   CrossCompilePrefix=""
+ fi
+-TargetPlatformFull="${target}"
++TargetPlatformFull="${TargetPlatform}"
+ AC_SUBST(CrossCompiling)
+ AC_SUBST(CrossCompilePrefix)
+ AC_SUBST(TargetPlatformFull)
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Fix-incorrect-calculated-relocations-on-Windows-x86_.patch
+++ b/mingw-w64-ghc/0001-Fix-incorrect-calculated-relocations-on-Windows-x86_.patch
@@ -1,0 +1,384 @@
+From b40e1b4c6746bdc34e6a53548a3925d309201c4d Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar@zhox.com>
+Date: Sat, 11 Jun 2016 10:18:19 +0200
+Subject: [PATCH] Fix incorrect calculated relocations on Windows x86_64
+
+Summary:
+See #12031 for analysis, but essentially what happens is:
+
+To sum up the issue, the reason this seems to go wrong is because
+of how we initialize the `.bss` section for Windows in the runtime linker.
+
+The first issue is where we calculate the zero space for the section:
+
+```
+zspace = stgCallocBytes(1, bss_sz, "ocGetNames_PEi386(anonymous bss)");
+sectab_i->PointerToRawData = ((UChar*)zspace) - ((UChar*)(oc->image));
+```
+
+Where
+```
+UInt32 PointerToRawData;
+```
+
+This means we're stuffing a `64-bit` value into a `32-bit` one. Also `zspace`
+can be larger than `oc->image`. In which case it'll overflow and
+then get truncated in the cast.
+
+The address of a value in the `.bss` section is then calculated as:
+
+```
+addr = ((UChar*)(oc->image))
+     + (sectabent->PointerToRawData
+     + symtab_i->Value);
+```
+
+If it does truncate then this calculation won't be correct (which is what is happening).
+
+We then later use the value of `addr` as the `S` (Symbol) value for the relocations
+
+```
+S = (size_t) lookupSymbol_( (char*)symbol );
+```
+
+Now the majority of the relocations are `R_X86_64_PC32` etc.
+e.g. They are guaranteed to fit in a `32-bit` value.
+
+The `R_X86_64_64` introduced for these pseudo-relocations so they can use
+the full `48-bit` addressing space isn't as lucky.
+As for why it sometimes work has to do on whether the value is truncated or not.
+
+`PointerToRawData` can't be changed because it's size is fixed by the PE specification.
+
+Instead just like with the other platforms, we now use `section` on Windows as well.
+This gives us a `start` parameter of type `void*` which solves the issue.
+
+This refactors the code to use `section.start` and to fix the issues.
+
+Test Plan: ./validate and new test added T12031
+
+Reviewers: RyanGlScott, erikd, bgamari, austin, simonmar
+
+Reviewed By: simonmar
+
+Subscribers: thomie, #ghc_windows_task_force
+
+Differential Revision: https://phabricator.haskell.org/D2316
+
+GHC Trac Issues: #12031, #11317
+---
+ rts/Linker.c                             | 73 ++++++++++++++++++--------------
+ rts/LinkerInternals.h                    |  4 +-
+ testsuite/tests/rts/T12031/ExternBug.hs  |  9 ++++
+ testsuite/tests/rts/T12031/Makefile      |  8 ++++
+ testsuite/tests/rts/T12031/T12031.stdout |  1 +
+ testsuite/tests/rts/T12031/all.T         |  4 ++
+ testsuite/tests/rts/T12031/bar.c         | 11 +++++
+ testsuite/tests/rts/T12031/baz.c         |  9 ++++
+ testsuite/tests/rts/T12031/foo.h         | 11 +++++
+ 9 files changed, 97 insertions(+), 33 deletions(-)
+ create mode 100644 testsuite/tests/rts/T12031/ExternBug.hs
+ create mode 100644 testsuite/tests/rts/T12031/Makefile
+ create mode 100644 testsuite/tests/rts/T12031/T12031.stdout
+ create mode 100644 testsuite/tests/rts/T12031/all.T
+ create mode 100644 testsuite/tests/rts/T12031/bar.c
+ create mode 100644 testsuite/tests/rts/T12031/baz.c
+ create mode 100644 testsuite/tests/rts/T12031/foo.h
+
+diff --git a/rts/Linker.c b/rts/Linker.c
+index a1f72e5..ef909f0 100644
+--- a/rts/Linker.c
++++ b/rts/Linker.c
+@@ -3497,6 +3497,26 @@ ocVerifyImage_PEi386 ( ObjectCode* oc )
+    }
+ #endif
+ 
++   /* .BSS Section is initialized in ocGetNames_PEi386
++      but we need the Sections array initialized here already. */
++   Section *sections;
++   sections = (Section*)stgCallocBytes(
++       sizeof(Section),
++       hdr->NumberOfSections + 1, /* +1 for the global BSS section see ocGetNames_PEi386 */
++       "ocVerifyImage_PEi386(sections)");
++   oc->sections = sections;
++   oc->n_sections = hdr->NumberOfSections + 1;
++
++   /* Initialize the Sections */
++   for (i = 0; i < hdr->NumberOfSections; i++) {
++       COFF_section* sectab_i
++           = (COFF_section*)
++           myindex(sizeof_COFF_section, sectab, i);
++
++       /* Calculate the start of the data section */
++       sections[i].start = oc->image + sectab_i->PointerToRawData;
++   }
++
+    /* No further verification after this point; only debug printing. */
+    i = 0;
+    IF_DEBUG(linker, i=1);
+@@ -3525,6 +3545,7 @@ ocVerifyImage_PEi386 ( ObjectCode* oc )
+       COFF_section* sectab_i
+          = (COFF_section*)
+            myindex ( sizeof_COFF_section, sectab, i );
++      Section section = sections[i];
+       debugBelch(
+                 "\n"
+                 "section %d\n"
+@@ -3537,14 +3558,14 @@ ocVerifyImage_PEi386 ( ObjectCode* oc )
+                 "    vsize %d\n"
+                 "    vaddr %d\n"
+                 "  data sz %d\n"
+-                " data off %d\n"
++                " data off 0x%p\n"
+                 "  num rel %d\n"
+                 "  off rel %d\n"
+                 "  ptr raw 0x%x\n",
+                 sectab_i->VirtualSize,
+                 sectab_i->VirtualAddress,
+                 sectab_i->SizeOfRawData,
+-                sectab_i->PointerToRawData,
++                section.start,
+                 sectab_i->NumberOfRelocations,
+                 sectab_i->PointerToRelocations,
+                 sectab_i->PointerToRawData
+@@ -3690,25 +3711,16 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+        * triggered this is libraries/base/cbits/dirUtils.c:__hscore_getFolderPath())
+        */
+       if (sectab_i->VirtualSize == 0 && sectab_i->SizeOfRawData == 0) continue;
+-      /* This is a non-empty .bss section.  Allocate zeroed space for
+-         it, and set its PointerToRawData field such that oc->image +
+-         PointerToRawData == addr_of_zeroed_space.  */
++      /* This is a non-empty .bss section.
++         Allocate zeroed space for it */
+       bss_sz = sectab_i->VirtualSize;
+       if ( bss_sz < sectab_i->SizeOfRawData) { bss_sz = sectab_i->SizeOfRawData; }
+       zspace = stgCallocBytes(1, bss_sz, "ocGetNames_PEi386(anonymous bss)");
+-      sectab_i->PointerToRawData = ((UChar*)zspace) - ((UChar*)(oc->image));
++      oc->sections[i].start = zspace;
+       addProddableBlock(oc, zspace, bss_sz);
+       /* debugBelch("BSS anon section at 0x%x\n", zspace); */
+    }
+ 
+-   Section *sections;
+-   sections = (Section*)stgCallocBytes(
+-       sizeof(Section),
+-       hdr->NumberOfSections + 1, /* +1 for the global BSS section see below */
+-       "ocGetNames_PEi386(sections)");
+-   oc->sections = sections;
+-   oc->n_sections = hdr->NumberOfSections + 1;
+-
+    /* Copy section information into the ObjectCode. */
+ 
+    for (i = 0; i < hdr->NumberOfSections; i++) {
+@@ -3722,6 +3734,7 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+       COFF_section* sectab_i
+          = (COFF_section*)
+            myindex ( sizeof_COFF_section, sectab, i );
++      Section section = oc->sections[i];
+ 
+       char *secname = cstring_from_section_name(sectab_i->Name, strtab);
+ 
+@@ -3748,11 +3761,11 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+       sz = sectab_i->SizeOfRawData;
+       if (sz < sectab_i->VirtualSize) sz = sectab_i->VirtualSize;
+ 
+-      start = ((UChar*)(oc->image)) + sectab_i->PointerToRawData;
++      start = section.start;
+       end   = start + sz - 1;
+ 
+       if (kind != SECTIONKIND_OTHER && end >= start) {
+-          addSection(&sections[i], kind, SECTION_NOMEM, start, sz, 0, 0, 0);
++          addSection(&oc->sections[i], kind, SECTION_NOMEM, start, sz, 0, 0, 0);
+           addProddableBlock(oc, start, sz);
+       }
+ 
+@@ -3784,13 +3797,13 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+    if (globalBssSize > 0) {
+        bss = stgCallocBytes(1, globalBssSize,
+                             "ocGetNames_PEi386(non-anonymous bss)");
+-       addSection(&sections[oc->n_sections-1],
++       addSection(&oc->sections[oc->n_sections-1],
+                   SECTIONKIND_RWDATA, SECTION_MALLOC,
+                   bss, globalBssSize, 0, 0, 0);
+        IF_DEBUG(linker, debugBelch("bss @ %p %" FMT_Word "\n", bss, globalBssSize));
+        addProddableBlock(oc, bss, globalBssSize);
+    } else {
+-       addSection(&sections[oc->n_sections-1],
++       addSection(&oc->sections[oc->n_sections-1],
+                   SECTIONKIND_OTHER, SECTION_NOMEM, NULL, 0, 0, 0, 0);
+    }
+ 
+@@ -3817,9 +3830,8 @@ ocGetNames_PEi386 ( ObjectCode* oc )
+             || (   symtab_i->StorageClass == MYIMAGE_SYM_CLASS_STATIC
+                 && sectabent->Characteristics & MYIMAGE_SCN_LNK_COMDAT)
+             ) {
+-                 addr = ((UChar*)(oc->image))
+-                        + (sectabent->PointerToRawData
+-                           + symtab_i->Value);
++                 addr = (void*)((size_t)oc->sections[symtab_i->SectionNumber-1].start
++                      + symtab_i->Value);
+                  if (sectabent->Characteristics & MYIMAGE_SCN_LNK_COMDAT) {
+                     isWeak = HS_BOOL_TRUE;
+               }
+@@ -3969,6 +3981,7 @@ ocResolve_PEi386 ( ObjectCode* oc )
+          = (COFF_reloc*) (
+               ((UChar*)(oc->image)) + sectab_i->PointerToRelocations
+            );
++      Section section = oc->sections[i];
+ 
+       char *secname = cstring_from_section_name(sectab_i->Name, strtab);
+ 
+@@ -4020,11 +4033,10 @@ ocResolve_PEi386 ( ObjectCode* oc )
+               myindex ( sizeof_COFF_reloc, reltab, j );
+ 
+          /* the location to patch */
+-         pP = (
+-                 ((UChar*)(oc->image))
+-                 + (sectab_i->PointerToRawData
+-                    + reltab_j->VirtualAddress
+-                    - sectab_i->VirtualAddress )
++         pP = (void*)(
++                   (size_t)section.start
++                 + reltab_j->VirtualAddress
++                 - sectab_i->VirtualAddress
+               );
+          /* the existing contents of pP */
+          A = *(UInt32*)pP;
+@@ -4043,10 +4055,8 @@ ocResolve_PEi386 ( ObjectCode* oc )
+                             debugBelch("'\n" ));
+ 
+          if (sym->StorageClass == MYIMAGE_SYM_CLASS_STATIC) {
+-            COFF_section* section_sym
+-              = (COFF_section*) myindex ( sizeof_COFF_section, sectab, sym->SectionNumber-1 );
+-            S = ((size_t)(oc->image))
+-              + ((size_t)(section_sym->PointerToRawData))
++            Section section = oc->sections[sym->SectionNumber-1];
++            S = ((size_t)(section.start))
+               + ((size_t)(sym->Value));
+          } else {
+             copyName ( sym->Name, strtab, symbol, 1000-1 );
+@@ -4201,9 +4211,10 @@ ocRunInit_PEi386 ( ObjectCode *oc )
+         COFF_section* sectab_i
+             = (COFF_section*)
+                 myindex ( sizeof_COFF_section, sectab, i );
++        Section section = oc->sections[i];
+         char *secname = cstring_from_section_name(sectab_i->Name, strtab);
+         if (0 == strcmp(".ctors", (char*)secname)) {
+-            UChar *init_startC = (UChar*)(oc->image) + sectab_i->PointerToRawData;
++            UChar *init_startC = section.start;
+             init_t *init_start, *init_end, *init;
+             init_start = (init_t*)init_startC;
+             init_end = (init_t*)(init_startC + sectab_i->SizeOfRawData);
+diff --git a/rts/LinkerInternals.h b/rts/LinkerInternals.h
+index 815180c..5686863 100644
+--- a/rts/LinkerInternals.h
++++ b/rts/LinkerInternals.h
+@@ -43,8 +43,8 @@ typedef
+ 
+ typedef
+    struct _Section {
+-      void* start;                /* actual start of section in memory */
+-      StgWord size;               /* actual size of section in memory */
++      void*    start;              /* actual start of section in memory */
++      StgWord  size;               /* actual size of section in memory */
+       SectionKind kind;
+       SectionAlloc alloc;
+ 
+diff --git a/testsuite/tests/rts/T12031/ExternBug.hs b/testsuite/tests/rts/T12031/ExternBug.hs
+new file mode 100644
+index 0000000..5c28aed
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/ExternBug.hs
+@@ -0,0 +1,9 @@
++-- Copyright (c) 2016, Ryan Scott
++-- ExternBug.hs
++{-# LANGUAGE ForeignFunctionInterface #-}
++module ExternBug (bar) where
++
++{-# INCLUDE foo.h #-}
++
++foreign import ccall "bar"
++  bar :: IO ()
+diff --git a/testsuite/tests/rts/T12031/Makefile b/testsuite/tests/rts/T12031/Makefile
+new file mode 100644
+index 0000000..0a94206
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/Makefile
+@@ -0,0 +1,8 @@
++TOP=../../..
++include $(TOP)/mk/boilerplate.mk
++include $(TOP)/mk/test.mk
++
++T12031:
++	'$(TEST_HC)' -c bar.c -o bar.o
++	'$(TEST_HC)' -c baz.c -o baz.o
++	echo bar | '$(TEST_HC)' $(TEST_HC_OPTS_INTERACTIVE) bar.o baz.o ExternBug.hs
+diff --git a/testsuite/tests/rts/T12031/T12031.stdout b/testsuite/tests/rts/T12031/T12031.stdout
+new file mode 100644
+index 0000000..e5cc126
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/T12031.stdout
+@@ -0,0 +1 @@
++The value of foo is 1
+diff --git a/testsuite/tests/rts/T12031/all.T b/testsuite/tests/rts/T12031/all.T
+new file mode 100644
+index 0000000..b051514
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/all.T
+@@ -0,0 +1,4 @@
++test('T12031', [ extra_clean(['bar.o', 'baz.o', 'ExternBug.o'])
++               , extra_files(['bar.c', 'baz.c', 'ExternBug.hs', 'foo.h'])
++               ],
++               run_command, ['$MAKE -s --no-print-directory T12031'])
+diff --git a/testsuite/tests/rts/T12031/bar.c b/testsuite/tests/rts/T12031/bar.c
+new file mode 100644
+index 0000000..257cc19
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/bar.c
+@@ -0,0 +1,11 @@
++// Copyright (c) 2016, Ryan Scott
++// bar.c
++#include "foo.h"
++
++int foo = 0;
++
++void bar(void) {
++    foo = 1;
++
++    baz();
++}
+diff --git a/testsuite/tests/rts/T12031/baz.c b/testsuite/tests/rts/T12031/baz.c
+new file mode 100644
+index 0000000..d710148
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/baz.c
+@@ -0,0 +1,9 @@
++// Copyright (c) 2016, Ryan Scott
++// baz.c
++#include "foo.h"
++#include <stdio.h>
++
++void baz(void) {
++    printf("The value of foo is %d\n", foo); // Segfaults on this line
++    fflush(stdout);
++}
+diff --git a/testsuite/tests/rts/T12031/foo.h b/testsuite/tests/rts/T12031/foo.h
+new file mode 100644
+index 0000000..d3ca4aa
+--- /dev/null
++++ b/testsuite/tests/rts/T12031/foo.h
+@@ -0,0 +1,11 @@
++// Copyright (c) 2016, Ryan Scott
++// foo.h
++#ifndef FOO_H
++#define FOO_H
++
++extern int foo;
++
++void bar(void);
++void baz(void);
++
++#endif
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Remove-special-casing-of-Windows-in-generic-files.patch
+++ b/mingw-w64-ghc/0001-Remove-special-casing-of-Windows-in-generic-files.patch
@@ -1,0 +1,161 @@
+From 48385cb2fc295eb8af9188cbe140142c1807d5a7 Mon Sep 17 00:00:00 2001
+From: Tamar Christina <tamar@zhox.com>
+Date: Tue, 31 May 2016 20:12:55 +0200
+Subject: [PATCH] Remove special casing of Windows in generic files
+
+Summary:
+Remove some Windows specific code from the .m4 files
+and have configure figure it out.
+
+Unfortunately touchy can't be removed since there
+is no mingw build of coreutils. Only msys builds
+which would give us a dependency on the msys runtime.
+
+Reviewers: hvr, austin, thomie, bgamari
+
+Reviewed By: thomie, bgamari
+
+Subscribers: thomie, erikd, #ghc_windows_task_force
+
+Differential Revision: https://phabricator.haskell.org/D2248
+---
+ aclocal.m4            | 49 +++++++++++++++++++++++++++++++------------------
+ configure.ac          | 13 +++++--------
+ utils/touchy/touchy.c |  5 +++++
+ 3 files changed, 41 insertions(+), 26 deletions(-)
+
+diff --git a/aclocal.m4 b/aclocal.m4
+index dcc3448..cbf51df 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -458,42 +458,55 @@ AC_DEFUN([GET_ARM_ISA],
+ # Set the variables used in the settings file
+ AC_DEFUN([FP_SETTINGS],
+ [
+-    if test "$windows" = YES
++    SettingsCCompilerCommand="$CC"
++    SettingsHaskellCPPCommand="$HaskellCPPCmd"
++    SettingsHaskellCPPFlags="$HaskellCPPArgs"
++    SettingsLdCommand="$LdCmd"
++    SettingsArCommand="$ArCmd"
++    SettingsPerlCommand="$PerlCmd"
++
++    if test -z "$DllWrap"
+     then
+-        mingw_bin_prefix=mingw/bin/
+-        SettingsCCompilerCommand="\$topdir/../${mingw_bin_prefix}gcc.exe"
+-        SettingsHaskellCPPCommand="\$topdir/../${mingw_bin_prefix}gcc.exe"
+-        SettingsHaskellCPPFlags="$HaskellCPPArgs"
+-        SettingsLdCommand="\$topdir/../${mingw_bin_prefix}ld.exe"
+-        SettingsArCommand="\$topdir/../${mingw_bin_prefix}ar.exe"
+-        SettingsPerlCommand='$topdir/../perl/perl.exe'
+-        SettingsDllWrapCommand="\$topdir/../${mingw_bin_prefix}dllwrap.exe"
+-        SettingsWindresCommand="\$topdir/../${mingw_bin_prefix}windres.exe"
+-        SettingsTouchCommand='$topdir/bin/touchy.exe'
+-    else
+-        SettingsCCompilerCommand="$CC"
+-        SettingsHaskellCPPCommand="$HaskellCPPCmd"
+-        SettingsHaskellCPPFlags="$HaskellCPPArgs"
+-        SettingsLdCommand="$LdCmd"
+-        SettingsArCommand="$ArCmd"
+-        SettingsPerlCommand="$PerlCmd"
+         SettingsDllWrapCommand="/bin/false"
++    else
++        SettingsDllWrapCommand="$DllWrap"
++    fi
++
++    if test -z "$Windres"
++    then
+         SettingsWindresCommand="/bin/false"
++    else
++        SettingsWindresCommand="$Windres"
++    fi
++
++    if test -z "$Libtool"
++    then
+         SettingsLibtoolCommand="libtool"
++    else
++        SettingsLibtoolCommand="$Libtool"
++    fi
++
++    if test -z "$Touch"
++    then
+         SettingsTouchCommand='touch'
++    else
++        SettingsTouchCommand='$Touch'
+     fi
++
+     if test -z "$LlcCmd"
+     then
+       SettingsLlcCommand="llc"
+     else
+       SettingsLlcCommand="$LlcCmd"
+     fi
++
+     if test -z "$OptCmd"
+     then
+       SettingsOptCommand="opt"
+     else
+       SettingsOptCommand="$OptCmd"
+     fi
++
+     SettingsCCompilerFlags="$CONF_CC_OPTS_STAGE2"
+     SettingsCCompilerLinkFlags="$CONF_GCC_LINKER_OPTS_STAGE2"
+     SettingsLdFlags="$CONF_LD_LINKER_OPTS_STAGE2"
+diff --git a/configure.ac b/configure.ac
+index 15561d0..d7eb738 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -177,13 +177,9 @@ then
+ 
+     if test "$ghc_host_os" = "mingw32"
+     then
+-        if test "${OSTYPE}" = "msys"
+-        then
+-            WithGhc=`echo "${WithGhc}" | sed "s#^/\([a-zA-Z]\)/#\1:/#"`
+-        else
+-            # Canonicalise to <drive>:/path/to/ghc
+-            WithGhc=`cygpath -m "${WithGhc}"`
+-        fi
++        # Canonicalise to <drive>:/path/to/ghc
++        WithGhc=`cygpath -m "${WithGhc}"`
++
+         echo "GHC path canonicalised to: ${WithGhc}"
+     fi
+ fi
+@@ -366,6 +362,8 @@ then
+     NM="${mingwbin}nm.exe"
+     RANLIB="${mingwbin}ranlib.exe"
+     OBJDUMP="${mingwbin}objdump.exe"
++    Windres="${mingwbin}windres.exe"
++    DllWrap="${mingwbin}dllwrap.exe"
+     fp_prog_ar="${mingwbin}ar.exe"
+ 
+     # NB. Download the perl binaries if required
+@@ -733,7 +731,6 @@ AC_SUBST(HaveDtrace)
+ AC_PATH_PROG(HSCOLOUR,HsColour)
+ # HsColour is passed to Cabal, so we need a native path
+ if test "$HostOS"      = "mingw32" && \
+-   test "${OSTYPE}"   != "msys"    && \
+    test "${HSCOLOUR}" != ""
+ then
+     # Canonicalise to <drive>:/path/to/gcc
+diff --git a/utils/touchy/touchy.c b/utils/touchy/touchy.c
+index 88ababa..dbcf712 100644
+--- a/utils/touchy/touchy.c
++++ b/utils/touchy/touchy.c
+@@ -14,6 +14,11 @@
+ #include <windows.h>
+ 
+ /*
++touch is used by GHC both during building and during compilation of
++Haskell files. Unfortunately this means we need a 'touch' like program
++in the GHC bindist. Since touch is not standard on Windows and msys2
++doesn't include a mingw-w64 build of coreutils we need touchy for now.
++
+ With Windows 7 in a virtual box VM on OS X, some very odd things happen
+ with dates and time stamps when SSHing into cygwin. e.g. here the
+ "Change" time is in the past:
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Rework-CC-CC_STAGE0-handling-in-configure.ac.patch
+++ b/mingw-w64-ghc/0001-Rework-CC-CC_STAGE0-handling-in-configure.ac.patch
@@ -1,0 +1,311 @@
+From 865602e0beb8e30ea1e1edf7db90f24088badb9e Mon Sep 17 00:00:00 2001
+From: Herbert Valerio Riedel <hvr@gnu.org>
+Date: Sat, 16 Apr 2016 18:12:09 +0200
+Subject: [PATCH] Rework CC/CC_STAGE0 handling in `configure.ac`
+
+Rather than using the non-standard/idiomatic `--with-{gcc,clang}=...`
+scheme use the `CC=...` style scheme.
+
+The basic idea is to have Autoconf's CC/CFLAG/CPPFLAG apply to
+stage{1,2,3}, while having a separate _STAGE0 set of env-vars
+denote the bootstrap-toolchain flags/programs.
+
+This should be simpler, less confusing, and somewhat more in line with
+Autoconf's idioms (allowing us to reuse more of Autoconf rather than
+(re)inventing our own confusing non-standard m4 macros to do stuff that
+Autoconf could almost do already for us)
+
+Morever, expose CC_STAGE0 as a so-called "precious" variable.
+
+So now we can better control which bootstrapping gcc is used
+(by default the one used by the stage0 ghc, unless CC_STAGE0 is
+overriden)
+
+```
+Some influential environment variables:
+  CC_STAGE0   C compiler command (bootstrap)
+  CC          C compiler command
+  CFLAGS      C compiler flags
+  ...
+
+Use these variables to override the choices made by `configure' or to
+help it to find libraries and programs with nonstandard names/locations.
+```
+
+Test Plan: I've tested that cross-compiling with
+`--target=powerpc-linux-gnu` still works, and tried a few variants of
+settting `CC=` and `CC_STAGE0=`; `./validate` passed as well
+
+Reviewers: erikd, austin, bgamari, simonmar
+
+Reviewed By: simonmar
+
+Subscribers: Phyx, thomie
+
+Differential Revision: https://phabricator.haskell.org/D2078
+---
+ aclocal.m4              | 38 +++-----------------------------------
+ bindisttest/ghc.mk      |  2 +-
+ configure.ac            | 37 +++++++++++++++++++++++++++++--------
+ distrib/configure.ac.in |  4 +---
+ includes/ghc.mk         |  2 +-
+ mk/config.mk.in         | 10 +++++-----
+ rts/ghc.mk              |  2 +-
+ rules/shell-wrapper.mk  |  2 +-
+ 8 files changed, 42 insertions(+), 55 deletions(-)
+
+diff --git a/aclocal.m4 b/aclocal.m4
+index 6403748..477da3f 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -471,7 +471,7 @@ AC_DEFUN([FP_SETTINGS],
+         SettingsWindresCommand="\$topdir/../${mingw_bin_prefix}windres.exe"
+         SettingsTouchCommand='$topdir/bin/touchy.exe'
+     else
+-        SettingsCCompilerCommand="$WhatGccIsCalled"
++        SettingsCCompilerCommand="$CC"
+         SettingsHaskellCPPCommand="$HaskellCPPCmd"
+         SettingsHaskellCPPFlags="$HaskellCPPArgs"
+         SettingsLdCommand="$LdCmd"
+@@ -2067,38 +2067,6 @@ AC_DEFUN([FIND_GHC_BOOTSTRAP_PROG],[
+ ])
+ 
+ 
+-# FIND_GCC()
+-# --------------------------------
+-# Finds where gcc is
+-#
+-# $1 = the variable to set
+-# $2 = the with option name
+-# $3 = the command to look for
+-AC_DEFUN([FIND_GCC],[
+-    if test "$windows" = YES
+-    then
+-        $1="$CC"
+-    else
+-        FP_ARG_WITH_PATH_GNU_PROG_OPTIONAL([$1], [$2], [$3])
+-        # fallback to CC if set and no --with-$2=... was used
+-        if test -z "$With_$2" -a -n "$CC"
+-        then
+-            With_$2="$CC"
+-            $1="$CC"
+-        # From Xcode 5 on/, OS X command line tools do not include gcc
+-        # anymore. Use clang.
+-        elif test -z "$$1"
+-        then
+-            FP_ARG_WITH_PATH_GNU_PROG_OPTIONAL([$1], [clang], [clang])
+-        fi
+-        if test -z "$$1"
+-        then
+-            AC_MSG_ERROR([cannot find $3 nor clang in your PATH])
+-        fi
+-    fi
+-    AC_SUBST($1)
+-])
+-
+ AC_DEFUN([MAYBE_OVERRIDE_STAGE0],[
+   if test ! -z "$With_$1" -a "$CrossCompiling" != "YES"; then
+       AC_MSG_NOTICE([Not cross-compiling, so --with-$1 also sets $2])
+@@ -2132,13 +2100,13 @@ AC_ARG_WITH(hs-cpp,
+ 
+     # We can't use $CPP here, since HS_CPP_CMD is expected to be a single
+     # command (no flags), and AC_PROG_CPP defines CPP as "/usr/bin/gcc -E".
+-    HS_CPP_CMD=$WhatGccIsCalled
++    HS_CPP_CMD=$CC
+ 
+     SOLARIS_GCC_CPP_BROKEN=NO
+     SOLARIS_FOUND_GOOD_CPP=NO
+     case $host in
+         i386-*-solaris2)
+-        GCC_MAJOR_MINOR=`$WhatGccIsCalled --version|grep "gcc (GCC)"|cut -d ' ' -f 3-3|cut -d '.' -f 1-2`
++        GCC_MAJOR_MINOR=`$CC --version|grep "gcc (GCC)"|cut -d ' ' -f 3-3|cut -d '.' -f 1-2`
+         if test "$GCC_MAJOR_MINOR" != "3.4"; then
+           # this is not 3.4.x release so with broken CPP
+           SOLARIS_GCC_CPP_BROKEN=YES
+diff --git a/bindisttest/ghc.mk b/bindisttest/ghc.mk
+index 4b21106..cf2e481 100644
+--- a/bindisttest/ghc.mk
++++ b/bindisttest/ghc.mk
+@@ -38,7 +38,7 @@ test_bindist:
+ ifeq "$(Windows_Host)" "YES"
+ 	mv bindisttest/a/b/c/$(BIN_DIST_NAME) $(BIN_DIST_INST_DIR)
+ else
+-	cd bindisttest/a/b/c/$(BIN_DIST_NAME) && ./configure --prefix=$(TOP)/$(BIN_DIST_INST_DIR) --with-gcc="$(WhatGccIsCalled)"
++	cd bindisttest/a/b/c/$(BIN_DIST_NAME) && ./configure --prefix=$(TOP)/$(BIN_DIST_INST_DIR) CC="$(CC)"
+ 	cd bindisttest/a/b/c/$(BIN_DIST_NAME) && $(MAKE) install
+ endif
+ ifeq "$(GhcProfiled)" "NO"
+diff --git a/configure.ac b/configure.ac
+index dd3236c..c5260ce 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -33,6 +33,11 @@ fi
+ 
+ AC_SUBST([CONFIGURE_ARGS], [$ac_configure_args])
+ 
++dnl this makes sure `./configure --target=<cross-compile-target>`
++dnl works as expected, since we're slightly modifying how Autoconf
++dnl interprets build/host/target and how this interacts with $CC tests
++test -n "$target_alias" && ac_tool_prefix=$target_alias-
++
+ dnl ----------------------------------------------------------
+ dnl ** Find unixy sort and find commands,
+ dnl ** which are needed by FP_SETUP_PROJECT_VERSION
+@@ -107,6 +112,11 @@ AC_ARG_ENABLE(tarballs-autodownload,
+         TarballsAutodownload=YES,
+         TarballsAutodownload=NO
+ )
++
++dnl CC_STAGE0 is like the "previous" variable CC (inherited by CC_STAGE[123])
++dnl but instead used by stage0 for bootstrapping stage1
++AC_ARG_VAR(CC_STAGE0, [C compiler command (bootstrap)])
++
+ if test "$WithGhc" != ""; then
+   FPTOOLS_GHC_VERSION([GhcVersion], [GhcMajVersion], [GhcMinVersion], [GhcPatchLevel])dnl
+ 
+@@ -121,7 +131,11 @@ if test "$WithGhc" != ""; then
+   GhcMinVersion2=`echo "$GhcMinVersion" | sed 's/^\\(.\\)$/0\\1/'`
+   GhcCanonVersion="$GhcMajVersion$GhcMinVersion2"
+ 
+-  BOOTSTRAPPING_GHC_INFO_FIELD([CC_STAGE0],[C compiler command])
++  dnl infer CC_STAGE0 from `ghc --info` unless explicitly set by user
++  if test -z "$CC_STAGE0"; then
++    BOOTSTRAPPING_GHC_INFO_FIELD([CC_STAGE0],[C compiler command])
++  fi
++
+   BOOTSTRAPPING_GHC_INFO_FIELD([LD_STAGE0],[ld command])
+   BOOTSTRAPPING_GHC_INFO_FIELD([AR_STAGE0],[ar command])
+   BOOTSTRAPPING_GHC_INFO_FIELD([AR_OPTS_STAGE0],[ar flags])
+@@ -432,13 +446,19 @@ AC_SUBST(TargetPlatformFull)
+ 
+ dnl ** Which gcc to use?
+ dnl --------------------------------------------------------------
+-FIND_GCC([WhatGccIsCalled], [gcc], [gcc])
+-CC="$WhatGccIsCalled"
+-export CC
+ 
+-# If --with-gcc was used, and we're not cross-compiling, then it also
+-# applies to the stage0 compiler.
+-MAYBE_OVERRIDE_STAGE0([gcc],[CC_STAGE0])
++AC_ARG_WITH([gcc],
++        AS_HELP_STRING([--with-gcc=ARG], [Use ARG as the path to gcc (obsolete, use CC=ARG instead) [default=autodetect]]),
++        AC_MSG_ERROR([--with-gcc=$withval is obsolete (use './configure CC=$withval' or 'CC=$withval ./configure' instead)]))
++
++AC_ARG_WITH([clang],
++        AS_HELP_STRING([--with-clang=ARG], [Use ARG as the path to gcc (obsolete, use CC=ARG instead) [default=autodetect]]),
++        AC_MSG_ERROR([--with-clang=$withval is obsolete (use './configure CC=$withval' or 'CC=$withval ./configure' instead)]))
++
++dnl detect compiler (prefer gcc over clang) and set $CC (unless CC already set),
++dnl later CC is copied to CC_STAGE{1,2,3}
++AC_PROG_CC([gcc clang])
++
+ MAYBE_OVERRIDE_STAGE0([ar],[AR_STAGE0])
+ 
+ dnl make extensions visible to allow feature-tests to detect them lateron
+@@ -1155,7 +1175,8 @@ else
+ fi
+ 
+ echo ["\
+-   Using $CompilerName       : $WhatGccIsCalled
++   Using (for bootstrapping) : $CC_STAGE0
++   Using $CompilerName       : $CC
+       which is version       : $GccVersion
+    Building a cross compiler : $CrossCompiling
+    hs-cpp       : $HaskellCPPCmd
+diff --git a/distrib/configure.ac.in b/distrib/configure.ac.in
+index c0610c6..fdd9fd9 100644
+--- a/distrib/configure.ac.in
++++ b/distrib/configure.ac.in
+@@ -59,9 +59,7 @@ XCODE_VERSION()
+ 
+ dnl ** Which gcc to use?
+ dnl --------------------------------------------------------------
+-FIND_GCC([WhatGccIsCalled], [gcc], [gcc])
+-CC="$WhatGccIsCalled"
+-export CC
++AC_PROG_CC([gcc clang])
+ 
+ # --with-hs-cpp/--with-hs-cpp-flags
+ FP_CPP_CMD_WITH_ARGS(HaskellCPPCmd, HaskellCPPArgs)
+diff --git a/includes/ghc.mk b/includes/ghc.mk
+index 31b2650..d08ecfb 100644
+--- a/includes/ghc.mk
++++ b/includes/ghc.mk
+@@ -177,7 +177,7 @@ includes_GHCCONSTANTS_HASKELL_EXPORTS = includes/dist-derivedconstants/header/GH
+ 
+ INSTALL_LIBS += $(includes_GHCCONSTANTS_HASKELL_VALUE)
+ 
+-DERIVE_CONSTANTS_FLAGS += --gcc-program "$(WhatGccIsCalled)"
++DERIVE_CONSTANTS_FLAGS += --gcc-program "$(CC)"
+ DERIVE_CONSTANTS_FLAGS += $(addprefix --gcc-flag$(space),$(includes_CC_OPTS) -fcommon)
+ DERIVE_CONSTANTS_FLAGS += --nm-program "$(NM)"
+ ifneq "$(OBJDUMP)" ""
+diff --git a/mk/config.mk.in b/mk/config.mk.in
+index 5d5e581..b5d910b 100644
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -509,11 +509,10 @@ SUPPORTS_THIS_UNIT_ID = @SUPPORTS_THIS_UNIT_ID@
+ #-----------------------------------------------------------------------------
+ # C compiler
+ #
+-# NB. Don't override $(WhatGccIsCalled) using build.mk,  re-configure using
+-# the flag --with-gcc=<blah> instead.  The reason is that the configure script
++# NB. Don't override $(CC) using build.mk,  re-configure using
++# the flag CC=<blah> instead.  The reason is that the configure script
+ # needs to know which gcc you're using in order to perform its tests.
+ 
+-WhatGccIsCalled       = @WhatGccIsCalled@
+ GccVersion            = @GccVersion@
+ ifeq "$(phase)" "0"
+ CrossCompilePrefix    =
+@@ -527,18 +526,19 @@ GccLT34         = @GccLT34@
+ GccLT46         = @GccLT46@
+ GccIsClang      = @GccIsClang@
+ 
+-CC              = $(WhatGccIsCalled)
++CC              = @CC@
+ CC_STAGE0       = @CC_STAGE0@
+ CC_STAGE1       = $(CC)
+ CC_STAGE2       = $(CC)
+ CC_STAGE3       = $(CC)
+ 
+-AS              = $(WhatGccIsCalled)
++AS              = @CC@
+ AS_STAGE0       = @CC_STAGE0@
+ AS_STAGE1       = $(AS)
+ AS_STAGE2       = $(AS)
+ AS_STAGE3       = $(AS)
+ 
++# why no LD=@LD@ ?
+ LD_STAGE0       = @LD_STAGE0@
+ LD_STAGE1       = $(LD)
+ LD_STAGE2       = $(LD)
+diff --git a/rts/ghc.mk b/rts/ghc.mk
+index f57f3da..d7a46f9 100644
+--- a/rts/ghc.mk
++++ b/rts/ghc.mk
+@@ -538,7 +538,7 @@ ifeq "$(TargetOS_CPP)" "darwin"
+ # Darwin has a flag to tell dtrace which cpp to use.
+ # Unfortunately, this isn't supported on Solaris (See Solaris Dynamic Tracing
+ # Guide, Chapter 16, for the configuration variables available on Solaris)
+-DTRACE_FLAGS = -x cpppath=$(WhatGccIsCalled)
++DTRACE_FLAGS = -x cpppath=$(CC)
+ endif
+ 
+ DTRACEPROBES_SRC = rts/RtsProbes.d
+diff --git a/rules/shell-wrapper.mk b/rules/shell-wrapper.mk
+index f674c0d..eb7d8f1 100644
+--- a/rules/shell-wrapper.mk
++++ b/rules/shell-wrapper.mk
+@@ -46,7 +46,7 @@ $$($1_$2_INPLACE_WRAPPER): $$($1_$2_INPLACE)
+ 	echo 'datadir="$$(TOP)/$$(INPLACE_LIB)"'                             >> $$@
+ 	echo 'bindir="$$(TOP)/$$(INPLACE_BIN)"'                              >> $$@
+ 	echo 'topdir="$$(TOP)/$$(INPLACE_TOPDIR)"'                           >> $$@
+-	echo 'pgmgcc="$$(WhatGccIsCalled)"'                                  >> $$@
++	echo 'pgmgcc="$$(CC)"'                                               >> $$@
+ 	$$($1_$2_SHELL_WRAPPER_EXTRA)
+ 	$$($1_$2_INPLACE_SHELL_WRAPPER_EXTRA)
+ ifeq "$$(DYNAMIC_GHC_PROGRAMS)" "YES"
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Switch-to-LLVM-version-3.8.patch
+++ b/mingw-w64-ghc/0001-Switch-to-LLVM-version-3.8.patch
@@ -1,0 +1,70 @@
+From 672314cbeb8ac386a58f17dc4650dbdf4c55d8b5 Mon Sep 17 00:00:00 2001
+From: Erik de Castro Lopo <erikd@mega-nerd.com>
+Date: Thu, 7 Jul 2016 05:38:14 +1000
+Subject: [PATCH] Switch to LLVM version 3.8
+
+LLVM 3.8 was released a couple of months ago.
+
+Test Plan: Build and test on x86_64/linux (perf-llvm) and armhf/linux.
+
+Reviewers: austin, hvr, rwbarton, bgamari
+
+Reviewed By: bgamari
+
+Subscribers: thomie
+
+Differential Revision: https://phabricator.haskell.org/D2382
+---
+ compiler/llvmGen/Llvm/PpLlvm.hs | 2 +-
+ compiler/llvmGen/Llvm/Types.hs  | 8 ++++++++
+ configure.ac                    | 2 +-
+ 3 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/compiler/llvmGen/Llvm/PpLlvm.hs b/compiler/llvmGen/Llvm/PpLlvm.hs
+index 47e26ab..c9c1f95 100644
+--- a/compiler/llvmGen/Llvm/PpLlvm.hs
++++ b/compiler/llvmGen/Llvm/PpLlvm.hs
+@@ -73,7 +73,7 @@ ppLlvmGlobal (LMGlobal var@(LMGlobalVar _ _ link x a c) dat) =
+             Nothing -> empty
+ 
+         rhs = case dat of
+-            Just stat -> ppr stat
++            Just stat -> pprSpecialStatic stat
+             Nothing   -> ppr (pLower $ getVarType var)
+ 
+         -- Position of linkage is different for aliases.
+diff --git a/compiler/llvmGen/Llvm/Types.hs b/compiler/llvmGen/Llvm/Types.hs
+index 5c2ce5e..d2cab44 100644
+--- a/compiler/llvmGen/Llvm/Types.hs
++++ b/compiler/llvmGen/Llvm/Types.hs
+@@ -175,6 +175,14 @@ instance Outputable LlvmStatic where
+   ppr (LMSub s1 s2)
+       = pprStaticArith s1 s2 (sLit "sub") (sLit "fsub") "LMSub"
+ 
++
++pprSpecialStatic :: LlvmStatic -> SDoc
++pprSpecialStatic (LMBitc v t) =
++    ppr (pLower t) <> text ", bitcast (" <> ppr v <> text " to " <> ppr t
++        <> char ')'
++pprSpecialStatic stat = ppr stat
++
++
+ pprStaticArith :: LlvmStatic -> LlvmStatic -> LitString -> LitString -> String -> SDoc
+ pprStaticArith s1 s2 int_op float_op op_name =
+   let ty1 = getStatType s1
+diff --git a/configure.ac b/configure.ac
+index 664deb4..f4b839e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -521,7 +521,7 @@ esac
+ # tools we are looking for. In the past, GHC supported a number of
+ # versions of LLVM simultaneously, but that stopped working around
+ # 3.5/3.6 release of LLVM.
+-LlvmVersion=3.7
++LlvmVersion=3.8
+ AC_SUBST([LlvmVersion])
+ sUPPORTED_LLVM_VERSION=$(echo \($LlvmVersion\) | sed 's/\./,/')
+ AC_DEFINE_UNQUOTED([sUPPORTED_LLVM_VERSION], ${sUPPORTED_LLVM_VERSION}, [The supported LLVM version number])
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/0001-Unstaged.patch
+++ b/mingw-w64-ghc/0001-Unstaged.patch
@@ -1,0 +1,222 @@
+diff --git a/Makefile b/Makefile
+index 9b888e7..cc14663 100644
+--- a/Makefile
++++ b/Makefile
+@@ -131,7 +131,7 @@ endif
+ 
+ .PHONY: binary-dist
+ binary-dist: binary-dist-prep
+-	mv bindistprep/*.tar.$(TAR_COMP_EXT) .
++	#mv bindistprep/*.tar.$(TAR_COMP_EXT) .
+ 
+ .PHONY: binary-dist-prep
+ binary-dist-prep:
+diff --git a/configure.ac b/configure.ac
+index 0fceb16..03b7574 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -298,10 +298,10 @@ set_up_tarballs() {
+     else
+         action="download"
+     fi
+-    mk/get-win32-tarballs.sh $action $HostArch > missing-win32-tarballs
++    #mk/get-win32-tarballs.sh $action $HostArch > missing-win32-tarballs
+     case $? in
+         0)
+-           rm missing-win32-tarballs
++           #rm missing-win32-tarballs
+            ;;
+         2)
+            echo
+@@ -325,28 +325,28 @@ set_up_tarballs() {
+     esac
+ 
+     # Extract all the tarballs in one go
+-    if ! test -d inplace/mingw
+-    then
+-        AC_MSG_NOTICE([Extracting Windows toolchain from archives (may take a while)...])
+-        rm -rf inplace/mingw
+-        local base_dir="../ghc-tarballs/${tarball_dest_dir}"
+-        ( cd inplace &&
+-        find "${base_dir}" -name "*.tar.xz" -exec tar xfJ {} \; &&
+-        rm ".MTREE" &&
+-        rm ".PKGINFO" &&
+-        cd .. ) || fail "Error: Could not extract Windows toolchains."
+-
+-        mv "inplace/${tarball_mingw_dir}" inplace/mingw &&
+-        touch inplace/mingw
+-
+-        # NB. Now since the GCC is hardcoded to use /mingw32 we need to
+-        # make a wrapper around it to give it the proper paths
+-        mv inplace/mingw/bin/gcc.exe inplace/mingw/bin/realgcc.exe
+-        PATH=`pwd`/inplace/mingw/bin:$PATH
+-        inplace/mingw/bin/realgcc.exe driver/gcc/gcc.c driver/utils/cwrapper.c driver/utils/getLocation.c -Idriver/utils -o inplace/mingw/bin/gcc.exe
+-
+-        AC_MSG_NOTICE([In-tree MingW-w64 tree created])
+-    fi
++    #if ! test -d inplace/mingw
++    #then
++    #    AC_MSG_NOTICE([Extracting Windows toolchain from archives (may take a while)...])
++    #    rm -rf inplace/mingw
++    #    local base_dir="../ghc-tarballs/${tarball_dest_dir}"
++    #    ( cd inplace &&
++    #    find "${base_dir}" -name "*.tar.xz" -exec tar xfJ {} \; &&
++    #    rm ".MTREE" &&
++    #    rm ".PKGINFO" &&
++    #    cd .. ) || fail "Error: Could not extract Windows toolchains."
++
++    #    mv "inplace/${tarball_mingw_dir}" inplace/mingw &&
++    #    touch inplace/mingw
++
++    #    # NB. Now since the GCC is hardcoded to use /mingw32 we need to
++    #    # make a wrapper around it to give it the proper paths
++    #    #mv inplace/mingw/bin/gcc.exe inplace/mingw/bin/realgcc.exe
++    #    #PATH=`pwd`/inplace/mingw/bin:$PATH
++    #    #gcc.exe driver/gcc/gcc.c driver/utils/cwrapper.c driver/utils/getLocation.c -Idriver/utils -o inplace/mingw/bin/gcc.exe
++
++    #    AC_MSG_NOTICE([In-tree MingW-w64 tree created])
++    #fi
+ }
+ 
+ if test "$HostOS" = "mingw32"
+@@ -356,7 +356,8 @@ then
+     # NB. Download and extract the MingW-w64 distribution if required
+     set_up_tarballs
+ 
+-    mingwbin="$hardtop/inplace/mingw/bin/"
++    mingwbin=""
++    #"$hardtop/inplace/mingw/bin/"
+     CC="${mingwbin}gcc.exe"
+     LD="${mingwbin}ld.exe"
+     NM="${mingwbin}nm.exe"
+@@ -367,18 +368,18 @@ then
+     fp_prog_ar="${mingwbin}ar.exe"
+ 
+     # NB. Download the perl binaries if required
+-    if ! test -d inplace/perl ||
+-         test inplace/perl -ot ghc-tarballs/perl/ghc-perl*.tar.gz
+-    then
+-        AC_MSG_NOTICE([Making in-tree perl tree])
+-        rm -rf inplace/perl
+-        mkdir inplace/perl
+-        (
+-            cd inplace/perl &&
+-            tar -zxf ../../ghc-tarballs/perl/ghc-perl*.tar.gz
+-        )
+-        AC_MSG_NOTICE([In-tree perl tree created])
+-    fi
++    #if ! test -d inplace/perl ||
++    #     test inplace/perl -ot ghc-tarballs/perl/ghc-perl*.tar.gz
++    #then
++    #    AC_MSG_NOTICE([Making in-tree perl tree])
++    #    rm -rf inplace/perl
++    #    mkdir inplace/perl
++    #    (
++    #        cd inplace/perl &&
++    #        tar -zxf ../../ghc-tarballs/perl/ghc-perl*.tar.gz
++    #    )
++    #    AC_MSG_NOTICE([In-tree perl tree created])
++    #fi
+ fi
+ 
+ FP_ICONV
+@@ -587,7 +588,7 @@ AC_SYS_INTERPRETER()
+ dnl ** look for `perl'
+ case $HostOS_CPP in
+ cygwin32|mingw32)
+-    PerlCmd=$hardtop/inplace/perl/perl
++    PerlCmd=perl
+     ;;
+ *)
+     AC_PATH_PROG(PerlCmd,perl)
+diff --git a/ghc.mk b/ghc.mk
+index 792bd21..ed38bdb 100644
+--- a/ghc.mk
++++ b/ghc.mk
+@@ -836,13 +836,13 @@ endif
+ 
+ ifeq "$(Windows_Host)" "YES"
+ 
+-install : install_mingw
+-.PHONY: install_mingw
++#install : install_mingw
++#.PHONY: install_mingw
+ install_mingw : $(INPLACE_MINGW)
+ 	"$(CP)" -Rp $(INPLACE_MINGW) $(prefix)
+ 
+-install : install_perl
+-.PHONY: install_perl
++#install : install_perl
++#.PHONY: install_perl
+ install_perl : $(INPLACE_PERL)
+ 	"$(CP)" -Rp $(INPLACE_PERL) $(prefix)
+ 
+@@ -1090,7 +1090,7 @@ unix-binary-dist-prep:
+ windows-binary-dist-prep:
+ 	$(call removeTrees,bindistprep/)
+ 	$(MAKE) prefix=$(TOP)/$(BIN_DIST_PREP_DIR) install
+-	cd bindistprep && "$(TAR_CMD)" cf - $(BIN_DIST_NAME) | $(TAR_COMP_CMD) -c > ../$(BIN_DIST_PREP_TAR_COMP)
++	#cd bindistprep && "$(TAR_CMD)" cf - $(BIN_DIST_NAME) | $(TAR_COMP_CMD) -c > ../$(BIN_DIST_PREP_TAR_COMP)
+ 
+ # tryTimes tries to run its third argument multiple times, until it
+ # succeeds. Don't call it directly; call try10Times instead.
+diff --git a/mk/config.mk.in b/mk/config.mk.in
+index 2163643..3995bf4 100644
+--- a/mk/config.mk.in
++++ b/mk/config.mk.in
+@@ -522,19 +522,19 @@ GccLT46         = @GccLT46@
+ GccIsClang      = @GccIsClang@
+ 
+ CC              = @CC@
+-CC_STAGE0       = @CC_STAGE0@
++CC_STAGE0       = $(CC)
+ CC_STAGE1       = $(CC)
+ CC_STAGE2       = $(CC)
+ CC_STAGE3       = $(CC)
+ 
+ AS              = @CC@
+-AS_STAGE0       = @CC_STAGE0@
++AS_STAGE0       = $(AS)
+ AS_STAGE1       = $(AS)
+ AS_STAGE2       = $(AS)
+ AS_STAGE3       = $(AS)
+ 
+ # why no LD=@LD@ ?
+-LD_STAGE0       = @LD_STAGE0@
++LD_STAGE0       = $(LD)
+ LD_STAGE1       = $(LD)
+ LD_STAGE2       = $(LD)
+ LD_STAGE3       = $(LD)
+@@ -645,9 +645,9 @@ SRC_HSC2HS_OPTS_STAGE1 += --cflag=-D$(TargetArch_CPP)_HOST_ARCH --cflag=-D$(Targ
+ SRC_HSC2HS_OPTS_STAGE2 += --cflag=-D$(TargetArch_CPP)_HOST_ARCH --cflag=-D$(TargetOS_CPP)_HOST_OS
+ 
+ ifeq "$(TARGETPLATFORM)" "i386-unknown-mingw32"
+-WINDRES = $(INPLACE_MINGW)/bin/windres
++WINDRES = windres
+ else ifeq "$(TARGETPLATFORM)" "x86_64-unknown-mingw32"
+-WINDRES = $(INPLACE_MINGW)/bin/windres
++WINDRES = windres
+ endif
+ 
+ #-----------------------------------------------------------------------------
+@@ -655,9 +655,9 @@ endif
+ #
+ HaveLibMingwEx	= @HaveLibMingwEx@
+ ifeq "$(TARGETPLATFORM)" "i386-unknown-mingw32"
+-DLLTOOL			= inplace/mingw/bin/dlltool.exe
++DLLTOOL			= dlltool.exe
+ else ifeq "$(TARGETPLATFORM)" "x86_64-unknown-mingw32"
+-DLLTOOL			= inplace/mingw/bin/dlltool.exe
++DLLTOOL			= dlltool.exe
+ endif
+ 
+ #-----------------------------------------------------------------------------
+@@ -747,7 +747,7 @@ XARGS_OPTS = -s 20000
+ endif
+ 
+ ifeq "$(TARGETPLATFORM)" "x86_64-unknown-mingw32"
+-STRIP_CMD      = $(TOP)/inplace/mingw/bin/strip.exe
++STRIP_CMD      = strip.exe
+ else ifeq "$(TARGETPLATFORM)" "arm-unknown-linux"
+ # The Cortex A8 hardware apparently has a bug which ld.gold will check for;
+ # however in order to do so it must have unstripped executables lest we

--- a/mingw-w64-ghc/0001-configure.ac-Remove-checks-for-bug-9439.patch
+++ b/mingw-w64-ghc/0001-configure.ac-Remove-checks-for-bug-9439.patch
@@ -1,0 +1,121 @@
+From 6fe235543de7ea4319269f164ea444e4af68f759 Mon Sep 17 00:00:00 2001
+From: Erik de Castro Lopo <erikd@mega-nerd.com>
+Date: Sun, 7 Aug 2016 08:24:16 +1000
+Subject: [PATCH] configure.ac: Remove checks for bug 9439
+
+Bug #9439 only affects some ghc 7.8 versions of the compiler and since
+git HEAD no longer builds with ghc-7.8 we can drop this check.
+
+Test Plan: Works here!
+
+Reviewers: hvr, austin, bgamari
+
+Reviewed By: bgamari
+
+Subscribers: thomie
+
+Differential Revision: https://phabricator.haskell.org/D2427
+---
+ Makefile     |  7 -------
+ configure.ac | 67 ------------------------------------------------------------
+ 2 files changed, 74 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 82ab2f7..9b888e7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -77,13 +77,6 @@ default : all
+ help:
+ 	@cat MAKEHELP.md
+ 
+-# Verify that stage 0 LLVM backend isn't affected by Bug #9439 if needed
+-ifeq "$(GHC_LLVM_AFFECTED_BY_9439)" "1"
+-ifneq "$(findstring -fllvm,$(SRC_HC_OPTS) $(GhcHcOpts) $(GhcStage1HcOpts))" ""
+-$(error Stage 0 compiler is affected by Bug #9439. Refusing to bootstrap with -fllvm)
+-endif
+-endif
+-
+ # No need to update makefiles for these targets:
+ # (the ones we're filtering out)
+ REALGOALS=$(filter-out \
+diff --git a/configure.ac b/configure.ac
+index f4b839e..e9569e9 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -544,73 +544,6 @@ dnl --------------------------------------------------------------
+ 
+ 
+ dnl --------------------------------------------------------------
+-dnl * General configuration checks
+-dnl --------------------------------------------------------------
+-
+-dnl ** Bug 9439: Some GHC 7.8 releases had broken LLVM code generator.
+-dnl Unfortunately we don't know whether the user is going to request a
+-dnl build with the LLVM backend as this is only given in build.mk.
+-dnl
+-dnl Instead, we try to do as much work as possible here, checking
+-dnl whether -fllvm is the stage 0 compiler's default. If so we
+-dnl fail. If not, we check whether -fllvm is affected explicitly and
+-dnl if so set a flag. The build system will later check this flag
+-dnl after the desired build flags are known.
+-
+-dnl This problem is further complicated by the fact that the llvm
+-dnl version used by the bootstrap compiler may be different from the
+-dnl version we arre trying to compile GHC against. Therefore, we need
+-dnl to find the boostrap compiler's `settings` file then check to see
+-dnl if the `opt` and `llc` command strings are non-empty and if these
+-dnl programs exist. Only if they exist to we test for bug #9439.
+-
+-FIND_GHC_BOOTSTRAP_PROG([BootstrapLlcCmd], [${WithGhc}], "LLVM llc command")
+-FIND_GHC_BOOTSTRAP_PROG([BootstrapOptCmd], [${WithGhc}], "LLVM opt command")
+-
+-if test -n "$BootstrapLlcCmd" && test -n "$BootstrapOptCmd"
+-then
+-    AC_MSG_CHECKING(whether bootstrap compiler is affected by bug 9439)
+-    echo "main = putStrLn \"%function\"" > conftestghc.hs
+-
+-    # Check whether LLVM backend is default for this platform
+-    "${WithGhc}" -pgmlc="${BootstrapLlcCmd}" -pgmlo="${BootstrapOptCmd}" conftestghc.hs 2>&1 >/dev/null
+-    res=`./conftestghc`
+-    if test "x$res" = "x%object"
+-    then
+-        AC_MSG_RESULT(yes)
+-        echo "Buggy bootstrap compiler"
+-        echo ""
+-        echo "The stage 0 compiler $WithGhc is affected by GHC Bug \#9439"
+-        echo "and therefore will miscompile the LLVM backend if -fllvm is"
+-        echo "used."
+-        echo
+-        echo "Please use another bootstrap compiler"
+-        exit 1
+-    fi
+-
+-    # -fllvm is not the default, but set a flag so the Makefile can check
+-    # -for it in the build flags later on
+-    "${WithGhc}" -fforce-recomp -pgmlc="${BootstrapLlcCmd}" -pgmlo="${BootstrapOptCmd}" -fllvm conftestghc.hs 2>&1 >/dev/null
+-    if test $? = 0
+-    then
+-        res=`./conftestghc`
+-        if test "x$res" = "x%object"
+-        then
+-            AC_MSG_RESULT(yes)
+-            GHC_LLVM_AFFECTED_BY_9439=1
+-        elif test "x$res" = "x%function"
+-        then
+-            AC_MSG_RESULT(no)
+-            GHC_LLVM_AFFECTED_BY_9439=0
+-        else
+-            AC_MSG_WARN(unexpected output $res)
+-        fi
+-    else
+-        AC_MSG_RESULT(failed to compile, assuming no)
+-    fi
+-fi
+-AC_SUBST([GHC_LLVM_AFFECTED_BY_9439])
+-
+ dnl ** Can the unix package be built?
+ dnl --------------------------------------------------------------
+ 
+-- 
+2.9.1
+

--- a/mingw-w64-ghc/PKGBUILD
+++ b/mingw-w64-ghc/PKGBUILD
@@ -22,8 +22,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-binutils"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-winpthreads-git"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=('perl' 'unzip' "${MINGW_PACKAGE_PREFIX}-python3-sphinx")
-optdepends=("${MINGW_PACKAGE_PREFIX}-llvm")
+makedepends=('perl' 'unzip') #"${MINGW_PACKAGE_PREFIX}-python3-sphinx")
+optdepends=("${MINGW_PACKAGE_PREFIX}-llvm: using LLVM as backend")
 source=(
   "http://downloads.haskell.org/~ghc/$pkgver/ghc-$pkgver-src.tar.xz"
   "http://downloads.haskell.org/~ghc/$pkgver/ghc-$pkgver-testsuite.tar.xz"
@@ -71,7 +71,7 @@ build() {
   ./boot
   ./configure --prefix=${MINGW_PREFIX}
   make
-  make html
+  #make html
   #Need xelatex
   #make pdf
 }
@@ -92,7 +92,7 @@ package() {
 
 md5sums=('c185b8a1f3e67e43533ec590b751c2ff'
          '289e4b030a3e36cdcae7d35553a1c658'
-         'b775f232fe7d73e7a0c3d0ab23ad3c48'
+         '042f4e2df7ebc1e2c6da15539158f4fc'
          'b68f5887575becd05feb010211a95164'
          '9420b494411a3e9faf743102fcff528b'
          '505e49f6ce1c89b7ae1b5d7233762567'

--- a/mingw-w64-ghc/PKGBUILD
+++ b/mingw-w64-ghc/PKGBUILD
@@ -1,0 +1,103 @@
+_realname=ghc
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=8.0.1
+pkgrel=1
+pkgdesc='The Glorious Glasgow Haskell Compilation System'
+arch=('any')
+url='http://www.haskell.org/ghc/'
+license=('The Glasgow Haskell Compiler License')
+depends=("${MINGW_PACKAGE_PREFIX}-binutils"
+         "${MINGW_PACKAGE_PREFIX}-crt-git"
+         "${MINGW_PACKAGE_PREFIX}-gcc"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-headers"
+         "${MINGW_PACKAGE_PREFIX}-isl"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread"
+         "${MINGW_PACKAGE_PREFIX}-mpc"
+         "${MINGW_PACKAGE_PREFIX}-mpfr"
+         "${MINGW_PACKAGE_PREFIX}-winpthreads-git"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=('perl' 'unzip')
+optdepends=("${MINGW_PACKAGE_PREFIX}-llvm")
+source=(
+  "http://downloads.haskell.org/~ghc/$pkgver/ghc-$pkgver-src.tar.xz"
+  "http://downloads.haskell.org/~ghc/$pkgver/ghc-$pkgver-testsuite.tar.xz"
+  'build.mk'
+  '0001-Rework-CC-CC_STAGE0-handling-in-configure.ac.patch'
+  '0001-Add-Windows-import-library-support-to-the-Runtime-Li.patch'
+  '0001-Remove-special-casing-of-Windows-in-generic-files.patch'
+  '0001-Enable-checkProddableBlock-on-x86_64.patch'
+  '0001-Add-relocation-type-R_X86_64_REX_GOTPCRELX.patch'
+  '0001-Fix-incorrect-calculated-relocations-on-Windows-x86_.patch'
+  '0001-Switch-to-LLVM-version-3.8.patch'
+  '0001-configure.ac-Remove-checks-for-bug-9439.patch'
+  '0001-Fix-configure-detection.patch'
+  '0001-Unstaged.patch'
+)
+
+prepare() {
+  SYST=$CARCH
+  if [[ $SYST == "i686" ]]; then
+     SYST="i386"
+  fi
+  mkdir -p host
+  curl -LO "https://www.haskell.org/cabal/release/cabal-install-1.24.0.0/cabal-install-1.24.0.0-$SYST-unknown-mingw32.zip"
+  curl -L "http://downloads.haskell.org/~${_realname}/$pkgver/${_realname}-$pkgver-$SYST-unknown-mingw32.tar.xz" | tar -Jx --strip-components=1 --directory=host
+  unzip -o cabal-install-1.24.0.0-$SYST-unknown-mingw32.zip -d host/bin
+  export PATH=$srcdir/host/bin:$PATH
+  cabal update
+  cabal install alex happy --prefix=$srcdir/host
+  cp build.mk "$srcdir/${_realname}-$pkgver/mk"
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Rework-CC-CC_STAGE0-handling-in-configure.ac.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Add-Windows-import-library-support-to-the-Runtime-Li.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Remove-special-casing-of-Windows-in-generic-files.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Enable-checkProddableBlock-on-x86_64.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Add-relocation-type-R_X86_64_REX_GOTPCRELX.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Fix-incorrect-calculated-relocations-on-Windows-x86_.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Switch-to-LLVM-version-3.8.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-configure.ac-Remove-checks-for-bug-9439.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Fix-configure-detection.patch
+  patch -d "$srcdir/${_realname}-$pkgver" -p1 < 0001-Unstaged.patch
+}
+
+build() {
+  export PATH=$srcdir/host/bin:$PATH
+  cd "$srcdir/${_realname}-$pkgver"
+  ./boot
+  ./configure --prefix=${MINGW_PREFIX}
+  make
+  #make html
+  #Need xelatex
+  #make pdf
+}
+
+check() {
+  export PATH=$srcdir/host/bin:$PATH
+  cd "$srcdir/${_realname}-$pkgver"
+  #Don't check to save time
+  #make test
+}
+
+package() {
+  export PATH=$srcdir/host/bin:$PATH
+  cd "$srcdir/${_realname}-$pkgver"
+  make binary-dist
+  mv bindistprep/${_realname}-$pkgver "$pkgdir"${MINGW_PREFIX}
+}
+
+md5sums=('c185b8a1f3e67e43533ec590b751c2ff'
+         '289e4b030a3e36cdcae7d35553a1c658'
+         '8d75aa687822b8210c4bc6aba4dd0a57'
+         'b68f5887575becd05feb010211a95164'
+         '9420b494411a3e9faf743102fcff528b'
+         '505e49f6ce1c89b7ae1b5d7233762567'
+         '3c094d3c1a49de3c0eb3398733bb001c'
+         '82ef617a59ec0e536e3e428aba9e7557'
+         'e25a592304825be687b645049eba3bc5'
+         '3db250cba393fdd3713c422a815e7d85'
+         '769794184c2e50cb36cadcddc8b4f906'
+         '08f498c8ec46c1e9d0afb645c1bdc104'
+         'ac49ab508c167c6fe1b548fcd6e2398e')

--- a/mingw-w64-ghc/PKGBUILD
+++ b/mingw-w64-ghc/PKGBUILD
@@ -1,3 +1,5 @@
+# Maintainer ncihnegn <ningchen@outlook.com>
+
 _realname=ghc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -20,7 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-binutils"
          "${MINGW_PACKAGE_PREFIX}-mpfr"
          "${MINGW_PACKAGE_PREFIX}-winpthreads-git"
          "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=('perl' 'unzip')
+makedepends=('perl' 'unzip' "${MINGW_PACKAGE_PREFIX}-python3-sphinx")
 optdepends=("${MINGW_PACKAGE_PREFIX}-llvm")
 source=(
   "http://downloads.haskell.org/~ghc/$pkgver/ghc-$pkgver-src.tar.xz"
@@ -69,7 +71,7 @@ build() {
   ./boot
   ./configure --prefix=${MINGW_PREFIX}
   make
-  #make html
+  make html
   #Need xelatex
   #make pdf
 }
@@ -90,7 +92,7 @@ package() {
 
 md5sums=('c185b8a1f3e67e43533ec590b751c2ff'
          '289e4b030a3e36cdcae7d35553a1c658'
-         '8d75aa687822b8210c4bc6aba4dd0a57'
+         'b775f232fe7d73e7a0c3d0ab23ad3c48'
          'b68f5887575becd05feb010211a95164'
          '9420b494411a3e9faf743102fcff528b'
          '505e49f6ce1c89b7ae1b5d7233762567'

--- a/mingw-w64-ghc/build.mk
+++ b/mingw-w64-ghc/build.mk
@@ -87,8 +87,8 @@ BUILD_EXTRA_PKGS=YES
 #libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-intree-gmp
 
 # Enable pretty hyperlinked sources
-HADDOCK_DOCS = YES
-EXTRA_HADDOCK_OPTS += --hyperlinked-source
+#HADDOCK_DOCS = YES
+#EXTRA_HADDOCK_OPTS += --hyperlinked-source
 
 # Don't strip debug and other unneeded symbols from libraries and executables.
 STRIP_CMD = :

--- a/mingw-w64-ghc/build.mk
+++ b/mingw-w64-ghc/build.mk
@@ -8,7 +8,7 @@
 # Uncomment one of these to select a build profile below:
 
 # Full build with max optimisation and everything enabled (very slow build)
-#BuildFlavour = perf
+BuildFlavour = perf
 
 # As above but build GHC using the LLVM backend
 #BuildFlavour = perf-llvm
@@ -28,7 +28,7 @@
 # Even faster build.  NOT RECOMMENDED: the libraries will be
 # completely unoptimised, so any code built with this compiler
 # (including stage2) will run very slowly:
-BuildFlavour = quickest
+#BuildFlavour = quickest
 
 # Profile the stage2 compiler:
 #BuildFlavour = prof
@@ -77,7 +77,7 @@ V=0
 
 # Build the "extra" packages (see ./packages). This enables more tests. See:
 # https://ghc.haskell.org/trac/ghc/wiki/Building/RunningTests/Running#AdditionalPackages
-#BUILD_EXTRA_PKGS=YES
+BUILD_EXTRA_PKGS=YES
 
 # Uncomment the following line to enable building DPH
 #BUILD_DPH=YES
@@ -87,8 +87,8 @@ V=0
 #libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-intree-gmp
 
 # Enable pretty hyperlinked sources
-#HADDOCK_DOCS = YES
-#EXTRA_HADDOCK_OPTS += --hyperlinked-source
+HADDOCK_DOCS = YES
+EXTRA_HADDOCK_OPTS += --hyperlinked-source
 
 # Don't strip debug and other unneeded symbols from libraries and executables.
 STRIP_CMD = :

--- a/mingw-w64-ghc/build.mk
+++ b/mingw-w64-ghc/build.mk
@@ -1,0 +1,94 @@
+# -----------------------------------------------------------------------------
+# A Sample build.mk
+#
+# Uncomment one of the following BuildFlavour settings to get the desired
+# overall build type.
+
+# -------- Build profiles -----------------------------------------------------
+# Uncomment one of these to select a build profile below:
+
+# Full build with max optimisation and everything enabled (very slow build)
+#BuildFlavour = perf
+
+# As above but build GHC using the LLVM backend
+#BuildFlavour = perf-llvm
+
+# Perf build configured for a cross-compiler
+#BuildFlavour = perf-cross
+
+# Fast build with optimised libraries, no profiling (RECOMMENDED):
+#BuildFlavour = quick
+
+# Fast build with optimised libraries, no profiling, with LLVM:
+#BuildFlavour = quick-llvm
+
+# Fast build configured for a cross compiler
+#BuildFlavour  = quick-cross
+
+# Even faster build.  NOT RECOMMENDED: the libraries will be
+# completely unoptimised, so any code built with this compiler
+# (including stage2) will run very slowly:
+BuildFlavour = quickest
+
+# Profile the stage2 compiler:
+#BuildFlavour = prof
+
+# A development build, working on the stage 1 compiler:
+#BuildFlavour = devel1
+
+# A development build, working on the stage 2 compiler:
+#BuildFlavour = devel2
+
+# A build with max optimisation that still builds the stage2 compiler
+# quickly. Compiled code will be the same as with "perf". Programs
+# will compile more slowly.
+#BuildFlavour = bench
+
+# As above but build GHC using the LLVM backend
+#BuildFlavour = bench-llvm
+
+# Bench build configured for a cross-compiler
+#BuildFlavour = bench-cross
+
+# Use the same settings as validate.
+#BuildFlavour = validate
+
+ifneq "$(BuildFlavour)" ""
+include mk/flavours/$(BuildFlavour).mk
+endif
+
+# -------- Miscellaneous variables --------------------------------------------
+
+# Set to V = 0 to get prettier build output.
+# Please use V=1 (the default) when reporting GHC bugs.
+V=0
+
+# Should all enabled warnings (see mk/warnings.mk) be turned into errors while
+# building stage 2?
+#WERROR=-Werror
+
+# After stage 1 and the libraries have been built, you can uncomment this line:
+#stage=2
+
+# Then stage 1 will not be touched by the build system, until
+# you comment the line again.  This is a useful trick for when you're
+# working on stage 2 and want to freeze stage 1 and the libraries for
+# a while.
+
+# Build the "extra" packages (see ./packages). This enables more tests. See:
+# https://ghc.haskell.org/trac/ghc/wiki/Building/RunningTests/Running#AdditionalPackages
+#BUILD_EXTRA_PKGS=YES
+
+# Uncomment the following line to enable building DPH
+#BUILD_DPH=YES
+
+# Uncomment the following to force `integer-gmp` to use the in-tree GMP 5.0.4
+# (other sometimes useful configure-options: `--with-gmp-{includes,libraries}`)
+#libraries/integer-gmp_CONFIGURE_OPTS += --configure-option=--with-intree-gmp
+
+# Enable pretty hyperlinked sources
+#HADDOCK_DOCS = YES
+#EXTRA_HADDOCK_OPTS += --hyperlinked-source
+
+# Don't strip debug and other unneeded symbols from libraries and executables.
+STRIP_CMD = :


### PR DESCRIPTION
I am quite satisfied that this builds without an inplace _mingw_ tree and runs without that.
In other words, this is a clean _ghc_ build for _mingw_, if you know what I am talking about.
But it still needs _ghc_ along with _alex_ and _happy_ to build itself, which we can't get around.
I am not sure how to put these in _makedepends_ or _prepare()_.

It also works with _mingw-llvm_ 3.8.