### PR TITLE
adding python-psutil: 4.3.0

### DIFF
--- a/mingw-w64-python-psutil/0001-MSYS-Allow-detecting-when-running-on-MSYS.patch
+++ b/mingw-w64-python-psutil/0001-MSYS-Allow-detecting-when-running-on-MSYS.patch
@@ -1,0 +1,98 @@
+From 92f37549d4be5632bde8373ec6329024455143aa Mon Sep 17 00:00:00 2001
+From: Manuel Naranjo <naranjo.manuel@gmail.com>
+Date: Thu, 23 Jun 2016 18:11:02 -0300
+Subject: [PATCH 1/2] [MSYS] Allow detecting when running on MSYS
+
+* Adding a check for testing for msys2
+* disabling inet_ntop.c on msys2 as it's provided by mingw
+---
+ psutil/_common.py |  3 ++-
+ setup.py          | 45 +++++++++++++++++++++++++--------------------
+ 2 files changed, 27 insertions(+), 21 deletions(-)
+
+diff --git a/psutil/_common.py b/psutil/_common.py
+index 1e48b63..38d46f8 100644
+--- a/psutil/_common.py
++++ b/psutil/_common.py
+@@ -39,7 +39,7 @@ else:
+ __all__ = [
+     # OS constants
+     'FREEBSD', 'BSD', 'LINUX', 'NETBSD', 'OPENBSD', 'OSX', 'POSIX', 'SUNOS',
+-    'WINDOWS',
++    'WINDOWS', 'MSYS',
+     # connection constants
+     'CONN_CLOSE', 'CONN_CLOSE_WAIT', 'CONN_CLOSING', 'CONN_ESTABLISHED',
+     'CONN_FIN_WAIT1', 'CONN_FIN_WAIT2', 'CONN_LAST_ACK', 'CONN_LISTEN',
+@@ -69,6 +69,7 @@ __all__ = [
+ 
+ POSIX = os.name == "posix"
+ WINDOWS = os.name == "nt"
++MSYS = "MSYSTEM" in os.environ
+ LINUX = sys.platform.startswith("linux")
+ OSX = sys.platform.startswith("darwin")
+ FREEBSD = sys.platform.startswith("freebsd")
+diff --git a/setup.py b/setup.py
+index a61b5ed..18472db 100644
+--- a/setup.py
++++ b/setup.py
+@@ -78,32 +78,37 @@ if _common.POSIX:
+             posix_extension.sources.append('psutil/arch/solaris/v10/ifaddrs.c')
+             posix_extension.define_macros.append(('PSUTIL_SUNOS10', 1))
+ # Windows
+-if _common.WINDOWS:
++if _common.WINDOWS or _common.MSYS:
+     def get_winver():
+         maj, min = sys.getwindowsversion()[0:2]
+         return '0x0%s' % ((maj * 100) + min)
++    sources=[
++        'psutil/_psutil_windows.c',
++        'psutil/_psutil_common.c',
++        'psutil/arch/windows/process_info.c',
++        'psutil/arch/windows/process_handles.c',
++        'psutil/arch/windows/security.c',
++        'psutil/arch/windows/services.c',
++    ]
++
++    if not _common.MSYS:
++        sources.append('psutil/arch/windows/inet_ntop.c')
++
++    define_macros=[
++        VERSION_MACRO,
++        # be nice to mingw, see:
++        # http://www.mingw.org/wiki/Use_more_recent_defined_functions
++        ('_WIN32_WINNT', get_winver()),
++        ('_AVAIL_WINVER_', get_winver()),
++        ('_CRT_SECURE_NO_WARNINGS', None),
++        # see: https://github.com/giampaolo/psutil/issues/348
++        ('PSAPI_VERSION', 1),
++    ]
+ 
+     ext = Extension(
+         'psutil._psutil_windows',
+-        sources=[
+-            'psutil/_psutil_windows.c',
+-            'psutil/_psutil_common.c',
+-            'psutil/arch/windows/process_info.c',
+-            'psutil/arch/windows/process_handles.c',
+-            'psutil/arch/windows/security.c',
+-            'psutil/arch/windows/inet_ntop.c',
+-            'psutil/arch/windows/services.c',
+-        ],
+-        define_macros=[
+-            VERSION_MACRO,
+-            # be nice to mingw, see:
+-            # http://www.mingw.org/wiki/Use_more_recent_defined_functions
+-            ('_WIN32_WINNT', get_winver()),
+-            ('_AVAIL_WINVER_', get_winver()),
+-            ('_CRT_SECURE_NO_WARNINGS', None),
+-            # see: https://github.com/giampaolo/psutil/issues/348
+-            ('PSAPI_VERSION', 1),
+-        ],
++        sources = sources,
++        define_macros = define_macros,
+         libraries=[
+             "psapi", "kernel32", "advapi32", "shell32", "netapi32",
+             "iphlpapi", "wtsapi32", "ws2_32",
+-- 
+2.7.2
+

--- a/mingw-w64-python-psutil/0002-msys-Fixes-for-msys2.patch
+++ b/mingw-w64-python-psutil/0002-msys-Fixes-for-msys2.patch
@@ -1,0 +1,242 @@
+From 221ae3655cdbbd49f288299bbd09996d930a5ce4 Mon Sep 17 00:00:00 2001
+From: Manuel Naranjo <naranjo.manuel@gmail.com>
+Date: Thu, 23 Jun 2016 18:15:39 -0300
+Subject: [PATCH 2/2] [msys] Fixes for msys2
+
+Fixes for building the lib in an msys environment with mingw32
+mingw64 should work as well.
+---
+ psutil/_psutil_windows.c              | 65 +++++++----------------------------
+ psutil/arch/windows/glpi.h            |  7 ++--
+ psutil/arch/windows/ntextapi.h        | 16 ++++++---
+ psutil/arch/windows/process_handles.h |  2 ++
+ psutil/arch/windows/services.c        | 12 +++++++
+ 5 files changed, 41 insertions(+), 61 deletions(-)
+
+diff --git a/psutil/_psutil_windows.c b/psutil/_psutil_windows.c
+index ebc4368..98c01df 100644
+--- a/psutil/_psutil_windows.c
++++ b/psutil/_psutil_windows.c
+@@ -21,6 +21,10 @@
+ #if (_WIN32_WINNT >= 0x0600) // Windows Vista and above
+ #include <ws2tcpip.h>
+ #endif
++#if defined(__MINGW32__)
++#include <Wincrypt.h>
++#endif
++#include <winternl.h>
+ #include <iphlpapi.h>
+ #include <wtsapi32.h>
+ #include <Winsvc.h>
+@@ -33,14 +37,14 @@
+ #include "arch/windows/security.h"
+ #include "arch/windows/process_info.h"
+ #include "arch/windows/process_handles.h"
++#ifndef __MINGW32__
+ #include "arch/windows/ntextapi.h"
+ #include "arch/windows/inet_ntop.h"
+-#include "arch/windows/services.h"
+-
+-#ifdef __MINGW32__
+-#include "arch/windows/glpi.h"
++#else
++#include <winternl.h>
++#include <ws2tcpip.h>
+ #endif
+-
++#include "arch/windows/services.h"
+ 
+ /*
+  * ============================================================================
+@@ -85,54 +89,8 @@ typedef struct _DISK_PERFORMANCE_WIN_2008 {
+     WCHAR         StorageManagerName[8];
+ } DISK_PERFORMANCE_WIN_2008;
+ 
+-// --- network connections mingw32 support
+-#ifndef _IPRTRMIB_H
+-#if (_WIN32_WINNT < 0x0600) // Windows XP
+-typedef struct _MIB_TCP6ROW_OWNER_PID {
+-    UCHAR ucLocalAddr[16];
+-    DWORD dwLocalScopeId;
+-    DWORD dwLocalPort;
+-    UCHAR ucRemoteAddr[16];
+-    DWORD dwRemoteScopeId;
+-    DWORD dwRemotePort;
+-    DWORD dwState;
+-    DWORD dwOwningPid;
+-} MIB_TCP6ROW_OWNER_PID, *PMIB_TCP6ROW_OWNER_PID;
+-
+-typedef struct _MIB_TCP6TABLE_OWNER_PID {
+-    DWORD dwNumEntries;
+-    MIB_TCP6ROW_OWNER_PID table[ANY_SIZE];
+-} MIB_TCP6TABLE_OWNER_PID, *PMIB_TCP6TABLE_OWNER_PID;
+-#endif
+-#endif
+-
+-#ifndef __IPHLPAPI_H__
+-typedef struct in6_addr {
+-    union {
+-        UCHAR Byte[16];
+-        USHORT Word[8];
+-    } u;
+-} IN6_ADDR, *PIN6_ADDR, FAR *LPIN6_ADDR;
+-
+-typedef enum _UDP_TABLE_CLASS {
+-    UDP_TABLE_BASIC,
+-    UDP_TABLE_OWNER_PID,
+-    UDP_TABLE_OWNER_MODULE
+-} UDP_TABLE_CLASS, *PUDP_TABLE_CLASS;
+-
+-typedef struct _MIB_UDPROW_OWNER_PID {
+-    DWORD dwLocalAddr;
+-    DWORD dwLocalPort;
+-    DWORD dwOwningPid;
+-} MIB_UDPROW_OWNER_PID, *PMIB_UDPROW_OWNER_PID;
+-
+-typedef struct _MIB_UDPTABLE_OWNER_PID {
+-    DWORD dwNumEntries;
+-    MIB_UDPROW_OWNER_PID table[ANY_SIZE];
+-} MIB_UDPTABLE_OWNER_PID, *PMIB_UDPTABLE_OWNER_PID;
+-#endif
+-
+ #if (_WIN32_WINNT < 0x0600) // Windows XP
++#if (!defined(__MINGW32__))
+ typedef struct _MIB_UDP6ROW_OWNER_PID {
+     UCHAR ucLocalAddr[16];
+     DWORD dwLocalScopeId;
+@@ -145,11 +103,12 @@ typedef struct _MIB_UDP6TABLE_OWNER_PID {
+     MIB_UDP6ROW_OWNER_PID table[ANY_SIZE];
+ } MIB_UDP6TABLE_OWNER_PID, *PMIB_UDP6TABLE_OWNER_PID;
+ #endif
++#endif
+ 
+ PIP_ADAPTER_ADDRESSES
+ psutil_get_nic_addresses() {
+     // allocate a 15 KB buffer to start with
+-    int outBufLen = 15000;
++    ULONG outBufLen = 15000;
+     DWORD dwRetVal = 0;
+     ULONG attempts = 0;
+     PIP_ADAPTER_ADDRESSES pAddresses = NULL;
+diff --git a/psutil/arch/windows/glpi.h b/psutil/arch/windows/glpi.h
+index 6f98483..f51080b 100644
+--- a/psutil/arch/windows/glpi.h
++++ b/psutil/arch/windows/glpi.h
+@@ -1,5 +1,5 @@
+-// mingw headers are missing this
+-
++#if !defined(__GLPI_H__) && !defined(USING_MSYS)
++#define __GLPI_H__
+ typedef enum _LOGICAL_PROCESSOR_RELATIONSHIP {
+     RelationProcessorCore,
+     RelationNumaNode,
+@@ -38,4 +38,5 @@ typedef struct _SYSTEM_LOGICAL_PROCESSOR_INFORMATION {
+ 
+ WINBASEAPI WINBOOL WINAPI
+ GetLogicalProcessorInformation(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION Buffer,
+-                               PDWORD ReturnedLength);
+\ No newline at end of file
++                               PDWORD ReturnedLength);
++#endif // __GLPI_H__
+diff --git a/psutil/arch/windows/ntextapi.h b/psutil/arch/windows/ntextapi.h
+index 74adce2..df1f436 100644
+--- a/psutil/arch/windows/ntextapi.h
++++ b/psutil/arch/windows/ntextapi.h
+@@ -120,7 +120,7 @@ typedef enum _KTHREAD_STATE {
+     MaximumThreadState
+ } KTHREAD_STATE, *PKTHREAD_STATE;
+ 
+-
++#ifndef __MINGW32__
+ typedef enum _KWAIT_REASON {
+     Executive = 0,
+     FreePage = 1,
+@@ -162,12 +162,11 @@ typedef enum _KWAIT_REASON {
+     MaximumWaitReason = 37
+ } KWAIT_REASON, *PKWAIT_REASON;
+ 
+-
+ typedef struct _CLIENT_ID {
+     HANDLE UniqueProcess;
+     HANDLE UniqueThread;
+ } CLIENT_ID, *PCLIENT_ID;
+-
++#endif
+ 
+ typedef struct _SYSTEM_THREAD_INFORMATION {
+     LARGE_INTEGER KernelTime;
+@@ -286,7 +285,7 @@ typedef NTSTATUS (NTAPI *_NtSetInformationProcess)(
+     DWORD ProcessInformationLength
+ );
+ 
+-
++#ifndef __MINGW32__
+ typedef enum _PROCESSINFOCLASS2 {
+     _ProcessBasicInformation,
+     ProcessQuotaLimits,
+@@ -334,11 +333,18 @@ typedef enum _PROCESSINFOCLASS2 {
+     MaxProcessInfoClass
+ } PROCESSINFOCLASS2;
+ 
+-
+ #define PROCESSINFOCLASS PROCESSINFOCLASS2
+ #define ProcessBasicInformation _ProcessBasicInformation
+ #define ProcessWow64Information _ProcessWow64Information
+ #define ProcessDebugPort _ProcessDebugPort
+ #define ProcessImageFileName _ProcessImageFileName
+ 
++#else
++// values from https://msdn.microsoft.com/en-us/library/windows/desktop/ms684280(v=vs.85).aspx
++#define ProcessBasicInformation 0
++#define ProcessWow64Information 26
++#define ProcessDebugPort 7
++#define ProcessImageFileName 27
++#endif
++
+ #endif // __NTEXTAPI_H__
+diff --git a/psutil/arch/windows/process_handles.h b/psutil/arch/windows/process_handles.h
+index ea5fbdb..583e3ff 100644
+--- a/psutil/arch/windows/process_handles.h
++++ b/psutil/arch/windows/process_handles.h
+@@ -75,6 +75,7 @@ typedef enum _POOL_TYPE {
+     NonPagedPoolCacheAlignedMustS
+ } POOL_TYPE, *PPOOL_TYPE;
+ 
++#if !defined(__MINGW32__)
+ typedef struct _OBJECT_TYPE_INFORMATION {
+     UNICODE_STRING Name;
+     ULONG TotalNumberOfObjects;
+@@ -99,6 +100,7 @@ typedef struct _OBJECT_TYPE_INFORMATION {
+     ULONG PagedPoolUsage;
+     ULONG NonPagedPoolUsage;
+ } OBJECT_TYPE_INFORMATION, *POBJECT_TYPE_INFORMATION;
++#endif // __MINGW32__
+ 
+ PVOID GetLibraryProcAddress(PSTR LibraryName, PSTR ProcName);
+ VOID psutil_get_open_files_init(BOOL threaded);
+diff --git a/psutil/arch/windows/services.c b/psutil/arch/windows/services.c
+index ddfe30e..8c279f0 100644
+--- a/psutil/arch/windows/services.c
++++ b/psutil/arch/windows/services.c
+@@ -10,6 +10,18 @@
+ 
+ #include "services.h"
+ 
++#ifdef __MINGW32__
++#if !defined(_UNICODE) && !defined(_MBCS)
++#define _tcslen(x) strlen(x)
++#elif defined(_UNICODE)
++#define _tclsen(x) wcslen(x)
++#elif defined(_MBCS)
++#define _tclsen(x) strlen(x)
++#else
++#error "Invalid value"
++#endif
++#endif //__MINGW32__
++
+ 
+ // ==================================================================
+ // utils
+-- 
+2.7.2
+

--- a/mingw-w64-python-psutil/PKGBUILD
+++ b/mingw-w64-python-psutil/PKGBUILD
@@ -1,0 +1,96 @@
+# Maintainer: Manuel Naranjo <naranjo.manuel@gmail.com>
+
+_pyname=psutil
+_realname=${_pyname}
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=4.3.0
+pkgrel=1
+pkgdesc="A cross-platform process and system utilities module for Python (mingw-w64)"
+arch=('any')
+url="https://github.com/giampaolo/"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=(
+  ${_realname}-${pkgver}.zip::"${url}/${_realname}/archive/release-${pkgver}.zip"
+  '0001-MSYS-Allow-detecting-when-running-on-MSYS.patch'
+  '0002-msys-fixes-for-msys2.patch'
+)
+sha256sums=(
+  'ee914ec129bf2c74e1e23d128fa203a580bfa9ace26ee4af18f4615e10b42ac4'
+  '0248f917fdf89a8d40acad44c646bcb7002f4cd9d943b4a95416d0964e1c2d75'
+  '68c394e580a5990cc2b5c5c84ff9d8d9c866efb946ba1ae492d1bf3c04f4f1fe'
+)
+
+prepare() {
+  cd "$srcdir"/
+  for builddir in python{2,3}-build; do
+    rm -rf $builddir | true
+    cp -r "${_realname}-release-${pkgver}" "${builddir}"
+    pushd "${builddir}"
+    patch -p1 -i "${srcdir}/0001-MSYS-Allow-detecting-when-running-on-MSYS.patch"
+    patch -p1 -i "${srcdir}/0002-msys-fixes-for-msys2.patch"
+    popd
+  done
+}
+
+build() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py check
+  done
+}
+
+# Note that build() is sometimes skipped because it's done in
+# the packages setup.py install for simplicity if you can do so.
+package_python3-psutil() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
+}
+
+package_python2-psutil() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+}
+
+package_mingw-w64-i686-python2-psutil() {
+  package_python2-psutil
+}
+
+package_mingw-w64-i686-python3-psutil() {
+  package_python3-psutil
+}
+
+package_mingw-w64-x86_64-python2-psutil() {
+  package_python2-psutil
+}
+
+package_mingw-w64-x86_64-python3-psutil() {
+  package_python3-psutil
+}


### PR DESCRIPTION
psutil (process and system utilities) is a cross-platform library for retrieving information on running processes and system utilization (CPU, memory, disks, network) in Python. It is useful mainly for system monitoring, profiling and limiting process resources and management of running processes.

I cared for this library so I could install wdb, so I haven't checked the rest of it.