### PR TITLE
cairo win32-print: fix unbounded surface assertion

### DIFF
--- a/mingw-w64-cairo/0027-win32-print-fix-unbounded-surface-assertion.patch
+++ b/mingw-w64-cairo/0027-win32-print-fix-unbounded-surface-assertion.patch
@@ -1,0 +1,23 @@
+From 90d50cd92315d6760069ad8062aba5e297370b20 Mon Sep 17 00:00:00 2001
+From: Adrian Johnson <ajohnson@redneon.com>
+Date: Sun, 19 Jun 2016 19:52:32 +0930
+Subject: win32-print: fix unbounded surface assertion
+
+https://lists.cairographics.org/archives/cairo/2016-June/027445.html
+
+diff --git a/src/win32/cairo-win32-printing-surface.c b/src/win32/cairo-win32-printing-surface.c
+index afc0b11..983ef59 100644
+--- a/src/win32/cairo-win32-printing-surface.c
++++ b/src/win32/cairo-win32-printing-surface.c
+@@ -389,7 +389,7 @@ _cairo_win32_printing_surface_analyze_operation (cairo_win32_printing_surface_t
+     if (pattern->type == CAIRO_PATTERN_TYPE_SURFACE) {
+ 	cairo_surface_pattern_t *surface_pattern = (cairo_surface_pattern_t *) pattern;
+ 
+-	if ( _cairo_surface_is_recording (surface_pattern->surface))
++	if (surface_pattern->surface->type == CAIRO_SURFACE_TYPE_RECORDING)
+ 	    return CAIRO_INT_STATUS_ANALYZE_RECORDING_SURFACE_PATTERN;
+     }
+ 
+-- 
+cgit v0.10.2
+

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cairo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.15.2
-pkgrel=3
+pkgrel=4
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 url="http://cairographics.org"
@@ -31,15 +31,18 @@ options=('strip' 'staticlibs')
 source=(#"http://cairographics.org/releases/cairo-${pkgver}.tar.xz"
         http://cairographics.org/snapshots/cairo-${pkgver}.tar.xz
         0009-standalone-headers.mingw.patch
-        0026-create-argb-fonts.all.patch)
+        0026-create-argb-fonts.all.patch
+        0027-win32-print-fix-unbounded-surface-assertion.patch)
 sha256sums=('268cc265a7f807403582f440643064bf52896556766890c8df7bad02d230f6c9'
             '234de8c5d4c28b03c19e638a353e8defb2de0367a634c002b0ea7d2877bd0756'
-            '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975')
+            '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975'
+            '14c6e8b33b6b0a8cdb81e1cb1e51991d8430bd1510fca471273f820310dacfab')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0009-standalone-headers.mingw.patch
   patch -p1 -i ${srcdir}/0026-create-argb-fonts.all.patch
+  patch -p1 -i ${srcdir}/0027-win32-print-fix-unbounded-surface-assertion.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
Taken from upstream:
https://cgit.freedesktop.org/cairo/commit/?id=90d50cd92315d6760069ad8062aba5e297370b20

Discussion at:
https://lists.cairographics.org/archives/cairo/2016-June/027445.html