### PR TITLE
qt5[-static]: add upstream patch for QTBUG-55482

### DIFF
--- a/mingw-w64-qt5-static/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
+++ b/mingw-w64-qt5-static/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
@@ -1,0 +1,44 @@
+From fcc2c95421710f98c7b2dec73e2c8b0d9164bc9b Mon Sep 17 00:00:00 2001
+From: Jonathan Liu <net147@gmail.com>
+Date: Wed, 24 Aug 2016 11:18:37 +1000
+Subject: [PATCH] Workaround crashes in QtQml code related to dead-store
+ elimination
+
+When compiled in release mode with GCC 6, QtQml may crash.
+This is because the C++ compiler is more aggressive about dead-store
+elimination in situations where a memory store to a location precedes
+the construction of an object at that memory location.
+
+The QV4::MemoryManager::allocate{Managed,Object} functions allocate
+memory and write to it before the caller does a placement new to
+construct an object in the same memory. The compiler considers these
+writes before the constructor as "dead stores" and eliminates them.
+
+The -fno-lifetime-dse compiler flag is added to disable this more
+aggressive dead-store eliminiation optimization.
+
+This is a temporary workaround until a proper solution is found.
+
+Task-number: QTBUG-55482
+Change-Id: I7dbae6e9e613e53ce5fb25957c449bc6657803b5
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+---
+ src/qml/qml.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qml/qml.pro b/src/qml/qml.pro
+index f4862a1..651afa6 100644
+--- a/src/qml/qml.pro
++++ b/src/qml/qml.pro
+@@ -18,7 +18,7 @@ exists("qqml_enable_gcov") {
+ 
+ greaterThan(QT_GCC_MAJOR_VERSION, 5) {
+     # Our code is bad. Temporary workaround.
+-    QMAKE_CXXFLAGS += -fno-delete-null-pointer-checks
++    QMAKE_CXXFLAGS += -fno-delete-null-pointer-checks -fno-lifetime-dse
+ }
+ 
+ QMAKE_DOCS = $$PWD/doc/qtqml.qdocconf
+-- 
+2.9.1
+

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -102,7 +102,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -227,7 +227,8 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0052-qt5-qtwebkit-mfence-mingw.patch
         0121-qt5-qtwebkit-dont-depend-on-icu.patch
         0122-revert-qt4-unicode-removal.patch
-        0124-qt5-qtwebkit-disambiguate-append.patch)
+        0124-qt5-qtwebkit-disambiguate-append.patch
+        0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch)
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -369,6 +370,10 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0051-qt5-qtwebkit-workaround-build-breakage-after-svn-commit-136242.patch
   patch -p1 -i ${srcdir}/0052-qt5-qtwebkit-mfence-mingw.patch
+
+  pushd qtdeclarative > /dev/null
+    patch -p1 -i ${srcdir}/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
+  popd
 
   # Skip using ICU, we should be sharing the exact same
   # sources between the different variants if possible.
@@ -742,4 +747,5 @@ sha256sums=('ce08a7eb54661705f55fb283d895a089b267c688fabe017062bd71b9231736db'
             'f7fe9ce6d2832b4e220d209ba08a1fbfb1adeb5abea1531240a1d5a96d2540e5'
             'e412e0715597331d69d2672f072b4578ed4c0d7a3b8f959bce216f6998c74922'
             'd9e3928ded3adf98bc6c57f0c40126be29679d767701bdb5d161cc5d85ce81ee'
-            '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900')
+            '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900'
+            '49922a70662f06daee35a2d8ea9474bf4181561ba7f0181d5e2a936f5a178dd5')

--- a/mingw-w64-qt5/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
+++ b/mingw-w64-qt5/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
@@ -1,0 +1,44 @@
+From fcc2c95421710f98c7b2dec73e2c8b0d9164bc9b Mon Sep 17 00:00:00 2001
+From: Jonathan Liu <net147@gmail.com>
+Date: Wed, 24 Aug 2016 11:18:37 +1000
+Subject: [PATCH] Workaround crashes in QtQml code related to dead-store
+ elimination
+
+When compiled in release mode with GCC 6, QtQml may crash.
+This is because the C++ compiler is more aggressive about dead-store
+elimination in situations where a memory store to a location precedes
+the construction of an object at that memory location.
+
+The QV4::MemoryManager::allocate{Managed,Object} functions allocate
+memory and write to it before the caller does a placement new to
+construct an object in the same memory. The compiler considers these
+writes before the constructor as "dead stores" and eliminates them.
+
+The -fno-lifetime-dse compiler flag is added to disable this more
+aggressive dead-store eliminiation optimization.
+
+This is a temporary workaround until a proper solution is found.
+
+Task-number: QTBUG-55482
+Change-Id: I7dbae6e9e613e53ce5fb25957c449bc6657803b5
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+---
+ src/qml/qml.pro | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qml/qml.pro b/src/qml/qml.pro
+index f4862a1..651afa6 100644
+--- a/src/qml/qml.pro
++++ b/src/qml/qml.pro
+@@ -18,7 +18,7 @@ exists("qqml_enable_gcov") {
+ 
+ greaterThan(QT_GCC_MAJOR_VERSION, 5) {
+     # Our code is bad. Temporary workaround.
+-    QMAKE_CXXFLAGS += -fno-delete-null-pointer-checks
++    QMAKE_CXXFLAGS += -fno-delete-null-pointer-checks -fno-lifetime-dse
+ }
+ 
+ QMAKE_DOCS = $$PWD/doc/qtqml.qdocconf
+-- 
+2.9.1
+

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -102,7 +102,7 @@ else
 fi
 
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -228,7 +228,8 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0121-qt5-qtwebkit-dont-depend-on-icu.patch
         0122-revert-qt4-unicode-removal.patch
         0124-qt5-qtwebkit-disambiguate-append.patch
-        0125-qt5-windeployqt-fixes.patch)
+        0125-qt5-windeployqt-fixes.patch
+        0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch)
 
 # Translates using cygpath according to the ${_make} being used
 # (so either mingw32-make or MSYS2 make can be used)
@@ -383,6 +384,10 @@ prepare() {
 
   pushd qttools > /dev/null
     patch -p1 -i ${srcdir}/0125-qt5-windeployqt-fixes.patch
+  popd
+
+  pushd qtdeclarative > /dev/null
+    patch -p1 -i ${srcdir}/0126-qt5-Workaround-crashes-in-QtQml-code-related-to-dead-store.patch
   popd
 
   # See: https://bugreports.qt-project.org/browse/QTBUG-37902
@@ -748,4 +753,5 @@ sha256sums=('ce08a7eb54661705f55fb283d895a089b267c688fabe017062bd71b9231736db'
             'e412e0715597331d69d2672f072b4578ed4c0d7a3b8f959bce216f6998c74922'
             'd9e3928ded3adf98bc6c57f0c40126be29679d767701bdb5d161cc5d85ce81ee'
             '9f95d0549b4bd416d760e715d0211932585ecfe8132d29e52cbe8025cee9e900'
-            'e868da7e8716fd3f09d448d003796feda77e59b38d194cab7c8a99fabbdb78af')
+            'e868da7e8716fd3f09d448d003796feda77e59b38d194cab7c8a99fabbdb78af'
+            '49922a70662f06daee35a2d8ea9474bf4181561ba7f0181d5e2a936f5a178dd5')


### PR DESCRIPTION
workaround crashes in QtQml code related to dead-store elimination
see https://bugreports.qt.io/browse/QTBUG-55482