### PR TITLE
[WIP] bump openssl to get latest security fixes

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_ver=1.0.2h
+_ver=1.0.2j
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=1
@@ -22,7 +22,7 @@ source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
         'openssl-1.0.1-x32.patch'
         'openssl-0.9.6-x509.patch'
         'openssl-1.0.1i-relocation.patch')
-sha256sums=('1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919'
+sha256sums=('e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431'
             'SKIP'
             '164aa4928b022cc716fac545b4fd69899cb274682aa487100e595abb652adbae'
             '906aad130d43e61d47d6843adc9f4a4f2ba027e698f9a840be77b53a36ca80b6'


### PR DESCRIPTION
As per https://www.openssl.org/news/secadv/20160926.txt