### PR TITLE
SDL2_Mixer: help ./configure find shared libraries for dynamic loading again

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -18,8 +18,21 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-flac"
          "${MINGW_PACKAGE_PREFIX}-fluidsynth")
 options=('staticlibs' 'strip')
-source=("$url/release/${_realname}-${pkgver}.zip")
-sha256sums=('06733c61deb10f0300017e3ddaa31bd10ad9ea5c1f6926b0ab5f0e322a036dda')
+source=("$url/release/${_realname}-${pkgver}.zip"
+        SDL2_mixer-2.0.1-find_lib.mingw.patch)
+sha256sums=('06733c61deb10f0300017e3ddaa31bd10ad9ea5c1f6926b0ab5f0e322a036dda'
+            'c7c03d36f5d4bf965ad7780aa75279dc6c338abab71096bd8d0852d45b86c478')
+
+prepare() {
+  [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
+  tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
+
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-find_lib.mingw.patch
+
+  autoreconf -fiv
+}
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}

--- a/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-find_lib.mingw.patch
+++ b/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-find_lib.mingw.patch
@@ -1,0 +1,101 @@
+diff --git a/configure.in_old b/configure.in
+index 77dc3fe..47ba19c 100644
+--- a/configure.in_old
++++ b/configure.in
+@@ -181,13 +181,14 @@ find_lib()
+     gcc_bin_path=[`$CC -print-search-dirs 2>/dev/null | fgrep programs: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`]
+     gcc_lib_path=[`$CC -print-search-dirs 2>/dev/null | fgrep libraries: | sed 's/[^=]*=\(.*\)/\1/' | sed 's/:/ /g'`]
+     env_lib_path=[`echo $LIBS $LDFLAGS $* | sed 's/-L[ ]*//g'`]
++    env_path=[`echo $PATH | sed 's/:/ /g'`]
+     if test "$cross_compiling" = yes; then
+         host_lib_path=""
+     else
+         host_lib_path="/usr/$base_libdir /usr/local/$base_libdir"
+     fi
+-    for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
+-        lib=[`ls -- $path/$1 2>/dev/null | sed -e '/\.so\..*\./d' -e 's,.*/,,' | sort | tail -1`]
++    for path in $env_lib_path $gcc_bin_path $gcc_lib_path $env_path $host_lib_path; do
++        lib=[`ls -- $path/$1 2>/dev/null | sort | sed 's/.*\/\(.*\)/\1/; q'`]
+         if test x$lib != x; then
+             echo $lib
+             return
+@@ -267,7 +268,7 @@ if test x$enable_music_mod = xyes -a x$enable_music_mod_modplug = xyes; then
+             *-*-darwin*)
+                 modplug_lib=[`find_lib libmodplug.dylib`]
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 modplug_lib=[`find_lib "libmodplug*.dll"`]
+                 ;;
+             *)
+@@ -335,7 +336,7 @@ return 1;
+             *-*-darwin*)
+                 mikmod_lib=[`find_lib libmikmod.dylib`]
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 mikmod_lib=[`find_lib "libmikmod*.dll"`]
+                 ;;
+             *)
+@@ -383,7 +384,7 @@ AC_HELP_STRING([--enable-music-midi-native], [enable native MIDI music output [[
+             *mingw32ce*)
+                 use_music_midi_native=no
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 use_music_midi_native=yes
+                 EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lwinmm"
+                 ;;
+@@ -420,8 +421,11 @@ AC_HELP_STRING([--enable-music-midi-fluidsynth-shared], [dynamically load FluidS
+                 *-*-darwin*)
+                     fluidsynth_lib=[`find_lib libfluidsynth.dylib`]
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     fluidsynth_lib=[`find_lib "fluidsynth*.dll"`]
++                    if test x$fluidsynth_lib = x; then
++                        fluidsynth_lib=[`find_lib "libfluidsynth*.dll"`]
++                    fi
+                     ;;
+                 *)
+                     fluidsynth_lib=[`find_lib "libfluidsynth[0-9]*.so.*"`]
+@@ -469,8 +473,11 @@ if test x$enable_music_ogg = xyes; then
+                 *-*-darwin*)
+                     ogg_lib=[`find_lib libvorbisidec.dylib`]
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=[`find_lib "vorbisidec*.dll"`]
++                    if test x$ogg_lib = x; then
++                        ogg_lib=[`find_lib "libvorbisidec*.dll"`]
++                    fi
+                     ;;
+                 *)
+                     ogg_lib=[`find_lib "libvorbisidec[0-9]*.so.*"`]
+@@ -499,7 +506,7 @@ if test x$enable_music_ogg = xyes; then
+                 *-*-darwin*)
+                     ogg_lib=[`find_lib libvorbisfile.dylib`]
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     ogg_lib=[`find_lib "libvorbisfile*.dll"`]
+                     ;;
+                 *)
+@@ -559,7 +566,7 @@ if test x$enable_music_flac = xyes; then
+                 *-*-darwin*)
+                     flac_lib=[`find_lib libFLAC.dylib`]
+                     ;;
+-                *-*-cygwin* | *-*-mingw32*)
++                *-*-cygwin* | *-*-mingw*)
+                     flac_lib=[`find_lib "libFLAC-*.dll"`]
+                     ;;
+                 *)
+@@ -602,7 +609,7 @@ if test x$enable_music_mp3 = xyes -a x$enable_music_mp3_smpeg = xyes; then
+             *-*-darwin*)
+                 smpeg_lib=[`find_lib libsmpeg2.dylib`]
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 smpeg_lib=[`find_lib "smpeg2*.dll"`]
+                 ;;
+             *)


### PR DESCRIPTION
While #865 was fixed by my pull request #867, the fix was completely
removed from SDL2_mixer in 276d9bd. Now this fixes #1641.

Bring back dynamic loading of shared libraries, this time by patching
configure.in and subsequently running autoreconf.