### PR TITLE
ImageMagick and dependencies

### DIFF
--- a/mingw-w64-imagemagick/002-7.0.3.1-build-fixes.patch
+++ b/mingw-w64-imagemagick/002-7.0.3.1-build-fixes.patch
@@ -1,0 +1,45 @@
+diff -aur ImageMagick-7.0.1-3/MagickCore/distribute-cache.c.orig ImageMagick-7.0.1-3/MagickCore/distribute-cache.c
+--- ImageMagick-7.0.1-3/MagickCore/distribute-cache.c.orig	2016-05-11 18:00:52 -0400
++++ ImageMagick-7.0.1-3/MagickCore/distribute-cache.c	2016-05-11 18:02:30 -0400
+@@ -88,6 +88,8 @@
+ #define LENGTH_TYPE size_t
+ #define MAGICKCORE_HAVE_DISTRIBUTE_CACHE
+ #elif defined(MAGICKCORE_WINDOWS_SUPPORT)
++#include <winsock2.h>
++#include <ws2tcpip.h>
+ #define CHAR_TYPE_CAST (char *)
+ #define CLOSE_SOCKET(socket) (void) closesocket(socket)
+ #define HANDLER_RETURN_TYPE DWORD WINAPI
+diff -aur ImageMagick-7.0.1-3/MagickCore/nt-base.h.orig ImageMagick-7.0.1-3/MagickCore/nt-base.h > patch
+--- ImageMagick-7.0.1-3/MagickCore/nt-base.h.orig	2016-05-11 18:03:33 -0400
++++ ImageMagick-7.0.1-3/MagickCore/nt-base.h	2016-05-11 18:04:48 -0400
+@@ -39,6 +39,8 @@
+ #include <errno.h>
+ #include <malloc.h>
+ #include <sys/utime.h>
++#include <winsock2.h>
++#include <ws2tcpip.h>
+ #if defined(_DEBUG) && !defined(__MINGW32__) && !defined(__MINGW64__)
+ #include <crtdbg.h>
+ #endif
+diff -aur ImageMagick-7.0.1-3/MagickCore/nt-base.c.orig ImageMagick-7.0.1-3/MagickCore/nt-base.c > patch
+--- ImageMagick-7.0.1-3/MagickCore/nt-base.c.orig	2016-05-11 18:05:52 -0400
++++ ImageMagick-7.0.1-3/MagickCore/nt-base.c	2016-05-11 18:09:20 -0400
+@@ -1687,12 +1687,16 @@
+   wchar_t
+     file_specification[MagickPathExtent];
+ 
++  wchar_t WCDirectorySeparator[strlen(DirectorySeparator)+1];
++  MultiByteToWideChar(CP_UTF8,0,DirectorySeparator,-1,WCDirectorySeparator,
++                     strlen(DirectorySeparator)+1);
++
+   assert(path != (const char *) NULL);
+   length=MultiByteToWideChar(CP_UTF8,0,path,-1,file_specification,
+     MagickPathExtent);
+   if (length == 0)
+     return((DIR *) NULL);
+-  if(wcsncat(file_specification,(const wchar_t*) DirectorySeparator,
++  if(wcsncat(file_specification, WCDirectorySeparator,
+        MagickPathExtent-wcslen(file_specification)-1) == (wchar_t*) NULL)
+     return((DIR *) NULL);
+   entry=(DIR *) AcquireMagickMemory(sizeof(DIR));

--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=imagemagick
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.0.1.10
+pkgver=7.0.3.1
 pkgrel=1
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
@@ -26,6 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-jasper"
          "${MINGW_PACKAGE_PREFIX}-jbigkit"
+         "${MINGW_PACKAGE_PREFIX}-libraqm"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-liblqr"
          "${MINGW_PACKAGE_PREFIX}-libpng"
@@ -50,16 +51,14 @@ options=('staticlibs' 'strip' '!debug' 'libtool')
 source=(https://www.imagemagick.org/download/ImageMagick-${pkgver%.*}-${pkgver##*.}.tar.xz{,.asc}
         ImageMagick-7.0.1.3-mingw.patch
         001-7.0.1.3-relocate.patch
-        002-7.0.1.3-build-fixes.patch
-        003-7.0.1.8-cplusplus-fixes.patch
-        winpath.patch)
-sha256sums=('4a17e54cd6b5f5fd0cea462dbe0cc1b74a91730d08e1d8edc4f539066feac8b8'
+        002-7.0.3.1-build-fixes.patch
+        003-7.0.1.8-cplusplus-fixes.patch)
+sha256sums=('9d9acda9061655569ff234bcc9a9e1d7c77c7d8b8e0035533fdb40b57846554b'
             'SKIP'
             '9e945a313f5da2962978ff7026c0cf93c0365afaf14c0f0e3223ce7917d81d2c'
             '5e75b298bbd3d5119a4391f65d4974a3f9edce51063a64ef2bd36f8cae0cdb6a'
-            '69797713782d0a3634be8a53d6f67fd23bb55479b14d8d13f2499c6a474cd96c'
-            'f628755b79753c00a22471a9562f5abcba67702f2156b38aa0e9b83d3644960a'
-            'fade8e9e2f6ebfdd2c82d0ebca8d052a5415c63d7b783c80bb6de14e8802eeed')
+            '37fc26a7f72b7da89f18ab262a0043f62a01a235e2b561dead904f23cfc315bd'
+            'f628755b79753c00a22471a9562f5abcba67702f2156b38aa0e9b83d3644960a')
 #Lexie Parsimoniae (ImageMagick code signing key) <lexie.parsimoniae@imagemagick.org>
 validpgpkeys=('D8272EF51DA223E4D05B466989AB63D48277377A')
 
@@ -68,9 +67,8 @@ prepare() {
   rm -f MagickCore/pathtools{.c,.h} > /dev/null 2>&1 || true
   patch -p1 -i ${srcdir}/ImageMagick-7.0.1.3-mingw.patch
   patch -p1 -i ${srcdir}/001-7.0.1.3-relocate.patch
-  patch -p1 -i ${srcdir}/002-7.0.1.3-build-fixes.patch
+  patch -p1 -i ${srcdir}/002-7.0.3.1-build-fixes.patch
   patch -p1 -i ${srcdir}/003-7.0.1.8-cplusplus-fixes.patch
-  #patch -p1 -i ${srcdir}/winpath.patch
   autoreconf -fi
 }
 
@@ -111,6 +109,7 @@ build() {
     --without-ltdl \
     --without-perl \
     --without-x \
+    --with-lraqm \
     --with-magick-plus-plus \
     --with-windows-font-dir=c:/Windows/fonts \
     $EXTRAOPTS \

--- a/mingw-w64-libraqm/PKGBUILD
+++ b/mingw-w64-libraqm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libraqm
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.1.1
+pkgver=0.2.0
 pkgrel=1
 pkgdesc="A library that encapsulates the logic for complex text layout (mingw-w64)"
 arch=('any')
@@ -14,11 +14,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-fribidi")
 makedepends=("gtk-doc")
 license=('custom')
-source=("${_realname}-$pkgver".tar.gz::"https://github.com/HOST-Oman/libraqm/archive/v${pkgver}.tar.gz")
-sha256sums=('d3a53bb6d10215a244d89e1c818d43e11b6ceca7b8cc8a580cca8b36fa537011')
+source=("${_realname}-$pkgver".tar.gz::"https://github.com/HOST-Oman/libraqm/archive/v${pkgver}.tar.gz"
+        "libraqm-enable-shared.patch")
+sha256sums=('a12a8428e18b4e35b4984a8f5afc225c8ec0ca7aeb64455a47671316c3e29cdb'
+            'ad4e69fe6e46904316dec4bf9d52d2a5cf2c9fac6dd86fd1af553ca616074f20')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}
+  patch -Np1 -i ${srcdir}/libraqm-enable-shared.patch
   ./autogen.sh
 }
 

--- a/mingw-w64-libraqm/libraqm-enable-shared.patch
+++ b/mingw-w64-libraqm/libraqm-enable-shared.patch
@@ -1,0 +1,11 @@
+--- libraqm-0.2.0/src/Makefile.am.orig	2016-09-26 09:14:15.278422700 -0400
++++ libraqm-0.2.0/src/Makefile.am	2016-09-26 09:15:40.108614900 -0400
+@@ -26,6 +26,8 @@
+     $(WARN_CFLAGS) \
+     $(NULL)
+ 
++libraqm_la_LDFLAGS= -no-undefined
++
+ libraqm_test_la_SOURCES = $(libraqm_la_SOURCES)
+ libraqm_test_la_LIBADD = $(libraqm_la_LIBADD)
+ libraqm_test_la_CPPFLAGS = $(libraqm_la_CPPFLAGS) -DRAQM_TESTING

--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libwebp
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.5.0
+pkgver=0.5.1
 pkgrel=1
 pkgdesc="the WebP library. Includes conversion tools (mingw-w64)"
 arch=('any')
@@ -15,8 +15,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-giflib"
          "${MINGW_PACKAGE_PREFIX}-libtiff")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=(http://downloads.webmproject.org/releases/webp/${_realname}-${pkgver}.tar.gz{,.asc})
-sha256sums=('5cd3bb7b623aff1f4e70bd611dc8dbabbf7688fd5eb225b32e02e09e37dfb274'
+sha256sums=('6ad66c6fcd60a023de20b6856b03da8c7d347269d76b1fd9c3287e8b5e8813df'
             'SKIP')
+validpgpkeys=('6B0E6B70976DE303EDF2F601F9C3D6BDB8232B5D')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -34,8 +35,8 @@ build() {
     --enable-experimental \
     --enable-libwebpmux \
     --enable-libwebpdemux \
-    --enable-libwebpdecoder
-
+    --enable-libwebpdecoder \
+--enable-libwebpextras
   make -j1
 }
 

--- a/mingw-w64-libwebp/PKGBUILD
+++ b/mingw-w64-libwebp/PKGBUILD
@@ -36,7 +36,7 @@ build() {
     --enable-libwebpmux \
     --enable-libwebpdemux \
     --enable-libwebpdecoder \
---enable-libwebpextras
+    --enable-libwebpextras
   make -j1
 }
 


### PR DESCRIPTION
imagemagick - 7.0.3.1 -
Update to latest version
add libraqm as dependency
Drop winpath.patch reference
rekey 002-7.0.3.1-build-fixes.patch
libwebp - 0.5.1
Update to latest version
add libwebpextras to package
libraqm - 0.2.0
Update to latest version
add patch to build static and shared libs