### PR TITLE
SDL2_Mixer: build fixes

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -28,9 +28,6 @@ sha256sums=('06733c61deb10f0300017e3ddaa31bd10ad9ea5c1f6926b0ab5f0e322a036dda'
             '3a6e7d1f14a9e49d20019dac9ee8c0113118023b4855ccb3e72e5caa682156ad')
 
 prepare() {
-  [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
-  bsdtar -xf ${srcdir}/${_realname}-${pkgver}.zip -C ${srcdir} || true
-
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-find_lib.mingw.patch

--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,12 +4,14 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 url="https://libsdl.org/projects/SDL_mixer"
 license=("MIT")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-smpeg2")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
@@ -19,17 +21,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-fluidsynth")
 options=('staticlibs' 'strip')
 source=("$url/release/${_realname}-${pkgver}.zip"
-        SDL2_mixer-2.0.1-find_lib.mingw.patch)
+        SDL2_mixer-2.0.1-find_lib.mingw.patch
+        SDL2_mixer-2.0.1-libtool_windres.mingw.patch)
 sha256sums=('06733c61deb10f0300017e3ddaa31bd10ad9ea5c1f6926b0ab5f0e322a036dda'
-            'c7c03d36f5d4bf965ad7780aa75279dc6c338abab71096bd8d0852d45b86c478')
+            'c7c03d36f5d4bf965ad7780aa75279dc6c338abab71096bd8d0852d45b86c478'
+            '3a6e7d1f14a9e49d20019dac9ee8c0113118023b4855ccb3e72e5caa682156ad')
 
 prepare() {
   [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
-  tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C ${srcdir} || true
+  bsdtar -xf ${srcdir}/${_realname}-${pkgver}.zip -C ${srcdir} || true
 
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-find_lib.mingw.patch
+  patch -Np1 -i ${srcdir}/SDL2_mixer-2.0.1-libtool_windres.mingw.patch
 
   autoreconf -fiv
 }

--- a/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-libtool_windres.mingw.patch
+++ b/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-libtool_windres.mingw.patch
@@ -1,0 +1,26 @@
+diff --git a/configure.in_old b/configure.in
+index 47ba19c..efb416f 100644
+--- a/configure.in_old
++++ b/configure.in
+@@ -55,6 +55,7 @@ else
+     hostaliaswindres="$host_alias-windres"
+ fi
+ AC_CHECK_PROGS(WINDRES, [windres $hostaliaswindres $host_os-windres])
++LT_PROG_RC
+ 
+ dnl Set up the compiler and linker flags
+ case "$host" in
+@@ -681,10 +682,10 @@ DEPENDS=`echo "$DEPENDS" | sed 's,\\$,\\\\$,g'`
+ 
+ VERSION_OBJECTS=`echo $VERSION_SOURCES`
+ VERSION_DEPENDS=`echo $VERSION_SOURCES`
+-VERSION_OBJECTS=`echo "$VERSION_OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.rc,$(objects)/\1.o,g'`
++VERSION_OBJECTS=`echo "$VERSION_OBJECTS" | sed 's,[[^ ]]*/\([[^ ]]*\)\.rc,$(objects)/\1.lo,g'`
+ VERSION_DEPENDS=`echo "$VERSION_DEPENDS" | sed 's,\([[^ ]]*\)/\([[^ ]]*\)\.rc,\\
+-$(objects)/\2.o: \1/\2.rc\\
+-	\$(WINDRES) \$< \$@,g'`
++$(objects)/\2.lo: \1/\2.rc\\
++	\$(LIBTOOL) --tag=RC --mode=compile \$(WINDRES) \$< -o \$@,g'`
+ VERSION_DEPENDS=`echo "$VERSION_DEPENDS" | sed 's,\\$,\\\\$,g'`
+ 
+ PLAYWAVE_SOURCES="$srcdir/playwave.c"


### PR DESCRIPTION
* Bump pkgrel to 2.
* Add smpeg2 to makedepends, some of its M4 macros are needed by autoreconf.
* Add another patch to compile version.rc into a libtool object (which suddenyl became
  necessary after running autoreconf).
* Unpack the zip archive with bsdtar. @mati865: I believe we prefer the zip file over
  tar.gz, because the latter contains symlinks that we have trouble to unpack.