### PR TITLE
libtool: rebuild after binutils change

### DIFF
--- a/mingw-w64-libtool/PKGBUILD
+++ b/mingw-w64-libtool/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libtool
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.4.6
-pkgrel=6
+pkgrel=7
 pkgdesc="A system independent dlopen wrapper for GNU libtool (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/libtool"
@@ -28,6 +28,7 @@ sha256sums=('7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f'
             '6a94ada08b0a0aa36240efd9ccb826e22ab94ef0969270f2edb8be344dc8c62b'
             'd96beecfc5d15f94ce46bbe0e89d6e6fdb973a25ad6be98c30504b58453792c1'
             'f00b44b49f83b20d4fbde89253666d0eb769172cfd711110f1be6a175294cb27')
+validpgpkeys=('CFE2BE707B538E8B26757D84151308092983D606') #Gary Vaughan (Free Software Developer) <gary@vaughan.pe>
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
@Alexpux, I don't know if it's required, but updating binutils from 2.25 to 2.27 is a big deal and libtool wasn't updated since then.

Now when we are at current binutils the ABI should be stable. So after upgrading GCC recompilation of libtool should be sufficient and we shouldn't have to recompile binutils.