### PR TITLE
Waf: Update to 1.9.4 and include unity tool

### DIFF
--- a/mingw-w64-waf/PKGBUILD
+++ b/mingw-w64-waf/PKGBUILD
@@ -4,7 +4,7 @@ _realname=waf
 
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8.21
+pkgver=1.9.4
 pkgrel=1
 pkgdesc="General-purpose build system modelled after Scons (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ makedepends=("setconf")
 depends=("${MINGW_PACKAGE_PREFIX}-python3")
 options=('!emptydirs')
 source=("https://github.com/waf-project/${_realname}/archive/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4007f38b5a0de2f0def758e30e0f66b0c3d7be0f7b832299e78b514513f3b013')
+sha256sums=('b2460ddd27131f347387b768877bf35c015735c5cd6fb4044070eb1a95de2ac3')
 
 prepare() {
   cd "${_realname}-${_realname}-$pkgver"
@@ -36,7 +36,7 @@ package() {
   cd "${_realname}-${_realname}-$pkgver"
 
   ${MINGW_PREFIX}/bin/python3 ./waf-light install -f --destdir="$pkgdir" \
-    --tools='compat,compat15,ocaml,go,cython,scala,erlang,cuda,gcj,boost,pep8,eclipse'
+    --tools='compat,compat15,ocaml,go,cython,scala,erlang,cuda,gcj,boost,pep8,eclipse,unity'
 
   install -Dm755 waf "${pkgdir}${MINGW_PREFIX}/bin/waf"
 


### PR DESCRIPTION
Is there a switch to include *all* tools? Maybe that should be done in the future.