### PR TITLE
Update Rust to 1.12.0

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -19,7 +19,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-libffi"
              "${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
 			 "${MINGW_PACKAGE_PREFIX}-perl")
 options=('!makeflags' 'staticlibs')
 #install=rust.install

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Zion Nimchuk <zionnimchuk@gmail.com>
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.2.0
+pkgver=1.12.0
 pkgrel=1
-pkgdesc="A safe, concurrent, practical language from Mozilla (mingw-w64)"
+pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 url="https://www.rust-lang.org/"
-license=('custom:MIT' 'Apache')
+license=('MIT' 'Apache')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("git"
              "bison"
@@ -17,40 +18,49 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-libffi"
-             "${MINGW_PACKAGE_PREFIX}-python2")
+             "${MINGW_PACKAGE_PREFIX}-python2"
+			 "${MINGW_PACKAGE_PREFIX}-perl")
 options=('!makeflags' 'staticlibs')
 #install=rust.install
 source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz)
-sha256sums=('ea6eb983daf2a073df57186a58f0d4ce0e85c711bec13c627a8c85d51b6a6d78')
-
-prepare() {
-  cd ${srcdir}/${_realname}c-$pkgver
-  #sed -e "s|CFG_WINDOWSY_\$(1)|0|g" -i mk/rustllvm.mk
-}
+sha256sums=('ac5907d6fa96c19bd5901d8d99383fb8755127571ead3d4070cce9c1fb5f337a')
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  #export CFG_LLVM_ROOT=${MINGW_PREFIX}
+  
   cd "${srcdir}/build-${MINGW_CHOST}"
+  
+  #We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
+  OSTYPE="$CARCH-pc-windows-gnu"
+  
+   #We have to get rust to build it's own version of LLVM because LLVM version 8.3 (which is what Mingw64 has) doesn't work: https://github.com/rust-lang/rust/issues/36774
   ../${_realname}c-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} \
-    --llvm-root=${MINGW_PREFIX} \
+    --build=$OSTYPE \
+    --host=$OSTYPE \
+    --target=$OSTYPE \
     --release-channel=stable
 
     #--enable-local-rust              use an installed rustc rather than downloading a snapshot
     #--local-rust-root=[/usr/local]   set prefix for local rust binary
     #--enable-clang                   prefer clang to gcc for building the runtime
 
-    make VERBOSE=1
+    make CFLAGS="$CFLAGS -fPIC -w"
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
+  
   make DESTDIR=${pkgdir} install
+  
+  install -Dm644 LICENSE-APACHE \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
+  install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
+
+  cd "$pkgdir/${MINGW_PREFIX}/lib"
+  rm rustlib/{components,manifest-rustc,rust-installer-version}
+  ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
   
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libgcc*.dll
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libstd*.dll

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -56,10 +56,10 @@ package() {
   make DESTDIR=${pkgdir} install
   
   install -Dm644 LICENSE-APACHE \
-    "$pkgdir/${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"
-  install -Dm644 LICENSE-MIT "$pkgdir/${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-MIT"
+    "$pkgdir${MINGW_PREFIX}/share/licenses/$_realname/LICENSE-APACHE"
+  install -Dm644 LICENSE-MIT "$pkgdir${MINGW_PREFIX}/share/licenses/$_realname/LICENSE-MIT"
 
-  cd "$pkgdir/${MINGW_PREFIX}/lib"
+  cd "$pkgdir${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
   

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -56,8 +56,8 @@ package() {
   make DESTDIR=${pkgdir} install
   
   install -Dm644 LICENSE-APACHE \
-    "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
-  install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
+    "$pkgdir/${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-APACHE"
+  install -Dm644 LICENSE-MIT "$pkgdir/${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE-MIT"
 
   cd "$pkgdir/${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -19,6 +19,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-llvm"
              "${MINGW_PACKAGE_PREFIX}-libffi"
              "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
 			 "${MINGW_PACKAGE_PREFIX}-perl")
 options=('!makeflags' 'staticlibs')
 #install=rust.install


### PR DESCRIPTION
Alright, so this is my first pull request to MINGW, tell me if I'm doing something wrong.
All the changes were based on Arch Linux's rust PKGBUILD, PR #1094 or the previous PKGBUILD.
It builds LLVM itself, so it takes FOREVER to build. I believe once we get CLANG/LLVM on 3.9 it should build with the system's LLVM.