### PR TITLE
Poco 1.6.0 PKGBUILD fix

### DIFF
--- a/mingw-w64-poco/014-unbundled-expat.patch
+++ b/mingw-w64-poco/014-unbundled-expat.patch
@@ -1,0 +1,13 @@
+--- poco-1.6.0-all.orig/XML/CMakeLists.txt	2014-12-22 09:04:47.000000000 +0100
++++ poco-1.6.0-all/XML/CMakeLists.txt	2016-10-16 10:10:48.148157900 +0200
+@@ -1,8 +1,10 @@
+ set(LIBNAME "XML")
+ set(POCO_LIBNAME "Poco${LIBNAME}")
+ 
++
+ # Sources
+ file(GLOB SRCS_G "src/*.cpp")
++list(REMOVE_ITEM SRCS_G "${CMAKE_CURRENT_SOURCE_DIR}/src/xmlparse.cpp")
+ POCO_SOURCES_AUTO( SRCS ${SRCS_G})
+ 
+ # Headers

--- a/mingw-w64-poco/PKGBUILD
+++ b/mingw-w64-poco/PKGBUILD
@@ -32,7 +32,7 @@ source=(http://pocoproject.org/releases/${_realname}-${pkgver}/${_realname}-${pk
         011-cmake-mingw.patch
         012-find-mysql.patch
         013-POCO_WIN32_UTF8-redefinition.patch
-		014-unbundled-expat.patch
+        014-unbundled-expat.patch
         100-fix-mingw-config.patch)
 sha256sums=('ed1be29ee413141269e7ccee861b11a2992a9f70072dbb28bec31ad432d71cab'
             '0ebf7f290e934453eb8e2330312f0393d7d40a61e4e7ec95c78a777363831398'
@@ -48,7 +48,7 @@ sha256sums=('ed1be29ee413141269e7ccee861b11a2992a9f70072dbb28bec31ad432d71cab'
             '0d8bef1423099a4d43ce58250df504f3cbf4366099ad68538cf7df5c69d0abf2'
             '8022b4de8b605932fd11ac879a288f52bf385784247db0b00cf5cee7f6d4c0f3'
             '57ca988afad8dfd73705f677a706518d635aea2936d4de8f35ad9943c9a4b1b0'
-			'd57cf40f2ad6c5f61ba4b954c96d15ada1cf5e115bb87c8b53fe231b2da1f863'
+            'd57cf40f2ad6c5f61ba4b954c96d15ada1cf5e115bb87c8b53fe231b2da1f863'
             '1dacb602e0163d0eb871b38fab411c3b89df1c5e5c505038931704b30b517776')
 
 prepare() {

--- a/mingw-w64-poco/PKGBUILD
+++ b/mingw-w64-poco/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="POrtable COmponents C++ Libraries (mingw-w64)"
 arch=('any')
 url="http://pocoproject.org"
 license=("boost")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libmariadbclient"

--- a/mingw-w64-poco/PKGBUILD
+++ b/mingw-w64-poco/PKGBUILD
@@ -4,7 +4,7 @@ _realname=poco
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="POrtable COmponents C++ Libraries (mingw-w64)"
 arch=('any')
 url="http://pocoproject.org"
@@ -32,6 +32,7 @@ source=(http://pocoproject.org/releases/${_realname}-${pkgver}/${_realname}-${pk
         011-cmake-mingw.patch
         012-find-mysql.patch
         013-POCO_WIN32_UTF8-redefinition.patch
+		014-unbundled-expat.patch
         100-fix-mingw-config.patch)
 sha256sums=('ed1be29ee413141269e7ccee861b11a2992a9f70072dbb28bec31ad432d71cab'
             '0ebf7f290e934453eb8e2330312f0393d7d40a61e4e7ec95c78a777363831398'
@@ -47,6 +48,7 @@ sha256sums=('ed1be29ee413141269e7ccee861b11a2992a9f70072dbb28bec31ad432d71cab'
             '0d8bef1423099a4d43ce58250df504f3cbf4366099ad68538cf7df5c69d0abf2'
             '8022b4de8b605932fd11ac879a288f52bf385784247db0b00cf5cee7f6d4c0f3'
             '57ca988afad8dfd73705f677a706518d635aea2936d4de8f35ad9943c9a4b1b0'
+			'd57cf40f2ad6c5f61ba4b954c96d15ada1cf5e115bb87c8b53fe231b2da1f863'
             '1dacb602e0163d0eb871b38fab411c3b89df1c5e5c505038931704b30b517776')
 
 prepare() {
@@ -64,6 +66,7 @@ prepare() {
   patch -p1 -i ${srcdir}/011-cmake-mingw.patch
   patch -p1 -i ${srcdir}/012-find-mysql.patch
   patch -p1 -i ${srcdir}/013-POCO_WIN32_UTF8-redefinition.patch
+  patch -p1 -i ${srcdir}/014-unbundled-expat.patch
   patch -p1 -i ${srcdir}/100-fix-mingw-config.patch
 }
 


### PR DESCRIPTION
fixes #1823
xmlparse.cpp (expat) was included in mingw32 build when POCO_UNBUNDLED is set and caused 'XMLUtf8Encode undefined reference' error when building