### PR TITLE
Fixed build issue in kicad-git

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Tim S. <stahta01@gmail.com>
+
+_realname=kicad-doc
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-de"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-en"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-es"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-fr"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-it"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-ja"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-nl"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-ru")
+pkgver=4.0.4
+pkgrel=1
+pkgdesc="Documentation for KiCad (mingw-w64)"
+arch=('any')
+url="http://kicad-pcb.org/download/source/"
+license=('GPL3' 'custom')
+makedepends=()
+options=('!strip')
+source=("http://downloads.kicad-pcb.org/docs/kicad-doc-${pkgver}.tar.gz")
+sha256sums=('3f180197ac8963f129239922c62530313b3344bfc0ec40a6512defb086163722')
+langid='en'
+
+prepare() {
+  plain "No step"
+}
+
+build() {
+  plain "No step"
+}
+
+build_lang() {
+  cd "${srcdir}/kicad-doc-${pkgver}/share/doc/kicad/help"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
+  cp -R ${langid} "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
+}
+
+# Wrappers; the last called function seems to need either newline or ";" after it.
+package_mingw-w64-x86_64-kicad-doc-ca() { langid='ca' build_lang; }
+package_mingw-w64-i686-kicad-doc-ca()   { langid='ca' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-de() { langid='de' build_lang; }
+package_mingw-w64-i686-kicad-doc-de()   { langid='de' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-en() { langid='en' build_lang; }
+package_mingw-w64-i686-kicad-doc-en()   { langid='en' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-es() { langid='es' build_lang; }
+package_mingw-w64-i686-kicad-doc-es()   { langid='es' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-fr() { langid='fr' build_lang; }
+package_mingw-w64-i686-kicad-doc-fr()   { langid='fr' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-it() { langid='it' build_lang; }
+package_mingw-w64-i686-kicad-doc-it()   { langid='it' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-ja() { langid='ja' build_lang; }
+package_mingw-w64-i686-kicad-doc-ja()   { langid='ja' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-nl() { langid='nl' build_lang; }
+package_mingw-w64-i686-kicad-doc-nl()   { langid='nl' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-pl() { langid='pl' build_lang; }
+package_mingw-w64-i686-kicad-doc-pl()   { langid='pl' build_lang; }
+package_mingw-w64-x86_64-kicad-doc-ru() { langid='ru' build_lang; }
+package_mingw-w64-i686-kicad-doc-ru()   { langid='ru' build_lang; }

--- a/mingw-w64-kicad-git/PKGBUILD
+++ b/mingw-w64-kicad-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=kicad
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r6328.22fb7da
+pkgver=r7314.d1e4399
 pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
 arch=('any')
@@ -20,15 +20,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-boost"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-glm"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-swig"
              "git")
 source=("${_realname}"::"git+https://github.com/KiCad/kicad-source-mirror.git"
-        "${_realname}-docs"::"git+https://github.com/KiCad/kicad-doc.git"
         "${_realname}-libs"::"git+https://github.com/KiCad/kicad-library.git")
 sha256sums=('SKIP'
-            'SKIP'
             'SKIP')
 
 pkgver() {
@@ -61,17 +60,6 @@ build() {
 
   cd "${srcdir}"
 
-  # Configure the documentation installation build.
-  [[ -d build-docs ]] && rm -r build-docs
-  mkdir build-docs && cd build-docs
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-docs
-
-  cd "${srcdir}"
-
   # Configure the library installation build.
   [[ -d build-libs ]] && rm -r build-libs
   mkdir build-libs && cd build-libs
@@ -86,10 +74,6 @@ build() {
 package() {
   # Install KiCad.
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
-
-  # Install KiCad documentation.
-  cd "${srcdir}/build-docs"
   make DESTDIR=${pkgdir} install
 
   # Install KiCad libraries.


### PR DESCRIPTION
I created a new package kicad-doc that packages already created doc files for the KiCad project to avoid having to port the packages needed to create the doc files under MSys2.

Tim S.
