### PR TITLE
Updated rust package to 1.12.1

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -64,11 +64,7 @@ package() {
   cd "${pkgdir}${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
-  
-  cd "$pkgdir${MINGW_PREFIX}/lib"
-  rm rustlib/{components,manifest-rustc,rust-installer-version}
-  ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
-  
+    
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libgcc*.dll
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libstd*.dll
   

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -65,10 +65,6 @@ package() {
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
   
-  install -Dm644 LICENSE-APACHE \
-    "${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname/LICENSE-APACHE"
-  install -Dm644 LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-MIT"
-
   cd "$pkgdir${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -22,13 +22,18 @@ makedepends=("git"
 options=('!makeflags' 'staticlibs')
 #install=rust.install
 source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
+        "force-curl-rust.patch"
         "force-curl-cargo.patch"
         "git+https://github.com/rust-lang/cargo.git#tag=0.13.0")
 sha256sums=('97913ae4cb255618aaacd1a534b11f343634b040b32656250d09d8d9ec02d3dc'
+	    '1325ffce8d8ea2b95ed1be0911d5730e82e879ca526422a0458f5da990fb04c1'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
             'SKIP')
 
 prepare() {
+  cd ${srcdir}/${_realname}c-${pkgver}
+  patch -p1 -i "${srcdir}/force-curl-rust.patch"
+  
   cd ${srcdir}/cargo
   git submodule update --init --recursive
   patch -p1 -i "${srcdir}/force-curl-cargo.patch"
@@ -64,7 +69,7 @@ package() {
   cd "${pkgdir}${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
-    
+  
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libgcc*.dll
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libstd*.dll
   

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.12.0
+pkgver=1.12.1
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ options=('!makeflags' 'staticlibs')
 source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
         "force-curl-cargo.patch"
         "git+https://github.com/rust-lang/cargo.git#tag=0.13.0")
-sha256sums=('ac5907d6fa96c19bd5901d8d99383fb8755127571ead3d4070cce9c1fb5f337a'
+sha256sums=('97913ae4cb255618aaacd1a534b11f343634b040b32656250d09d8d9ec02d3dc'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
             'SKIP')
 

--- a/mingw-w64-rust/force-curl-rust.patch
+++ b/mingw-w64-rust/force-curl-rust.patch
@@ -1,0 +1,20 @@
+diff --git a/src/bootstrap/bootstrap.py b/src/bootstrap/bootstrap.py
+index 17a7c9c..4e3ca0d 100644
+--- a/src/bootstrap/bootstrap.py
++++ b/src/bootstrap/bootstrap.py
+@@ -56,14 +56,7 @@ def delete_if_present(path):
+ 
+ def download(path, url, verbose):
+     print("downloading {} to {}".format(url, path))
+-    # see http://serverfault.com/questions/301128/how-to-download
+-    if sys.platform == 'win32':
+-        run(["PowerShell.exe", "/nologo", "-Command",
+-             "(New-Object System.Net.WebClient)"
+-             ".DownloadFile('{}', '{}')".format(url, path)],
+-            verbose=verbose)
+-    else:
+-        run(["curl", "-o", path, url], verbose=verbose)
++    run(["curl", "-o", path, url], verbose=verbose)
+ 
+ 
+ def verify(path, sha_path, verbose):


### PR DESCRIPTION
Update rust package to 1.12.1. Small changes in preparation for version 1.13.0: https://blog.rust-lang.org/2016/10/20/Rust-1.12.1.html 
I noticed that 1.12.0 hasn't been updated in the official pacman repo. Is there a reason for that? Is there a way I can get that updated?
CI will fail because it will time out.