### PR TITLE
Updated the go package to 1.7.1

### DIFF
--- a/mingw-w64-go/PKGBUILD
+++ b/mingw-w64-go/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=go
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.7
+pkgver=1.7.1
 pkgrel=1
 pkgdesc="Go Lang (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip')
 source=("https://golang.org/dl/go${pkgver}.src.tar.gz"
         0010-go1.7-proper-go-binary-path.patch)
-sha256sums=('72680c16ba0891fcf2ccf46d0f809e4ecf47bbf889f5d884ccb54c5e9a17e1c0'
+sha256sums=('2b843f133b81b7995f26d0cb64bbdbb9d0704b90c44df45f844d28881ad442d3'
             'feccfe481221f063acef00f7d9daf33ce0f369b2a065513067d8308d56258cc5')
 
 prepare() {


### PR DESCRIPTION
Just a small update to the go package to 1.7.1. This is also a reminder to update the official pacman repo. The current version is 1.4.2 which was released at the start of 2015!