### PR TITLE
Adds a TUI in GNU debugger, GDB.

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -17,7 +17,8 @@ groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-python2"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-readline")
 checkdepends=('dejagnu' 'bc')
 makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
              "${MINGW_PACKAGE_PREFIX}-ncurses"
@@ -75,10 +76,11 @@ build() {
     --with-system-gdbinit=${MINGW_PREFIX}/etc/gdbinit \
     --with-python=${MINGW_PREFIX}/bin/python-config-u.sh \
     --with-expat \
+    --with-system-readline \
     --with-libiconv-prefix=${MINGW_PREFIX} \
     --with-zlib \
     --with-lzma \
-    --disable-tui
+    --enable-tui
 
   make
 }


### PR DESCRIPTION
Enables text interface (TUI) in the build of GDB. The TUI can be used only in cmd.exe and not in mintty, and is somewhat buggy on Windows 10 as documented in #1744. Nevertheless, it serves its purpose.
