### PR TITLE
chromaprint: use fftw instead of ffmpeg

### DIFF
--- a/mingw-w64-chromaprint/PKGBUILD
+++ b/mingw-w64-chromaprint/PKGBUILD
@@ -4,7 +4,7 @@ _realname=chromaprint
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Library that implements a custom algorithm for extracting fingerprints from any audio source (mingw-w64)"
 arch=('any')
 url="http://acoustid.org/chromaprint/"
@@ -12,7 +12,7 @@ license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
-depends=("${MINGW_PACKAGE_PREFIX}-ffmpeg")
+depends=("${MINGW_PACKAGE_PREFIX}-fftw")
 options=('strip' 'staticlibs')
 source=("https://bitbucket.org/acoustid/${_realname}/downloads/${_realname}-${pkgver}.tar.gz")
 sha256sums=('c3af900d8e7a42afd74315b51b79ebd2e43bc66630b4ba585a54bf3160439652')
@@ -31,7 +31,7 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
-    -DWITH_AVFFT=ON \
+    -DWITH_FFTW3=ON \
     ../${_realname}-${pkgver}
 
   make


### PR DESCRIPTION
fftw is smaller and has less dependencies. This is the only
thing pulling in ffmpeg in gstreamer afaics
(besides the optdepends in opencv)