### PR TITLE
gst-plugins-bad: depend on libsrtp

### DIFF
--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gst-plugins-bad
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.3
-pkgrel=3
+pkgrel=4
 pkgdesc="GStreamer Multimedia Framework Bad Plugins (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
@@ -36,6 +36,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-celt"
          "${MINGW_PACKAGE_PREFIX}-libmpeg2"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-librsvg"
+         "${MINGW_PACKAGE_PREFIX}-libsrtp"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-mpg123"


### PR DESCRIPTION
for the srtp plugin