### PR TITLE
cURL: update to v7.51.0

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.50.3
+pkgver=7.51.0
 pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
@@ -32,7 +32,7 @@ options=('staticlibs')
 source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-curl-relocation.patch"
         "0004-cURL-Get-relocatable-base-from-dll.patch")
-sha256sums=('7b7347d976661d02c84a1f4d6daf40dee377efdc45b9e2c77dedb8acf140d8ec'
+sha256sums=('7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde'
             'SKIP'
             '3aa3e42dc35daba84470def39d7b6e16ce15f3397e99d341b844d8cd8796bab5'
             'e21fb106ebda8559ba2d34633a9d7d94be541de02de01982f92d67048bb9854b')


### PR DESCRIPTION
There are 11 security advisories associated with this version. It's rather important to update.