### PR TITLE
Python: Fixed patch for distutils.util.change_root to account for cases when neither path has a drive letter

### DIFF
--- a/mingw-w64-python2/0670-msys-convert_path-fix-and-root-hack.patch
+++ b/mingw-w64-python2/0670-msys-convert_path-fix-and-root-hack.patch
@@ -64,7 +64,7 @@ diff -Naur Python-2.7.9-orig/Lib/distutils/util.py Python-2.7.9/Lib/distutils/ut
 +                   % (drive_r,drive))
 +        elif len(drive_r) == 2:
 +            drive_used = drive_r+os.sep
-+        else:
++        elif len(drive) == 2:
 +            drive_used = drive+os.sep
 +        return os.path.join(drive_used+path_r, path)
  

--- a/mingw-w64-python3/0670-msys-convert_path-fix-and-root-hack.patch
+++ b/mingw-w64-python3/0670-msys-convert_path-fix-and-root-hack.patch
@@ -56,7 +56,7 @@ diff -Naur Python-3.5.2-orig/Lib/distutils/util.py Python-3.5.2/Lib/distutils/ut
 +                   % (drive_r,drive))
 +        elif len(drive_r) == 2:
 +            drive_used = drive_r+os.sep
-+        else:
++        elif len(drive) == 2:
 +            drive_used = drive+os.sep
 +        return os.path.join(drive_used+path_r, path)
  


### PR DESCRIPTION
Found this bug because on msys2, `python setup.py bdist_wheel` produces totally empty wheels, save for metadata! Turns out that `bdist_wheel` calls `install` with a chroot into the build directory set. Without this patch, applying the chroot caused the internal install to get installed to the root of the drive, so nothing ever got copied to the wheel.

This is the result of a solid 6 hours of debugging hahaha