### PR TITLE
gst-plugins-good: Fix 100 CPU when using directsoundsink

### DIFF
--- a/mingw-w64-gst-plugins-good/PKGBUILD
+++ b/mingw-w64-gst-plugins-good/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gst-plugins-good
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.3
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer Multimedia Framework Base Plugins (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
@@ -28,13 +28,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
         )
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz
-        0002-fix-test-running.mingw.patch)
+        0002-fix-test-running.mingw.patch
+        Revert-directsoundsink-Fix-sleep-for-buffer-time-low.patch)
 sha256sums=('a1d6579ba203a7734927c24b90bf6590d846c5a5fcec01a48201018c8ad2827a'
-            '68314b7f2a522f369d22ab661d7ea58b7071fe2002314d982578ef40d05caba8')
+            '68314b7f2a522f369d22ab661d7ea58b7071fe2002314d982578ef40d05caba8'
+            'c7541ebabf3fa62b69db7246f8e1aaf22861a0a83b5487a7c517f1a495cf041d')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0002-fix-test-running.mingw.patch
+  patch -p1 -i ${srcdir}/Revert-directsoundsink-Fix-sleep-for-buffer-time-low.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }

--- a/mingw-w64-gst-plugins-good/Revert-directsoundsink-Fix-sleep-for-buffer-time-low.patch
+++ b/mingw-w64-gst-plugins-good/Revert-directsoundsink-Fix-sleep-for-buffer-time-low.patch
@@ -1,0 +1,49 @@
+From 7be9473fdc2c20cafb40bc40193819d56083a891 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 6 Nov 2016 15:20:57 +0100
+Subject: [PATCH] Revert "directsoundsink: Fix sleep for buffer-time lower than
+ 200000"
+
+This reverts commit 51f94288ce66a0a6a28e45801f4e17eb74044298.
+
+See https://bugzilla.gnome.org/show_bug.cgi?id=773681#c4
+---
+ sys/directsound/gstdirectsoundsink.c | 15 ++-------------
+ 1 file changed, 2 insertions(+), 13 deletions(-)
+
+diff --git a/sys/directsound/gstdirectsoundsink.c b/sys/directsound/gstdirectsoundsink.c
+index 573e2b8..62a3470 100644
+--- a/sys/directsound/gstdirectsoundsink.c
++++ b/sys/directsound/gstdirectsoundsink.c
+@@ -623,8 +623,7 @@ gst_directsound_sink_write (GstAudioSink * asink, gpointer data, guint length)
+       &dwCurrentPlayCursor, NULL);
+ 
+   if (SUCCEEDED (hRes) && SUCCEEDED (hRes2) && (dwStatus & DSBSTATUS_PLAYING)) {
+-    DWORD dwFreeBufferSize = 0;
+-    DWORD sleepTime = 0;
++    DWORD dwFreeBufferSize;
+ 
+   calculate_freesize:
+     /* calculate the free size of the circular buffer */
+@@ -637,17 +636,7 @@ gst_directsound_sink_write (GstAudioSink * asink, gpointer data, guint length)
+           dwCurrentPlayCursor - dsoundsink->current_circular_offset;
+ 
+     if (length >= dwFreeBufferSize) {
+-      sleepTime =
+-          ((length -
+-              dwFreeBufferSize) * 1000) / (dsoundsink->bytes_per_sample *
+-          GST_AUDIO_BASE_SINK (asink)->ringbuffer->spec.info.rate);
+-      if (sleepTime > 0) {
+-        GST_DEBUG_OBJECT (dsoundsink,
+-            "gst_directsound_sink_write: length:%i, FreeBufSiz: %ld, sleepTime: %ld, bps: %i, rate: %i",
+-            length, dwFreeBufferSize, sleepTime, dsoundsink->bytes_per_sample,
+-            GST_AUDIO_BASE_SINK (asink)->ringbuffer->spec.info.rate);
+-        Sleep (sleepTime);
+-      }
++      Sleep (100);
+       hRes = IDirectSoundBuffer_GetCurrentPosition (dsoundsink->pDSBSecondary,
+           &dwCurrentPlayCursor, NULL);
+ 
+-- 
+2.10.2
+


### PR DESCRIPTION
See https://bugzilla.gnome.org/show_bug.cgi?id=773681

The added patch reverts the git commit introducing this bug.