### PR TITLE
ImageMagick: Update to 7.0.3.5

### DIFF
--- a/mingw-w64-imagemagick/001-7.0.1.3-relocate.patch
+++ b/mingw-w64-imagemagick/001-7.0.1.3-relocate.patch
@@ -16,17 +16,17 @@ diff -Naur ImageMagick-7.0.1-3-orig/config/ImageMagick.rc ImageMagick-6.8.9-8/co
 -THRESHOLDS.XML  IMAGEMAGICK DISCARDABLE "..\\bin\\thresholds.xml"
 -TYPE.XML       IMAGEMAGICK DISCARDABLE "..\\bin\\type.xml"
 -TYPE-GHOSTSCRIPT.XML  IMAGEMAGICK DISCARDABLE "..\\bin\\type-ghostscript.xml"
-+CODER.XML      IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\coder.xml"
-+COLORS.XML     IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\colors.xml"
-+CONFIGURE.XML     IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\configure.xml"
-+DELEGATES.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\delegates.xml"
-+ENGLISH.XML    IMAGEMAGICK DISCARDABLE "..\\share\\ImageMagick-6\\english.xml"
-+LOCALE.XML     IMAGEMAGICK DISCARDABLE "..\\share\\ImageMagick-6\\locale.xml"
-+LOG.XML        IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\log.xml"
-+MAGIC.XML      IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\magic.xml"
-+THRESHOLDS.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\thresholds.xml"
-+TYPE.XML       IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\type.xml"
-+TYPE-GHOSTSCRIPT.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-6\\type-ghostscript.xml"
++CODER.XML      IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\coder.xml"
++COLORS.XML     IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\colors.xml"
++CONFIGURE.XML     IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\configure.xml"
++DELEGATES.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\delegates.xml"
++ENGLISH.XML    IMAGEMAGICK DISCARDABLE "..\\share\\ImageMagick-7\\english.xml"
++LOCALE.XML     IMAGEMAGICK DISCARDABLE "..\\share\\ImageMagick-7\\locale.xml"
++LOG.XML        IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\log.xml"
++MAGIC.XML      IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\magic.xml"
++THRESHOLDS.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\thresholds.xml"
++TYPE.XML       IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\type.xml"
++TYPE-GHOSTSCRIPT.XML  IMAGEMAGICK DISCARDABLE "..\\etc\\ImageMagick-7\\type-ghostscript.xml"
  
  
  /////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@ diff -Naur ImageMagick-7.0.1-3-orig/config/ImageMagick.rc ImageMagick-6.8.9-8/co
  /////////////////////////////////////////////////////////////////////////////
  
 -IDR_MAGICKICON          ICON    DISCARDABLE     "..\\..\\images\\ImageMagick.ico"
-+IDR_MAGICKICON          ICON    DISCARDABLE     "..\\share\\doc\\ImageMagick-6\\images\\ImageMagick.ico"
++IDR_MAGICKICON          ICON    DISCARDABLE     "..\\share\\doc\\ImageMagick-7\\images\\ImageMagick.ico"
 diff -aur ImageMagick-7.0.1-3/MagickCore/configure.c.orig ImageMagick-7.0.1-3/MagickCore/configure.c
 --- ImageMagick-7.0.1-3/MagickCore/configure.c.orig	2016-05-11 15:14:58 -0400
 +++ ImageMagick-7.0.1-3/MagickCore/configure.c	2016-05-11 15:22:25 -0400
@@ -121,7 +121,7 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/module.c.orig ImageMagick-7.0.1-3/Magic
 -      if (module_path == (char *) NULL)
 -        module_path=AcquireString(MAGICKCORE_FILTER_PATH);
 +      if (module_path == (char *) NULL) {
-+        char * coderdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_CODER_PATH);
++        char * coderdir = single_path_relocation(MAGICKCORE_EXECUTABLE_PATH, MAGICKCORE_FILTER_PATH);
 +        module_path=AcquireString(coderdir);
 +      }
  #endif

--- a/mingw-w64-imagemagick/002-7.0.3.1-build-fixes.patch
+++ b/mingw-w64-imagemagick/002-7.0.3.1-build-fixes.patch
@@ -22,6 +22,15 @@ diff -aur ImageMagick-7.0.1-3/MagickCore/nt-base.h.orig ImageMagick-7.0.1-3/Magi
  #if defined(_DEBUG) && !defined(__MINGW32__) && !defined(__MINGW64__)
  #include <crtdbg.h>
  #endif
+@@ -97,7 +97,7 @@
+ #if !defined(closedir)
+ #  define closedir(directory)  NTCloseDirectory(directory)
+ #endif
+-#define MAGICKCORE_HAVE_ERF
++//#define MAGICKCORE_HAVE_ERF
+ #if defined(_VISUALC_) && (_MSC_VER < 1700)
+ #  define erf(x)  NTErf(x)
+ #endif
 diff -aur ImageMagick-7.0.1-3/MagickCore/nt-base.c.orig ImageMagick-7.0.1-3/MagickCore/nt-base.c > patch
 --- ImageMagick-7.0.1-3/MagickCore/nt-base.c.orig	2016-05-11 18:05:52 -0400
 +++ ImageMagick-7.0.1-3/MagickCore/nt-base.c	2016-05-11 18:09:20 -0400

--- a/mingw-w64-imagemagick/004-7.0.3.5-build-fixes.patch
+++ b/mingw-w64-imagemagick/004-7.0.3.5-build-fixes.patch
@@ -1,0 +1,14 @@
+diff -aur ImageMagick-7.0.1-3/MagickCore/magick-config.h.orig ImageMagick-7.0.1-3/MagickCore/magick-config.h
+--- ImageMagick-7.0.1-3/MagickCore/magick-config.h.orig	2016-10-31 01:34:24.000000000 +0100
++++ ImageMagick-7.0.1-3/MagickCore/magick-config.h	2016-11-06 21:44:26.295428100 +0100
+@@ -142,8 +142,8 @@
+ #  define MAGICKCORE_PATH_SEPARATOR		":"
+ #endif /* !DIR_SEPARATOR_CHAR */
+ 
+-# if defined(MAGICKCORE_POSIX_SUPPORT)
+- 
++# if defined(MAGICKCORE_POSIX_SUPPORT) || defined(__MINGW32__) || defined(__MINGW64__)
++
+ /* module dir */
+ #ifndef MAGICKCORE_MODULES_DIRNAME
+ # define MAGICKCORE_MODULES_DIRNAME MAGICKCORE_MODULES_BASEDIRNAME "-" MAGICKCORE_ABI_SUFFIX

--- a/mingw-w64-imagemagick/PKGBUILD
+++ b/mingw-w64-imagemagick/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=imagemagick
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.0.3.1
+pkgver=7.0.3.5
 pkgrel=1
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
@@ -48,17 +48,18 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-ghostscript: for Ghostscript support"
             #"${MINGW_PACKAGE_PREFIX}-libwebp: for WEBP support"
             )
 options=('staticlibs' 'strip' '!debug' 'libtool')
-source=(https://www.imagemagick.org/download/ImageMagick-${pkgver%.*}-${pkgver##*.}.tar.xz{,.asc}
+source=(https://www.imagemagick.org/download/ImageMagick-${pkgver%.*}-${pkgver##*.}.tar.xz
         ImageMagick-7.0.1.3-mingw.patch
         001-7.0.1.3-relocate.patch
         002-7.0.3.1-build-fixes.patch
-        003-7.0.1.8-cplusplus-fixes.patch)
-sha256sums=('9d9acda9061655569ff234bcc9a9e1d7c77c7d8b8e0035533fdb40b57846554b'
-            'SKIP'
+        003-7.0.1.8-cplusplus-fixes.patch
+        004-7.0.3.5-build-fixes.patch)
+sha256sums=('fbf920be8ac523cf459d133c5694a284916fe8289fe26400a773ee7eaa9a27fb'
             '9e945a313f5da2962978ff7026c0cf93c0365afaf14c0f0e3223ce7917d81d2c'
-            '5e75b298bbd3d5119a4391f65d4974a3f9edce51063a64ef2bd36f8cae0cdb6a'
-            '37fc26a7f72b7da89f18ab262a0043f62a01a235e2b561dead904f23cfc315bd'
-            'f628755b79753c00a22471a9562f5abcba67702f2156b38aa0e9b83d3644960a')
+            '919a1bccea333c525f24a96e3229f5a85e0261da907e6f983d05af0c5b8bdddf'
+            '77330cc7da6dffbe09be59ccec134e4ba630c9e8a90f8ad43ee606e7a0553708'
+            'f628755b79753c00a22471a9562f5abcba67702f2156b38aa0e9b83d3644960a'
+            'b3471be1bd0ad4e0756ab206be53770e540e7242ca90f33bd1692f8ab6b53dc2')
 #Lexie Parsimoniae (ImageMagick code signing key) <lexie.parsimoniae@imagemagick.org>
 validpgpkeys=('D8272EF51DA223E4D05B466989AB63D48277377A')
 
@@ -69,6 +70,7 @@ prepare() {
   patch -p1 -i ${srcdir}/001-7.0.1.3-relocate.patch
   patch -p1 -i ${srcdir}/002-7.0.3.1-build-fixes.patch
   patch -p1 -i ${srcdir}/003-7.0.1.8-cplusplus-fixes.patch
+  patch -p1 -i ${srcdir}/004-7.0.3.5-build-fixes.patch
   autoreconf -fi
 }
 


### PR DESCRIPTION
Additionally:
Fixed the issue of not finding the coder and filter modules.  Fixes: #1885 
Updated constants to Imagemagick-7
Fixed compile warnings due to redefinition of MAGICKCORE_HAVE_ERF
 