### PR TITLE
mingw-w64-sfml: updated to release version 2.4.1

### DIFF
--- a/mingw-w64-sfml/PKGBUILD
+++ b/mingw-w64-sfml/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=sfml
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.0
+pkgver=2.4.1
 pkgrel=1
 pkgdesc="A simple, fast, cross-platform, and object-oriented multimedia API (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 source=(http://www.sfml-dev.org/files/SFML-${pkgver}-sources.zip
         mingw-w64-msys2.patch)
 sha256sums=('868a1a1e43a7ee40c1a90efcbcea061b6f0a6ed129075d9a8f19c8c69e644b0f'
-            '99e614b91e2631737ff5b8c964530611c725db1964519f8d693875b0dda6dc43')
+            'f75096b2dc9cae67e10a28dbbefc9fe02e9dbe2e1ed50f2e208046bae9d3c9a4')
 noextract=(SFML-${pkgver}-sources.zip)
 
 prepare() {


### PR DESCRIPTION
Please build and distribute updated i686 and x86_64 packages.