### PR TITLE
gcc: Detect mintty or the Windows console for diagnostic colors

### DIFF
--- a/mingw-w64-gcc/0017-diagnostic-color.patch
+++ b/mingw-w64-gcc/0017-diagnostic-color.patch
@@ -1,0 +1,73 @@
+--- gcc/diagnostic-color.c	2015-01-05 13:33:28.000000000 +0100
++++ gcc/diagnostic-color.c	2016-03-05 12:57:08.156905200 +0100
+@@ -264,12 +264,61 @@
+ }
+ 
+ #if defined(_WIN32)
+-bool
+-colorize_init (diagnostic_color_rule_t)
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++#include <winternl.h>
++
++#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
++#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
++#endif
++
++static int
++w_isatty (int num)
+ {
+-  return false;
++  HANDLE fh = (HANDLE)_get_osfhandle (num);
++  if (fh == INVALID_HANDLE_VALUE)
++    return 0;
++
++  DWORD flags;
++  if (GetConsoleMode (fh, &flags))
++    /* Check if console understands terminal escape sequences.  */
++    return SetConsoleMode (fh, flags | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
++
++  HMODULE ntdll = GetModuleHandle ("ntdll.dll");
++  if (!ntdll)
++    return 0;
++
++  typedef NTSTATUS NTAPI func_NtQueryObject (HANDLE, OBJECT_INFORMATION_CLASS,
++					     PVOID, ULONG, PULONG);
++  func_NtQueryObject *fNtQueryObject =
++    (func_NtQueryObject*) GetProcAddress (ntdll, "NtQueryObject");
++  if (!fNtQueryObject)
++    return 0;
++
++  ULONG s = 0xffff * sizeof (WCHAR);
++  OBJECT_NAME_INFORMATION *oni = (OBJECT_NAME_INFORMATION*) xmalloc (s);
++  ULONG len;
++  int is_a_tty = 0;
++  /* mintty uses a named pipe like "ptyNNNN-to-master".  */
++  if (!fNtQueryObject (fh, ObjectNameInformation, oni, s, &len))
++    {
++      wchar_t namedPipe[] = L"\\Device\\NamedPipe\\";
++      size_t l1 = sizeof (namedPipe) / 2 - 1;
++      wchar_t toMaster[] = L"-to-master";
++      size_t l2 = sizeof (toMaster) / 2 - 1;
++      USHORT name_length = oni->Name.Length / 2;
++      if (name_length > l1 + l2 &&
++	  !memcmp (oni->Name.Buffer, namedPipe, l1 * 2) &&
++	  !memcmp (oni->Name.Buffer + (name_length - l2), toMaster, l2 * 2))
++	is_a_tty = 1;
++    }
++
++  free (oni);
++
++  return is_a_tty;
+ }
+-#else
++#define isatty w_isatty
++#endif
+ 
+ /* Return true if we should use color when in auto mode, false otherwise. */
+ static bool
+@@ -298,4 +347,3 @@
+       gcc_unreachable ();
+     }
+ }
+-#endif

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
 pkgver=6.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -51,6 +51,7 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}/${_realname}-${pkgve
         "0014-gcc-6-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch"
         "0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch"
         "0016-disable-weak-refs-in-libstdc++.patch"
+        "0017-diagnostic-color.patch"
         "0100-gcc-4.8-libstdc++export.patch"
         "0110-gcc-4.7-stdthreads.patch")
 sha256sums=('9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5'
@@ -70,6 +71,7 @@ sha256sums=('9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5'
             '60a58ed41389691a68ef4b7d47a0328df4d28d26e6c680a6b06b31191481ca65'
             '262c6fb0f6c9951d69e4c2dcc27949aa8f2cca8e672faf66740a7dbba4a4cd2c'
             '09f27e0dae8d962f2a46a33a9891f2d14303629bb40f91ed8c5824c90da653a9'
+            'af291b64812ed6d1d1d357c9fb5fe5a520154aa072f342a72dc9a190732952e0'
             '21191b4fd57ce5f230fcc97b4d9ae31bdc387d7c7c8e39436aa7e4268d278d3d'
             '5e0fc1437ce0b357e78d440692e3a30a7905a5f360a67928a95b14ec8d45365b')
 
@@ -94,6 +96,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0014-gcc-6-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch
   patch -p1 -i ${srcdir}/0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch
   patch -p1 -i ${srcdir}/0016-disable-weak-refs-in-libstdc++.patch
+  patch -p0 -i ${srcdir}/0017-diagnostic-color.patch
 
   #patch -p1 -i ${srcdir}/0100-gcc-4.8-libstdc++export.patch
   #patch -p1 -i ${srcdir}/0110-gcc-4.7-stdthreads.patch


### PR DESCRIPTION
Patch by Hannes Domani <ssbssa@yahoo.de>, see
https://sourceforge.net/p/msys2/mailman/message/34910994/