### PR TITLE
clang: fix 32 bit LLDB build

### DIFF
--- a/mingw-w64-clang/0502-hack-to-use-64-bit-time-for-mingw.patch
+++ b/mingw-w64-clang/0502-hack-to-use-64-bit-time-for-mingw.patch
@@ -1,0 +1,12 @@
+diff -urN lldb-3.9.0.src.orig/source/Host/windows/FileSystem.cpp lldb-3.9.0.src/source/Host/windows/FileSystem.cpp
+--- lldb-3.9.0.src.orig/source/Host/windows/FileSystem.cpp	2016-03-22 18:58:09.000000000 +0100
++++ lldb-3.9.0.src/source/Host/windows/FileSystem.cpp	2016-11-10 01:55:34.663530600 +0100
+@@ -276,7 +276,7 @@
+         return -EINVAL;
+     }
+     int stat_result;
+-#ifdef _USE_32BIT_TIME_T
++#if defined(_USE_32BIT_TIME_T) && !defined(__MINGW64_VERSION_MAJOR)
+     struct _stat32 file_stats;
+     stat_result = ::_wstat32(wpath.c_str(), &file_stats);
+ #else

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -72,6 +72,7 @@ source=(http://llvm.org/releases/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"
         "0402-fix-compilation-with-gcc.patch"
         "0501-lldb-mingw-fixes.patch"
+        "0502-hack-to-use-64-bit-time-for-mingw.patch"
         "0601-libunwind-add-support-for-mingw-w64.patch")
 # Some patch notes :)
 #0001-0099 -> llvm
@@ -124,6 +125,7 @@ sha256sums=('66c73179da42cee1386371641241f79ded250e117a79f571bbd69e56daa48948'
             'd9b46363c0db63316bdaa29580c446bfe5bc7b43eb8d00f894b72415066da53e'
             '461c75905768ce9ed14db48e6c959695f8a61c58c60486c2671b6d4d10923bad'
             '0371289d17563a2f29dd7041349e7fe24ed5f217c548c8bff93b47c5b5df2d20'
+            '4be9205a90b3ed2d23b8e84cac36697c5a85026b6ab3193061fbb0b3915d76c9'
             '0a5529a5e9871ec5252c3853f1fdda69253c1a7505837e9c45ae14bcb76a8660')
 validpgpkeys=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg, Google.
 noextract=(cfe-${pkgver}.src.tar.xz
@@ -186,6 +188,8 @@ prepare() {
 
   cd "${srcdir}/lldb-${pkgver}.src"
   patch -p1 -i "${srcdir}/0501-lldb-mingw-fixes.patch"
+  # this hack allows to build 32 bit lldb but probably breaks XP support
+  patch -p1 -i "${srcdir}/0502-hack-to-use-64-bit-time-for-mingw.patch"
 
   cd "${srcdir}/libunwind-${pkgver}.src"
   patch -p1 -i "${srcdir}/0601-libunwind-add-support-for-mingw-w64.patch"
@@ -284,7 +288,7 @@ build() {
 
 package_llvm() {
   pkgdesc="Low Level Virtual Machine (mingw-w64)"
-  #depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs") # "compiler-rt"
+  depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs") # "compiler-rt"
   #install=llvm-${CARCH}.install
 
   cd "${srcdir}"/llvm-${pkgver}.src


### PR DESCRIPTION
32-bit version fails to build