### PR TITLE
gtk3-git: chase stable, but add branch var

### DIFF
--- a/mingw-w64-gtk3-git/PKGBUILD
+++ b/mingw-w64-gtk3-git/PKGBUILD
@@ -2,13 +2,14 @@
 # Maintainer: Ray Donnelly <mingw.android@gmail.com>
 
 _realname=gtk3
+_branch=gtk-3-22
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=3.21.1.29.g71c1e86
+pkgver=3.22.3.21.gd3bdd38
 pkgrel=1
-pkgdesc="GObject-based multi-platform GUI toolkit (v3) (git) (mingw-w64)"
+pkgdesc="GObject-based multi-platform GUI toolkit (git $_branch) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
 license=("LGPL")
@@ -31,7 +32,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('!strip' 'debug')
-source=("${_realname}::git+https://git.gnome.org/browse/gtk+")
+source=("${_realname}::git+https://git.gnome.org/browse/gtk+#branch=${_branch}")
 sha256sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
Gtk 3.22.x was [split off to branch gtk-3-22 last month](https://blog.gtk.org/2016/10/11/this-week-in-gtk-19/), but more notably master is now off chasing gtk4 (and also not building on MSYS2). Until everything shakes out, make gtk3-git build the stable branch, but allow easy branch switching in case people want to try to experiment with master.