### PR TITLE
gtk3-git (@master): add missing makedepend

### DIFF
--- a/mingw-w64-gtk3-git/PKGBUILD
+++ b/mingw-w64-gtk3-git/PKGBUILD
@@ -19,7 +19,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
 # python2 is required to run gdbus-codegen
-makedepends+=("autoconf" "automake" "libtool" "gtk-doc" "git")
+makedepends+=("autoconf" "automake" "libtool" "gtk-doc" "git"
+              "autoconf-archive")
 # autotools are required because several Makefile.am are modified
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"


### PR DESCRIPTION
Git master has added some AX_* macros, meaning that autoconf-archive is now required if building that branch.

The build is still broken though. This just gets it further.

```
$ MINGW_INSTALLS=mingw64 makepkg-mingw -sf
[...]
libtool: compile:  x86_64-w64-mingw32-gcc -DHAVE_CONFIG_H -I. -I.. -DG_LOG_DOMAIN=\"Gdk\" -DG_LOG_USE_STRUCTURED=1 -DGDK_COMPILATION -I.. -I../gdk -I.. -DG_ENABLE_DEBUG -DG_ENABLE_CONSISTENCY_CHECKS -DGLIB_MIN_REQUIRED_VERSION=GLIB_VERSION_2_48 -DGLIB_MAX_ALLOWED_VERSION=GLIB_VERSION_2_50 -pthread -mms-bitfields -IC:/msys64/mingw64/include/pango-1.0 -IC:/msys64/mingw64/include/gdk-pixbuf-2.0 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/cairo -IC:/msys64/mingw64/include/pixman-1 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -I/mingw64/include -Wall -Wundef -Wnested-externs -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wuninitialized -Wmissing-include-dirs -Wshadow -Wformat=2 -Wformat-nonliteral -Wformat-security -Wimplicit-function-declaration -Werror=redundant-decls -Werror=write-strings -Werror=missing-declarations -Werror=missing-prototypes -Werror=empty-body -Werror=init-self -march=x86-64 -mtune=generic -O2 -pipe -ggdb -Og -ggdb -Og -Wall -mms-bitfields -fvisibility=hidden -MT libgdk_4_la-gdkenumtypes.lo -MD -MP -MF .deps/libgdk_4_la-gdkenumtypes.Tpo -c gdkenumtypes.c  -DDLL_EXPORT -DPIC -o .libs/libgdk_4_la-gdkenumtypes.o
mv -f .deps/libgdk_4_la-gdkwindowimpl.Tpo .deps/libgdk_4_la-gdkwindowimpl.Plo
/bin/sh ../libtool  --tag=CC   --mode=compile x86_64-w64-mingw32-gcc -DHAVE_CONFIG_H -I. -I..  -DG_LOG_DOMAIN=\"Gdk\" -DG_LOG_USE_STRUCTURED=1 -DGDK_COMPILATION -I.. -I../gdk -I.. -DG_ENABLE_DEBUG -DG_ENABLE_CONSISTENCY_CHECKS -DGLIB_MIN_REQUIRED_VERSION=GLIB_VERSION_2_48 -DGLIB_MAX_ALLOWED_VERSION=GLIB_VERSION_2_50 -pthread -mms-bitfields -IC:/msys64/mingw64/include/pango-1.0 -IC:/msys64/mingw64/include/gdk-pixbuf-2.0 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/cairo -IC:/msys64/mingw64/include/pixman-1 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include  -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -I/mingw64/include  -Wall -Wundef -Wnested-externs -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wuninitialized -Wmissing-include-dirs -Wshadow -Wformat=2 -Wformat-nonliteral -Wformat-security -Wimplicit-function-declaration -Werror=redundant-decls -Werror=write-strings -Werror=missing-declarations -Werror=missing-prototypes -Werror=empty-body -Werror=init-self   -march=x86-64 -mtune=generic -O2 -pipe -ggdb -Og -ggdb -Og -Wall -mms-bitfields -fvisibility=hidden -MT libgdk_4_la-gdkresources.lo -MD -MP -MF .deps/libgdk_4_la-gdkresources.Tpo -c -o libgdk_4_la-gdkresources.lo `test -f 'gdkresources.c' || echo './'`gdkresources.c
mv -f .deps/libgdk_4_la-gdkenumtypes.Tpo .deps/libgdk_4_la-gdkenumtypes.Plo
make[4]: *** No rule to make target 'libgdk-3.la', needed by 'GdkWin32-noinst-4.0.gir'.  Stop.
make[4]: *** Waiting for unfinished jobs....
libtool: compile:  x86_64-w64-mingw32-gcc -DHAVE_CONFIG_H -I. -I.. -DG_LOG_DOMAIN=\"Gdk\" -DG_LOG_USE_STRUCTURED=1 -DGDK_COMPILATION -I.. -I../gdk -I.. -DG_ENABLE_DEBUG -DG_ENABLE_CONSISTENCY_CHECKS -DGLIB_MIN_REQUIRED_VERSION=GLIB_VERSION_2_48 -DGLIB_MAX_ALLOWED_VERSION=GLIB_VERSION_2_50 -pthread -mms-bitfields -IC:/msys64/mingw64/include/pango-1.0 -IC:/msys64/mingw64/include/gdk-pixbuf-2.0 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/cairo -IC:/msys64/mingw64/include/pixman-1 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -I/mingw64/include -Wall -Wundef -Wnested-externs -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wuninitialized -Wmissing-include-dirs -Wshadow -Wformat=2 -Wformat-nonliteral -Wformat-security -Wimplicit-function-declaration -Werror=redundant-decls -Werror=write-strings -Werror=missing-declarations -Werror=missing-prototypes -Werror=empty-body -Werror=init-self -march=x86-64 -mtune=generic -O2 -pipe -ggdb -Og -ggdb -Og -Wall -mms-bitfields -fvisibility=hidden -MT libgdk_4_la-gdkmarshalers.lo -MD -MP -MF .deps/libgdk_4_la-gdkmarshalers.Tpo -c gdkmarshalers.c  -DDLL_EXPORT -DPIC -o .libs/libgdk_4_la-gdkmarshalers.o
mv -f .deps/libgdk_4_la-gdkmarshalers.Tpo .deps/libgdk_4_la-gdkmarshalers.Plo
libtool: compile:  x86_64-w64-mingw32-gcc -DHAVE_CONFIG_H -I. -I.. -DG_LOG_DOMAIN=\"Gdk\" -DG_LOG_USE_STRUCTURED=1 -DGDK_COMPILATION -I.. -I../gdk -I.. -DG_ENABLE_DEBUG -DG_ENABLE_CONSISTENCY_CHECKS -DGLIB_MIN_REQUIRED_VERSION=GLIB_VERSION_2_48 -DGLIB_MAX_ALLOWED_VERSION=GLIB_VERSION_2_50 -pthread -mms-bitfields -IC:/msys64/mingw64/include/pango-1.0 -IC:/msys64/mingw64/include/gdk-pixbuf-2.0 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/cairo -IC:/msys64/mingw64/include/pixman-1 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/freetype2 -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/harfbuzz -IC:/msys64/mingw64/include/glib-2.0 -IC:/msys64/mingw64/lib/glib-2.0/include -IC:/msys64/mingw64/include -IC:/msys64/mingw64/include/libpng16 -IC:/msys64/mingw64/include -D_FORTIFY_SOURCE=2 -D__USE_MINGW_ANSI_STDIO=1 -I/mingw64/include -Wall -Wundef -Wnested-externs -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wuninitialized -Wmissing-include-dirs -Wshadow -Wformat=2 -Wformat-nonliteral -Wformat-security -Wimplicit-function-declaration -Werror=redundant-decls -Werror=write-strings -Werror=missing-declarations -Werror=missing-prototypes -Werror=empty-body -Werror=init-self -march=x86-64 -mtune=generic -O2 -pipe -ggdb -Og -ggdb -Og -Wall -mms-bitfields -fvisibility=hidden -MT libgdk_4_la-gdkresources.lo -MD -MP -MF .deps/libgdk_4_la-gdkresources.Tpo -c gdkresources.c  -DDLL_EXPORT -DPIC -o .libs/libgdk_4_la-gdkresources.o
mv -f .deps/libgdk_4_la-gdkresources.Tpo .deps/libgdk_4_la-gdkresources.Plo
make[4]: Leaving directory '/usr/src/MINGW-packages/mingw-w64-gtk3-git/src/build-x86_64-w64-mingw32/gdk'
make[3]: *** [Makefile:1533: all-recursive] Error 1
make[3]: Leaving directory '/usr/src/MINGW-packages/mingw-w64-gtk3-git/src/build-x86_64-w64-mingw32/gdk'
make[2]: *** [Makefile:1063: all] Error 2
make[2]: Leaving directory '/usr/src/MINGW-packages/mingw-w64-gtk3-git/src/build-x86_64-w64-mingw32/gdk'
make[1]: *** [Makefile:717: all-recursive] Error 1
make[1]: Leaving directory '/usr/src/MINGW-packages/mingw-w64-gtk3-git/src/build-x86_64-w64-mingw32'
make: *** [Makefile:613: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
```
