### PR TITLE
opencv: add opencv_contrib

### DIFF
--- a/mingw-w64-opencv/0008-calib3d-fix-missing-cv-redirectError-symbol-error.patch
+++ b/mingw-w64-opencv/0008-calib3d-fix-missing-cv-redirectError-symbol-error.patch
@@ -1,0 +1,44 @@
+From e79f83e573ae2d5b60947d9f7964943425234b92 Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Tue, 15 Nov 2016 00:33:11 +0100
+Subject: [PATCH] calib3d: fix missing cv::redirectError symbol error
+
+happens on msys2 with gcc 6.2.0
+see also http://stackoverflow.com/questions/38552221/undefined-reference-to-cvredirecterror-while-creating-shared-build-of-opencv-3
+---
+ modules/core/src/system.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/modules/core/src/system.cpp b/modules/core/src/system.cpp
+index b2c0a3b..3c8f39d 100644
+--- a/modules/core/src/system.cpp
++++ b/modules/core/src/system.cpp
+@@ -621,7 +621,7 @@ String tempfile( const char* suffix )
+     return fname;
+ }
+ 
+-static CvErrorCallback customErrorCallback = 0;
++static ErrorCallback customErrorCallback = 0;
+ static void* customErrorCallbackData = 0;
+ static bool breakOnError = false;
+ 
+@@ -666,13 +666,13 @@ void error(int _code, const String& _err, const char* _func, const char* _file,
+     error(cv::Exception(_code, _err, _func, _file, _line));
+ }
+ 
+-CvErrorCallback
+-redirectError( CvErrorCallback errCallback, void* userdata, void** prevUserdata)
++ErrorCallback
++redirectError( ErrorCallback errCallback, void* userdata, void** prevUserdata)
+ {
+     if( prevUserdata )
+         *prevUserdata = customErrorCallbackData;
+ 
+-    CvErrorCallback prevCallback = customErrorCallback;
++    ErrorCallback prevCallback = customErrorCallback;
+ 
+     customErrorCallback     = errCallback;
+     customErrorCallbackData = userdata;
+-- 
+2.10.2
+

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -4,10 +4,11 @@ _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
+license=("BSD")
 depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base0.10"
          "${MINGW_PACKAGE_PREFIX}-intel-tbb"
          "${MINGW_PACKAGE_PREFIX}-jasper"
@@ -18,35 +19,37 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base0.10"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          #"${MINGW_PACKAGE_PREFIX}-qt5"
          #"${MINGW_PACKAGE_PREFIX}-gtkglext"
-         #"${MINGW_PACKAGE_PREFIX}-gtk2"
-        )
+         #"${MINGW_PACKAGE_PREFIX}-gtk2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              #"${MINGW_PACKAGE_PREFIX}-qt5"
              "${MINGW_PACKAGE_PREFIX}-eigen3"
              "${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-python2-numpy"
              "${MINGW_PACKAGE_PREFIX}-python3-numpy"
-             "${MINGW_PACKAGE_PREFIX}-vtk"
-            )
+             "${MINGW_PACKAGE_PREFIX}-vtk")
 optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
             "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface"
             "${MINGW_PACKAGE_PREFIX}-python3-numpy: Python 3.x interface"
             "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module")
-source=("${_realname}-${pkgver}.tar.gz"::https://github.com/Itseez/opencv/archive/${pkgver}.tar.gz
+source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
+        "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz
         '0001-mingw-w64-cmake.patch'
         '0002-solve_deg3-underflow.patch'
         '0003-issue-4107.patch'
         '0004-generate-proper-pkg-config-file.patch'
         '0005-opencv-support-python-3.5.patch'
-        '0007-vtk7-opengl2.patch')
+        '0007-vtk7-opengl2.patch'
+        '0008-calib3d-fix-missing-cv-redirectError-symbol-error.patch')
 sha256sums=('f00b3c4f42acda07d89031a2ebb5ebe390764a133502c03a511f67b78bbd4fbf'
+            'ef2084bcd4c3812eb53c21fa81477d800e8ce8075b68d9dedec90fef395156e5'
             '22c8e8892e6e1e88ad130518567b7e30fb5fabfc117ae257f055cde000ba8100'
             'fd4e095c3c879413184fc6b91a7b0a77dbb128612341a8be2c99d804a203e362'
             '52ebc8875b9ef3ea70897f34509228daeff73d0cab0aa9eb8b931be6a7d32d7f'
             '47447c78acc810cd0604b641644f1c546c29e925b7b9671a4fa18468ff3ad330'
             'e50f69c6c1fbce255b3e7ef4b489bf1a01ba28cf828a6adb80c73a7f9c08a666'
-            '49476d4b9cc0061123aae5d8d5897c21fced16f88599c435ba077ee60b9dcca8')
+            '49476d4b9cc0061123aae5d8d5897c21fced16f88599c435ba077ee60b9dcca8'
+            '91ff5441acef762229c969eedd8f2d1799c6ec67e6c5dbebcb6ffbe8cff48933')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -57,20 +60,21 @@ prepare() {
   patch -Np1 -i "${srcdir}/0004-generate-proper-pkg-config-file.patch"
   patch -Np1 -i "${srcdir}/0005-opencv-support-python-3.5.patch"
   patch -Np1 -i "${srcdir}/0007-vtk7-opengl2.patch"
+  patch -Np1 -i "${srcdir}/0008-calib3d-fix-missing-cv-redirectError-symbol-error.patch"
 }
 
 build() {
-  # SSE only available from Pentium 3 onwards (i686 is way older)
-  [[ "$CARCH" = 'i686' ]] && {
-    _cmakeopts=('-D ENABLE_SSE=OFF'
+  [[ "${CARCH}" = "i686" ]] && {
+    # SSE only available from Pentium 3 onwards (i686 is way older)
+    _cmakeopts=('-DENABLE_SSE=OFF'
       '-DENABLE_SSE2=OFF'
       '-DENABLE_SSE3=OFF')
     CXXFLAGS+=" -DEIGEN_DONT_VECTORIZE"
     _ffmpeg_plugin='opencv_ffmpeg.dll'
   }
 
-  # all x64 CPUs support SSE2 but not SSE3
   [[ "${CARCH}" = "x86_64" ]] && {
+    # all x64 CPUs support SSE2 but not SSE3
     _cmakeopts+=('-DENABLE_SSE3=OFF')
     _ffmpeg_plugin='opencv_ffmpeg_64.dll'
   }
@@ -84,7 +88,6 @@ build() {
 
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
-
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe -Wno-dev \
@@ -110,6 +113,8 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_SKIP_RPATH=ON \
     -DENABLE_PRECOMPILED_HEADERS=OFF \
+    -DOPENCV_EXTRA_MODULES_PATH=../${_realname}_contrib-${pkgver}/modules \
+    -DBUILD_opencv_bioinspired=OFF \
     ${_cmakeopts[@]} \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
Requires vtk 7.0.0-2.

Switched to the official opencv repo.

opencv_contrib is needed by gst-plugins-bad to build the opencv plugin.