### PR TITLE
gtk3: update to 3.22.3

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.22.1
+pkgver=3.22.3
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -28,11 +28,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
-source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz")
-sha256sums=('127c8c5cfc32681f9ab3cb542eb0d5c16c1c02faba68bf8fcac9a3cf278ef471')
+source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
+        gdkdisplay-win32.c-Define-_WIN32_WINNT.patch
+        gdkscreen-win32.c-Also-define-_WIN32_WINNT.patch)
+sha256sums=('e190ab1a9a893861b8e8be341aa57bce8b7146d6445ebfe5a8ab64236fe82ed3'
+            'c3aadfa67e29adea61cec87bd65229d4fb8dc25301cb448bb59f0ead63829ae2'
+            '6af598b8e9bdace52485013c7b4393903ae829a1f3f637611cedbdee506861c3')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
+
+  patch -Np1 -i "${srcdir}"/gdkdisplay-win32.c-Define-_WIN32_WINNT.patch
+  patch -Np1 -i "${srcdir}"/gdkscreen-win32.c-Also-define-_WIN32_WINNT.patch
 
   autoreconf -i
 }

--- a/mingw-w64-gtk3/gdkdisplay-win32.c-Define-_WIN32_WINNT.patch
+++ b/mingw-w64-gtk3/gdkdisplay-win32.c-Define-_WIN32_WINNT.patch
@@ -1,0 +1,33 @@
+From 27b68ff1931a2750a1a3effd6a06414142630867 Mon Sep 17 00:00:00 2001
+From: Chun-wei Fan <fanchunwei@src.gnome.org>
+Date: Fri, 11 Nov 2016 20:53:41 +0800
+Subject: gdkdisplay-win32.c: Define _WIN32_WINNT
+
+... to be for Vista (0x0600) or later.  This is so that the necessary
+items in the Windows headers be activated so that the code will build
+properly on mingw-w64, and we already require Vista or later for GTK+.
+
+Thanks Ting-Wei Lan for pointing this out.
+
+See: https://bugzilla.gnome.org/show_bug.cgi?id=768081#c62
+---
+ gdk/win32/gdkdisplay-win32.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gdk/win32/gdkdisplay-win32.c b/gdk/win32/gdkdisplay-win32.c
+index 9267640..ceec5b3 100644
+--- a/gdk/win32/gdkdisplay-win32.c
++++ b/gdk/win32/gdkdisplay-win32.c
+@@ -17,6 +17,9 @@
+  */
+ 
+ #include "config.h"
++
++#define _WIN32_WINNT 0x0600
++
+ #include "gdk.h"
+ #include "gdkprivate-win32.h"
+ #include "gdkdisplay-win32.h"
+-- 
+cgit v0.12
+

--- a/mingw-w64-gtk3/gdkscreen-win32.c-Also-define-_WIN32_WINNT.patch
+++ b/mingw-w64-gtk3/gdkscreen-win32.c-Also-define-_WIN32_WINNT.patch
@@ -1,0 +1,31 @@
+From d3bdd384a18edaf90eab0d387a08beb8e7044f62 Mon Sep 17 00:00:00 2001
+From: Chun-wei Fan <fanchunwei@src.gnome.org>
+Date: Fri, 11 Nov 2016 21:03:46 +0800
+Subject: gdkscreen-win32.c: Also define _WIN32_WINNT
+
+As in the last commit on gdkdisplay-win32.c, we need to define that to be
+0x0600 (Vista) or later so that the items needed in the Windows headers be
+activated.
+
+See: https://bugzilla.gnome.org/show_bug.cgi?id=768081#c62
+---
+ gdk/win32/gdkscreen-win32.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gdk/win32/gdkscreen-win32.c b/gdk/win32/gdkscreen-win32.c
+index 3c14227..281b680 100644
+--- a/gdk/win32/gdkscreen-win32.c
++++ b/gdk/win32/gdkscreen-win32.c
+@@ -16,6 +16,9 @@
+  */
+ 
+ #include "config.h"
++
++#define _WIN32_WINNT 0x0600
++
+ #include "gdk.h"
+ #include "gdkprivate-win32.h"
+ #include "gdkscreenprivate.h"
+-- 
+cgit v0.12
+


### PR DESCRIPTION
Includes two patch taken from master which fix the build

This release adds HiDPI support (try "GDK_SCALE=2 gtk3-demo")