### PR TITLE
Updated rust package to 1.13, rustc now compiles on i686

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.12.1
+pkgver=1.13.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -18,14 +18,15 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libffi"
              "${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3")
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
+             "${MINGW_PACKAGE_PREFIX}-llvm")
 options=('!makeflags' 'staticlibs')
 #install=rust.install
 source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
         "force-curl-rust.patch"
         "force-curl-cargo.patch"
-        "git+https://github.com/rust-lang/cargo.git#tag=0.13.0")
-sha256sums=('97913ae4cb255618aaacd1a534b11f343634b040b32656250d09d8d9ec02d3dc'
+        "git+https://github.com/rust-lang/cargo.git#tag=0.14.0")
+sha256sums=('ecb84775ca977a5efec14d0cad19621a155bfcbbf46e8050d18721bb1e3e5084'
 	    '1325ffce8d8ea2b95ed1be0911d5730e82e879ca526422a0458f5da990fb04c1'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
             'SKIP')
@@ -48,16 +49,16 @@ build() {
   
   #We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
   OSTYPE="$CARCH-pc-windows-gnu"
-  
-  #We have to get rust to build it's own version of LLVM because LLVM version 8.3 (which is what Mingw64 has) doesn't work: https://github.com/rust-lang/rust/issues/36774
+
   ../${_realname}c-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=$OSTYPE \
     --host=$OSTYPE \
     --target=$OSTYPE \
-    --release-channel=stable
+    --release-channel=stable \
+    --llvm-root=${MINGW_PREFIX}
 
-  make CFLAGS="$CFLAGS -fPIC -w"
+  make RUSTFLAGS="$RUSTFLAGS -C link-args='-lffi -lpthread'" CFLAGS="$CFLAGS -fPIC -w"
 }
 
 package() {

--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -58,7 +58,7 @@ build() {
     --release-channel=stable \
     --llvm-root=${MINGW_PREFIX}
 
-  make RUSTFLAGS="$RUSTFLAGS -C link-args='-lffi -lpthread'" CFLAGS="$CFLAGS -fPIC -w"
+  make RUSTFLAGS="$RUSTFLAGS -C link-args='-lffi -lpthread'"
 }
 
 package() {


### PR DESCRIPTION
Do not merge this yet.
I've got rust building on 64-bit and 32-bit mingw, but cargo (rust's package manager) stubbornly won't listen to any flags I give it, so it won't compile on i686.
Is it okay if we just don't include cargo with the i686 version? If yes than wait on merging this, if not just merge it, it'll be useful to some people.