### PR TITLE
docbook-xml: adding v 5.0

### DIFF
--- a/mingw-w64-docbook-xml/PKGBUILD
+++ b/mingw-w64-docbook-xml/PKGBUILD
@@ -3,15 +3,16 @@
 _realname=docbook-xml
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.5
-pkgrel=5
+pkgver=5.0
+pkgrel=1
 pkgdesc="A widely used XML scheme for writing documentation and help"
 arch=('any')
 url="http://www.oasis-open.org/docbook/"
 license=('MIT')
 depends=("${MINGW_PACKAGE_PREFIX}-libxml2")
 install=docbook-xml-${CARCH}.install
-source=('http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip'
+source=('http://docbook.org/xml/5.0/docbook-5.0.zip'
+        'http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip'
         'http://www.docbook.org/xml/4.4/docbook-xml-4.4.zip'
         'http://www.docbook.org/xml/4.3/docbook-xml-4.3.zip'
         'http://www.docbook.org/xml/4.2/docbook-xml-4.2.zip'
@@ -20,8 +21,9 @@ source=('http://www.docbook.org/xml/4.5/docbook-xml-4.5.zip'
         '4.1.2-add-catalog.all.patch'
         '4.2-Add-system.all.patch'
         '4.3-Add-system-and-htmltbl.all.patch')
-noextract=('docbook-xml-4.5.zip' 'docbook-xml-4.4.zip' 'docbook-xml-4.3.zip' 'docbook-xml-4.2.zip' 'docbkx412.zip')
-sha256sums=('4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
+noextract=('docbook-5.0.zip', 'docbook-xml-4.5.zip' 'docbook-xml-4.4.zip' 'docbook-xml-4.3.zip' 'docbook-xml-4.2.zip' 'docbkx412.zip')
+sha256sums=('3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e'
+            '4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
             '02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090'
             '23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464'
             'acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2'
@@ -34,6 +36,7 @@ sha256sums=('4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4'
 package() {
   # export MSYS2_ARG_CONV_EXCL="-//OASIS"
   for ver in 4.2 4.3 4.4 4.5; do
+    rm -rf docbook-xml-${ver} || true
     mkdir docbook-xml-${ver}
     pushd docbook-xml-${ver}
       /usr/bin/bsdtar xf "${srcdir}/docbook-xml-${ver}.zip"
@@ -49,6 +52,7 @@ package() {
       4.5)
       ;;
       esac
+      rm -rf "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}" || true
       mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}"
       cp -dRf docbook.cat *.dtd ent/ *.mod \
       "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-${ver}/"
@@ -56,6 +60,7 @@ package() {
   done
 
   #extract v4.1.2
+  rm -rf docbook-xml-4.1.2 || true
   mkdir docbook-xml-4.1.2
   pushd docbook-xml-4.1.2
     /usr/bin/bsdtar xf "${srcdir}/docbkx412.zip"
@@ -63,6 +68,22 @@ package() {
     mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-4.1.2"
     cp -dRf docbook.cat *.dtd ent/ *.mod \
     "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-4.1.2/"
+  popd
+
+  #extract v5.0
+  rm -rf docbook-xml-5.0 || true
+  mkdir docbook-xml-5.0
+  pushd docbook-xml-5.0
+    /usr/bin/bsdtar xf "${srcdir}/docbook-5.0.zip"
+    mkdir -p "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-5.0"
+    #cp -dRf docbook-5.0/catalog.xml docbook-5.0/xsd/*.xsd docbook-5.0/sch/docbook.sch docbook-5.0/dtd/docbook.dtd  \   
+    cp -dRf \
+      docbook-5.0/catalog.xml \
+      docbook-5.0/xsd/ \
+      docbook-5.0/sch/ \
+      docbook-5.0/dtd/ \
+      docbook-5.0/rng/ \
+    "${pkgdir}${MINGW_PREFIX}/share/xml/docbook/xml-dtd-5.0/"
   popd
 
   mkdir -p "${pkgdir}${MINGW_PREFIX}/etc/xml"
@@ -335,6 +356,37 @@ package() {
   ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
     "http://www.oasis-open.org/docbook/xml/4.5" \
     "../../share/xml/docbook/xml-dtd-4.5" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  # 5.0
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+    "-//OASIS//DTD DocBook XML 5.0//EN" \
+    "http://docbook.org/xml/5.0/dtd/docbook.dtd" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "public" \
+    "-//OASIS//ENTITIES DocBook XML Character Entities V4.5//EN" \
+    "../../share/xml/docbook/xml-dtd-4.5/dbcentx.mod" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+    "http://www.oasis-open.org/docbook/xml/5.0" \
+    "../../share/xml/docbook/xml-dtd-5.0" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteSystem" \
+    "http://docbook.org/xml/5.0" \
+    "../../share/xml/docbook/xml-dtd-5.0" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+    "http://www.oasis-open.org/docbook/xml/5.0" \
+    "../../share/xml/docbook/xml-dtd-5.0" \
+    "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
+
+  ${MINGW_PREFIX}/bin/xmlcatalog --noout --add "rewriteURI" \
+    "http://docbook.org/xml/5.0/" \
+    "../../share/xml/docbook/xml-dtd-5.0" \
     "${pkgdir}${MINGW_PREFIX}/etc/xml/docbook-xml"
 
   # license

--- a/mingw-w64-docbook-xml/docbook-xml-i686.install
+++ b/mingw-w64-docbook-xml/docbook-xml-i686.install
@@ -20,10 +20,18 @@ post_install() {
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
+    "http://docbook.org/" \
+    "./docbook-xml" \
+    ${MINGW_XML_CATALOG}/catalog      
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+    "http://docbook.org/" \
+    "./docbook-xml" \
+    ${MINGW_XML_CATALOG}/catalog       
 }
 
 # arg 1:  the new package version

--- a/mingw-w64-docbook-xml/docbook-xml-x86_64.install
+++ b/mingw-w64-docbook-xml/docbook-xml-x86_64.install
@@ -20,10 +20,18 @@ post_install() {
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateSystem" \
+    "http://docbook.org/" \
+    "./docbook-xml" \
+    ${MINGW_XML_CATALOG}/catalog    
   ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
     "http://www.oasis-open.org/docbook/" \
     "./docbook-xml" \
     ${MINGW_XML_CATALOG}/catalog
+  ${MINGW_INSTALL}/bin/xmlcatalog --noout --add "delegateURI" \
+    "http://docbook.org/" \
+    "./docbook-xml" \
+    ${MINGW_XML_CATALOG}/catalog    
 }
 
 # arg 1:  the new package version


### PR DESCRIPTION
I have tested 5.0 sample documents using:
`XML_CATALOG_FILES="/mingw64/etc/xml/catalog" xmllint  --noout --nonet --relaxng http://docbook.org/xml/5.0/rng/docbook.rng valid.xml`

resulted:
```
Resolve: sysID http://docbook.org/xml/5.0/rng/docbook.rng
10564 Parsing catalog C:/Dev/msys64/mingw64/etc/xml/catalog
C:/Dev/msys64/mingw64/etc/xml/catalog added to file hash
C:/Dev/msys64/mingw64/etc/xml/docbook-xml not found in file hash
10564 Parsing catalog C:/Dev/msys64/mingw64/etc/xml/docbook-xml
C:/Dev/msys64/mingw64/etc/xml/docbook-xml added to file hash
Trying system delegate C:/Dev/msys64/mingw64/etc/xml/docbook-xml
Using rewriting rule http://docbook.org/xml/5.0
valid.xml validates
```

And with an invalid file:
`XML_CATALOG_FILES="/mingw64/etc/xml/catalog" xmllint  --noout --nonet --relaxng http://docbook.org/xml/5.0/rng/docbook.rng invalid.xml`

resulted:

```
Resolve: sysID http://docbook.org/xml/5.0/rng/docbook.rng
4656 Parsing catalog C:/Dev/msys64/mingw64/etc/xml/catalog
C:/Dev/msys64/mingw64/etc/xml/catalog added to file hash
C:/Dev/msys64/mingw64/etc/xml/docbook-xml not found in file hash
4656 Parsing catalog C:/Dev/msys64/mingw64/etc/xml/docbook-xml
C:/Dev/msys64/mingw64/etc/xml/docbook-xml added to file hash
Trying system delegate C:/Dev/msys64/mingw64/etc/xml/docbook-xml
Using rewriting rule http://docbook.org/xml/5.0
Did not expect element chapterX there
Element book has extra content: chapterX
invalid.xml fails to validate
```
