### PR TITLE
rust: link to pthread and use _Unwind_Resume

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Zion Nimchuk <zionnimchuk@gmail.com>
+# Contributor: Mateusz Mikuła <mati865@gmail.com
 
 _realname=rust
 pkgbase=mingw-w64-${_realname}
@@ -25,16 +26,19 @@ options=('!makeflags' 'staticlibs')
 source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
         "force-curl-rust.patch"
         "force-curl-cargo.patch"
+        "force-pthread.patch"
         "git+https://github.com/rust-lang/cargo.git#tag=0.14.0")
 sha256sums=('ecb84775ca977a5efec14d0cad19621a155bfcbbf46e8050d18721bb1e3e5084'
-	    '1325ffce8d8ea2b95ed1be0911d5730e82e879ca526422a0458f5da990fb04c1'
+            '1325ffce8d8ea2b95ed1be0911d5730e82e879ca526422a0458f5da990fb04c1'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
+            'dd076adf4fc17fcbbae921c98cdea84485eec190a55968fc79efe226d253cb5d'
             'SKIP')
 
 prepare() {
   cd ${srcdir}/${_realname}c-${pkgver}
   patch -p1 -i "${srcdir}/force-curl-rust.patch"
-  
+  patch -p1 -i "${srcdir}/force-pthread.patch"
+
   cd ${srcdir}/cargo
   git submodule update --init --recursive
   patch -p1 -i "${srcdir}/force-curl-cargo.patch"
@@ -44,9 +48,9 @@ prepare() {
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  
+
   cd "${srcdir}/build-${MINGW_CHOST}"
-  
+
   #We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
   OSTYPE="$CARCH-pc-windows-gnu"
 
@@ -64,30 +68,30 @@ build() {
 package() {
   #install rust
   cd "${srcdir}/build-${MINGW_CHOST}"
-  
+
   make DESTDIR=${pkgdir} install
 
   cd "${pkgdir}${MINGW_PREFIX}/lib"
   rm rustlib/{components,manifest-rustc,rust-installer-version}
   ln -sf rustlib/$CARCH-pc-windows-gnu/lib/*.dll .
-  
+
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libgcc*.dll
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/libstd*.dll
-  
+
   install -Dm644 ${srcdir}/${_realname}c-${pkgver}/LICENSE-APACHE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-APACHE"
   install -Dm644 ${srcdir}/${_realname}c-${pkgver}/LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE-MIT"
-  
+
   #build cargo
   #We need to build cargo here because it requires rustc, so we need to wait until rustc is packaged.
   [[ -d "${srcdir}/build-cargo-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-cargo-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-cargo-${MINGW_CHOST}"
   cd "${srcdir}/build-cargo-${MINGW_CHOST}"
-  
+
   OSTYPE="$CARCH-pc-windows-gnu"
-  
+
   ../cargo/configure --local-rust-root=${pkgdir}${MINGW_PREFIX} --prefix=${MINGW_PREFIX} --build=$OSTYPE --host=$OSTYPE --target=$OSTYPE --enable-optimize
   make
-  
+
   #Install cargo
   cd "${srcdir}/build-cargo-${MINGW_CHOST}"
 

--- a/mingw-w64-rust/force-pthread.patch
+++ b/mingw-w64-rust/force-pthread.patch
@@ -1,0 +1,54 @@
+diff -urN rustc-1.13.0.orig/src/etc/make-win-dist.py rustc-1.13.0/src/etc/make-win-dist.py
+--- rustc-1.13.0.orig/src/etc/make-win-dist.py	2016-11-08 04:16:18.000000000 +0100
++++ rustc-1.13.0/src/etc/make-win-dist.py	2016-11-19 21:15:10.536033700 +0100
+@@ -58,6 +58,7 @@
+         rustc_dlls.append("libgcc_s_seh-1.dll")
+ 
+     target_libs = [ # MinGW libs
++                    "libffi.a",
+                     "libgcc.a",
+                     "libgcc_eh.a",
+                     "libgcc_s.a",
+@@ -67,6 +68,7 @@
+                     "libstdc++.a",
+                     "libiconv.a",
+                     "libmoldname.a",
++                    "libpthread.a",
+                     # Windows import libs
+                     "libadvapi32.a",
+                     "libbcrypt.a",
+diff -urN rustc-1.13.0.orig/src/libpanic_unwind/gcc.rs rustc-1.13.0/src/libpanic_unwind/gcc.rs
+--- rustc-1.13.0.orig/src/libpanic_unwind/gcc.rs	2016-11-08 04:16:18.000000000 +0100
++++ rustc-1.13.0/src/libpanic_unwind/gcc.rs	2016-11-20 22:57:13.126150100 +0100
+@@ -268,7 +268,7 @@
+ }
+ 
+ // See docs in the `unwind` module.
+-#[cfg(all(target_os="windows", target_arch = "x86", target_env="gnu"))]
++#[cfg(all(target_os="windows", target_env="gnu"))]
+ #[lang = "eh_unwind_resume"]
+ #[unwind]
+ unsafe extern "C" fn rust_eh_unwind_resume(panic_ctx: *mut u8) -> ! {
+diff -urN rustc-1.13.0.orig/src/libpanic_unwind/lib.rs rustc-1.13.0/src/libpanic_unwind/lib.rs
+--- rustc-1.13.0.orig/src/libpanic_unwind/lib.rs	2016-11-08 04:16:18.000000000 +0100
++++ rustc-1.13.0/src/libpanic_unwind/lib.rs	2016-11-20 22:40:49.821298800 +0100
+@@ -64,7 +64,7 @@
+ 
+ // x86_64-pc-windows-gnu
+ #[cfg(all(windows, target_arch = "x86_64", target_env = "gnu"))]
+-#[path = "seh64_gnu.rs"]
++#[path = "gcc.rs"]
+ mod imp;
+ 
+ // i686-pc-windows-gnu and all others
+diff -urN rustc-1.13.0.orig/src/librustc_back/target/windows_base.rs rustc-1.13.0/src/librustc_back/target/windows_base.rs
+--- rustc-1.13.0.orig/src/librustc_back/target/windows_base.rs	2016-11-08 04:16:18.000000000 +0100
++++ rustc-1.13.0/src/librustc_back/target/windows_base.rs	2016-11-20 21:33:03.356687200 +0100
+@@ -79,6 +79,7 @@
+             "-lmsvcrt".to_string(),
+             "-luser32".to_string(),
+             "-lkernel32".to_string(),
++            "-lpthread".to_string(),
+         ),
+         post_link_objects: vec!(
+             "rsend.o".to_string()


### PR DESCRIPTION
~~Probably `RUSTFLAGS="$RUSTFLAGS -C link-args='-lffi -lpthread'"` can be removed but I'm waiting for compilation to finish.~~ If everything goes well I'll update this PR.

CC @hcorion

EDIT: `RUSTFLAGS` must stay for now.