### PR TITLE
Add styrene-git

### DIFF
--- a/styrene-git/PKGBUILD
+++ b/styrene-git/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Andrew Chadwick <a.t.chadwick@gmail.com>
+
+_realname=styrene
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-git
+pkgbase=mingw-w64-${_realname}-git
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="Repacks MSYS2 packages into installer .exes and standalone .zips (mingw-w64)"
+url="https://github.com/achadwick/styrene"
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+makedepends=('git')
+depends=(
+    "zip"
+    "${MINGW_PACKAGE_PREFIX}-python3"
+    "${MINGW_PACKAGE_PREFIX}-gcc"
+    "${MINGW_PACKAGE_PREFIX}-binutils"
+    "${MINGW_PACKAGE_PREFIX}-nsis"
+)
+license=('GPLv3+')
+source=("${_realname}::git+https://github.com/achadwick/styrene.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}"/${_realname}
+    git describe --tags | sed 's,-\(alpha\|beta\),\1,' \
+      | sed 's,-,.,g' | sed 's,^v,,'
+}
+
+prepare() {
+    cd "${srcdir}"/${_realname}
+    git reset --hard HEAD
+    git clean -fx
+}
+
+build() {
+    cd "${srcdir}"/${_realname}
+    rm -fr build
+    python3 setup.py build
+}
+
+package() {
+    cd "${srcdir}"/${_realname}
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+        ${MINGW_PREFIX}/bin/python3 setup.py install \
+        --prefix="${MINGW_PREFIX}" --root="${pkgdir}"
+
+    # De-hardcode script paths
+    local MINGW_PREFIX_W=$(cygpath -m "${MINGW_PREFIX}")
+    sed -i -e "s,${MINGW_PREFIX_W},${MINGW_PREFIX},g" \
+        "${pkgdir}${MINGW_PREFIX}/bin/styrene"
+
+    install -Dm644 COPYING "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/COPYING
+}


### PR DESCRIPTION
Styrene is a developer tool for bundling up combinations of local native builds and binary MSYS packages into convenient app bundles shaped for regular Windows users. "All" developers need to do is maintain their normal .desktop files and write a config file for their app. The Styrene tool takes care of all the repackaging and installer-making details.

https://github.com/achadwick/styrene

Would it be OK to incorporate this relatively early draft of the tool into MINGW-packages in -git form? Stable PKGBUILD to follow when this thing is actually stable.

As discussed in Alexpux/MSYS-packages#759, the code belongs in MINGW-packages.