### PR TITLE
uchardet: Fix PKGBUILD

### DIFF
--- a/mingw-w64-uchardet/PKGBUILD
+++ b/mingw-w64-uchardet/PKGBUILD
@@ -9,10 +9,8 @@ pkgdesc="An encoding detector library ported from Mozilla (mingw-w64)"
 arch=('any')
 url='https://www.freedesktop.org/wiki/Software/uchardet/'
 license=('MPL')
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
-replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("git" "${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("https://www.freedesktop.org/software/uchardet/releases/${_realname}-${pkgver}.tar.xz")
 sha256sums=('8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61')
 


### PR DESCRIPTION
uchardet shouldn't conflict with uchardet-git since it does not exist in msys2 repos. 

I have a custom made package named uchardet-git and pacman always tries to replace it with uchardet from the repos on executing `pacman -Syyu`. For now I have to name my custom package as uchardet (without -git part) as a workaround.
This commit fixes it.

Also removed unnecessary git dependency.