### PR TITLE
mingw-w64-libarchive - 3.2.2 - Note it requires libxml-2.  Reported a…

### DIFF
--- a/mingw-w64-expat/PKGBUILD
+++ b/mingw-w64-expat/PKGBUILD
@@ -5,7 +5,7 @@ _realname=expat
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An XML parser library (mingw-w64)"
 arch=('any')
 url="http://expat.sourceforge.net"
@@ -13,14 +13,16 @@ license=(MIT)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' 'staticlibs')
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.bz2"
-        001-fix-extension.patch)
+        001-fix-extension.patch
+        expat-2.2.0-CVE-2016-0718-regression.patch)
 sha256sums=('d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff'
-            '3d97bc769ad70d81ba9c488619e71cf21f43122076857a0b7d0ed425a1cbe68e')
+            '3d97bc769ad70d81ba9c488619e71cf21f43122076857a0b7d0ed425a1cbe68e'
+            'e64ff17753e601f23a6825beeb930aef1bec17b7eec7dce4e8c465b3c0cd66ff')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/001-fix-extension.patch
-
+  patch -p2 -i ${srcdir}/expat-2.2.0-CVE-2016-0718-regression.patch
   autoreconf -fiv
 }
 

--- a/mingw-w64-expat/expat-2.2.0-CVE-2016-0718-regression.patch
+++ b/mingw-w64-expat/expat-2.2.0-CVE-2016-0718-regression.patch
@@ -1,0 +1,27 @@
+From 3e6190e433479e56f8c1e5adc1198b3c86b15577 Mon Sep 17 00:00:00 2001
+From: Sebastian Pipping <sebastian@pipping.org>
+Date: Sun, 17 Jul 2016 20:22:29 +0200
+Subject: [PATCH] Fix regression introduced by patch to CVE-2016-0718 (bug
+ #539)
+
+Tag names were cut off in some cases; reported by Andy Wang
+---
+ expat/lib/xmlparse.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/expat/lib/xmlparse.c b/expat/lib/xmlparse.c
+index 13e080d..2630310 100644
+--- a/expat/lib/xmlparse.c
++++ b/expat/lib/xmlparse.c
+@@ -2430,7 +2430,7 @@ doContent(XML_Parser parser,
+                        &fromPtr, rawNameEnd,
+                        (ICHAR **)&toPtr, (ICHAR *)tag->bufEnd - 1);
+             convLen = (int)(toPtr - (XML_Char *)tag->buf);
+-            if ((convert_res == XML_CONVERT_COMPLETED) || (convert_res == XML_CONVERT_INPUT_INCOMPLETE)) {
++            if ((fromPtr >= rawNameEnd) || (convert_res == XML_CONVERT_INPUT_INCOMPLETE)) {
+               tag->name.strLen = convLen;
+               break;
+             }
+-- 
+2.9.2
+

--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -12,11 +12,11 @@ license=("BSD")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-bzip2
+         ${MINGW_PACKAGE_PREFIX}-expat
          ${MINGW_PACKAGE_PREFIX}-libiconv
          ${MINGW_PACKAGE_PREFIX}-lz4
          ${MINGW_PACKAGE_PREFIX}-lzo2
          ${MINGW_PACKAGE_PREFIX}-libsystre
-         ${MINGW_PACKAGE_PREFIX}-libxml2
          ${MINGW_PACKAGE_PREFIX}-nettle
          ${MINGW_PACKAGE_PREFIX}-openssl
          ${MINGW_PACKAGE_PREFIX}-xz
@@ -37,7 +37,8 @@ build() {
     --build="${MINGW_CHOST}" \
     --host="${MINGW_CHOST}" \
     --target="${MINGW_CHOST}" \
-    --prefix="${MINGW_PREFIX}"
+    --prefix="${MINGW_PREFIX}" \
+    --without-xml2
   make
 }
 

--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.2
-pkgrel=3
+pkgrel=4
 pkgdesc="library that can create and read several streaming archive formats (mingw-w64)"
 arch=('any')
 url="http://www.libarchive.org"
@@ -12,11 +12,11 @@ license=("BSD")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-bzip2
-         ${MINGW_PACKAGE_PREFIX}-expat
          ${MINGW_PACKAGE_PREFIX}-libiconv
          ${MINGW_PACKAGE_PREFIX}-lz4
          ${MINGW_PACKAGE_PREFIX}-lzo2
          ${MINGW_PACKAGE_PREFIX}-libsystre
+         ${MINGW_PACKAGE_PREFIX}-libxml2
          ${MINGW_PACKAGE_PREFIX}-nettle
          ${MINGW_PACKAGE_PREFIX}-openssl
          ${MINGW_PACKAGE_PREFIX}-xz
@@ -37,8 +37,7 @@ build() {
     --build="${MINGW_CHOST}" \
     --host="${MINGW_CHOST}" \
     --target="${MINGW_CHOST}" \
-    --prefix="${MINGW_PREFIX}" \
-    --with-expat
+    --prefix="${MINGW_PREFIX}"
   make
 }
 


### PR DESCRIPTION
…s https://github.com/Alexpux/MINGW-packages/issues/1991 .