### PR TITLE
python3-cairo-git: package(): fix argument order

### DIFF
--- a/mingw-w64-python3-cairo-git/PKGBUILD
+++ b/mingw-w64-python3-cairo-git/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-python3-cairo-git"
 provides=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
-pkgver=1.10.1.36.c0fc2b9
-pkgrel=1
+pkgver=1.10.1.36.8910a35
+pkgrel=2
 pkgdesc="Python 3 bindings for the cairo graphics library (mingw-w64)"
 url="http://www.cairographics.org/pycairo"
 arch=('any')
@@ -44,5 +44,6 @@ build() {
 package() {
   cd ${_realname}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python3 setup.py --prefix=${MINGW_PREFIX} --root="${pkgdir}" install
+    ${MINGW_PREFIX}/bin/python3 setup.py install \
+    --prefix=${MINGW_PREFIX} --root="${pkgdir}"
 }


### PR DESCRIPTION
Addresses the build failures in Alexpux/MINGW-packages#195.