### PR TITLE
Fix use of "git am": reinstate sensible versioning

### DIFF
--- a/mingw-w64-python3-cairo-git/PKGBUILD
+++ b/mingw-w64-python3-cairo-git/PKGBUILD
@@ -5,8 +5,8 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-python3-cairo-git"
 provides=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
 conflicts=("${MINGW_PACKAGE_PREFIX}-python3-cairo")
-pkgver=1.10.1.36.8910a35
-pkgrel=2
+pkgver=1.10.1.37.really.34.5a45b0b
+pkgrel=1
 pkgdesc="Python 3 bindings for the cairo graphics library (mingw-w64)"
 url="http://www.cairographics.org/pycairo"
 arch=('any')
@@ -26,13 +26,21 @@ pkgver() {
   ver=$(grep "$PREFIX" setup.py | sed "s/$PREFIX//" | sed "s/'//")
   revision=$(git rev-list --count HEAD)
   hash=$(git log --pretty=format:'%h' -n 1)
-  echo ${ver}.${revision}.${hash}
+  echo ${ver}.37.really.${revision}.${hash}
+  # FIXME: Remove the ".37.really" hack when it's not needed.
+  #  We accidentally pushed a 1.10.1.36 which reflected 2 local "git am" revs
+  #  when the real upstream $revision would have been 34.
+  #  Can't use epochs to correct this mistake: the -git package has to match
+  #  pash and future non-git packages.
 }
 
 prepare() {
   cd ${_realname}
-  git am ${srcdir}/0001-msys2-port-to-subprocess.check_output.patch
-  git am ${srcdir}/0003-fix-PyVarObject_HEAD_INIT-problem.patch
+  # NOTE: avoid "git am". It will create a new pkgver() each time!
+  #  The ${hash} above should correspond to the ${revision} number on
+  #  the pycairo master.
+  git apply -v ${srcdir}/0001-msys2-port-to-subprocess.check_output.patch
+  git apply -v ${srcdir}/0003-fix-PyVarObject_HEAD_INIT-problem.patch
 }
 
 build() {


### PR DESCRIPTION
This package was using plain "git am" to apply its patches, meaning that revision counts were 2 revisions ahead of master, and that pkgver was different every time because the hash was different.

This commit adds a temporary versioning scheme fix which will allow this git package to get back on track without resorting to epochs. It can be reverted later when it is not needed.

### Addendum

We've been ahead of upstream's true revision count since the cc1e846e5a6b78a4a3afe0b5ba5fb53cefac56a5 rebuild, and my c28b47a19303214fba2eb17916929f1ef554df17 only compounded the error in #1994 by making revisions go backwards. Sorry.

I do not think we should be using "git am" to apply *any* local patches to git packages. It messes with the revision counts too much. I believe we should only be presenting upstream's hashes too, not our own local commits. Even if we apply with `git am --committer-date-is-author-date`, we will increment the revision count. If upstream has not changed, then ideally `pkgver` should not change!

If we add or remove or change a patch while upstream remains the same, we should be bumping `pkgrel` instead, and not changing `pkgver`.

```
$ vercmp 1.10.1.37.really.34.5a45b0b 1.10.1.36.8910a35
1
```

The "`.37.really`" hack is disgusting but quite readable. And Debian do it sometimes, so it must be OK :wink: