### PR TITLE
Fix mingw-w64-unbound to build correctly

### DIFF
--- a/mingw-w64-unbound/PKGBUILD
+++ b/mingw-w64-unbound/PKGBUILD
@@ -4,7 +4,7 @@ _realname=unbound
 
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.4.21
+pkgver=1.5.10
 pkgrel=1
 pkgdesc="Validating, recursive, and caching DNS resolver (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-openssl"
 options=(strip staticlibs)
 source=("https://unbound.net/downloads/${_realname}-${pkgver}.tar.gz"
     'manifest')
-sha256sums=('502f817a72721f78243923eb1d6187029639f7a8bdcc33a6ce0819bbb2a80970'
+sha256sums=('a39b8b4fcca2a2b35a2daa53fe35150cc3f09038dc9acede09c912fc248a9486'
             '838098b25a8044176b3139b4003594570c62a8d64f5470fbbd769f3bf44e0855')
 
 prepare() {
@@ -31,7 +31,7 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
   cp -f ${srcdir}/manifest anchor-update.exe.manifest
-  ../${_realname}-${pkgver}/configure \
+  libtool=${MINGW_PREFIX}/bin/libtool ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \


### PR DESCRIPTION
Hello,
I have been able to get the newest version of unbound to build correctly. The only other change I have made is to overwrite the libtool path used by the make file to point to ${MINGW_PREFIX}/bin instead of the one that comes with the unbound package as this seemed to fully resolve the issue I was seeing before.