### PR TITLE
chromaprint: update to 1.4

### DIFF
--- a/mingw-w64-chromaprint/PKGBUILD
+++ b/mingw-w64-chromaprint/PKGBUILD
@@ -3,41 +3,68 @@
 _realname=chromaprint
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.2
-pkgrel=2
+pkgver=1.4
+pkgrel=1
 pkgdesc="Library that implements a custom algorithm for extracting fingerprints from any audio source (mingw-w64)"
 arch=('any')
 url="http://acoustid.org/chromaprint/"
 license=("LGPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
-             "${MINGW_PACKAGE_PREFIX}-cmake"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc")
-depends=("${MINGW_PACKAGE_PREFIX}-fftw")
 options=('strip' 'staticlibs')
 source=("https://bitbucket.org/acoustid/${_realname}/downloads/${_realname}-${pkgver}.tar.gz")
-sha256sums=('c3af900d8e7a42afd74315b51b79ebd2e43bc66630b4ba585a54bf3160439652')
+sha256sums=('4b8ed053d99e35ca3543e41f581659307a705c677e1f7eded91f047a580cebe8')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   #patch -p1 -i ${srcdir}/001-no-undefined.patch
+  sed -i 's|PROJECT_VERSION|chromaprint_VERSION|g' \
+    "${srcdir}"/${_realname}-${pkgver}/libchromaprint.pc.cmake
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  _common_opts=(
+    -G"MSYS Makefiles"
+    -DCMAKE_BUILD_TYPE=Release \
+    -DFFT_LIB=kissfft \
+    -DAUDIO_PROCESSOR_LIB="dummy" \
+    -DBUILD_TESTS=off \
+    -DBUILD_TOOLS=off \
+  )
+
+  msg "Build static version"
+  [[ -d "${srcdir}/static-${MINGW_CHOST}" ]] && rm -r "${srcdir}/static-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/static-${MINGW_CHOST}" && cd "${srcdir}/static-${MINGW_CHOST}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
-    -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DWITH_FFTW3=ON \
+    -DBUILD_SHARED_LIBS=off \
+    "${_common_opts[@]}" \
+    ../${_realname}-${pkgver}
+
+  make
+
+  msg "Build shared version"
+  [[ -d "${srcdir}/shared-${MINGW_CHOST}" ]] && rm -r "${srcdir}/shared-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/shared-${MINGW_CHOST}" && cd "${srcdir}/shared-${MINGW_CHOST}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=on \
+    "${_common_opts[@]}" \
     ../${_realname}-${pkgver}
 
   make
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  # static
+  cd "${srcdir}/static-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+
+  # shared
+  cd "${srcdir}/shared-${MINGW_CHOST}"
   make DESTDIR=${pkgdir} install
 }


### PR DESCRIPTION
- boost is no longer needed
- KissFFT used instead of FFTW to remove another dependency (slightly slower)
- avoid potential dependency on swresample/avresample (untested)
- add static lib