### PR TITLE
gdk-pixbuf2: install script: correcting path to loaders.cache

### DIFF
--- a/mingw-w64-gdk-pixbuf2/gdk-pixbuf2-i686.install
+++ b/mingw-w64-gdk-pixbuf2/gdk-pixbuf2-i686.install
@@ -7,5 +7,5 @@ post_upgrade() {
 }
 
 pre_remove() {
-  rm -f mingw32/lib/gdk-pixbuf-2.0/2.10.0/loaders/loaders.cache
+  rm -f mingw32/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 }

--- a/mingw-w64-gdk-pixbuf2/gdk-pixbuf2-x86_64.install
+++ b/mingw-w64-gdk-pixbuf2/gdk-pixbuf2-x86_64.install
@@ -7,5 +7,5 @@ post_upgrade() {
 }
 
 pre_remove() {
-  rm -f mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders/loaders.cache
+  rm -f mingw64/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 }


### PR DESCRIPTION
Fixes #2009 