### PR TITLE
mingw-w64-ccache: updated to 3.3.3, removed all patches, and added th…

### DIFF
--- a/mingw-w64-ccache/PKGBUILD
+++ b/mingw-w64-ccache/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Mario Emmenlauer <memmenlauer@biodataanalysis.de>
 
 _realname=ccache
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.2.5
+pkgver=3.3.3
 pkgrel=1
 pkgdesc="A compiler cache (mingw-w64)"
 arch=('any')
@@ -14,22 +15,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
-source=(https://samba.org/ftp/ccache/${_realname}-${pkgver}.tar.bz2{,.asc}
-        "MinGW-add-ifdeds.patch"
-        "Revert-Handle-some-more-stale-NFS-file-handle-cases.patch")
-sha256sums=('7a553809e90faf9de3a23ee9c5b5f786cfd4836bf502744bedb824a24bee1097'
-            'SKIP'
-            '30977bff713a10de0392aeeff86f8aa09f13ccf76823edb985b028790d0da472'
-            'c21342e871c1199eb2be9c11904a034566f59dad135a73e4f60a39e925ae6d5c')
+source=(https://www.samba.org/ftp/ccache/${_realname}-${pkgver}.tar.bz2{,.asc})
+sha256sums=('2985bc5e32ebe38d2958d508eb54ddcad39eed909489c0c2988035214597ca54'
+            'SKIP')
+validpgpkeys=('5A939A71A46792CF57866A51996DDA075594ADB8') # Joel Rosdahl <joel@rosdahl.net>
 
 prepare() {
   cd ${_realname}-${pkgver}
   #./autogen.sh
-
-  #backported patch from git; fixed in unreleased 3.3
-  patch -p1 -i ${srcdir}/MinGW-add-ifdeds.patch
-  #MinGW-w64 errno.h doesn't define "ESTALE", revert upstream patch
-  patch -p1 -i ${srcdir}/Revert-Handle-some-more-stale-NFS-file-handle-cases.patch
 }
 
 build() {


### PR DESCRIPTION
…e static checksum for the public key (so makepkg does not require key import before building)