### PR TITLE
pngcrush: 1.8.8 --> 1.8.10

### DIFF
--- a/mingw-w64-pngcrush/PKGBUILD
+++ b/mingw-w64-pngcrush/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pngcrush
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8.8
+pkgver=1.8.10
 pkgrel=1
 pkgdesc="A tool for optimizing the compression of PNG files (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://downloads.sourceforge.net/pmt/${_realname}-${pkgver}-nolib.tar.gz"
         LICENSE)
-sha256sums=('1cf88f842b6748669bf0adfd0838483bc2d82f977b06e7b8a0a1dfda0d5ab33b'
+sha256sums=('4d6818929fcfa41c35c868ff422885c22e04546e621495ff121aeee2f7887fb1'
             '5628338f1b1c711b2b2e82d14124bc3001b37216a66f00b18d0b3b9c7e016720')
 
 prepare() {


### PR DESCRIPTION
Tested 32 & 64.