### PR TITLE
libmypaint*: various fixes

### DIFF
--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -8,7 +8,7 @@ conflicts=(
     "${MINGW_PACKAGE_PREFIX}-${_realname}"
     "${MINGW_PACKAGE_PREFIX}-mypaint<1.3.0alpha"
 )
-pkgver=1.3.0beta.0.3.gae76bd4
+pkgver=1.3.0
 pkgrel=1
 pkgdesc="Brush engine used by MyPaint (git) (mingw-w64)"
 arch=('any')
@@ -49,7 +49,14 @@ build() {
   cd build-${MINGW_CHOST}
 
   PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/share/pkgconfig" \
-  ./configure --prefix=${MINGW_PREFIX}
+  ./configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --enable-shared \
+    --enable-static
+
   make
 }
 

--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -19,13 +19,13 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-pkg-config"
     "${MINGW_PACKAGE_PREFIX}-json-c"
     "${MINGW_PACKAGE_PREFIX}-glib2"
+    "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
 )
 makedepends+=("autoconf" "automake" "libtool" "git")
 # autotools are required because several Makefile.am are modified
 depends=(
     "${MINGW_PACKAGE_PREFIX}-gcc-libs"
     "${MINGW_PACKAGE_PREFIX}-glib2"
-    "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
 )
 options=('!strip' 'debug')
 source=("${_realname}::git+https://github.com/mypaint/libmypaint.git")

--- a/mingw-w64-libmypaint/PKGBUILD
+++ b/mingw-w64-libmypaint/PKGBUILD
@@ -6,19 +6,19 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-mypaint<1.3.0alpha")
 pkgver=${_realver/-/}
-pkgrel=1
+pkgrel=2
 pkgdesc="Brush engine used by MyPaint (mingw-w64)"
 arch=('any')
 url="http://mypaint.org"
 license=("ISC")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-glib2"
              "git")
 # autotools are required because several Makefile.am are modified
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2"
-         "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
          "${MINGW_PACKAGE_PREFIX}-json-c")
 options=('strip' '!debug')
 source=("https://github.com/mypaint/${_realname}/releases/download/v${_realver}/${_realname}-${_realver}.tar.xz")


### PR DESCRIPTION
* `libmypaint-git` was generating the wrong DLL name (`msys-` prefix in `/mingw*/bin`)
* `libmypaint*`: were mistakenly depending on `gobject-introspection`.