### PR TITLE
gdk-pixbuf2: Make loaders cache relocatable

### DIFF
--- a/mingw-w64-gdk-pixbuf2/0001-windows-rework-loaders-cache-relocation-support.patch
+++ b/mingw-w64-gdk-pixbuf2/0001-windows-rework-loaders-cache-relocation-support.patch
@@ -1,0 +1,202 @@
+From 3d51473ebf4a2c39ef4b49775244bfea1b882a11 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <creiter@src.gnome.org>
+Date: Tue, 13 Dec 2016 20:43:10 +0100
+Subject: [PATCH] windows: rework loaders cache relocation support
+
+Relocation works by recognizing paths in the loaders cache
+which start with the built time prefix and extract the relative
+path from that.
+
+This leads to the following problem when updating the cache:
+
+In case the package is build on another machine one has to
+either match the build directory layout or adjust the
+cache by hand for the resulting cache to stay relocatable.
+
+This commonly occurs with msys2 where mostly pre-build packages
+are used which are built on another machine and the cache gets
+generated at install time. Another case is updating the cache
+in a separate deployment environment.
+
+This patch takes the package installation directory as a base
+and writes relative paths into the cache when relocation
+is enabled. When loading the cache a relative path is made
+absolute by prepending the package base again.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=776081
+---
+ gdk-pixbuf/gdk-pixbuf-io.c | 36 +++++++--------------
+ gdk-pixbuf/queryloaders.c  | 78 +++++++++++++++++++++++++++++++++++++++-------
+ 2 files changed, 78 insertions(+), 36 deletions(-)
+
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+index 3e9e8683c..015f1b703 100644
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -347,30 +347,17 @@ get_libdir (void)
+ #undef GDK_PIXBUF_LIBDIR
+ #define GDK_PIXBUF_LIBDIR get_libdir()
+ 
+-static void
+-correct_prefix (gchar **path)
++/* In case we have a relative module path in the loaders cache
++ * prepend the toplevel dir */
++static gchar *
++build_module_path (const gchar *path)
+ {
+-  if (strncmp (*path, GDK_PIXBUF_PREFIX "/", strlen (GDK_PIXBUF_PREFIX "/")) == 0 ||
+-      strncmp (*path, GDK_PIXBUF_PREFIX "\\", strlen (GDK_PIXBUF_PREFIX "\\")) == 0)
+-    {
+-          gchar *tem = NULL;
+-      if (g_str_has_suffix (*path, ".libs"))
++        if (g_path_is_absolute (path))
+         {
+-          /* We are being run from inside the build tree, and shouldn't mess about. */
+-          return;
++                return g_strdup (path);
++        } else {
++                return g_build_filename (gdk_pixbuf_get_toplevel (), path, NULL);
+         }
+-
+-      /* This is an entry put there by gdk-pixbuf-query-loaders on the
+-       * packager's system. On Windows a prebuilt gdk-pixbuf package can be
+-       * installed in a random location. The loaders.cache file
+-       * distributed in such a package contains paths from the package
+-       * builder's machine. Replace the build-time prefix with the
+-       * installation prefix on this machine.
+-       */
+-      tem = *path;
+-      *path = g_strconcat (gdk_pixbuf_get_toplevel (), tem + strlen (GDK_PIXBUF_PREFIX), NULL);
+-      g_free (tem);
+-    }
+ }
+ 
+ #endif  /* GDK_PIXBUF_RELOCATABLE */
+@@ -512,9 +499,6 @@ gdk_pixbuf_io_init (void)
+                                 /* Blank line marking the end of a module
+                                  */
+                         if (module && *p != '#') {
+-#ifdef GDK_PIXBUF_RELOCATABLE
+-                                correct_prefix (&module->module_path);
+-#endif
+                                 file_formats = g_slist_prepend (file_formats, module);
+                                 module = NULL;
+                         }
+@@ -536,7 +520,11 @@ gdk_pixbuf_io_init (void)
+                                            filename, line_buf);
+                                 have_error = TRUE;
+                         }
++#ifdef GDK_PIXBUF_RELOCATABLE
++                        module->module_path = build_module_path (tmp_buf->str);
++#else
+                         module->module_path = g_strdup (tmp_buf->str);
++#endif
+                 }
+                 else if (!module->module_name) {
+                         module->info = g_new0 (GdkPixbufFormat, 1);
+diff --git a/gdk-pixbuf/queryloaders.c b/gdk-pixbuf/queryloaders.c
+index a9ca01524..edc652fe2 100644
+--- a/gdk-pixbuf/queryloaders.c
++++ b/gdk-pixbuf/queryloaders.c
+@@ -116,14 +116,79 @@ loader_sanity_check (const char *path, GdkPixbufFormat *info, GdkPixbufModule *v
+         return 0;
+ }
+ 
++#ifdef GDK_PIXBUF_RELOCATABLE
++
++static gchar *
++get_toplevel (void)
++{
++        static gchar *toplevel = NULL;
++
++        if (toplevel == NULL) {
++#if defined (G_OS_WIN32)
++                toplevel = g_win32_get_package_installation_directory_of_module (NULL);
++#elif defined(OS_DARWIN)
++                char pathbuf[PATH_MAX + 1];
++                uint32_t  bufsize = sizeof(pathbuf);
++                gchar *bin_dir;
++
++                _NSGetExecutablePath(pathbuf, &bufsize);
++                bin_dir = g_dirname(pathbuf);
++                toplevel = g_build_path (G_DIR_SEPARATOR_S, bin_dir, "..", NULL);
++                g_free (bin_dir);
++#elif defined (OS_LINUX) || defined(__MINGW32__)
++                gchar *exe_path, *bin_dir;
++
++                exe_path = g_file_read_link ("/proc/self/exe", NULL);
++                bin_dir = g_dirname(exe_path);
++                toplevel = g_build_path (G_DIR_SEPARATOR_S, bin_dir, "..", NULL);
++                g_free (exe_path);
++                g_free (bin_dir);
++#else
++#error "Relocations not supported for this platform"
++#endif
++        }
++        return toplevel;
++}
++
++/* Returns the relative path or NULL; transfer full */
++static gchar *
++get_relative_path(const gchar *parent, const gchar *descendant)
++{
++        GFile *parent_file, *descendant_file;
++        char *relative_path;
++
++        parent_file = g_file_new_for_path (parent);
++        descendant_file = g_file_new_for_path (descendant);
++        relative_path = g_file_get_relative_path (parent_file, descendant_file);
++        g_object_unref (parent_file);
++        g_object_unref (descendant_file);
++
++        return relative_path;
++}
++
++#endif  /* GDK_PIXBUF_RELOCATABLE */
++
+ static void
+ write_loader_info (GString *contents, const char *path, GdkPixbufFormat *info)
+ {
+         const GdkPixbufModulePattern *pattern;
+         char **mime;
+         char **ext;
++        gchar *module_path = NULL, *escaped_path;
++
++#ifdef GDK_PIXBUF_RELOCATABLE
++        module_path = get_relative_path (get_toplevel (), path);
++#endif
++
++        if (module_path == NULL) {
++                module_path = g_strdup (path);
++        }
++
++        escaped_path = g_strescape (module_path, "");
++        g_string_append_printf (contents, "\"%s\"\n", escaped_path);
++        g_free (module_path);
++        g_free (escaped_path);
+ 
+-        g_string_append_printf (contents, "\"%s\"\n", path);
+         g_string_append_printf (contents, "\"%s\" %u \"%s\" \"%s\" \"%s\"\n",
+                   info->name,
+                   info->flags,
+@@ -213,17 +278,6 @@ query_module (GString *contents, const char *dir, const char *file)
+ #ifdef G_OS_WIN32
+ 
+ static char *
+-get_toplevel (void)
+-{
+-  static char *toplevel = NULL;
+-
+-  if (toplevel == NULL)
+-          toplevel = g_win32_get_package_installation_directory_of_module (NULL);
+-
+-  return toplevel;
+-}
+-
+-static char *
+ get_libdir (void)
+ {
+   static char *libdir = NULL;
+-- 
+2.11.0
+

--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.36.0
-pkgrel=4
+pkgrel=5
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -25,17 +25,21 @@ install=${_realname}-${CARCH}.install
 source=("https://download.gnome.org/sources/gdk-pixbuf/${pkgver%.*}/gdk-pixbuf-${pkgver}.tar.xz"
         0003-fix-dllmain.patch
         gdk_pixbuf_loader_get_pixbuf.patch
-        0001-windows-Remove-old-codepage-ABI-compat-code.patch)
+        0001-windows-Remove-old-codepage-ABI-compat-code.patch
+        0001-windows-rework-loaders-cache-relocation-support.patch
+        )
 sha256sums=('85ab52ce9f2c26327141b3dcf21cca3da6a3f8de84b95fa1e727d8871a23245c'
             '21bd9b2ba1447267c84f1b445cbcf50c62299254856c1c227cc7ba4babc9f27e'
             '47a4fb86cb791a7b0544484d62aa1c267745b1a61e594b08a82c12868947ae26'
-            '4bf68b740305fc8acfc2657b0c7d0eeb5de49fbede99b279842fd2b6f691a57b')
+            '4bf68b740305fc8acfc2657b0c7d0eeb5de49fbede99b279842fd2b6f691a57b'
+            '50e5e0f9d6ab91809c1c96522240b0519b70f101c98689c51d493833d3859a5d')
 
 prepare() {
   cd ${srcdir}/gdk-pixbuf-${pkgver}
   patch -p1 -i "${srcdir}"/0003-fix-dllmain.patch
   patch -p1 -i "${srcdir}"/gdk_pixbuf_loader_get_pixbuf.patch
   patch -p1 -i "${srcdir}"/0001-windows-Remove-old-codepage-ABI-compat-code.patch
+  patch -p1 -i "${srcdir}"/0001-windows-rework-loaders-cache-relocation-support.patch
   
   autoreconf -fi
 }


### PR DESCRIPTION
Changes the loaders cache format to use paths relative to the
package installation directory.

This is the last thing preventing gtk+ apps from working
if the msys2 root is renamed.

Also submitted upstream:
    https://bugzilla.gnome.org/show_bug.cgi?id=776081