### PR TITLE
Adwaita icon theme: update to 3.22.0

### DIFF
--- a/mingw-w64-adwaita-icon-theme/0001-symbolic-re-render-send-to.patch
+++ b/mingw-w64-adwaita-icon-theme/0001-symbolic-re-render-send-to.patch
@@ -1,0 +1,41 @@
+From 58cd459e1fdba84f3c7e745636188750ad6d44c8 Mon Sep 17 00:00:00 2001
+From: Iain Lane <iain@orangesquash.org.uk>
+Date: Tue, 13 Dec 2016 11:52:56 +0000
+Subject: symbolic: re-render send-to
+
+Re-render send-to to clean up merge conflict grabage.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=772031
+---
+ Adwaita/scalable/actions/send-to-symbolic.svg | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/Adwaita/scalable/actions/send-to-symbolic.svg b/Adwaita/scalable/actions/send-to-symbolic.svg
+index ac20050..0b661cb 100644
+--- a/Adwaita/scalable/actions/send-to-symbolic.svg
++++ b/Adwaita/scalable/actions/send-to-symbolic.svg
+@@ -1,7 +1,7 @@
+ <?xml version='1.0' encoding='UTF-8' standalone='no'?>
+ <!-- Created with Inkscape (http://www.inkscape.org/) -->
+ 
+-<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='send-to-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.91 r13725' width='16' xmlns='http://www.w3.org/2000/svg'>
++<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='send-to-symbolic.svg' inkscape:export-filename='/home/sam/dev/RESOURCES/gnome-icon-theme-symbolic/src/gnome-stencils.png' inkscape:export-xdpi='90' inkscape:export-ydpi='90' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:osb='http://www.openswatchbook.org/uri/2009/osb' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' version='1.1' inkscape:version='0.91 r13725' viewBox='0 0 16 16' width='16' xmlns='http://www.w3.org/2000/svg'>
+   <metadata id='metadata90'>
+     <rdf:RDF>
+       <cc:Work rdf:about=''>
+@@ -11,11 +11,7 @@
+       </cc:Work>
+     </rdf:RDF>
+   </metadata>
+-<<<<<<< HEAD
+-  <sodipodi:namedview inkscape:bbox-nodes='true' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='92.476456' inkscape:cy='581.81839' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='true' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1376' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='1'>
+-=======
+-  <sodipodi:namedview inkscape:bbox-nodes='true' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='10.488082' inkscape:cy='-1.0971361' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='true' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='true' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1376' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='0' inkscape:window-y='27' inkscape:zoom='11.313708'>
+->>>>>>> db54204... symbolic: odd recoloring issue workaround
++  <sodipodi:namedview inkscape:bbox-nodes='true' inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer12' inkscape:cx='140.31652' inkscape:cy='125.322' inkscape:document-units='px' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='true' inkscape:object-paths='false' objecttolerance='10' pagecolor='#3a3b39' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='false' showguides='true' inkscape:snap-bbox='true' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='false' inkscape:snap-grids='true' inkscape:snap-nodes='false' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1056' inkscape:window-maximized='1' inkscape:window-width='1920' inkscape:window-x='0' inkscape:window-y='24' inkscape:zoom='4'>
+     <inkscape:grid dotted='false' empspacing='2' enabled='true' id='grid4866' originx='200.0002' originy='690' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
+   </sodipodi:namedview>
+   <title id='title9167'>Gnome Symbolic Icon Theme</title>
+-- 
+cgit v0.12
+

--- a/mingw-w64-adwaita-icon-theme/PKGBUILD
+++ b/mingw-w64-adwaita-icon-theme/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=adwaita-icon-theme
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.20
+pkgver=3.22.0
 pkgrel=1
 pkgdesc="GNOME icon theme (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
 options=(!libtool strip staticlibs)
 install=theme-${CARCH}.install
 source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('7a0a887349f340dd644032f89d81264b694c4b006bd51af1c2c368d431e7ae35')
+sha256sums=('c18bf6e26087d9819a962c77288b291efab25d0419b73d909dd771716a45dcb7')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-adwaita-icon-theme/PKGBUILD
+++ b/mingw-w64-adwaita-icon-theme/PKGBUILD
@@ -14,11 +14,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-librsvg")
 options=(!libtool strip staticlibs)
 install=theme-${CARCH}.install
-source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('c18bf6e26087d9819a962c77288b291efab25d0419b73d909dd771716a45dcb7')
+source=(
+  "https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
+  "0001-symbolic-re-render-send-to.patch"
+)
+sha256sums=(
+  'c18bf6e26087d9819a962c77288b291efab25d0419b73d909dd771716a45dcb7'
+  'fec942933d7bffb028b4978c2e7cda06bb50df5b14f63fecc6aa8cb625a63094'
+)
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i "${srcdir}/0001-symbolic-re-render-send-to.patch"
 }
 
 build() {


### PR DESCRIPTION
News summary:

3.21.2
  - network-wireless-connected improvements
  - document-edit, text-editor, modem-symbolic shape improvement
  - baseline-align folders
  - reshape folders
  - add a context-menu cursor
  - improve grab and dnd-no-drop cursors

3.21.91
  - user-available-symbolic transparency fix
  - calculator app icon update
  - fixed cursors
  - folder-download-symbolic style fixes
  - vertical visual centering for go-up, go-down-symbolic icons

3.22.0
  - simplified input-tablet-symbolic
  - opacity fixes for networking-vpn-acquring
  - invisible go-down-symbolic