### PR TITLE
rename {lang}-large to {lang}

### DIFF
--- a/mingw-w64-hunspell-en/PKGBUILD
+++ b/mingw-w64-hunspell-en/PKGBUILD
@@ -4,7 +4,7 @@ _realname=hunspell-en
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2014.11.17
-pkgrel=1
+pkgrel=2
 pkgdesc="Hunspell dictionaries (mingw-w64)"
 arch=('any')
 url="http://wordlist.sourceforge.net/"
@@ -38,6 +38,11 @@ package() {
     for lang in $en_US_aliases; do
       ln -s en_US-large.aff $lang.aff
       ln -s en_US-large.dic $lang.dic
+    done
+    larges="en_CA en_GB en_US"
+    for lang in $larges; do
+      mv $lang-large.aff $lang.aff
+      mv $lang-large.dic $lang.dic
     done
   popd
 


### PR DESCRIPTION
By default hunspell needs en_US instead of en_US-large.