### PR TITLE
add ngraph-gtk package.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Hiroyuki Ito <ZXB01226@nifty.com>
+
+_realname=ngraph-gtk
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=6.07.02
+pkgrel=1
+arch=('any')
+pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
+         "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
+         "${MINGW_PACKAGE_PREFIX}-gtk3"
+         "${MINGW_PACKAGE_PREFIX}-readline"
+         "${MINGW_PACKAGE_PREFIX}-gsl"
+         "${MINGW_PACKAGE_PREFIX}-ruby")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+license=("GPL")
+url="http://htrb.github.io/ngraph-gtk/"
+source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
+sha256sums=('a24c4f7c45b0c347b881cafa0fa10f87dcd359e303bee65ecd8252ce733cda99')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  AUTOPOINT='initltoolize --automake --copy' autoreconf -if
+}
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+  MAKEFLAGS="-j1"
+
+  ../${_realname}-${pkgver}/configure \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --build=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --libexecdir=${MINGW_PREFIX}/lib
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/build-${MINGW_CHOST}/plugins/ruby/ngraph.so" "${pkgdir}${MINGW_PREFIX}/lib/${_realname}/ruby/ngraph.so"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/plugins/ruby/lib/ngraph.rb.win" "${pkgdir}${MINGW_PREFIX}/lib/${_realname}/ruby/ngraph.rb"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/plugins/ruby/lib/ngraph/ngp2.rb" "${pkgdir}${MINGW_PREFIX}/lib/${_realname}/ruby/ngraph/ngp2.rb"
+}


### PR DESCRIPTION
I want to add ngraph-gtk package to MINGW-package.
Ngraph is the program to create scientific 2-dimensional graphs for researchers and engineers.
Graphs can be exported to PostScript, SVG, PNG or PDF format.
https://github.com/htrb/ngraph-gtk/