### PR TITLE
Fix Lua license install path

### DIFF
--- a/mingw-w64-lua/PKGBUILD
+++ b/mingw-w64-lua/PKGBUILD
@@ -80,5 +80,5 @@ package() {
   # Install the documentation
   install -d "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
   install -m644 doc/*.{gif,png,css,html} "${pkgdir}${MINGW_PREFIX}"/share/doc/lua
-  install -Dm644 ../LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+  install -Dm644 ../LICENSE "$pkgdir"/${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
As per title. The install path for Lua's license was incorrect.