### PR TITLE
Updated rust to 1.14.0

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.13.0
+pkgver=1.14.0
 pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
@@ -27,11 +27,11 @@ source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
         "force-curl-rust.patch"
         "force-curl-cargo.patch"
         "force-pthread.patch"
-        "git+https://github.com/rust-lang/cargo.git#tag=0.14.0")
-sha256sums=('ecb84775ca977a5efec14d0cad19621a155bfcbbf46e8050d18721bb1e3e5084'
+        "git+https://github.com/rust-lang/cargo.git#tag=0.15.0")
+sha256sums=('c790edd2e915bd01bea46122af2942108479a2fda9a6f76d1094add520ac3b6b'
             '1325ffce8d8ea2b95ed1be0911d5730e82e879ca526422a0458f5da990fb04c1'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
-            'dd076adf4fc17fcbbae921c98cdea84485eec190a55968fc79efe226d253cb5d'
+            '7f32bd7c43f13a61b2e4f66c40be47fc5fd025b2aad3fa6507d20316b02e3c17'
             'SKIP')
 
 prepare() {

--- a/mingw-w64-rust/force-pthread.patch
+++ b/mingw-w64-rust/force-pthread.patch
@@ -49,6 +49,6 @@ diff -urN rustc-1.13.0.orig/src/librustc_back/target/windows_base.rs rustc-1.13.
              "-luser32".to_string(),
              "-lkernel32".to_string(),
 +            "-lpthread".to_string(),
-         ),
-         post_link_objects: vec!(
+         ],
+         post_link_objects: vec![
              "rsend.o".to_string()


### PR DESCRIPTION
Tested and builds both 64-bit and 32-bit.