### PR TITLE
RFC: libusb: bump version to 1.0.21 and build a UsbDk variant

### DIFF
--- a/mingw-w64-libusb/PKGBUILD
+++ b/mingw-w64-libusb/PKGBUILD
@@ -2,8 +2,9 @@
 
 _realname=libusb
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.20
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+	 "${MINGW_PACKAGE_PREFIX}-${_realname}-usbdk")
+pkgver=1.0.21
 pkgrel=1
 pkgdesc="Library that provides generic access to USB devices (mingw-w64)"
 arch=('any')
@@ -12,7 +13,7 @@ license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('cb057190ba0a961768224e4dc6883104c6f945b2bf2ef90d7da39e7c1834f7ff')
+sha256sums=('7dce9cce9a81194b7065ee912bcd55eeffebab694ea403ffb91b67db66b1824b')
 
 build() {
   #export lt_cv_deplibs_check_method='pass_all'
@@ -23,6 +24,7 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
+    $1 \
     --enable-static
 
   make -j1
@@ -36,4 +38,31 @@ check() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
+}
+
+package_libusb-usbdk() {
+  pkgdesc="Library that provides generic access to USB devices via UsbDk backend (mingw-w64)"
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+
+  # rebuild libusb with UsbDk support
+  build --enable-usbdk
+  check
+  package
+}
+
+package_mingw-w64-i686-libusb() {
+  package
+}
+
+package_mingw-w64-x86_64-libusb() {
+  package
+}
+
+package_mingw-w64-i686-libusb-usbdk() {
+  package_libusb-usbdk
+}
+
+package_mingw-w64-x86_64-libusb-usbdk() {
+  package_libusb-usbdk
 }


### PR DESCRIPTION
From 1.0.21 libusb provides an alteranative to the regular WinUSB
backend called UsbDk, available from https://github.com/daynix/UsbDk .

This new backend allows to dynamically take control over any USB
device without removing the vendor driver.

The resulting libusb libraries have compatible binary APIs but are
mutually exclusive.