### PR TITLE
catch: Update from 1.5.0 to 1.6.0.

### DIFF
--- a/mingw-w64-catch/PKGBUILD
+++ b/mingw-w64-catch/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=catch
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.5.0
+pkgver=1.6.0
 pkgrel=1
 pkgdesc="Multi-paradigm automated test framework for C++ and Objective-C (mingw-w64)"
 arch=('any')
@@ -12,13 +12,13 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-gcc"
               "${MINGW_PACKAGE_PREFIX}-cmake")
 license=('custom')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/philsquared/Catch/archive/v${pkgver}.tar.gz)
-sha256sums=('f694634bc56422f28d61052eedc29d43ea20e60a1726eda3ff9acc8fdfca3c08')
+sha256sums=('83532346983c43963cf89a69c1544be493e6b4cccaf20975e53f5cf2239b73a9')
 
 check() {
   rm -rf "${srcdir}/test-${MINGW_CHOST}"
   mkdir -p "${srcdir}/test-${MINGW_CHOST}"
   cd "${srcdir}/test-${MINGW_CHOST}"
-  cmake "../Catch-${pkgver}/projects/CMake" -G"MSYS Makefiles" -DCMAKE_CXX_FLAGS='--std=gnu++11'
+  cmake "../Catch-${pkgver}" -G"MSYS Makefiles" -DCMAKE_CXX_FLAGS='--std=gnu++11'
   make
   ./SelfTest.exe
 }


### PR DESCRIPTION
I briefly tested the resulting catch 1.6.0 package (64-bit version only) and it seems to work fine.