### PR TITLE
mingw-w64-bzip2 - 1.0.6 - add bzip2-1.0.6-fix-heap-use-after-free-bzi…

### DIFF
--- a/mingw-w64-bzip2/PKGBUILD
+++ b/mingw-w64-bzip2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=bzip2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.0.6
-pkgrel=5
+pkgrel=6
 pkgdesc="A high-quality data compression program (mingw-w64)"
 arch=('any')
 url="http://www.bzip.org"
@@ -19,14 +19,16 @@ source=("http://www.bzip.org/${pkgver}/bzip2-${pkgver}.tar.gz"
         "bzgrep-debian-1.0.5-6.all.patch"
         "bzip2-cygming-1.0.6.src.all.patch"
         "bzip2-buildsystem.all.patch"
-        "bzip2-1.0.6-progress.all.patch")
+        "bzip2-1.0.6-progress.all.patch"
+       "bzip2-1.0.6-fix-heap-use-after-free-bzip2recover.patch")
 sha256sums=('a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd'
             '672216b20cf29438ffe43ebf38b9a648d9a0ac6fdc6be55bb4181d57ed5462be'
             '0585fb92a4b409404147a3f940ed2ca03b3eaed1ec4fb68ae6ad74db668bea83'
             'fe9212dcd0400d34269877b8de44b18767b9570048b85ed2a8d3c04e03940e9a'
             '7e67f77172b19f3e6c1f0875b1d3e9cb79211f8e1c752794ef9afd3704f928cf'
             'e519a50a4adaf05b18650d3e9d644badc66e80ca86063681ffe9a2c2226319d0'
-            'f93e6b50082a8e880ee8436c7ec6a65a8f01e9282436af77f95bb259b1c7f7f7')
+            'f93e6b50082a8e880ee8436c7ec6a65a8f01e9282436af77f95bb259b1c7f7f7'
+            '7b96cf49248ff3eb24f9e552861b91848f45526a2ce07219bef925e663afe313')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -44,7 +46,7 @@ prepare() {
   patch -p1 -i "$srcdir/"bzip2-cygming-1.0.6.src.all.patch
   patch -p1 -i "$srcdir/"bzip2-buildsystem.all.patch
   patch -p1 -i "$srcdir/"bzip2-1.0.6-progress.all.patch
-
+  patch -p1 -i "$srcdir/bzip2-1.0.6-fix-heap-use-after-free-bzip2recover.patch"
   autoreconf -fi
 }
 

--- a/mingw-w64-bzip2/bzip2-1.0.6-fix-heap-use-after-free-bzip2recover.patch
+++ b/mingw-w64-bzip2/bzip2-1.0.6-fix-heap-use-after-free-bzip2recover.patch
@@ -1,0 +1,11 @@
+diff -up ./bzip2recover.c.old ./bzip2recover.c
+--- ./bzip2recover.c.old	2016-03-22 08:49:38.855620000 +0100
++++ ./bzip2recover.c	2016-03-30 10:22:27.341430099 +0200
+@@ -458,6 +458,7 @@ Int32 main ( Int32 argc, Char** argv )
+             bsPutUChar ( bsWr, 0x50 ); bsPutUChar ( bsWr, 0x90 );
+             bsPutUInt32 ( bsWr, blockCRC );
+             bsClose ( bsWr );
++            outFile = NULL;
+          }
+          if (wrBlock >= rbCtr) break;
+          wrBlock++;

--- a/mingw-w64-lz4/001-mingw-install-over-msys.patch
+++ b/mingw-w64-lz4/001-mingw-install-over-msys.patch
@@ -1,33 +1,32 @@
---- build-i686-w64-mingw32/Makefile.orig	2015-01-15 20:34:15.599200000 +0300
-+++ build-i686-w64-mingw32/Makefile	2015-01-15 20:34:58.733200000 +0300
-@@ -86,10 +86,6 @@
+--- lz4/Makefile.orig	2017-01-14 09:15:06.753551500 -0500
++++ lz4/Makefile	2017-01-14 09:18:13.485092800 -0500
+@@ -83,13 +83,6 @@
+ 	@$(RM) lz4$(EXT)
  	@echo Cleaning completed
  
- 
+-
 -#------------------------------------------------------------------------
--#make install is validated only for Linux, OSX, kFreeBSD and Hurd targets
--ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU))
+-#make install is validated only for Linux, OSX, kFreeBSD, Hurd and
+-#FreeBSD targets
+-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU FreeBSD))
+-HOST_OS = POSIX
 -
  install:
- 	@cd $(LZ4DIR); $(MAKE) -e install
- 	@cd $(PRGDIR); $(MAKE) -e install
-@@ -132,5 +128,3 @@
+ 	@$(MAKE) -C $(LZ4DIR) $@
+ 	@$(MAKE) -C $(PRGDIR) $@
+@@ -141,9 +134,6 @@
+ 	$(MAKE) -C $(PRGDIR) lz4
+ 	$(MAKE) -C examples test
  
- prg-travis:
- 	@cd $(PRGDIR); $(MAKE) -e test-travis
--
 -endif
---- build-i686-w64-mingw32/lib/Makefile.orig	2015-01-15 20:39:30.808200000 +0300
-+++ build-i686-w64-mingw32/lib/Makefile	2015-01-15 20:39:39.715800000 +0300
-@@ -43,6 +43,7 @@
- CFLAGS ?= -O3
- CFLAGS += -I. -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes -pedantic
- 
-+BINDIR=$(PREFIX)/bin
- LIBDIR?= $(PREFIX)/lib
- INCLUDEDIR=$(PREFIX)/include
- 
-@@ -55,11 +55,18 @@
+-
+-
+ ifneq (,$(filter MSYS%,$(shell uname)))
+ HOST_OS = MSYS
+ CMAKE_PARAMS = -G"MSYS Makefiles"
+--- lz4/lib/Makefile.orig	2017-01-14 09:19:37.846242400 -0500
++++ lz4/lib/Makefile	2017-01-14 09:31:05.500986000 -0500
+@@ -60,11 +60,18 @@
  	SHARED_EXT_VER = $(LIBVER).$(SHARED_EXT)
  	SONAME_FLAGS = -install_name $(PREFIX)/lib/liblz4.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR) -current_version $(LIBVER)
  else
@@ -44,65 +43,100 @@
  endif
 +endif
  
- default: liblz4
+ LIBLZ4 = liblz4.$(SHARED_EXT_VER)
  
-@@ -71,19 +78,11 @@
- 	@$(AR) rcs liblz4.a lz4.o lz4hc.o lz4frame.o xxhash.o
+@@ -89,15 +96,7 @@
+ 
+ $(LIBLZ4): *.c
  	@echo compiling dynamic library $(LIBVER)
- 	@$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared $^ -fPIC $(SONAME_FLAGS) -o $@.$(SHARED_EXT_VER)
+-ifneq (,$(filter Windows%,$(OS)))
+-	@$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll\$@.dll
+-	dlltool -D dll\liblz4.dll -d dll\liblz4.def -l dll\liblz4.lib
+-else
+-	@$(CC) $(FLAGS) -shared $^ -fPIC $(SONAME_FLAGS) -o $@
 -	@echo creating versioned links
--	@ln -sf $@.$(SHARED_EXT_VER) $@.$(SHARED_EXT_MAJOR)
--	@ln -sf $@.$(SHARED_EXT_VER) $@.$(SHARED_EXT)
+-	@ln -sf $@ liblz4.$(SHARED_EXT_MAJOR)
+-	@ln -sf $@ liblz4.$(SHARED_EXT)
+-endif
++	@$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared $^ -fPIC $(SONAME_FLAGS) -o $@
  
- clean:
- 	@rm -f core *.o *.a *.$(SHARED_EXT) *.$(SHARED_EXT).* liblz4.pc
+ liblz4: $(LIBLZ4)
+ 
+@@ -106,12 +105,6 @@
+ 	@$(RM) *.a *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
  	@echo Cleaning library completed
  
 -
--#------------------------------------------------------------------------
--#make install is validated only for Linux, OSX, kFreeBSD and Hurd targets
--ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU))
+-#-----------------------------------------------------------------------------
+-# make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
+-#-----------------------------------------------------------------------------
+-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS))
 -
- liblz4.pc: liblz4.pc.in Makefile
- 	@echo creating pkgconfig
- 	@sed -e 's|@PREFIX@|$(PREFIX)|' \
-@@ -88,10 +92,9 @@
-              $< >$@
+ ifneq (,$(filter $(shell uname),SunOS))
+ INSTALL ?= ginstall
+ else
+@@ -120,6 +113,7 @@
  
- install: liblz4 liblz4.pc
--	@install -d -m 755 $(DESTDIR)$(LIBDIR)/pkgconfig/ $(DESTDIR)$(INCLUDEDIR)/
--	@install -m 755 liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(LIBDIR)/liblz4.$(SHARED_EXT_VER)
--	@cp -a liblz4.$(SHARED_EXT_MAJOR) $(DESTDIR)$(LIBDIR)
--	@cp -a liblz4.$(SHARED_EXT) $(DESTDIR)$(LIBDIR)
-+	@install -d -m 755 $(DESTDIR)$(LIBDIR)/pkgconfig/ $(DESTDIR)$(INCLUDEDIR)/ $(DESTDIR)$(BINDIR)/
-+	@install -m 755 liblz4.$(SHARED_EXT) $(DESTDIR)$(BINDIR)/liblz4.$(SHARED_EXT_VER)
-+	@cp -a liblz4.$(SHARED_EXT).a $(DESTDIR)$(LIBDIR)
- 	@cp -a liblz4.pc $(DESTDIR)$(LIBDIR)/pkgconfig/
- 	@install -m 644 liblz4.a $(DESTDIR)$(LIBDIR)/liblz4.a
- 	@install -m 644 lz4.h $(DESTDIR)$(INCLUDEDIR)/lz4.h
-@@ -113,5 +108,3 @@
- 	@[ -f $(DESTDIR)$(INCLUDEDIR)/lz4.h ] && rm -f $(DESTDIR)$(INCLUDEDIR)/lz4.h
- 	@[ -f $(DESTDIR)$(INCLUDEDIR)/lz4hc.h ] && rm -f $(DESTDIR)$(INCLUDEDIR)/lz4hc.h
+ PREFIX     ?= /usr/local
+ DESTDIR    ?=
++BINDIR     ?= $(PREFIX)/bin
+ LIBDIR     ?= $(PREFIX)/lib
+ INCLUDEDIR ?= $(PREFIX)/include
+ 
+@@ -141,15 +135,16 @@
+           $< >$@
+ 
+ install: lib liblz4.pc
+-	@$(INSTALL) -d -m 755 $(DESTDIR)$(PKGCONFIGDIR)/ $(DESTDIR)$(INCLUDEDIR)/
++	@echo Installing binaries
++	@$(INSTALL) -d -m 755 $(DESTDIR)$(PKGCONFIGDIR)/ $(DESTDIR)$(INCLUDEDIR)/ $(DESTDIR)$(BINDIR)/ $(DESTDIR)$(MANDIR)/
+ 	@$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(PKGCONFIGDIR)/
+ 	@echo Installing libraries
+ ifeq ($(BUILD_STATIC),yes)
+ 	@$(INSTALL_LIB) liblz4.a $(DESTDIR)$(LIBDIR)/liblz4.a
+ endif
+-	@$(INSTALL_LIB) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(LIBDIR)
+-	@ln -sf liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(LIBDIR)/liblz4.$(SHARED_EXT_MAJOR)
+-	@ln -sf liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(LIBDIR)/liblz4.$(SHARED_EXT)
++	@$(INSTALL_LIB) liblz4.$(SHARED_EXT) $(DESTDIR)$(BINDIR)/liblz4.$(SHARED_EXT_VER)
++	@$(INSTALL_LIB) liblz4.$(SHARED_EXT).a $(DESTDIR)$(LIBDIR)
++
+ 	@echo Installing includes
+ 	@$(INSTALL_DATA) lz4.h $(DESTDIR)$(INCLUDEDIR)/lz4.h
+ 	@$(INSTALL_DATA) lz4hc.h $(DESTDIR)$(INCLUDEDIR)/lz4hc.h
+@@ -166,5 +161,3 @@
+ 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4hc.h
+ 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4frame.h
  	@echo lz4 libraries successfully uninstalled
 -
 -endif
---- build-i686-w64-mingw32/programs/Makefile.orig	2015-01-15 20:38:56.379000000 +0300
-+++ build-i686-w64-mingw32/programs/Makefile	2015-01-15 20:39:13.102200000 +0300
-@@ -105,11 +105,6 @@
-         datagen$(EXT)
- 	@echo Cleaning completed
+--- lz4/programs/Makefile.orig	2017-01-14 09:36:56.470728300 -0500
++++ lz4/programs/Makefile	2017-01-14 09:39:49.200207500 -0500
+@@ -107,12 +107,6 @@
+ preview-man: clean-man man
+ 	man ./lz4.1
  
 -
--#------------------------------------------------------------------------
--#make install is validated only for Linux, OSX, kFreeBSD and Hurd targets
--ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU))
+-#-----------------------------------------------------------------------------
+-# make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
+-#-----------------------------------------------------------------------------
+-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS))
 -
- install: lz4 lz4c
+ unlz4: lz4
+ 	ln -s lz4 unlz4
+ 
+@@ -141,7 +135,7 @@
+ INSTALL_MAN     ?= $(INSTALL) -m 644
+ 
+ 
+-install: lz4$(EXT) lz4c$(EXT)
++install: lz4 lz4c
  	@echo Installing binaries
- 	@install -d -m 755 $(DESTDIR)$(BINDIR)/ $(DESTDIR)$(MANDIR)/
-@@ -202,5 +197,3 @@
- 
- test-mem32: lz4c32 datagen
- # unfortunately, valgrind doesn't seem to work with non-native binary. If someone knows how to do a valgrind-test on a 32-bits exe with a 64-bits system...
+ 	@$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR)/ $(DESTDIR)$(MANDIR)/
+ 	@$(INSTALL_PROGRAM) lz4 $(DESTDIR)$(BINDIR)/lz4
+@@ -165,5 +159,3 @@
+ 	@$(RM) $(DESTDIR)$(MANDIR)/lz4cat.1
+ 	@$(RM) $(DESTDIR)$(MANDIR)/unlz4.1
+ 	@echo lz4 programs successfully uninstalled
 -
 -endif

--- a/mingw-w64-lz4/PKGBUILD
+++ b/mingw-w64-lz4/PKGBUILD
@@ -3,53 +3,46 @@
 _realname=lz4
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.7.1.r656
+pkgver=1.7.5
 pkgrel=1
 pkgdesc="Very fast lossless compression algorithm (mingw-w64)"
 arch=('any')
 url="http://cyan4973.github.io/lz4/"
 license=('BSD' 'GPL2')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 checkdepends=('diffutils')
 options=('staticlibs' 'strip')
-source=("${_realname}::git+https://github.com/Cyan4973/lz4.git"
-        001-mingw-install-over-msys.patch)
-sha256sums=('SKIP'
-            'c85c4e93db6634b42a2420aa1fc6908ed3152004ca37fada6223afd29e09e876')
-
-pkgver() {
-  cd ${_realname}
-  local _MAJOR=`sed -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < lib/lz4.h`
-  local _MINOR=`sed -n '/define LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < lib/lz4.h`
-  local _PATCH=`sed -n '/define LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < lib/lz4.h`
-  local _REV="$(git rev-list --count HEAD)"
-  printf "%s.%s.%s.r%s" "${_MAJOR}" "${_MINOR}" "${_PATCH}" "${_REV//[[:alpha:]]}"
-
-}
+source=("https://github.com/lz4/lz4/archive/v${pkgver}.tar.gz"
+"001-mingw-install-over-msys.patch")
+sha256sums=('0190cacd63022ccb86f44fa5041dc6c3804407ad61550ca21c382827319e7e7e'
+            'b0ab00fc803b75530f2c0df7c85d8fca5c6213ca3124e58c52de1c6480552fed')
 
 prepare() {
-  cd ${_realname}
-  patch -p1 -i ${srcdir}/001-mingw-install-over-msys.patch
+  cd ${_realname}-${pkgver}
+  patch -bp1 -i ${srcdir}/001-mingw-install-over-msys.patch
   cd -
 
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  cp -rf "${srcdir}/${_realname}" "${srcdir}/build-${MINGW_CHOST}"
+  cp -rf "${srcdir}/${_realname}-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
 }
 
 build() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make CC=${MINGW_PREFIX}/bin/gcc
+  make -C lib CC=${MINGW_PREFIX}/bin/gcc
+  make -C programs CC=${MINGW_PREFIX}/bin/gcc lz4 lz4c
 }
 
 check() {
-  build-${MINGW_CHOST}/programs/lz4 /etc/profile profile.lz4
-  build-${MINGW_CHOST}/programs/lz4 -d profile.lz4 profile
-  diff -q /etc/profile profile
-  rm profile
+  cd ${srcdir}
+  msg2 "rm -f profile.lz4"
+  rm -f profile.lz4 || true
 
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make CC=${MINGW_PREFIX}/bin/gcc test
+  ${srcdir}/build-${MINGW_CHOST}/programs/lz4 /etc/profile profile.lz4
+  ${srcdir}/build-${MINGW_CHOST}/programs/lz4 -d profile.lz4 profile
+  diff -q /etc/profile profile
+
+  rm profile
 }
 
 package() {


### PR DESCRIPTION
…p2recover.patch patch.

mingw-w64-lz4 - 1.7.5 - Update to latest release version.  Drop git dependency, rekey patch.