### PR TITLE
Add support for SjLj and SEH Exception Handling for ObjC language

### DIFF
--- a/mingw-w64-clang/0112-objc-eh-personality.patch
+++ b/mingw-w64-clang/0112-objc-eh-personality.patch
@@ -1,0 +1,54 @@
+From 3a07c87d4dc20c8d6b02a1d6cf38a5d1eb245a7f Mon Sep 17 00:00:00 2001
+From: Benjamin Kramer <benny.kra@googlemail.com>
+Date: Sun, 8 Jan 2017 22:58:07 +0000
+Subject: [PATCH] Use the correct ObjC EH personality
+
+This fixes ObjC exceptions on Win64 (which uses SEH), among others.
+
+Patch by Jonathan Schleifer!
+
+git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@291408 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ lib/CodeGen/CGCleanup.h     | 2 ++
+ lib/CodeGen/CGException.cpp | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/lib/CodeGen/CGCleanup.h b/lib/CodeGen/CGCleanup.h
+index 2166490..105c562 100644
+--- a/lib/CodeGen/CGCleanup.h
++++ b/lib/CodeGen/CGCleanup.h
+@@ -616,6 +616,8 @@ struct EHPersonality {
+   static const EHPersonality GNU_C_SJLJ;
+   static const EHPersonality GNU_C_SEH;
+   static const EHPersonality GNU_ObjC;
++  static const EHPersonality GNU_ObjC_SJLJ;
++  static const EHPersonality GNU_ObjC_SEH;
+   static const EHPersonality GNUstep_ObjC;
+   static const EHPersonality GNU_ObjCXX;
+   static const EHPersonality NeXT_ObjC;
+diff --git a/lib/CodeGen/CGException.cpp b/lib/CodeGen/CGException.cpp
+index 7b7880e..f908bf2 100644
+--- a/lib/CodeGen/CGException.cpp
++++ b/lib/CodeGen/CGException.cpp
+@@ -97,6 +97,10 @@ EHPersonality::GNU_CPlusPlus_SEH = { "__gxx_personality_seh0", nullptr };
+ const EHPersonality
+ EHPersonality::GNU_ObjC = {"__gnu_objc_personality_v0", "objc_exception_throw"};
+ const EHPersonality
++EHPersonality::GNU_ObjC_SJLJ = {"__gnu_objc_personality_sj0", "objc_exception_throw"};
++const EHPersonality
++EHPersonality::GNU_ObjC_SEH = {"__gnu_objc_personality_seh0", "objc_exception_throw"};
++const EHPersonality
+ EHPersonality::GNU_ObjCXX = { "__gnustep_objcxx_personality_v0", nullptr };
+ const EHPersonality
+ EHPersonality::GNUstep_ObjC = { "__gnustep_objc_personality_v0", nullptr };
+@@ -137,6 +141,10 @@ static const EHPersonality &getObjCPersonality(const llvm::Triple &T,
+     // fallthrough
+   case ObjCRuntime::GCC:
+   case ObjCRuntime::ObjFW:
++    if (L.SjLjExceptions)
++      return EHPersonality::GNU_ObjC_SJLJ;
++    else if (useLibGCCSEHPersonality(T))
++      return EHPersonality::GNU_ObjC_SEH;
+     return EHPersonality::GNU_ObjC;
+   }
+   llvm_unreachable("bad runtime kind");

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          )
 pkgver=3.9.1
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="http://llvm.org"
@@ -67,6 +67,7 @@ source=(http://llvm.org/releases/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0109-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
         "0110-enable-support-for-float128.patch"
         "0111-fix-clang-with-libstdc.patch"
+        "0112-objc-eh-personality.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
         "0202-mingw-fixes-for-compiler-rt.patch"
         "0301-COFF-gnu-driver-support.patch"
@@ -123,6 +124,7 @@ sha256sums=('1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee'
             '13a95a61e9c1c44c18a69947734e07515332a549446394f48b86b52511d221de'
             '7abd9894abe9d28da975fadbad27478c308ed1455a5130091ad0ffd0351bfa52'
             '72cae8e17236d6ad625641a6661ce179b8446bd5119f32a352e5b3b9c1a3f397'
+            '19d6b59c47f62abcd7fcc2f510e305a1fcdfb4e2016b71245db8e312c038e8b2'
             'fb1ef06b26e88d37d52c3e0b3b261089e92bb7c08231ec8fa234465fdbdab308'
             'c19a3e49f692eba9143bb67c39a9e6df33fa604d85b0b7834d99cdd58a28d23a'
             '852d55907b469739fca96b043e41c596824ad9d933268ce65a82100b975e91fb'
@@ -183,6 +185,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0109-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
   patch -p1 -R -i "${srcdir}/0110-enable-support-for-float128.patch"
   patch -p1 -i "${srcdir}/0111-fix-clang-with-libstdc.patch"
+  patch -p1 -i "${srcdir}/0112-objc-eh-personality.patch"
 
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   patch -p1 -i "${srcdir}/0201-mingw-w64-__udivdi3-mangle-hack.patch"


### PR DESCRIPTION
#2078 

Use the correct ObjC EH personality
This fixes ObjC exceptions on Win64 (which uses SEH), among others.

Patch by Jonathan Schleifer!

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@291408 91177308-0d34-0410-b5e6-96231b3b80d8