### PR TITLE
gtk2: Use gdkwin32keys.h patch from upstream instead of a custom fix

### DIFF
--- a/mingw-w64-gtk2/0013-fix-dead-keys-part-1.patch
+++ b/mingw-w64-gtk2/0013-fix-dead-keys-part-1.patch
@@ -38,15 +38,6 @@ diff --git a/gdk/win32/Makefile.am b/gdk/win32/Makefile.am
 index d57ad35..e3e4608 100644
 --- a/gdk/win32/Makefile.am
 +++ b/gdk/win32/Makefile.am
-@@ -2,6 +2,8 @@
- include $(top_srcdir)/Makefile.decl
- 
- libgdkincludedir = $(includedir)/gtk-2.0/gdk
-+
-+ platformincludedir = $(includedir)/gtk-2.0/gdk/win32
- 
- INCLUDES = \
- 	-DG_LOG_DOMAIN=\"Gdk\"	\
 @@ -55,6 +55,7 @@ libgdk_win32_la_SOURCES = \
  	gdktestutils-win32.c \
  	gdkvisual-win32.c \
@@ -55,25 +46,6 @@ index d57ad35..e3e4608 100644
  	gdkwin32id.c \
  	gdkwindow-win32.c \
  	gdkwindow-win32.h \
-@@ -62,6 +62,9 @@
- 
- libgdkinclude_HEADERS =		\
- 	gdkwin32.h
-+
-+platforminclude_HEADERS =		\
-+	gdkwin32keys.h
- 
- # -------- MSVC Project Items -----
- MSVCPROJS = gdk-win32
-@@ -71,7 +71,7 @@
- gdk_win32_EXCLUDES = gdkwin32dummy
- 
- gdk_win32_HEADERS_DIR = $(libgdkincludedir)
--gdk_win32_HEADERS_INST = $(libgdkinclude_HEADERS)
-+gdk_win32_HEADERS_INST = $(libgdkinclude_HEADERS) $(platforminclude_HEADERS)
- gdk_win32_HEADERS_EXCLUDES = gdkwin32dummy
- 
- include $(top_srcdir)/build/Makefile.msvcproj
 diff --git a/gdk/win32/gdkkeys-win32.c b/gdk/win32/gdkkeys-win32.c
 index b70066e..dd4cb0c 100644
 --- a/gdk/win32/gdkkeys-win32.c

--- a/mingw-w64-gtk2/0018-fix-gdkwin32keys-header.patch
+++ b/mingw-w64-gtk2/0018-fix-gdkwin32keys-header.patch
@@ -1,0 +1,64 @@
+From cc2d701289ec3fe7b0e375e89981cde333bef989 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=A0=D1=83=D1=81=D0=BB=D0=B0=D0=BD=20=D0=98=D0=B6=D0=B1?=
+ =?UTF-8?q?=D1=83=D0=BB=D0=B0=D1=82=D0=BE=D0=B2?= <lrn1986@gmail.com>
+Date: Sun, 27 Nov 2016 09:36:38 +0000
+Subject: W32: Ensure that gtkwin32keys.h is not needed by GTK+ users
+
+Throw away the gdkwin32keys.h-must-not-be-included-by-itself check,
+include gdkwin32keys.h directly instead of including gdkwin32.h,
+remove gdkwin32keys.h inclusion from gdkwin32.h
+
+https://bugzilla.gnome.org/show_bug.cgi?id=775163
+---
+ gdk/win32/gdkwin32.h     | 6 ------
+ gdk/win32/gdkwin32keys.h | 3 ---
+ gtk/gtkimcontextsimple.c | 2 +-
+ 3 files changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/gdk/win32/gdkwin32.h b/gdk/win32/gdkwin32.h
+index d7ba5a0..32777ad 100644
+--- a/gdk/win32/gdkwin32.h
++++ b/gdk/win32/gdkwin32.h
+@@ -35,12 +35,6 @@
+ #include <windows.h>
+ #include <commctrl.h>
+ 
+-#define __GDKWIN32_H_INSIDE__
+-
+-#include <gdk/win32/gdkwin32keys.h>
+-
+-#undef __GDKWIN32_H_INSIDE__
+-
+ G_BEGIN_DECLS
+ 
+ #ifdef INSIDE_GDK_WIN32
+diff --git a/gdk/win32/gdkwin32keys.h b/gdk/win32/gdkwin32keys.h
+index cbd1dfc..8c8aed1 100644
+--- a/gdk/win32/gdkwin32keys.h
++++ b/gdk/win32/gdkwin32keys.h
+@@ -18,9 +18,6 @@
+ #ifndef __GDK_WIN32_KEYS_H__
+ #define __GDK_WIN32_KEYS_H__
+ 
+-#if !defined (__GDKWIN32_H_INSIDE__) && !defined (GDK_COMPILATION)
+-#error "Only <gdk/gdkwin32.h> can be included directly."
+-#endif
+ 
+ #include <gdk/gdk.h>
+ 
+diff --git a/gtk/gtkimcontextsimple.c b/gtk/gtkimcontextsimple.c
+index 6d8b3bd..5c1fc04 100644
+--- a/gtk/gtkimcontextsimple.c
++++ b/gtk/gtkimcontextsimple.c
+@@ -32,7 +32,7 @@
+ #include "gtkalias.h"
+ 
+ #ifdef GDK_WINDOWING_WIN32
+-#include <win32/gdkwin32.h>
++#include <win32/gdkwin32keys.h>
+ #endif
+ 
+ typedef struct _GtkComposeTable GtkComposeTable;
+-- 
+cgit v0.12
+

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.31
-pkgrel=3
+pkgrel=4
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -43,7 +43,8 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0014-fix-dead-keys-part-2.patch
         0015-fix-dead-keys-part-3.patch
         0016-handle-pause-key-correctly.patch
-        0017-fix-dead-keys-part-4.patch)
+        0017-fix-dead-keys-part-4.patch
+        0018-fix-gdkwin32keys-header.patch)
 
 sha256sums=('68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658'
             'b77a427df55a14182c10ad7e683b4d662df2846fcd38df2aa8918159d6be3ae2'
@@ -55,11 +56,12 @@ sha256sums=('68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658'
             '75f3bd1098c39ccf881508f4c9d23278465bcfe15beaed4bed2af4b00efa00f3'
             '10569e2bc2afe6ab320dcb4b0e708ddd8235244ec0daff05ca518cb8463f2924'
             '4bc70de68084585dcf2b5a7e4abe32a789360fc2be97a9c94ba3b52dac89ad93'
-            '3a5459614bc5178cb02bbedb6b09b13a803f5ed5d0c9d753f7a03494e95b24b3'
+            '48d643e3ee8fa1098faa7dab82945f8d56358c164bb680df0f85656719b28dba'
             '2787b4e9431570c3c5ab88e0ea9faf38d198900e1f2a4462bd10e6b352f019aa'
             'fe24b559c08cb4b2f4ff5c8f8fe06e45dc00dc36e4de032205bf15fd18febfda'
             '85b084d0638ad47714f8d9af26d6799c4a02d84c4f52b65e49a64b6985ecbe70'
-            'ab80ac886be618cb582981b5847bf43fd47e3fdc36e55bdcdf38e928f305d2a0')
+            'ab80ac886be618cb582981b5847bf43fd47e3fdc36e55bdcdf38e928f305d2a0'
+            '3f449b452274b816d7bd2155aeaa6cb4f0f8071653b03316efc48d9a6e63ac05')
 
 prepare() {
   cd gtk+-$pkgver
@@ -79,6 +81,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0015-fix-dead-keys-part-3.patch
   patch -p1 -i ${srcdir}/0016-handle-pause-key-correctly.patch
   patch -p1 -i ${srcdir}/0017-fix-dead-keys-part-4.patch
+  patch -p1 -i ${srcdir}/0018-fix-gdkwin32keys-header.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
Adding [the official patch](https://bugzilla.gnome.org/show_bug.cgi?id=775163) that is missing from #1979. It completes the series of commits that were only partially merged there.

This pull request also rolls back custom fixes for this header issue that were introduced here afterwards.

I've tested that it works by compiling Geany successfully with this version.