### PR TITLE
pygobject: python-cairo is a build-time dep

### DIFF
--- a/mingw-w64-pygobject/PKGBUILD
+++ b/mingw-w64-pygobject/PKGBUILD
@@ -12,6 +12,8 @@ license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             "${MINGW_PACKAGE_PREFIX}-python3-cairo"
+             "${MINGW_PACKAGE_PREFIX}-python2-cairo"
              "${MINGW_PACKAGE_PREFIX}-gnome-common")
 options=('staticlibs' 'strip')
 source=(https://download.gnome.org/sources/pygobject/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)


### PR DESCRIPTION
If it's omitted, build failures like the following happen:

```
checking for python module _thread... yes
checking whether to enable threading in pygobject... yes
../pygobject-3.22.0/configure: line 13778: ./libtool: No such file or directory
checking for x86_64-w64-mingw32-pkg-config... /mingw64/bin/x86_64-w64-mingw32-pkg-config
checking pkg-config is at least version 0.16... yes
checking for GLIB - version >= 2.38.0... yes (version 2.50.2)
checking for FFI... yes
checking for GIO... yes
checking for GI... yes
checking for CAIRO... yes
checking for PYCAIRO... no
configure: error: Package requirements (py3cairo >= 1.10.0
        ) were not met:

No package 'py3cairo' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables PYCAIRO_CFLAGS
and PYCAIRO_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
==> ERROR: A failure occurred in build().
    Aborting...
```