### PR TITLE
diffutils: gettext is a runtime dependency

### DIFF
--- a/mingw-w64-diffutils/PKGBUILD
+++ b/mingw-w64-diffutils/PKGBUILD
@@ -5,12 +5,13 @@ _realname=diffutils
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=3.3
-pkgrel=2
+pkgrel=3
 pkgdesc="GNU Diffutils is a package of several programs related to finding differences between files (mingw-w64)"
 arch=('any')
 url='https://www.gnu.org/software/diffutils/'
 license=('GPL3')
-depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
+         "${MINGW_PACKAGE_PREFIX}-gettext")
 options=('strip' '!libtool' 'staticlibs')
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.xz"
         "win_use_raise_rather_than_kill.patch"


### PR DESCRIPTION
Closes Alexpux/MINGW-packages#2048.