### PR TITLE
opencl-headers: add d3d and dx9 headers

### DIFF
--- a/mingw-w64-opencl-headers/PKGBUILD
+++ b/mingw-w64-opencl-headers/PKGBUILD
@@ -3,7 +3,7 @@ _realname=opencl-headers
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgver=2.1.20161129 # date of the commit, branch 2.1
-pkgrel=2
+pkgrel=3
 epoch=2
 pkgdesc='OpenCL (Open Computing Language) header files'
 arch=('any')
@@ -32,9 +32,6 @@ package() {
   for h in *.h; do
     install -m 644 ${h} "${pkgdir}${MINGW_PREFIX}/include/CL/"
   done
-
-  # remove useless headers
-  rm "${pkgdir}${MINGW_PREFIX}"/include/CL/{cl_d3d,cl_dx9}*.h
 
   cd "${srcdir}"/OpenCL-CLHPP
 


### PR DESCRIPTION
See issue #2116 (mingw-w64-opencl-headers: missing cl_d3d10.h and cl_d3d11.h).