### PR TITLE
mingw-w64-libgd - 2.2,4 - Update to latest version and enable libimag…

### DIFF
--- a/mingw-w64-libgd/PKGBUILD
+++ b/mingw-w64-libgd/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.3
+pkgver=2.2.4
 pkgrel=1
 pkgdesc="GD is an open source code library for the dynamic creation of images by programmers. (mingw-w64)"
 arch=('any')
@@ -16,17 +16,15 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-libjpeg"
     "${MINGW_PACKAGE_PREFIX}-libtiff"
     "${MINGW_PACKAGE_PREFIX}-freetype"
-    "${MINGW_PACKAGE_PREFIX}-libwebp"
-)
+    "${MINGW_PACKAGE_PREFIX}-libwebp")
+replaces=("${MINGW_PACKAGE_PREFIX}-gd")
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-gcc"
-  "${MINGW_PACKAGE_PREFIX}-cmake"
-)
-
-source=(https://github.com/libgd/libgd/releases/download/gd-${pkgver}/${_realname}-${pkgver}.tar.gz
-        libgd-export-pkg-config-build-in-subdirs.patch)
-sha256sums=('458F80FFCAC0DDFBA7D3FB2986B6EC271123D4193478A4E807764134E5A6261D'
-            'CC94958C583FF5A7EE53444AD92AB27F5719C2C1ECA6549F3370922E03C6B95A')
+  "${MINGW_PACKAGE_PREFIX}-cmake")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libgd/libgd/releases/download/gd-${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "libgd-export-pkg-config-build-in-subdirs.patch")
+sha256sums=('487a650aa614217ed08ab1bd1aa5d282f9d379cfd95c756aed0b43406381be65'
+            'cc94958c583ff5a7ee53444ad92ab27f5719c2c1eca6549f3370922e03c6b95a')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"
@@ -41,6 +39,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe             \
     -G"MSYS Makefiles"                      \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX}  \
+    -DBUILD_{SHARED,STATIC}_LIBS=ON \
     -DENABLE_PNG=ON                         \
     -DENABLE_JPEG=ON                        \
     -DENABLE_TIFF=ON                        \
@@ -48,6 +47,8 @@ build() {
     -DENABLE_XPM=ON                         \
     -DENABLE_FREETYPE=ON                    \
     -DENABLE_WEBP=ON                        \
+    -DENABLE_LIQ=ON                         \
+    -DFREETYPE_INCLUDE_DIRS="${MINGW_PREFIX}/include/freetype2" \
     ../${_realname}-${pkgver}
 
   make


### PR DESCRIPTION
…equant 2.0 support - automatically downloaded