### PR TITLE
snappy: update to 1.1.4

### DIFF
--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=snappy
 pkgbase=mingw-w64-${_realname}
 pkgname="$MINGW_PACKAGE_PREFIX-${_realname}"
-pkgver=1.1.3
+pkgver=1.1.4
 pkgrel=1
 pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ checkdepends=("$MINGW_PACKAGE_PREFIX-lzo2"
 source=(https://github.com/google/snappy/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
         001-no-undefined.patch
         002-am_prog-ar.patch)
-sha256sums=('2f1e82adf0868c9e26a5a7a3115111b6da7e432ddbac268a7ca2fae2a247eef3'
+sha256sums=('134bfe122fd25599bb807bb8130e7ba6d9bdb851e0b16efcb83ac4f5d0b70057'
             '3163a8cde8a0aef67498bb70975ff8f2f9b3dd075060c13472ef9b818e771faa'
             '88144991583e9b6cca6f00cfc4926305491601496a952e99e788898553debcc5')
 
@@ -43,8 +43,8 @@ build() {
 }
 
 check() {
-  cd "build-${MINGW_CHOST}"
-  ./snappy_unittest.exe
+  cd "${srcdir}/${_realname}-${pkgver}"
+  "../build-${MINGW_CHOST}/snappy_unittest.exe"
 }
 
 package() {


### PR DESCRIPTION
the tests were never copied to the build directory
so i’m not sure how check() ever worked the way it was before