### PR TITLE
mingw-w64-qt5/PKGBUILD: fixed the sql build options for qt 5.8.0

### DIFF
--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -490,10 +490,12 @@ build() {
   local -a _sql_config
   if [ "${_variant}" = "-static" ]; then
     _sql_config+=("-no-sql-ibase")
-    _sql_config+=("-no-sql-psql")
     _sql_config+=("-no-sql-mysql")
     _sql_config+=("-no-sql-odbc")
-    _sql_config+=("-qt-sql-sqlite")
+    _sql_config+=("-no-sql-psql")
+    _sql_config+=("-no-sql-sqlite2")
+    _sql_config+=("-sql-sqlite")
+    _sql_config+=("-qt-sqlite")
   else
     _sql_config+=("-plugin-sql-ibase")
     _sql_config+=("-plugin-sql-psql")


### PR DESCRIPTION
Fix for the static compile, so currently unused for most people