### PR TITLE
osslsigncode: add libgsf as a dependency

### DIFF
--- a/mingw-w64-osslsigncode/PKGBUILD
+++ b/mingw-w64-osslsigncode/PKGBUILD
@@ -4,12 +4,13 @@ _realname=osslsigncode
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.7.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Tool for Authenticode signing of PE, CAB and MSI files (mingw-w64)"
 arch=('any')
 url="https://sourceforge.net/projects/osslsigncode/"
 license=("GPL3")
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-libgsf"
          "${MINGW_PACKAGE_PREFIX}-openssl")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")


### PR DESCRIPTION
Turns out this was the full error:
```
$ osslsigncode
F:/msys64/mingw64/bin/osslsigncode.exe: error while loading shared libraries: libgsf-1-114.dll: cannot open shared object file: No such file or directory
```
osslsigncode uses libgsf for `.msi` support.