### PR TITLE
mingw-w64-mesa - 3.0.4 - Update to latest version

### DIFF
--- a/mingw-w64-libcerf/PKGBUILD
+++ b/mingw-w64-libcerf/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=libcerf
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.5
+pkgrel=1
+pkgdesc="Complex error functions, Dawson, Faddeeva, and Voigt function (mingw-w64)"
+arch=('any')
+url='http://apps.jcns.fz-juelich.de/doku/sc/libcerf'
+license=('MIT')
+source=("http://apps.jcns.fz-juelich.de/src/${_realname}/${_realname}-${pkgver}.tgz")
+sha256sums=('e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86')
+
+prepare() {
+  cd $srcdir/${_realname}-${pkgver}
+#  patch -p1 -i ${srcdir}/0001-A-fix.patch
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared 
+
+  make
+}
+
+check() {
+  cd "${srcdir}"/build-${CARCH}
+  make check
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  install -m 644 -p ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+}

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=13.0.3
+pkgver=13.0.4
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
         001-extra-libs.patch)
-sha256sums=('d9aa8be5c176d00d0cd503cb2f64a5a403ea471ec819c022581414860d7ba40e'
+sha256sums=('a95d7ce8f7bd5f88585e4be3144a341236d8c0fc91f6feaec59bb8ba3120e726'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D')

--- a/mingw-w64-mingw-w64-libsigsegv-git/PKGBUILD
+++ b/mingw-w64-mingw-w64-libsigsegv-git/PKGBUILD
@@ -1,0 +1,60 @@
+# $Id$
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+# I had to obtain the latest from git because 2.10 does not work well with Win64
+_realname=libsigsegv
+pkgbase=mingw-w64-${_realname}-git
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=496.95dc411
+pkgrel=1
+arch=(any)
+pkgdesc='Page fault detection library (git) (mingw-w64)'
+url='http://www.gnu.org/software/libsigsegv/'
+license=('GPL2')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepend=('git')
+source=("${_realname}"::"git://git.savannah.gnu.org/libsigsegv.git#branch=master"
+        "fix-win64.patch")
+sha256sums=('SKIP'
+            '79e2da894c70136e2805d28177bc632cc0ae18905e3bfcdd92c52421ea1bb7bd')
+
+pkgver() {
+  cd "${srcdir}"/${_realname}
+  printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  cd $srcdir/${_realname}
+  patch -Np1 -i "${srcdir}"/fix-win64.patch
+  autoreconf -fiv
+}
+
+
+build() {
+  cd $srcdir/${_realname}
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  ../${_realname}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared \
+    CPPFLAGS="-I${MINGW_PREFIX}/include -Wall" \
+    LDFLAGS="-L${MINGW_PREFIX}/mingw32/lib"
+  make
+}
+
+check() {
+  cd ${srcdir}/build-${CARCH}
+  make check || true
+}
+
+
+package() {
+  cd ${srcdir}/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-mingw-w64-libsigsegv-git/fix-win64.patch
+++ b/mingw-w64-mingw-w64-libsigsegv-git/fix-win64.patch
@@ -1,0 +1,29 @@
+--- libsigsegv/src/handler-win32.c.orig	2017-02-02 00:32:44.314628900 -0500
++++ libsigsegv/src/handler-win32.c	2017-02-02 00:38:05.028896800 -0500
+@@ -215,9 +215,15 @@
+               new_safe_esp -= 8; /* make room for arguments */
+               new_safe_esp &= -16; /* align */
+               new_safe_esp -= 4; /* make room for (unused) return address slot */
++#if defined (_AMD64_)
++              ExceptionInfo->ContextRecord->Rsp = new_safe_esp;
++              /* Call stack_overflow_handler(faulting_page_address,safe_context).  */
++              ExceptionInfo->ContextRecord->Rip = (uintptr_t)&stack_overflow_handler;
++#else
+               ExceptionInfo->ContextRecord->Esp = new_safe_esp;
+               /* Call stack_overflow_handler(faulting_page_address,safe_context).  */
+               ExceptionInfo->ContextRecord->Eip = (uintptr_t)&stack_overflow_handler;
++#endif
+               *(uintptr_t *)(new_safe_esp + 4) = faulting_page_address;
+               *(uintptr_t *)(new_safe_esp + 8) = (uintptr_t) safe_context;
+               return EXCEPTION_CONTINUE_EXECUTION;
+--- libsigsegv/configure.ac.orig	2017-02-02 00:46:44.715482200 -0500
++++ libsigsegv/configure.ac	2017-02-02 00:47:20.110497100 -0500
+@@ -21,7 +21,7 @@
+ AC_INIT
+ AC_CONFIG_SRCDIR([src/sigsegv.h.in])
+ AC_CONFIG_AUX_DIR([build-aux])
+-
++AC_CONFIG_MACRO_DIRS([m4])
+ RSE_BOLD
+ 
+ { echo; echo "${term_bold}Build Tools:${term_norm}"; } >& AS_MESSAGE_FD

--- a/mingw-w64-readline/PKGBUILD
+++ b/mingw-w64-readline/PKGBUILD
@@ -4,7 +4,7 @@ _realname=readline
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _basever=7.0
-_patchlevel=001
+_patchlevel=003
 pkgver=${_basever}.${_patchlevel}
 pkgrel=1
 pkgdesc="MinGW port of readline for editing typed command lines (mingw-w64)"
@@ -29,6 +29,10 @@ sha256sums=('750d437185286f40a369e1e4f4764eda932b9459b5ec9a731628393dd3d32334'
             'SKIP'
             '9a4308f7d664d24154f1cbbaea8e1ae4bb716cbff01b8a707c541f70db6fc8cc'
             '9ac1b3ac2ec7b1bf0709af047f2d7d2a34ccde353684e57c6b47ebca77d7a376'
+            'SKIP'
+            '8747c92c35d5db32eae99af66f17b384abaca961653e185677f9c9a571ed2d58'
+            'SKIP'
+            '9e43aa93378c7e9f7001d8174b1beb948deefa6799b6f581673f465b7d9d4780'
             'SKIP')
 
 prepare() {

--- a/mingw-w64-readline/readline70-001
+++ b/mingw-w64-readline/readline70-001
@@ -1,0 +1,57 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 7.0
+Patch-ID: readline70-001
+
+Bug-Reported-by:        Sean Zha <freeman_cha@hotmail.com>
+Bug-Reference-ID:       <BN3PR01MB13657D9303EB94BF6E54216E8CCA0@BN3PR01MB1365.prod.exchangelabs.com>
+Bug-Reference-URL:      http://lists.gnu.org/archive/html/bug-bash/2016-09/msg00107.html
+
+Bug-Description:
+
+Readline-7.0 changed the way the history list is initially allocated to reduce
+the number of reallocations and copies.  Users who set the readline
+history-size variable to a very large number to essentially unlimit the size
+of the history list will get memory allocation errors 
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-7.0/history.c	2015-12-28 13:50:31.000000000 -0500
+--- history.c	2016-09-30 14:28:40.000000000 -0400
+***************
+*** 58,61 ****
+--- 58,63 ----
+  #define DEFAULT_HISTORY_INITIAL_SIZE	502
+  
++ #define MAX_HISTORY_INITIAL_SIZE	8192
++ 
+  /* The number of slots to increase the_history by. */
+  #define DEFAULT_HISTORY_GROW_SIZE 50
+***************
+*** 308,312 ****
+  	{
+  	  if (history_stifled && history_max_entries > 0)
+! 	    history_size = history_max_entries + 2;
+  	  else
+  	    history_size = DEFAULT_HISTORY_INITIAL_SIZE;
+--- 310,316 ----
+  	{
+  	  if (history_stifled && history_max_entries > 0)
+! 	    history_size = (history_max_entries > MAX_HISTORY_INITIAL_SIZE)
+! 				? MAX_HISTORY_INITIAL_SIZE
+! 				: history_max_entries + 2;
+  	  else
+  	    history_size = DEFAULT_HISTORY_INITIAL_SIZE;
+
+*** ../readline-7.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 0
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 1

--- a/mingw-w64-readline/readline70-002
+++ b/mingw-w64-readline/readline70-002
@@ -1,0 +1,103 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 7.0
+Patch-ID: readline70-002
+
+Bug-Reported-by:	Hong Cho <hong.cho@citrix.com>
+Bug-Reference-ID:	<c30b5fe62b2543af8297e47ca487c29c@SJCPEX02CL02.citrite.net>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-readline/2016-12/msg00002.html
+
+Bug-Description:
+
+There is a race condition in add_history() that can be triggered by a fatal
+signal arriving between the time the history length is updated and the time
+the history list update is completed. A later attempt to reference an
+invalid history entry can cause a crash.
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-7.0-patched/history.c	2016-11-11 13:42:49.000000000 -0500
+--- history.c	2016-12-05 10:37:51.000000000 -0500
+***************
+*** 280,283 ****
+--- 280,284 ----
+  {
+    HIST_ENTRY *temp;
++   int new_length;
+  
+    if (history_stifled && (history_length == history_max_entries))
+***************
+*** 296,306 ****
+        /* Copy the rest of the entries, moving down one slot.  Copy includes
+  	 trailing NULL.  */
+- #if 0
+-       for (i = 0; i < history_length; i++)
+- 	the_history[i] = the_history[i + 1];
+- #else
+        memmove (the_history, the_history + 1, history_length * sizeof (HIST_ENTRY *));
+- #endif
+  
+        history_base++;
+      }
+--- 297,303 ----
+        /* Copy the rest of the entries, moving down one slot.  Copy includes
+  	 trailing NULL.  */
+        memmove (the_history, the_history + 1, history_length * sizeof (HIST_ENTRY *));
+  
++       new_length = history_length;
+        history_base++;
+      }
+***************
+*** 316,320 ****
+  	    history_size = DEFAULT_HISTORY_INITIAL_SIZE;
+  	  the_history = (HIST_ENTRY **)xmalloc (history_size * sizeof (HIST_ENTRY *));
+! 	  history_length = 1;
+  	}
+        else
+--- 313,317 ----
+  	    history_size = DEFAULT_HISTORY_INITIAL_SIZE;
+  	  the_history = (HIST_ENTRY **)xmalloc (history_size * sizeof (HIST_ENTRY *));
+! 	  new_length = 1;
+  	}
+        else
+***************
+*** 326,330 ****
+  		xrealloc (the_history, history_size * sizeof (HIST_ENTRY *));
+  	    }
+! 	  history_length++;
+  	}
+      }
+--- 323,327 ----
+  		xrealloc (the_history, history_size * sizeof (HIST_ENTRY *));
+  	    }
+! 	  new_length = history_length + 1;
+  	}
+      }
+***************
+*** 332,337 ****
+    temp = alloc_history_entry ((char *)string, hist_inittime ());
+  
+!   the_history[history_length] = (HIST_ENTRY *)NULL;
+!   the_history[history_length - 1] = temp;
+  }
+  
+--- 329,335 ----
+    temp = alloc_history_entry ((char *)string, hist_inittime ());
+  
+!   the_history[new_length] = (HIST_ENTRY *)NULL;
+!   the_history[new_length - 1] = temp;
+!   history_length = new_length;
+  }
+  
+*** ../readline-7.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 1
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 2

--- a/mingw-w64-readline/readline70-003
+++ b/mingw-w64-readline/readline70-003
@@ -1,0 +1,40 @@
+			   READLINE PATCH REPORT
+			   =====================
+
+Readline-Release: 7.0
+Patch-ID: readline70-003
+
+Bug-Reported-by:	Frédéric Brière <fbriere@fbriere.net>
+Bug-Reference-ID:	<20170120180724.7ydq7fb2hsp366dj@fabul.fbriere.net>
+Bug-Reference-URL:	http://lists.gnu.org/archive/html/bug-readline/2017-01/msg00002.html
+
+Bug-Description:
+
+Readline-7.0 uses pselect(2) to allow readline to handle signals that do not
+interrupt read(2), such as SIGALRM, before reading another character.  The
+signal mask used in the pselect call did not take into account signals the
+calling application blocked before calling readline().
+
+Patch (apply with `patch -p0'):
+
+*** ../readline-7.0-patched/input.c	2016-08-30 10:21:47.000000000 -0400
+--- input.c	2017-01-23 10:21:56.000000000 -0500
+***************
+*** 514,517 ****
+--- 514,518 ----
+  #if defined (HAVE_PSELECT)
+        sigemptyset (&empty_set);
++       sigprocmask (SIG_BLOCK, (sigset_t *)NULL, &empty_set);
+        FD_ZERO (&readfds);
+        FD_SET (fileno (stream), &readfds);
+*** ../readline-7.0/patchlevel	2013-11-15 08:11:11.000000000 -0500
+--- patchlevel	2014-03-21 08:28:40.000000000 -0400
+***************
+*** 1,3 ****
+  # Do not edit -- exists only for use by patch
+  
+! 2
+--- 1,3 ----
+  # Do not edit -- exists only for use by patch
+  
+! 3


### PR DESCRIPTION
mingw-w64-readline - 7.0 - patchlevel 3
mingw-w64-libcerf - 1.5 - new package
mingw-w64-libsigsegv - git version - new package