### PR TITLE
git-lfs: bump version + some cleaning

### DIFF
--- a/mingw-w64-git-lfs/0001-Translate-git-paths-from-msys-to-windows.patch
+++ b/mingw-w64-git-lfs/0001-Translate-git-paths-from-msys-to-windows.patch
@@ -1,18 +1,18 @@
-From d55bb10e7788630a057320c64e661d9db4f7e76b Mon Sep 17 00:00:00 2001
-Message-Id: <d55bb10e7788630a057320c64e661d9db4f7e76b.1471609754.git-series.abdo.roig@gmail.com>
+From 46ade92e68e3041f315867afd4b157258a1981b5 Mon Sep 17 00:00:00 2001
+Message-Id: <46ade92e68e3041f315867afd4b157258a1981b5.1483358798.git-series.abdo.roig@gmail.com>
 From: Abdo Roig-Maranges <abdo.roig@gmail.com>
 Date: Fri, 19 Aug 2016 13:46:27 +0200
-Subject: [PATCH 1/1] Translate git paths from msys to windows
+Subject: [PATCH] Translate git paths from msys to windows
 
 ---
- git/git.go | 22 ++++++++++++++++++----
- 1 file changed, 18 insertions(+), 4 deletions(-)
+ git/git.go | 26 ++++++++++++++++++++++----
+ 1 file changed, 22 insertions(+), 4 deletions(-)
 
 diff --git a/git/git.go b/git/git.go
-index 2edaa99..9780958 100644
+index 72ab9c7..c66048c 100644
 --- a/git/git.go
 +++ b/git/git.go
-@@ -502,6 +502,20 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
+@@ -574,6 +574,20 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
  	}
  }
  
@@ -33,7 +33,7 @@ index 2edaa99..9780958 100644
  func GitAndRootDirs() (string, string, error) {
  	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir", "--show-toplevel")
  	buf := &bytes.Buffer{}
-@@ -520,7 +534,7 @@ func GitAndRootDirs() (string, string, error) {
+@@ -592,7 +606,7 @@ func GitAndRootDirs() (string, string, error) {
  		return "", "", fmt.Errorf("Bad git rev-parse output: %q", output)
  	}
  
@@ -42,16 +42,20 @@ index 2edaa99..9780958 100644
  	if err != nil {
  		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[0], err)
  	}
-@@ -529,7 +543,7 @@ func GitAndRootDirs() (string, string, error) {
+@@ -601,7 +615,11 @@ func GitAndRootDirs() (string, string, error) {
  		return absGitDir, "", nil
  	}
  
--	absRootDir, err := filepath.Abs(paths[1])
+-	absRootDir := paths[1]
 +	absRootDir, err := CygpathWindowsAbsolute(paths[1])
- 	if err != nil {
- 		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[1], err)
- 	}
-@@ -546,7 +560,7 @@ func RootDir() (string, error) {
++	if err != nil {
++		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[1], err)
++	}
++
+ 	return absGitDir, absRootDir, nil
+ }
+ 
+@@ -614,7 +632,7 @@ func RootDir() (string, error) {
  
  	path := strings.TrimSpace(string(out))
  	if len(path) > 0 {
@@ -60,7 +64,7 @@ index 2edaa99..9780958 100644
  	}
  	return "", nil
  
-@@ -560,7 +574,7 @@ func GitDir() (string, error) {
+@@ -628,7 +646,7 @@ func GitDir() (string, error) {
  	}
  	path := strings.TrimSpace(string(out))
  	if len(path) > 0 {
@@ -69,5 +73,7 @@ index 2edaa99..9780958 100644
  	}
  	return "", nil
  }
+
+base-commit: 71b637f1dfa4ea5f200465536190c290f190f58d
 -- 
-git-series 0.8.7
+git-series 0.9.0

--- a/mingw-w64-git-lfs/PKGBUILD
+++ b/mingw-w64-git-lfs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=git-lfs
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.3.1
+pkgver=1.5.4
 pkgrel=1
 arch=("any")
 pkgdesc="An open source Git extension for versioning large files (mingw-w64)"
@@ -16,25 +16,30 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-go")
 source=(${_realname}-${pkgver}.zip::"https://github.com/github/git-lfs/archive/v${pkgver}.zip"
         "0001-Translate-git-paths-from-msys-to-windows.patch")
 
-sha256sums=('94b13cb4593a2e7319bd24c96cac835df309adfb8ec68c4040779c2b7f1d7e5c'
-            '3a66340cd262f550ba193336024d78dc3da123f59c2a9456bb5f7af87b56420a')
+sha256sums=('95e64dbc6ce6acfd014e789030f8f2c0b5fae0e7005a9760d0c917535fa29e65'
+            '9f991fae2f0439b747b8cac577fe22924f963a6e15a27df6310b0d50c7f4a899')
 
 prepare() {
   # apply patches
   cd "${srcdir}/git-lfs-${pkgver}"
   patch -N -p1 -i "$srcdir/0001-Translate-git-paths-from-msys-to-windows.patch"
 
-  # setup local gopath
-  mkdir -p "${srcdir}/src/github.com/github"
-  rm -Rf "${srcdir}/src/github.com/github/git-lfs"
-  cp -R "${srcdir}/git-lfs-${pkgver}" "${srcdir}/src/github.com/github/git-lfs"
+  # Clear go cache
+  rm -Rf "$srcdir/src"
+
+  # Setup local gopath
+  mkdir -p "$srcdir/src/github.com/git-lfs"
+  cp -R "$srcdir/git-lfs-$pkgver/" "$srcdir/src/github.com/git-lfs/git-lfs"
+
+  # Fetch dependencies
+  GOPATH="$srcdir" go get -v -d
 }
 
 build() {
   cd "${srcdir}/git-lfs-${pkgver}"
-  export GOPATH="$srcdir"
-  go get -v -d
-  go run script/*.go -cmd build
+
+  # build
+  GOPATH="$srcdir" go run script/*.go -cmd build
 
   # The man pages need ronn, which needs a bunch of missing ruby dependencies.
   # ronn docs/man/*.ronn


### PR DESCRIPTION
- Fetch go dependencies in prepare() instead of build.

- Use actual git sources for git-lfs instead of fetching them with go get.