### PR TITLE
rust: update to 1.15.1

### DIFF
--- a/mingw-w64-rust/PKGBUILD
+++ b/mingw-w64-rust/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=rust
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.15.0
-pkgrel=2
+pkgver=1.15.1
+pkgrel=1
 pkgdesc="Systems programming language focused on safety, speed and concurrency (mingw-w64)"
 arch=('any')
 url="https://www.rust-lang.org/"
@@ -30,12 +30,14 @@ source=(https://static.rust-lang.org/dist/${_realname}c-${pkgver}-src.tar.gz
         "force-curl-cargo.patch"
         "force-pthread.patch"
         "fix-jemalloc.patch"
+        "pass-windows-paths-to-python-script.patch"
         "git+https://github.com/rust-lang/cargo.git#tag=0.16.0")
-sha256sums=('33f3747d231ede34b56c6cc0ae6be8cbaa29d2fdb39d86f25693dceb9fc5f164'
+sha256sums=('2e7daad418a830b45b977cd7ecf181b65f30f73df63ff36e124ea5fe5d1af327'
             'c11cd761809d08a108ddc3ac126a38caca740b3d11ed493cf317178b0e0f6f58'
             '50c979b48ebc86dfddb295f2bea62e491ce868eb4308a0ae2324514c8d45e4fd'
             '7f32bd7c43f13a61b2e4f66c40be47fc5fd025b2aad3fa6507d20316b02e3c17'
             '9d5e57a67d98427eb3d34c2e19b3b9f5beadd5ddf62c76c2fd65905034eae84d'
+            'f19f83d0bd1a0265328331e8c5fff82df6b05ca847c7bda9fec1c7ef2ddc702e'
             'SKIP')
 
 prepare() {
@@ -44,8 +46,15 @@ prepare() {
   patch -p1 -i "${srcdir}/force-pthread.patch"
   patch -p1 -i "${srcdir}/fix-jemalloc.patch"
 
+  # next version will remove --disable-rustbuild, this patch will solve one issue
+  # but more patches will be required
+  #patch -p1 -i "${srcdir}/pass-windows-paths-to-python-script.patch"
+
   cd ${srcdir}/cargo
-  #git submodule update --init --recursive
+  
+  # download cargo installer
+  git submodule update --init --recursive
+  
   #patch -p1 -i "${srcdir}/force-curl-cargo.patch"
   sed 's^share/doc^share/licenses^g' -i Makefile.in
 }
@@ -59,6 +68,7 @@ build() {
   #We have to do the following because rust doesn't count x86_64-w64-mingw32 as a target triple
   OSTYPE="$CARCH-pc-windows-gnu"
 
+  # official rustc is using wrong exception handling, use our rustc it with --enable-local-rust
   ../${_realname}c-${pkgver}-src/configure \
     --prefix=${MINGW_PREFIX} \
     --build=$OSTYPE \
@@ -66,7 +76,9 @@ build() {
     --target=$OSTYPE \
     --release-channel=stable \
     --llvm-root=${MINGW_PREFIX} \
-    --jemalloc-root=${MINGW_PREFIX}/lib
+    --jemalloc-root=${MINGW_PREFIX}/lib \
+    --enable-local-rust \
+    --disable-rustbuild
 
   make RUSTFLAGS="$RUSTFLAGS -C link-args='-lffi -lpthread'"
 }

--- a/mingw-w64-rust/pass-windows-paths-to-python-script.patch
+++ b/mingw-w64-rust/pass-windows-paths-to-python-script.patch
@@ -1,0 +1,11 @@
+--- rustc-1.15.1-src/configure.orig	2017-02-16 11:51:16.890386400 +0100
++++ rustc-1.15.1-src/configure	2017-02-16 10:38:12.893169900 +0100
+@@ -944,7 +944,7 @@
+ 
+ if [ -n "$CFG_ENABLE_LOCAL_RUST" ]
+ then
+-    system_rustc=$(which rustc)
++    system_rustc=$(cygpath -m $(which rustc))
+     if [ -f ${CFG_LOCAL_RUST_ROOT}/bin/rustc${BIN_SUF} ]
+     then
+         : # everything already configured


### PR DESCRIPTION
Tested 64 bit rust and cargo, currently I don't have time to build and test 32 bit.

`pass-windows-paths-to-python-script.patch` will be helpful at next release when `--disable-rustbuild` is removed. I had no time to fully fix new build system.