### PR TITLE
mesa: update to version 17.0.0

### DIFF
--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=13.0.4
+pkgver=17.0.0
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
         001-extra-libs.patch)
-sha256sums=('a95d7ce8f7bd5f88585e4be3144a341236d8c0fc91f6feaec59bb8ba3120e726'
+sha256sums=('39db3d59700159add7f977307d12a7dfe016363e760ad82280ac4168ea668481'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D')

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -16,10 +16,12 @@ url="http://www.mesa3d.org"
 license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${pkgver}/${_realname}-${pkgver}.tar.xz{,.sig}
-        001-extra-libs.patch)
+        001-extra-libs.patch
+        osmesa.pc)
 sha256sums=('39db3d59700159add7f977307d12a7dfe016363e760ad82280ac4168ea668481'
             'SKIP'
-            'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9')
+            'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
+            'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D')
 
 case ${MINGW_CHOST} in
@@ -49,8 +51,8 @@ build() {
 package() {
   cd ${srcdir}/${_realname}-${pkgver}
   mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/GL
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/mesa/GL
 
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/gallium/targets/libgl-gdi/opengl32.dll ${pkgdir}${MINGW_PREFIX}/bin/
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/gallium/targets/graw-gdi/graw.dll ${pkgdir}${MINGW_PREFIX}/bin/
@@ -58,6 +60,7 @@ package() {
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/gallium/targets/osmesa/osmesa.dll ${pkgdir}${MINGW_PREFIX}/bin/
   cp -f ${srcdir}/${_realname}-${pkgver}/build/windows-${_mach}/gallium/targets/osmesa/libosmesa.a ${pkgdir}${MINGW_PREFIX}/lib/
 
-#  cp -f cd ${srcdir}/${_realname}-${pkgver}/include/GL/gl.h ${pkgdir}${MINGW_PREFIX}/include/GL/
-#  cp -f cd ${srcdir}/${_realname}-${pkgver}/include/GL/osmesa.h ${pkgdir}${MINGW_PREFIX}/include/GL/
+  cp -f ${srcdir}/${_realname}-${pkgver}/include/GL/gl.h ${pkgdir}${MINGW_PREFIX}/include/mesa/GL/
+  cp -f ${srcdir}/${_realname}-${pkgver}/include/GL/osmesa.h ${pkgdir}${MINGW_PREFIX}/include/mesa/GL/
+  cp -f ${srcdir}/osmesa.pc ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/
 }

--- a/mingw-w64-mesa/osmesa.pc
+++ b/mingw-w64-mesa/osmesa.pc
@@ -1,0 +1,11 @@
+prefix=/mingw64
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/mesa
+
+Name: osmesa
+Description: Mesa Off-screen Rendering library
+Requires:
+Version: 8
+Libs: -L${libdir} -lOSMesa
+Cflags: -I${includedir}


### PR DESCRIPTION
Besides, the header files are necessary for using osmesa. 
I wonder why they were deleted in a070cca548397fa11feb7dd4485aafdafaddfe40.