### PR TITLE
mingw-w64-zlib: fixed patches for latest minizip

### DIFF
--- a/mingw-w64-zlib/010-unzip-add-function-unzOpenBuffer.patch
+++ b/mingw-w64-zlib/010-unzip-add-function-unzOpenBuffer.patch
@@ -22,18 +22,18 @@ index d83fee7..e2958e6 100644
  
  libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
 diff --git a/unzip.c b/unzip.c
-index ce02265..bb72a66 100644
+index 11030cb..1f4bdda 100644
 --- a/unzip.c
 +++ b/unzip.c
-@@ -26,6 +26,7 @@
+@@ -29,6 +29,7 @@
  
  #include "zlib.h"
  #include "unzip.h"
 +#include "ioapi_mem.h"
  
- #ifdef STDC
- #  include <stddef.h>
-@@ -581,6 +582,16 @@ extern unzFile ZEXPORT unzOpen64(const void *path)
+ #ifdef HAVE_AES
+ #  define AES_METHOD          (99)
+@@ -553,6 +554,16 @@ extern unzFile ZEXPORT unzOpen64(const void *path)
      return unzOpenInternal(path, NULL);
  }
  
@@ -49,20 +49,20 @@ index ce02265..bb72a66 100644
 +
  extern int ZEXPORT unzClose(unzFile file)
  {
-     unz64_s* s;
+     unz64_s *s;
 diff --git a/unzip.h b/unzip.h
-index 22c830f..28fedb9 100644
+index 1aa197f..8503471 100644
 --- a/unzip.h
 +++ b/unzip.h
-@@ -143,6 +143,8 @@ extern unzFile ZEXPORT unzOpen64 OF((const void *path));
+@@ -131,6 +131,8 @@ extern unzFile ZEXPORT unzOpen64(const void *path);
     open64_file_func callback. Under Windows, if UNICODE is defined, using fill_fopen64_filefunc, the path 
-    is a pointer to a wide unicode string  (LPCTSTR is LPCWSTR), so const char* does not describe the reality */
+    is a pointer to a wide unicode string  (LPCTSTR is LPCWSTR), so const char *does not describe the reality */
  
 +extern unzFile ZEXPORT unzOpenBuffer OF((const void* buffer, uLong size));
 +/* Open a Zip file, like unzOpen, but from a buffer */
- extern unzFile ZEXPORT unzOpen2 OF((const char *path, zlib_filefunc_def* pzlib_filefunc_def));
+ extern unzFile ZEXPORT unzOpen2(const char *path, zlib_filefunc_def *pzlib_filefunc_def);
  /* Open a Zip file, like unzOpen, but provide a set of file low level API for read/write operations */
- extern unzFile ZEXPORT unzOpen2_64 OF((const void *path, zlib_filefunc64_def* pzlib_filefunc_def));
+ extern unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_filefunc_def);
 -- 
 2.1.2
 

--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2")
 makedepends=('git')
 options=('staticlibs')
 source=("http://zlib.net/current/${_realname}-${pkgver}.tar.gz"
-        "git+https://github.com/nmoinvaz/minizip.git"
+        "git+https://github.com/nmoinvaz/minizip.git#commit=7914ff3c"
         01-zlib-1.2.11-1-buildsys.mingw.patch
         03-dont-put-sodir-into-L.mingw.patch
         04-fix-largefile-support.patch
@@ -28,7 +28,7 @@ sha256sums=('c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1'
             'ac91f905b695d71f6c9c471ac98c14a3ed989a1e2b2a3b1171b3f6dc6bfc31b4'
             '3d039f42194aade91dadf4174f55fd6db349fd8044db93875bed1042dcfe1f31'
             '3b36fe536a7458af2a9a494d70d24048da10c43423fd620ed93fa0a6ddd14f78'
-            'ebbc1b8c988a6af3c0d77f404befe40abfe7c7303883b24c94d1468e685306a3'
+            'e3e85ac0df92d4b0a777631c064ae92c9a73d9f8baea93d35e01620838c4010d'
             'ebf118d3754c1cb9a07f391bfdb24d2941bc4e11a7b3956b17fa095f97e6eae8'
             '08269402dc15bb6d1600e011633ca3ace43e2d74613fdabdd516a05f5939cc78')
 


### PR DESCRIPTION
Fixed the minizip checkout to specific commit revision, and updated line numbers in one patch.