### PR TITLE
mingw-w64-make: switch from git to official 4.2.1 release

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -4,8 +4,7 @@ _realname=make
 _autotools=yes
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_ver_base=4.1
-pkgver=4.1.2366.168f123
+pkgver=4.2.1
 pkgrel=1
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
@@ -13,39 +12,32 @@ url="https://www.gnu.org/software/make"
 license=('GPL3')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 depends=()
-makedepends=('git' 'wget')
-source=("${_realname}"::'git://git.savannah.gnu.org/make.git'
+makedepends=('wget')
+source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.bz2"
         'make-getopt.patch'
         'make-linebuf-mingw.patch')
-sha256sums=('SKIP'
-            '8b69d3e28f789ed69a38b37367345ce15f4773237825cbed65ea1013559bb2f4'
-            '11859c48a641baf9a5f000fa4e5c10d0cdf602bc8e3aaea3ed74005943dcd8da')
+sha256sums=('d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589'
+            '15a86d5143c9ec6337bdd69fecb7c33c36e4fd925528dc1498b0bc4fbd31b0bb'
+            'cbb8c0a1bdd6e8174febce01946bd42da26dfcb73a7338c0a1df89ac6b8e157b')
 
-pkgver() {
-  cd "${srcdir}"/${_realname}
-  printf "%s.%s.%s" "$_ver_base" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
-}
 
 prepare() {
-  cd ${srcdir}/${_realname}
+  cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/make-getopt.patch
   patch -p1 -i ${srcdir}/make-linebuf-mingw.patch
-  if [[ "${_autotools}" = "yes" ]]; then
-    autoreconf -fi
-  fi
 }
 
 build() {
   if [[ "${_autotools}" = "yes" ]]; then
-      [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
-      mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
-      ../${_realname}/configure \
+    [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+    mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+    ../${_realname}-${pkgver}/configure \
       --prefix=${MINGW_PREFIX} \
       --host=${MINGW_CHOST} \
       --without-libintl-prefix \
       --without-libiconv-prefix \
       ac_cv_dos_paths=yes
-    make -j1 scm-update do-po-update all
+    make -j1
   else
     cmd /c 'build_w32.bat --without-guile gcc'
   fi
@@ -56,9 +48,9 @@ package() {
   if [[ "${_autotools}" = "yes" ]]; then
     cd ${srcdir}/build-${MINGW_CHOST}
     cp -f make.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
-    cp -f ${srcdir}/${_realname}/gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
+    cp -f ${srcdir}/${_realname}-${pkgver}/gnumake.h ${pkgdir}${MINGW_PREFIX}/include/
   else
-    cd ${srcdir}/${_realname}
+    cd ${srcdir}/${_realname}-${pkgver}
     cp -f gnumake.exe ${pkgdir}${MINGW_PREFIX}/bin/mingw32-make.exe
     cp -f libgnumake-1.dll.a ${pkgdir}${MINGW_PREFIX}/lib/
     cp -f gnumake.h ${pkgdir}${MINGW_PREFIX}/include/

--- a/mingw-w64-make/make-getopt.patch
+++ b/mingw-w64-make/make-getopt.patch
@@ -6,14 +6,10 @@ getopt.c:382: warning: unused parameter 'argv'
 getopt.c: In function '_getopt_internal':
 getopt.c:681: warning: suggest explicit braces to avoid ambiguous 'else'
 
-Index: getopt.c
-===================================================================
-RCS file: /sources/make/make/getopt.c,v
-retrieving revision 1.22
-diff -u -p -r1.22 getopt.c
---- make-3.82.orig/getopt.c	25 Oct 2009 18:56:45 -0000	1.22
-+++ make-3.82/getopt.c	5 Jul 2010 20:05:22 -0000
-@@ -436,6 +436,9 @@ _getopt_initialize (int argc, char *cons
+diff -Naur make-4.2.1/getopt.c make-4.2.1.new/getopt.c
+--- make-4.2.1/getopt.c	2016-02-28 18:48:44.000000000 +0100
++++ make-4.2.1.new/getopt.c	2017-02-20 22:52:36.688693011 +0100
+@@ -434,6 +434,9 @@
      }
    else
      nonoption_flags_len = 0;
@@ -23,7 +19,7 @@ diff -u -p -r1.22 getopt.c
  #endif
  
    return optstring;
-@@ -678,7 +681,7 @@ _getopt_internal (int argc, char *const 
+@@ -676,7 +679,7 @@
  		optarg = nameend + 1;
  	      else
  		{
@@ -32,9 +28,9 @@ diff -u -p -r1.22 getopt.c
  		   if (argv[optind - 1][1] == '-')
  		    /* --option */
  		    fprintf (stderr,
-@@ -689,7 +692,7 @@ _getopt_internal (int argc, char *const 
+@@ -687,7 +690,7 @@
  		    fprintf (stderr,
- 		     _("%s: option `%c%s' doesn't allow an argument\n"),
+ 		     _("%s: option '%c%s' doesn't allow an argument\n"),
  		     argv[0], argv[optind - 1][0], pfound->name);
 -
 +		  }

--- a/mingw-w64-make/make-linebuf-mingw.patch
+++ b/mingw-w64-make/make-linebuf-mingw.patch
@@ -1,6 +1,7 @@
---- make.orig/main.c
-+++ make/main.c
-@@ -971,8 +971,11 @@
+diff -Naur make-4.2.1/main.c make-4.2.1.new/main.c
+--- make-4.2.1/main.c	2016-05-31 09:17:26.000000000 +0200
++++ make-4.2.1.new/main.c	2017-02-20 22:55:09.051617838 +0100
+@@ -1126,8 +1126,11 @@
  
  #endif
  


### PR DESCRIPTION
Fixes many build problems in current git snapshot.