### PR TITLE
mingw-w64-pkg-config/PKGBUILD: add dependency on glib2

### DIFF
--- a/mingw-w64-pkg-config/PKGBUILD
+++ b/mingw-w64-pkg-config/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="A system for managing library compile/link flags (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/pkg-config/"
 license=('GPL')
-depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread")
+depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
+         "${MINGW_PACKAGE_PREFIX}-glib2")
 conflicts=("${MINGW_PACKAGE_PREFIX}-pkgconf")
 replaces=("${MINGW_PACKAGE_PREFIX}-pkgconf")
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")


### PR DESCRIPTION
Fixes build problem if glib2 is not installed.