### PR TITLE
Python requests v2.13.0

### DIFF
--- a/mingw-w64-python-requests/PKGBUILD
+++ b/mingw-w64-python-requests/PKGBUILD
@@ -1,6 +1,5 @@
 # Contributor: Alethea Rose <alethea@alethearose.com>
 
-_pyname=requests
 _realname=requests
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -21,7 +20,7 @@ prepare() {
   cd "$srcdir"
   for builddir in python{2,3}-build; do  
     rm -rf $builddir | true
-    cp -r "${_pyname}-${pkgver}" "${builddir}"
+    cp -r "${_realname}-${pkgver}" "${builddir}"
   done
 }
 

--- a/mingw-w64-python-requests/PKGBUILD
+++ b/mingw-w64-python-requests/PKGBUILD
@@ -1,0 +1,70 @@
+# Contributor: Alethea Rose <alethea@alethearose.com>
+
+_pyname=requests
+_realname=requests
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=2.13.0
+pkgrel=1
+pkgdesc="Requests is the only Non-GMO HTTP library for Python, safe for human consumption. (mingw-w64)"
+arch=('any')
+license=('Apache')
+url="http://python-requests.org/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=("https://github.com/kennethreitz/requests/archive/v$pkgver.tar.gz")
+sha256sums=('48fd188aaa388b4193bf7b917cf861a00eafacad651148475bc65ffaef445627')
+
+prepare() {
+  cd "$srcdir"
+  for builddir in python{2,3}-build; do  
+    rm -rf $builddir | true
+    cp -r "${_pyname}-${pkgver}" "${builddir}"
+  done
+}
+
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+package_python3-requests() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-requests() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python3-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-requests() {
+  package_python2-requests
+}
+
+package_mingw-w64-i686-python3-requests() {
+  package_python3-requests
+}
+
+package_mingw-w64-x86_64-python2-requests() {
+  package_python2-requests
+}
+
+package_mingw-w64-x86_64-python3-requests() {
+  package_python3-requests
+}

--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -6,10 +6,10 @@ _realname=sphinx
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
-license=('LGPL-2.1')
+license=('BSD')
 url="http://sphinx.pocoo.org/"
 makedepends=(
             "${MINGW_PACKAGE_PREFIX}-python3-colorama"
@@ -17,6 +17,7 @@ makedepends=(
             "${MINGW_PACKAGE_PREFIX}-python3-imagesize"
             "${MINGW_PACKAGE_PREFIX}-python3-jinja"
             "${MINGW_PACKAGE_PREFIX}-python3-pygments"
+	    "${MINGW_PACKAGE_PREFIX}-python3-requests"
             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
             "${MINGW_PACKAGE_PREFIX}-python3-six"
 
@@ -25,6 +26,7 @@ makedepends=(
             "${MINGW_PACKAGE_PREFIX}-python2-imagesize"
             "${MINGW_PACKAGE_PREFIX}-python2-jinja"
             "${MINGW_PACKAGE_PREFIX}-python2-pygments"
+	    "${MINGW_PACKAGE_PREFIX}-python2-requests"
             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
             "${MINGW_PACKAGE_PREFIX}-python2-six"
             )
@@ -81,6 +83,7 @@ package_python3-sphinx() {
            "${MINGW_PACKAGE_PREFIX}-python3-imagesize"
            "${MINGW_PACKAGE_PREFIX}-python3-jinja"
            "${MINGW_PACKAGE_PREFIX}-python3-pygments"
+           "${MINGW_PACKAGE_PREFIX}-python3-requests"
            "${MINGW_PACKAGE_PREFIX}-python3-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python3-snowballstemmer"
            "${MINGW_PACKAGE_PREFIX}-python3-sphinx-alabaster-theme"
@@ -108,6 +111,7 @@ package_python2-sphinx() {
            "${MINGW_PACKAGE_PREFIX}-python2-imagesize"
            "${MINGW_PACKAGE_PREFIX}-python2-jinja"
            "${MINGW_PACKAGE_PREFIX}-python2-pygments"
+           "${MINGW_PACKAGE_PREFIX}-python2-requests"
            "${MINGW_PACKAGE_PREFIX}-python2-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python2-snowballstemmer"
            "${MINGW_PACKAGE_PREFIX}-python2-sphinx-alabaster-theme"


### PR DESCRIPTION
Add a build for `mingw-w64-python-requests` since Sphinx depends on it.