### PR TITLE
cURL 7.53.0

### DIFF
--- a/mingw-w64-curl/0001-Make-cURL-relocatable.patch
+++ b/mingw-w64-curl/0001-Make-cURL-relocatable.patch
@@ -1,7 +1,24 @@
-diff -aur curl-7.49.0/configure.ac.orig curl-7.49.0/configure.ac
---- curl-7.49.0/configure.ac.orig	2016-05-16 03:23:33 -0400
-+++ curl-7.49.0/configure.ac	2016-05-23 10:38:16 -0400
-@@ -3191,6 +3191,7 @@
+From a8f6e04613d0a90f754685518119e3004b126318 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 22 Feb 2017 11:03:04 +0100
+Subject: [PATCH 1/3] Make cURL relocatable
+
+---
+ configure.ac         |   1 +
+ lib/Makefile.inc     |   4 +-
+ lib/curl_config.h.in |   3 +
+ lib/pathtools.c      | 499 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ lib/pathtools.h      |  49 +++++
+ lib/url.c            |  16 ++
+ 6 files changed, 570 insertions(+), 2 deletions(-)
+ create mode 100644 lib/pathtools.c
+ create mode 100644 lib/pathtools.h
+
+diff --git a/configure.ac b/configure.ac
+index 1e76c49..17f477a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3186,6 +3186,7 @@ if test "xyes" = "x$longlong"; then
    ])
  fi
  
@@ -9,9 +26,32 @@ diff -aur curl-7.49.0/configure.ac.orig curl-7.49.0/configure.ac
  
  # check for ssize_t
  AC_CHECK_TYPE(ssize_t, ,
-diff -aur curl-7.49.0/lib/curl_config.h.in.orig curl-7.49.0/lib/curl_config.h.in > patch
---- curl-7.49.0/lib/curl_config.h.in.orig	2016-05-16 03:24:14 -0400
-+++ curl-7.49.0/lib/curl_config.h.in	2016-05-23 11:21:50 -0400
+diff --git a/lib/Makefile.inc b/lib/Makefile.inc
+index 19f5800..d8eb6d5 100644
+--- a/lib/Makefile.inc
++++ b/lib/Makefile.inc
+@@ -53,7 +53,7 @@ LIB_CFILES = file.c timeval.c base64.c hostip.c progress.c formdata.c   \
+   http_proxy.c non-ascii.c asyn-ares.c asyn-thread.c curl_gssapi.c      \
+   http_ntlm.c curl_ntlm_wb.c curl_ntlm_core.c curl_sasl.c rand.c        \
+   curl_multibyte.c hostcheck.c conncache.c pipeline.c dotdot.c          \
+-  x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c
++  x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c pathtools.c
+ 
+ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
+   formdata.h cookie.h http.h sendf.h ftp.h url.h dict.h if2ip.h         \
+@@ -72,7 +72,7 @@ LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
+   curl_sasl.h curl_multibyte.h hostcheck.h conncache.h                  \
+   curl_setup_once.h multihandle.h setup-vms.h pipeline.h dotdot.h       \
+   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \
+-  curl_printf.h system_win32.h rand.h
++  curl_printf.h pathtools.h system_win32.h rand.h
+ 
+ LIB_RCFILES = libcurl.rc
+ 
+diff --git a/lib/curl_config.h.in b/lib/curl_config.h.in
+index 60e9d23..4bddddd 100644
+--- a/lib/curl_config.h.in
++++ b/lib/curl_config.h.in
 @@ -9,6 +9,9 @@
  /* Location of default ca path */
  #undef CURL_CA_PATH
@@ -22,30 +62,11 @@ diff -aur curl-7.49.0/lib/curl_config.h.in.orig curl-7.49.0/lib/curl_config.h.in
  /* to disable cookies support */
  #undef CURL_DISABLE_COOKIES
  
-diff -aur curl-7.49.1/lib/Makefile.inc.orig curl-7.49.1/lib/Makefile.inc
---- curl-7.49.1/lib/Makefile.inc.orig	2016-06-07 10:59:01.002092000 -0400
-+++ curl-7.49.1/lib/Makefile.inc	2016-06-07 11:05:34.750518900 -0400
-@@ -53,7 +53,7 @@
-   http_proxy.c non-ascii.c asyn-ares.c asyn-thread.c curl_gssapi.c      \
-   http_ntlm.c curl_ntlm_wb.c curl_ntlm_core.c curl_sasl.c               \
-   curl_multibyte.c hostcheck.c conncache.c pipeline.c dotdot.c          \
--  x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c
-+  x509asn1.c http2.c smb.c curl_endian.c curl_des.c system_win32.c pathtools.c
- 
- LIB_HFILES = arpa_telnet.h netrc.h file.h timeval.h hostip.h progress.h \
-   formdata.h cookie.h http.h sendf.h ftp.h url.h dict.h if2ip.h         \
-@@ -72,7 +72,7 @@
-   curl_sasl.h curl_multibyte.h hostcheck.h conncache.h                  \
-   curl_setup_once.h multihandle.h setup-vms.h pipeline.h dotdot.h       \
-   x509asn1.h http2.h sigpipe.h smb.h curl_endian.h curl_des.h           \
--  curl_printf.h system_win32.h rand.h
-+  curl_printf.h pathtools.h system_win32.h rand.h
- 
- LIB_RCFILES = libcurl.rc
- 
-diff -urN curl-7.37.1.orig/lib/pathtools.c curl-7.37.1/lib/pathtools.c
---- curl-7.37.1.orig/lib/pathtools.c	1970-01-01 01:00:00.000000000 +0100
-+++ curl-7.37.1/lib/pathtools.c	2014-08-28 18:39:56.831658100 +0100
+diff --git a/lib/pathtools.c b/lib/pathtools.c
+new file mode 100644
+index 0000000..81ffa7e
+--- /dev/null
++++ b/lib/pathtools.c
 @@ -0,0 +1,499 @@
 +/*
 +      .Some useful path tools.
@@ -546,9 +567,11 @@ diff -urN curl-7.37.1.orig/lib/pathtools.c curl-7.37.1/lib/pathtools.c
 +  free ((void*)arr);
 +  return result;
 +}
-diff -urN curl-7.37.1.orig/lib/pathtools.h curl-7.37.1/lib/pathtools.h
---- curl-7.37.1.orig/lib/pathtools.h	1970-01-01 01:00:00.000000000 +0100
-+++ curl-7.37.1/lib/pathtools.h	2014-08-28 18:39:54.123503200 +0100
+diff --git a/lib/pathtools.h b/lib/pathtools.h
+new file mode 100644
+index 0000000..a8a2928
+--- /dev/null
++++ b/lib/pathtools.h
 @@ -0,0 +1,49 @@
 +/*
 +      .Some useful path tools.
@@ -599,10 +622,11 @@ diff -urN curl-7.37.1.orig/lib/pathtools.h curl-7.37.1/lib/pathtools.h
 +char * get_relocated_path_list(char const * from, char const * to_path_list);
 +
 +#endif /* PATHTOOLS_H */
-diff -aur curl-7.49.0/lib/url.c.orig curl-7.49.0/lib/url.c
---- curl-7.49.0/lib/url.c.orig	2016-05-16 03:23:43 -0400
-+++ curl-7.49.0/lib/url.c	2016-05-23 11:39:21 -0400
-@@ -130,6 +130,9 @@
+diff --git a/lib/url.c b/lib/url.c
+index b8f7cfb..a84ff75 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -119,6 +119,9 @@ bool curl_win32_idn_to_ascii(const char *in, char **out);
  #include "pipeline.h"
  #include "dotdot.h"
  #include "strdup.h"
@@ -612,7 +636,7 @@ diff -aur curl-7.49.0/lib/url.c.orig curl-7.49.0/lib/url.c
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
  #include "curl_memory.h"
-@@ -581,7 +584,20 @@
+@@ -574,7 +577,20 @@ CURLcode Curl_init_userdefined(struct UserDefined *set)
  
    /* This is our preferred CA cert bundle/path since install time */
  #if defined(CURL_CA_BUNDLE)
@@ -633,3 +657,6 @@ diff -aur curl-7.49.0/lib/url.c.orig curl-7.49.0/lib/url.c
    if(result)
      return result;
  #endif
+-- 
+2.11.1.windows.1.dirty
+

--- a/mingw-w64-curl/0002-cURL-Get-relocatable-base-from-.dll-instead-of-.exe.patch
+++ b/mingw-w64-curl/0002-cURL-Get-relocatable-base-from-.dll-instead-of-.exe.patch
@@ -1,7 +1,7 @@
-From 6ae2e927271b441e759e4c7a6d41dc4cbcd7a929 Mon Sep 17 00:00:00 2001
+From d3188584136bb1b5f45cab97e7e10281f3cb3124 Mon Sep 17 00:00:00 2001
 From: Johannes Schindelin <johannes.schindelin@gmx.de>
 Date: Sat, 9 Jan 2016 12:35:03 +0000
-Subject: [PATCH] cURL: Get relocatable base from .dll instead of .exe
+Subject: [PATCH 2/3] cURL: Get relocatable base from .dll instead of .exe
 
 Currently, cURL uses the path to the current executable to figure out
 where the certificates are. This works as long as all executables are in
@@ -100,10 +100,10 @@ index a8a2928..d4ff40f 100644
  void simplify_path(char * path);
  
 diff --git a/lib/url.c b/lib/url.c
-index 460137f..8e74a64 100644
+index a84ff75..e054d59 100644
 --- a/lib/url.c
 +++ b/lib/url.c
-@@ -599,9 +599,9 @@ CURLcode Curl_init_userdefined(struct UserDefined *set)
+@@ -580,9 +580,9 @@ CURLcode Curl_init_userdefined(struct UserDefined *set)
  #if defined(__MINGW32__)
    const size_t path_max = PATH_MAX;
    char relocated[path_max];
@@ -117,5 +117,5 @@ index 460137f..8e74a64 100644
    strncat(relocated, relative, path_max);
    simplify_path(relocated);
 -- 
-2.6.4.windows.1
+2.11.1.windows.1.dirty
 

--- a/mingw-w64-curl/0003-urldata-include-curl_sspi.h-when-Windows-SSPI-is-ena.patch
+++ b/mingw-w64-curl/0003-urldata-include-curl_sspi.h-when-Windows-SSPI-is-ena.patch
@@ -1,0 +1,32 @@
+From e2f4f042d0872089257b346015e9b03e8247338f Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <vszakats@users.noreply.github.com>
+Date: Tue, 21 Feb 2017 23:01:37 -0500
+Subject: [PATCH 3/3] urldata: include curl_sspi.h when Windows SSPI is enabled
+
+f77dabe broke builds in Windows using Windows SSPI but not Windows SSL.
+
+Bug: https://github.com/curl/curl/issues/1276
+Reported-by: jveazey@users.noreply.github.com
+---
+ lib/urldata.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/urldata.h b/lib/urldata.h
+index 648b3e8..7f87913 100644
+--- a/lib/urldata.h
++++ b/lib/urldata.h
+@@ -136,8 +136,10 @@
+ #undef realloc
+ #endif /* USE_AXTLS */
+ 
+-#ifdef USE_SCHANNEL
++#if defined(USE_SCHANNEL) || defined(USE_WINDOWS_SSPI)
+ #include "curl_sspi.h"
++#endif
++#ifdef USE_SCHANNEL
+ #include <schnlsp.h>
+ #include <schannel.h>
+ #endif
+-- 
+2.11.1.windows.1.dirty
+

--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -6,7 +6,7 @@ _variant=-openssl
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.52.1
+pkgver=7.53.0
 pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
 arch=('any')
@@ -30,12 +30,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          )
 options=('staticlibs')
 source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
-        "0001-curl-relocation.patch"
-        "0004-cURL-Get-relocatable-base-from-dll.patch")
-sha256sums=('d16185a767cb2c1ba3d5b9096ec54e5ec198b213f45864a38b3bda4bbf87389b'
+        "0001-Make-cURL-relocatable.patch"
+        "0002-cURL-Get-relocatable-base-from-.dll-instead-of-.exe.patch"
+        "0003-urldata-include-curl_sspi.h-when-Windows-SSPI-is-ena.patch")
+sha256sums=('b2345a8bef87b4c229dedf637cb203b5e21db05e20277c8e1094f0d4da180801'
             'SKIP'
-            'c09b2bcc1b85912c2e96c3b976d2a9fd016ac5debcdd9ad6a009faa04940d782'
-            'e21fb106ebda8559ba2d34633a9d7d94be541de02de01982f92d67048bb9854b')
+            '577e900086f91adb332f5ddb95adce980c530445d22aa0fbf4b43b25c2efe80e'
+            '604b34b5ca9b3520a83a23959f943e330c1ef36b50ee377f8210b59be3e5f62b'
+            '3ba9e1765d7cb8c96fb65bb4862ca01b759b22a22f44d77047e19639d564d600')
 validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
               '27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2'
               '4461EAF0F8E9097F48AF0555F9FEAFF9D34A1BDB')
@@ -43,8 +45,9 @@ validpgpkeys=('914C533DF9B2ADA2204F586D78E11C6B279D5C91'  # Daniel Stenberg
 prepare() {
   cd "${_realname}-${pkgver}"
   rm -f lib/pathtools.h lib/pathtools.c > /dev/null 2>&1 || true
-  patch -p1 -i "${srcdir}/0001-curl-relocation.patch"
-  patch -p1 -i "${srcdir}/0004-cURL-Get-relocatable-base-from-dll.patch"
+  patch -p1 -i "${srcdir}/0001-Make-cURL-relocatable.patch"
+  patch -p1 -i "${srcdir}/0002-cURL-Get-relocatable-base-from-.dll-instead-of-.exe.patch"
+  patch -p1 -i "${srcdir}/0003-urldata-include-curl_sspi.h-when-Windows-SSPI-is-ena.patch"
   autoreconf -vfi
 }
 


### PR DESCRIPTION
This required a backport of a fix that already made it into cURL's
master branch for a build error discovered only after 7.53.0 was
released.

While at it, I just regenerated the patch files for easier future
adjustments (of course, the easiest would be to just maintain these
patches in a long-running Git branch instead of patch files, but that
is too much to hope for).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>