### PR TITLE
mingw-w64-curl: add name suffix to alternative packages

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -3,9 +3,15 @@ _variant=-openssl
 #_variant=-winssl
 #_variant=-gnutls
 
+if [ "${_variant}" = "-openssl" ]; then
+  _namesuff=
+else
+  _namesuff="${_variant}"
+fi
+
 _realname=curl
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
 pkgver=7.53.1
 pkgrel=1
 pkgdesc="An URL retrival utility and library. (mingw-w64)"
@@ -28,6 +34,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
             "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
             "${MINGW_PACKAGE_PREFIX}-gnutls")
          )
+if [ -n "${_namesuff}" ]; then
+  provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+fi
 options=('staticlibs')
 source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-Make-cURL-relocatable.patch"


### PR DESCRIPTION
*UPDATE: Only mingw-w64-curl/PKGBUILD was modified (see discussion below).*

New package provides cURL compiled with WinSSL. It will be used with git as an alternative option to the ca-cert file: https://github.com/git-for-windows/git/issues/301#issuecomment-281644692.

I copied all the patches and the PKGBUILD file from `mingw-w64-curl` to `mingw-w64-curl-winssl` and modified the PKGBUILD files so that they're still the same except the value of the `_variant` variable.

The same technique is used in `mingw-w64-qt5` and `mingw-w64-qt5-static` packages. If there is a better way to share sources and patches among different packages, I'm ready to do some rework of the changes.

`mingw-w64-curl-winssl` provides the same binary files as `mingw-w64-curl`, so they're marked as conflict. You cannot have both installed at the same time. The `provides` variable is set in addition to the `conflicts` variable just in case there will be `mingw-w64-curl-gnutls` that should conflict with both `mingw-w64-curl` and `mingw-w64-curl-winssl`. Details: https://wiki.archlinux.org/index.php/PKGBUILD#conflicts