### PR TITLE
Inkscape: update dependencies

### DIFF
--- a/mingw-w64-inkscape/PKGBUILD
+++ b/mingw-w64-inkscape/PKGBUILD
@@ -12,7 +12,7 @@ _realname=inkscape
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.92.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Vector graphics editor using the SVG file format (mingw-w64)"
 arch=('any')
 url="http://inkscape.sourceforge.net/"
@@ -34,11 +34,13 @@ depends=(
           "${MINGW_PACKAGE_PREFIX}-imagemagick"
           "${MINGW_PACKAGE_PREFIX}-lcms2"
           "${MINGW_PACKAGE_PREFIX}-libcdr"
+          "${MINGW_PACKAGE_PREFIX}-libvisio"
           "${MINGW_PACKAGE_PREFIX}-libxml2"
           "${MINGW_PACKAGE_PREFIX}-libxslt"
           "${MINGW_PACKAGE_PREFIX}-libwpg"
           "${MINGW_PACKAGE_PREFIX}-poppler"
           "${MINGW_PACKAGE_PREFIX}-popt"
+          "${MINGW_PACKAGE_PREFIX}-potrace"
           "${MINGW_PACKAGE_PREFIX}-python2"
           $([[ "${_use_gtk3}" == "yes" ]] && echo \
             "${MINGW_PACKAGE_PREFIX}-gdl" ) \
@@ -47,6 +49,7 @@ optdepends=(#"${MINGW_PACKAGE_PREFIX}-pstoedit: latex formulas"
             #"${MINGW_PACKAGE_PREFIX}-texlive-core: latex formulas"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy: some extensions"
             "${MINGW_PACKAGE_PREFIX}-python2-lxml: some extensions and filters"
+            #"${MINGW_PACKAGE_PREFIX}-python2-scour: optimized SVG output"
             #"${MINGW_PACKAGE_PREFIX}-uniconvertor: reading/writing to some proprietary formats"
             )
 options=('staticlibs' 'strip')


### PR DESCRIPTION
Inkscape 0.92 has some new dependencies.

We now have libvisio (#2194) and already had potrace for some time.