### PR TITLE
gcc-git: generate _realpkgver from given branch

### DIFF
--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -34,14 +34,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
 #checkdepends=('dejagnu')
 optdepends=()
 options=('staticlibs' '!emptydirs' '!strip' 'debug')
+
 #_branch=gcc-5-branch
 _branch=gcc-6-branch
-# TODO :: Automate this somehow?
-if [ "${_branch}" = "gcc-6-branch" ]; then
-  _realpkgver=6.3.1
-else
-  _realpkgver=5.4.1
-fi
+_realpkgver="$(git archive --remote=git://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
 
 source=("git://gcc.gnu.org/git/gcc.git#branch=${_branch}"
         "0001-gcc-5-branch-gfortran-incorrect-reading-of-values-fr.patch"


### PR DESCRIPTION
`tar` is required by `libtool` which is part of `base-devel` group.