### PR TITLE
mingw-w64-gcc{,-git}: unified layout, and minor code cleanup

### DIFF
--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -96,25 +96,25 @@ pkgver() {
 prepare() {
   cd ${srcdir}/${_realname}
   GIT_AM="git am --committer-date-is-author-date"
-  ${GIT_AM} "${srcdir}"/0001-${_branch}-gfortran-incorrect-reading-of-values-fr.patch || true
-  ${GIT_AM} "${srcdir}"/0002-Relocate-libintl.patch
-  ${GIT_AM} "${srcdir}"/0003-Windows-Follow-Posix-dir-exists-semantics-more-close.patch
-  ${GIT_AM} "${srcdir}"/0004-Windows-Use-not-in-progpath-and-leave-case-as-is.patch
-  ${GIT_AM} "${srcdir}"/0005-Windows-Don-t-ignore-native-system-header-dir.patch
-  ${GIT_AM} "${srcdir}"/0006-${_branch}-Windows-New-feature-to-allow-overriding.patch
-  ${GIT_AM} "${srcdir}"/0007-Build-EXTRA_GNATTOOLS-for-Ada.patch
-  ${GIT_AM} "${srcdir}"/0008-Prettify-linking-no-undefined.patch
-  ${GIT_AM} "${srcdir}"/0009-gcc-make-xmmintrin-header-cplusplus-compatible-depre.patch
-  ${GIT_AM} "${srcdir}"/0010-Fix-using-large-PCH.patch
-  ${GIT_AM} "${srcdir}"/0011-Enable-shared-gnat-implib.patch
+  ${GIT_AM} ${srcdir}/0001-${_branch}-gfortran-incorrect-reading-of-values-fr.patch || true
+  ${GIT_AM} ${srcdir}/0002-Relocate-libintl.patch
+  ${GIT_AM} ${srcdir}/0003-Windows-Follow-Posix-dir-exists-semantics-more-close.patch
+  ${GIT_AM} ${srcdir}/0004-Windows-Use-not-in-progpath-and-leave-case-as-is.patch
+  ${GIT_AM} ${srcdir}/0005-Windows-Don-t-ignore-native-system-header-dir.patch
+  ${GIT_AM} ${srcdir}/0006-${_branch}-Windows-New-feature-to-allow-overriding.patch
+  ${GIT_AM} ${srcdir}/0007-Build-EXTRA_GNATTOOLS-for-Ada.patch
+  ${GIT_AM} ${srcdir}/0008-Prettify-linking-no-undefined.patch
+  ${GIT_AM} ${srcdir}/0009-gcc-make-xmmintrin-header-cplusplus-compatible-depre.patch
+  ${GIT_AM} ${srcdir}/0010-Fix-using-large-PCH.patch
+  ${GIT_AM} ${srcdir}/0011-Enable-shared-gnat-implib.patch
   # it doesn't work at all
-  # ${GIT_AM} "${srcdir}"/0012-MinGW-w64-Enable-libitm.patch
-  ${GIT_AM} "${srcdir}"/0013-MinGW-w64-Enable-shared-gnat.patch
-  ${GIT_AM} "${srcdir}"/0014-${_branch}-clone_function_name_1-Retain-any-stdcall-suffix.patch
-  ${GIT_AM} "${srcdir}"/0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch
-  ${GIT_AM} "${srcdir}"/0016-disable-weak-refs-in-libstdc++.patch
-  ${GIT_AM} "${srcdir}"/0017-PR-77333-Set-clone-call-fntype-to-callee-type.patch
-  # ${GIT_AM} "${srcdir}"/9999-gcc-6-branch-Add-defines-to-disable-optimize-for-size-changes.patch
+  # ${GIT_AM} ${srcdir}/0012-MinGW-w64-Enable-libitm.patch
+  ${GIT_AM} ${srcdir}/0013-MinGW-w64-Enable-shared-gnat.patch
+  ${GIT_AM} ${srcdir}/0014-${_branch}-clone_function_name_1-Retain-any-stdcall-suffix.patch
+  ${GIT_AM} ${srcdir}/0015-Force-linking-to-libgcc_s_dw2-1.dll-deprecated.patch
+  ${GIT_AM} ${srcdir}/0016-disable-weak-refs-in-libstdc++.patch
+  ${GIT_AM} ${srcdir}/0017-PR-77333-Set-clone-call-fntype-to-callee-type.patch
+  # ${GIT_AM} ${srcdir}/9999-gcc-6-branch-Add-defines-to-disable-optimize-for-size-changes.patch
 
   # do not expect $prefix/mingw symlink - this should be superceded by
   # 0004-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!
@@ -203,8 +203,9 @@ build() {
 package_mingw-w64-gcc-libs-git() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-gmp"
-           "${MINGW_PACKAGE_PREFIX}-libwinpthread"
-           "${MINGW_PACKAGE_PREFIX}-${_realname}-libgfortran-git")
+           "${MINGW_PACKAGE_PREFIX}-mpc"
+           "${MINGW_PACKAGE_PREFIX}-mpfr"
+           "${MINGW_PACKAGE_PREFIX}-libwinpthread")
   provides=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs")
   conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-libs")
 
@@ -394,8 +395,8 @@ package_mingw-w64-gcc-objc-git() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include
   cp -r lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/objc    ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/include/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/cc1obj.exe         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
-  cp lib/libobjc.*                                            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
   cp lib/gcc/${MINGW_CHOST}/${_realpkgver}/cc1objplus.exe     ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
+  cp lib/libobjc.*                                            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${_realpkgver}/
 }
 
 # Wrappers for package functions

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -181,6 +181,8 @@ build() {
 
   make all
 
+  rm -rf ${srcdir}${MINGW_PREFIX}
+
   make -j1 DESTDIR=${srcdir} install
   mv ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/adalib/*.dll ${srcdir}${MINGW_PREFIX}/bin/
 }
@@ -188,6 +190,8 @@ build() {
 package_mingw-w64-gcc-libs() {
   pkgdesc="GNU Compiler Collection (libraries) for MinGW-w64"
   depends=("${MINGW_PACKAGE_PREFIX}-gmp"
+           "${MINGW_PACKAGE_PREFIX}-mpc"
+           "${MINGW_PACKAGE_PREFIX}-mpfr"
            "${MINGW_PACKAGE_PREFIX}-libwinpthread")
 
   # Licensing information
@@ -265,10 +269,11 @@ package_mingw-w64-gcc() {
   cp lib/gcc/${MINGW_CHOST}/${pkgver}/liblto*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   cp lib/gcc/${MINGW_CHOST}/${pkgver}/libgcov*           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   cp lib/gcc/${MINGW_CHOST}/${pkgver}/lto*.exe           ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
+  cp lib/gcc/${MINGW_CHOST}/${pkgver}/cc1plus.exe        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
 
   cp lib/libatomic*                                      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver}/libgcc*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   cp lib/libgcc*                                         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
+  cp lib/gcc/${MINGW_CHOST}/${pkgver}/libgcc*            ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
 
   cp lib/libgomp*                                        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   # cp lib/libitm*                                         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
@@ -280,11 +285,10 @@ package_mingw-w64-gcc() {
 
   #mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib
   #cp ${srcdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
-  #cp lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/
+  #cp lib/gcc/${MINGW_CHOST}/lib/libgcc_s.a                ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/lib/
 
-  #cp -r lib/gcc/${MINGW_CHOST}/${pkgver}/include/c++ ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/include/
-  cp -r include/c++ ${pkgdir}${MINGW_PREFIX}/include/
-  cp lib/gcc/${MINGW_CHOST}/${pkgver}/cc1plus.exe        ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
+  #cp -r lib/gcc/${MINGW_CHOST}/${pkgver}/include/c++      ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/include/
+  cp -r include/c++                                       ${pkgdir}${MINGW_PREFIX}/include/
   #cp lib/gcc/${MINGW_CHOST}/${pkgver}/libstdc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
   #cp lib/gcc/${MINGW_CHOST}/${pkgver}/libsupc++*         ${pkgdir}${MINGW_PREFIX}/lib/gcc/${MINGW_CHOST}/${pkgver}/
 
@@ -295,8 +299,8 @@ package_mingw-w64-gcc() {
   cp share/info/gcc.info*                                ${pkgdir}${MINGW_PREFIX}/share/info/
   cp share/info/gccinstall.info*                         ${pkgdir}${MINGW_PREFIX}/share/info/
   cp share/info/gccint.info*                             ${pkgdir}${MINGW_PREFIX}/share/info/
-  cp share/info/libgomp.info*                            ${pkgdir}${MINGW_PREFIX}/share/info/
   # cp share/info/libitm.info*                             ${pkgdir}${MINGW_PREFIX}/share/info/
+  cp share/info/libgomp.info*                            ${pkgdir}${MINGW_PREFIX}/share/info/
   cp share/info/libquadmath.info*                        ${pkgdir}${MINGW_PREFIX}/share/info/
 
   #cp share/locale/* ${pkgdir}${MINGW_PREFIX}/share/locale/


### PR DESCRIPTION
mingw-w64-gcc and mingw-w64-gcc-git have minor differences in the PKGBUILD. For example mingw-w64-gcc-git specifies more "provides" sections for the tools. To make the maintenance easier, I unified mingw-w64-gcc and mingw-w64-gcc-git, by taking some code from mingw-w64-gcc-git to mingw-w64-gcc.