### PR TITLE
npm: minor correction to PKGBUILD

### DIFF
--- a/mingw-w64-npm/PKGBUILD
+++ b/mingw-w64-npm/PKGBUILD
@@ -21,7 +21,7 @@ source=("npm-$pkgver.tar.gz::https://github.com/npm/npm/archive/v$pkgver.tar.gz"
         "npm-marked-$_marked_ver.tgz::https://registry.npmjs.org/marked/-/marked-$_marked_ver.tgz")
 noextract=("npm-$pkgver.tar.gz"
            "npm-marked-$_marked_ver.tgz"
-           "marked-man-$_marked_man_ver.tgz")
+           "npm-marked-man-$_marked_man_ver.tgz")
 
 sha256sums=('a4b083e0694ce786777d55f803551635b7c958e773b4ff5990103eab7c6e46a2'
             'ea48226f08675656a9794d44aef458e10d076b5f116be77a04986122b7c1c4c2'


### PR DESCRIPTION
After mailing AppVeyor support they said CI is fixed.
This PR was created to verify it.

Also there was typo in npm PKGBUILD