### PR TITLE
fixed tre libs build

### DIFF
--- a/mingw-w64-libsystre/PKGBUILD
+++ b/mingw-w64-libsystre/PKGBUILD
@@ -3,11 +3,11 @@
 _realname=libsystre
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-provides="${MINGW_PACKAGE_PREFIX}-libgnurx"
-conflicts="${MINGW_PACKAGE_PREFIX}-libgnurx"
-replaces="${MINGW_PACKAGE_PREFIX}-libgnurx"
+provides=("${MINGW_PACKAGE_PREFIX}-libgnurx")
+conflicts=("${MINGW_PACKAGE_PREFIX}-libgnurx")
+replaces=("${MINGW_PACKAGE_PREFIX}-libgnurx")
 pkgver=1.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="Wrapper library around TRE that provides POSIX API (mingw-w64)"
 arch=('any')
 url=""
@@ -24,8 +24,8 @@ prepare() {
 }
 
 build() {
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
   ../systre-${pkgver}/configure\
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -40,5 +40,5 @@ build() {
 package() {
   cd build-${MINGW_CHOST}
   make DESTDIR="${pkgdir}" install
-  install -D -m644 ${srcdir}/systre-${pkgver}/COPYING "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  install -D -m644 "${srcdir}/systre-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-libtre-git/001-autotools.patch
+++ b/mingw-w64-libtre-git/001-autotools.patch
@@ -1,26 +1,25 @@
-diff -Naur libtre-orig/configure.ac libtre/configure.ac
---- libtre-orig/configure.ac	2015-01-13 21:37:45.236000000 +0300
-+++ libtre/configure.ac	2015-01-13 22:03:05.152200000 +0300
-@@ -2,10 +2,11 @@
- AC_INIT(TRE, 0.8.0, [tre-general@lists.laurikari.net])
+diff --git a/configure.ac b/configure.ac
+index e4a94af..fac4ed7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2,10 +2,11 @@ dnl Process this file with autoconf to produce a configure script.
+ AC_INIT(TRE, 0.8.0)
  AC_CONFIG_SRCDIR([lib/regcomp.c])
  AC_CONFIG_AUX_DIR(utils)
 +AC_CONFIG_MACRO_DIRS([m4])
  AC_CANONICAL_TARGET
--AM_INIT_AUTOMAKE(1.9.0)
+ AM_INIT_AUTOMAKE([foreign])
 -AC_PREREQ(2.59)
 -AM_GNU_GETTEXT_VERSION(0.17)
-+AM_INIT_AUTOMAKE([subdir-objects])
 +AC_PREREQ(2.69)
 +AM_GNU_GETTEXT_VERSION(0.18)
  
  dnl Checks for programs.
  AC_PROG_CC
-@@ -433,16 +433,6 @@
-       [ $tre_includes ])
+@@ -433,16 +434,6 @@ if test "$tre_enable_wchar" != "no"; then
    fi
  fi
--
+ 
 -case $host in
 -  *-mingw*)
 -    dnl wcsrtombs and wcstombs don't seem to work at all on MinGW.
@@ -30,30 +29,7 @@ diff -Naur libtre-orig/configure.ac libtre/configure.ac
 -    fi
 -    ;;
 -esac
- 
+-
  # Fail if wide character support was specifically requested but is
  # not supported on this system.
-diff -Naur libtre-orig/src/Makefile.am libtre/src/Makefile.am
---- libtre-orig/src/Makefile.am	2015-01-13 21:37:45.267200000 +0300
-+++ libtre/src/Makefile.am	2015-01-13 21:54:03.773400000 +0300
-@@ -1,7 +1,7 @@
- ## Process this file with automake to produce Makefile.in
- 
- localedir = $(datadir)/locale
--INCLUDES = -I$(top_srcdir)/lib
-+AM_CPPFLAGS = -I$(top_srcdir)/lib
- 
- if TRE_AGREP
- bin_PROGRAMS = agrep
-diff -Naur libtre-orig/tests/Makefile.am libtre/tests/Makefile.am
---- libtre-orig/tests/Makefile.am	2015-01-13 21:37:45.267200000 +0300
-+++ libtre/tests/Makefile.am	2015-01-13 21:52:35.508600000 +0300
-@@ -59,7 +59,7 @@
-   randtest_LDADD = libxtre.la $(LDADD)
- endif !TRE_DEBUG
- 
--INCLUDES = -I$(top_srcdir)/lib
-+AM_CPPFLAGS = -I$(top_srcdir)/lib
- 
- EXTRA_DIST = build-tests.sh
- 
+ if test "$tre_enable_wchar" = "yes"; then

--- a/mingw-w64-libtre-git/PKGBUILD
+++ b/mingw-w64-libtre-git/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Mario Emmenlauer <memmenlauer@biodataanalysis.de>
 
 _realname=libtre
 pkgbase=mingw-w64-${_realname}-git
@@ -7,7 +8,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=r122.c2f5d13
-pkgrel=4
+pkgrel=5
 pkgdesc="The approximate regex matching library and agrep command line tool (mingw-w64)"
 url="https://github.com/laurikari/tre"
 arch=('any')
@@ -15,11 +16,11 @@ license=('BSD')
 options=(strip staticlibs)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "git")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-gettext")
-source=("${_realname}"::"git+https://github.com/laurikari/tre.git"
+source=("${_realname}"::"git+https://github.com/laurikari/tre.git#commit=6fb7206"
         001-autotools.patch
         002-pointer-cast.patch)
 sha256sums=('SKIP'
-            '381b8878178ce60442308340eea89a88b850b8e3ad4e49ed36f42eeacf9aa28e'
+            '470134e966eabe90371f68b89183217cf0631a6c221f6329b594a587d4390b6f'
             '72c87b956eade17ed5444c3c6eae7be09b93d145573f20017ec590d9c2516c52')
 
 pkgver() {
@@ -29,8 +30,8 @@ pkgver() {
 
 prepare() {
   cd "${_realname}"
-  patch -p1 -i ${srcdir}/001-autotools.patch
-  patch -p1 -i ${srcdir}/002-pointer-cast.patch
+  patch -p1 -i "${srcdir}/001-autotools.patch"
+  patch -p1 -i "${srcdir}/002-pointer-cast.patch"
   mv ChangeLog{.old,}
   autoreconf -fiv
 }
@@ -53,6 +54,6 @@ build() {
 
 package() {
   cd build-${MINGW_CHOST}
-  make DESTDIR=${pkgdir} install
+  make DESTDIR="${pkgdir}" install
   install -Dm644 "${srcdir}/${_realname}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
build of `mingw-w64-libsystre` was broken with a trivial problem missing round braces around provides, conflicts and replaces. build of `mingw-w64-libtre-git` did not specify a git commit, and the upstream head had changes.