### PR TITLE
add libtool to binutils

### DIFF
--- a/mingw-w64-binutils-git/PKGBUILD
+++ b/mingw-w64-binutils-git/PKGBUILD
@@ -15,9 +15,13 @@ arch=('any')
 url="https://www.gnu.org/software/binutils/"
 license=('GPL')
 #groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
-depends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 #checkdepends=('dejagnu' 'bc')
-makedepends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib" "git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-libtool"
+             "${MINGW_PACKAGE_PREFIX}-libiconv"
+             "${MINGW_PACKAGE_PREFIX}-zlib"
+             "git")
 options=('staticlibs' '!distcc' '!ccache' 'debug' '!strip')
 #install=binutils.install
 source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git#branch=${_realname}-${_base_ver//./_}-branch"
@@ -60,8 +64,7 @@ build() {
     CFLAGS+=" -O0"
   fi
 
-  cd $srcdir
-  rm -rf build-${MINGW_CHOST}
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
   ../${_realname}/configure \
     --build=${MINGW_CHOST} \

--- a/mingw-w64-binutils/PKGBUILD
+++ b/mingw-w64-binutils/PKGBUILD
@@ -8,12 +8,15 @@ pkgver=2.27
 pkgrel=5
 pkgdesc="A set of programs to assemble and manipulate binary and object files (mingw-w64)"
 arch=('any')
-url="http://www.gnu.org/software/binutils/"
+url="https://www.gnu.org/software/binutils/"
 license=('GPL')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
-depends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib")
+depends=("${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
 #checkdepends=('dejagnu' 'bc')
-makedepends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-libtool"
+             "${MINGW_PACKAGE_PREFIX}-libiconv"
+             "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' '!distcc' '!ccache') # 'debug' '!strip')
 #install=binutils.install
 source=(https://ftp.gnu.org/gnu/binutils/${_realname}-${pkgver}.tar.bz2{,.sig}


### PR DESCRIPTION
To build a working `mingw-w64-binutils` the `mingw-w64-libtool` is required, otherwise `ld` is broken. However `mingw-w64-libtool` is not in `base-devel` and not in `toolchain` so it is required as an explicit `makedepends`.