### PR TITLE
mingw-w64-gettext: added make-dependency to mingw-w64-libtool

### DIFF
--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -13,7 +13,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          #"${MINGW_PACKAGE_PREFIX}-termcap"
         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-ncurses")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-libtool"
+             "${MINGW_PACKAGE_PREFIX}-ncurses")
 options=('strip' 'staticlibs')
 
 # GPL3 for the package as a whole and LGPL for some parts, see the license files


### PR DESCRIPTION
To build a working `mingw-w64-gettext` the `mingw-w64-libtool` is required. Since `mingw-w64-libtool` is not in `base-devel` and not in `toolchain`, it is required as an explicit makedepends.