### PR TITLE
mingw-w64-ca-certificates: fixing download URL

### DIFF
--- a/mingw-w64-ca-certificates/PKGBUILD
+++ b/mingw-w64-ca-certificates/PKGBUILD
@@ -4,13 +4,13 @@ _realname=ca-certificates
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20160104
-pkgrel=2
+pkgrel=3
 pkgdesc='Common CA certificates (mingw-w64)'
 arch=('any')
 url='https://packages.qa.debian.org/c/ca-certificates.html'
 license=('MPL' 'GPL')
 install="ca-certificates-${CARCH}.install"
-source=("http://ftp.debian.org/debian/pool/main/c/${_realname}/${_realname}_${pkgver}.tar.xz"
+source=("http://data.biodataanalysis.de/files/packages/mingw64/${_realname}/${_realname}_${pkgver}.tar.xz"
         'StartSSL.sub.class1.server.ca.pem'::'https://www.startssl.com/certs/sub.class1.server.ca.pem'
         'certdata2pem-redhat.patch'
         'diff-from-upstream-2.3.patch'


### PR DESCRIPTION
Until a real update of the certificates will happen, use another mirror of ca-certificates file. Build untested, but should work.