### PR TITLE
mingw-w64-kicad-git: Updated the PKGBUILD to respect pacman debug fla…

### DIFF
--- a/mingw-w64-kicad-git/PKGBUILD
+++ b/mingw-w64-kicad-git/PKGBUILD
@@ -42,14 +42,22 @@ build() {
   [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
   mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
 
+  declare -a _btype
+  if check_option "debug" "y"; then
+    _btype=Debug
+  else
+    _btype=Release
+  fi
+
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=${_btype} \
     -DDEFAULT_INSTALL_PATH=${MINGW_PREFIX} \
     -DOPENSSL_ROOT_DIR=${MINGW_PREFIX} \
-    -DKICAD_SKIP_BOOST=ON \
     -DKICAD_SCRIPTING=ON \
     -DKICAD_SCRIPTING_MODULES=ON \
     -DKICAD_SCRIPTING_WXPYTHON=ON \


### PR DESCRIPTION
…g and pass it into cmake to build kicad with debugging symbols etc. for gdb.
Removed cruft "skip boost" variable.