### PR TITLE
gdb: Fix crash on mingw32

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -8,7 +8,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=7.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -31,7 +31,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'gdb-7.6.2-mingw-gcc-4.7.patch'
         'gdb-perfomance.patch'
         'gdb-fix-using-gnu-print.patch'
-        'gdb-7.12-readline-mingw.patch')
+        'gdb-7.12-readline-mingw.patch'
+        'gdb-7.12-dynamic-libs.patch')
 sha256sums=('4607680b973d3ec92c30ad029f1b7dbde3876869e6b3a117d8a7e90081113186'
             'SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
@@ -40,7 +41,8 @@ sha256sums=('4607680b973d3ec92c30ad029f1b7dbde3876869e6b3a117d8a7e90081113186'
             '82ea717b628c8970055a9cbb8edaed8fbebc2cac27467337426dfc4b4c514a6b'
             '6be0f95483e02d5447c93ab5e2c9554d254c6888b1fa3f3a4c011cd6a0a403ad'
             '264eba33ef71c4762514a634dcf94fdb778914dbba6ce99e63804fe063225d97'
-            'db047e044a573b6cd1cc154a6a505a1f1b80ec5654f3779c2486cdea24c13feb')
+            'db047e044a573b6cd1cc154a6a505a1f1b80ec5654f3779c2486cdea24c13feb'
+            '4398bd83a798baa15c0f91878391a0882239a682cf523ef6551766cba7b03699')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -57,6 +59,9 @@ prepare() {
 
   # https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=7f3c5ec870943f7f32c946ff9459dfd04fcb8e07
   patch -p1 -i ${srcdir}/gdb-7.12-readline-mingw.patch
+
+  # https://sourceware.org/bugzilla/show_bug.cgi?id=21078
+  patch -p1 -i ${srcdir}/gdb-7.12-dynamic-libs.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure

--- a/mingw-w64-gdb/gdb-7.12-dynamic-libs.patch
+++ b/mingw-w64-gdb/gdb-7.12-dynamic-libs.patch
@@ -1,0 +1,36 @@
+From 04a27a15b268e07c76578c074c3822477ceabc50 Mon Sep 17 00:00:00 2001
+From: Orgad Shaneh <orgads@gmail.com>
+Date: Tue, 7 Mar 2017 19:13:41 +0200
+Subject: [PATCH] configure: Disable static linking with standard libs
+
+Linking statically causes spurious crashes on exception handling
+with mingw32.
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index a5f4fc5aa7..f5a9766c39 100755
+--- a/configure
++++ b/configure
+@@ -5902,7 +5902,7 @@ else
+  # if supported.  But if the user explicitly specified the libraries to use,
+  # trust that they are doing what they want.
+  if test "$stage1_libs" = "" -a "$have_static_libs" = yes; then
+-   stage1_ldflags="-static-libstdc++ -static-libgcc"
++   stage1_ldflags=""
+  fi
+ fi
+ 
+@@ -5938,7 +5938,7 @@ else
+  # statically.  But if the user explicitly specified the libraries to
+  # use, trust that they are doing what they want.
+  if test "$poststage1_libs" = ""; then
+-   poststage1_ldflags="-static-libstdc++ -static-libgcc"
++   poststage1_ldflags=""
+  fi
+ fi
+ 
+-- 
+2.12.0.windows.1
+


### PR DESCRIPTION
Fixes https://github.com/Alexpux/MSYS2-packages/issues/716.

Future versions of gdb will have a flag for that[1].

[1] https://sourceware.org/bugzilla/show_bug.cgi?id=21187