### PR TITLE
mingw-w64-xmlstarlet: use realname instead of name

### DIFF
--- a/mingw-w64-xmlstarlet/PKGBUILD
+++ b/mingw-w64-xmlstarlet/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Renato Silva <br.renatosilva@gmail.com>
 
-_name=xmlstarlet
+_realname=xmlstarlet
 pkgdesc="Command-line XML toolkit"
 pkgver=r678.9a470e3
 pkgrel=2
@@ -8,27 +8,27 @@ arch=('any')
 license=('MIT')
 url="http://xmlstar.sourceforge.net"
 pkgbase=mingw-w64-${_realname}-git
-pkgname=(${MINGW_PACKAGE_PREFIX}-${_name}-git)
-provides=(${MINGW_PACKAGE_PREFIX}-${_name})
-conflicts=(${MINGW_PACKAGE_PREFIX}-${_name})
+pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}-git)
+provides=(${MINGW_PACKAGE_PREFIX}-${_realname})
+conflicts=(${MINGW_PACKAGE_PREFIX}-${_realname})
 sha256sums=('SKIP')
-source=(${_name}::"git://git.code.sourceforge.net/p/xmlstar/code")
+source=(${_realname}::"git://git.code.sourceforge.net/p/xmlstar/code")
 depends=(${MINGW_PACKAGE_PREFIX}-libxml2
          ${MINGW_PACKAGE_PREFIX}-libxslt)
 makedepends=(${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-libiconv git)
 
 prepare() {
-  cd "${srcdir}/${_name}"
+  cd "${srcdir}/${_realname}"
   autoreconf -sif
 }
 
 pkgver() {
-  cd "${srcdir}/${_name}"
+  cd "${srcdir}/${_realname}"
   printf "r%s.%s" $(git rev-list --count HEAD) $(git rev-parse --short HEAD)
 }
 
 build() {
-  cd "${srcdir}/${_name}"
+  cd "${srcdir}/${_realname}"
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -43,9 +43,9 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${_name}"
+  cd "${srcdir}/${_realname}"
   make DESTDIR="${pkgdir}" install
-  local license_dir="${pkgdir}${MINGW_PREFIX}/share/licenses/${_name}"
+  local license_dir="${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
   mkdir -p "${license_dir}"
   cp -v Copyright "${license_dir}/Copyright"
   mv -v "${pkgdir}${MINGW_PREFIX}/bin/xml.exe" "${pkgdir}${MINGW_PREFIX}/bin/xmlstarlet.exe"


### PR DESCRIPTION
Minor whitespace change, for consistency between different PKGBUILD files. Renamed `_name` to `_realname`.