### PR TITLE
mingw-w64-jxrlib: changed download to launchpad offical

### DIFF
--- a/mingw-w64-jxrlib/PKGBUILD
+++ b/mingw-w64-jxrlib/PKGBUILD
@@ -15,22 +15,20 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-iconv")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' 'staticlibs')
-source=(#jxrlib_${pkgver//./_}.tar.gz::http://jxrlib.codeplex.com/downloads/get/685250
-        #http://jxrlib.codeplex.com/downloads/get/685250#/jxrlib_${pkgver//./_}.tar.gz
-        jxrlib_${pkgver//./_}.tar.gz::"https://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=jxrlib&DownloadId=685250&FileTime=130142428056630000&Build=21031"
+source=(${_realname}-${pkgver}.tar.gz::"https://launchpad.net/ubuntu/+archive/primary/+files/jxrlib_1.1.orig.tar.gz"
         "CMakeLists.txt"
         "jxrlib_warnings.patch"
         "jxrlib_mingw.patch")
-sha256sums=('a79e27801ab19af936beb9ece36f1c6c1914c3baf25597fd270709dc4520a190'
+sha256sums=('c7287b86780befa0914f2eeb8be2ac83e672ebd4bd16dc5574a36a59d9708303'
             '0ebdba82daab11e94783de4ce675db3cb612167c164b15cda8cf754da45b40dd'
             'be85117d2f0af1f0edc2389c9379198d2b69f00ab1d036911a8436cd3abbe96e'
             'aa0cd3b0c9c96876e8d7d204cd3b240d91864a54de82fb83db3e094a1cf03302')
 
 prepare() {
-  cd "${srcdir}"/${_realname}
+  cd "${srcdir}/${_realname}-${pkgver}"
   
   # Sanitize charset and line endings
-  for file in `find . -type f -name '*.c' -or -name '*.h' -or -name '*.txt'`; do
+  for file in $(find . -type f \( -name '*.c' -or -name '*.h' -or -name '*.txt' \) ); do
     ${MINGW_PREFIX}/bin/iconv -f ISO-8859-15 -t UTF-8 ${file} > ${file}.new && \
         sed -i 's|\r||g' ${file}.new && \
         touch -r ${file} ${file}.new && mv ${file}.new ${file}
@@ -39,15 +37,15 @@ prepare() {
   # Remove file which already exists as part of the mingw headers
   rm -f common/include/guiddef.h
   
-  cp -f ${srcdir}/CMakeLists.txt .
+  cp -f "${srcdir}/CMakeLists.txt" .
   
-  patch -p1 -i ${srcdir}/jxrlib_warnings.patch
-  patch -p1 -i ${srcdir}/jxrlib_mingw.patch
+  patch -p1 -i "${srcdir}/jxrlib_warnings.patch"
+  patch -p1 -i "${srcdir}/jxrlib_mingw.patch"
 }
 
 build() {
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
  
   declare -a extra_config
   if check_option "debug" "n"; then
@@ -61,12 +59,12 @@ build() {
       -G'MSYS Makefiles' \
       -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
       "${extra_config[@]}" \
-      ../${_realname}
+      ../${_realname}-${pkgver}
 
   make
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
-  make DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
 }


### PR DESCRIPTION
`jxrlib` download had a broken the sha256, so I switched to the Debian launchpad download. The packages are identical except that the lauchpad version does not ship the pre-compiled binaries `hdr2hdr.exe` and `imagecomp.exe`.
I also slightly changed the PKGBUILD formatting.