### PR TITLE
Fix detection of opencv lib path

### DIFF
--- a/mingw-w64-opencv/0008-mingw-w64-cmake-lib-path.patch
+++ b/mingw-w64-opencv/0008-mingw-w64-cmake-lib-path.patch
@@ -1,0 +1,17 @@
+diff -Naur a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+--- a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in	2017-03-08 20:21:41.669934400 -0500
++++ b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in	2017-03-08 20:23:59.354590300 -0500
+@@ -109,11 +109,11 @@
+     else()
+       set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/staticlib")
+     endif()
+-  elseif(EXISTS "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib/OpenCVConfig.cmake")
++  elseif(EXISTS "${OpenCV_CONFIG_PATH}/lib/OpenCVConfig.cmake")
+     if(OpenCV_CUDA AND EXISTS "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib/OpenCVConfig.cmake")
+       set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/gpu/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
+     else()
+-      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib")
++      set(OpenCV_LIB_PATH "${OpenCV_CONFIG_PATH}/lib")
+     endif()
+   endif()
+ endif()

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
@@ -41,7 +41,8 @@ source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archiv
         '0004-generate-proper-pkg-config-file.patch'
         '0005-opencv-support-python-3.5.patch'
         '0006-somehow-uint-not-detected.patch'
-        '0007-mingw-w64-have-sincos.patch')
+        '0007-mingw-w64-have-sincos.patch'
+        '0008-mingw-w64-cmake-lib-path.patch')
 sha256sums=('b9d62dfffb8130d59d587627703d5f3e6252dce4a94c1955784998da7a39dd35'
             '1e2bb6c9a41c602904cc7df3f8fb8f98363a88ea564f2a087240483426bf8cbe'
             '9ce9cd5cbf76aea9f007f388dd71ccd7c9a656a274a84ef9a4e45af77b211fc0'
@@ -50,7 +51,8 @@ sha256sums=('b9d62dfffb8130d59d587627703d5f3e6252dce4a94c1955784998da7a39dd35'
             '47447c78acc810cd0604b641644f1c546c29e925b7b9671a4fa18468ff3ad330'
             'e50f69c6c1fbce255b3e7ef4b489bf1a01ba28cf828a6adb80c73a7f9c08a666'
             '7d2ff25f97c84b59793502786dd64e25c8ca991b0523ffea56b45ce031e80c3f'
-            'ba227bb88c7e6948c54c5a3c8347daf5e2c930e99fb155047015bc5cfa2b33e5')
+            'ba227bb88c7e6948c54c5a3c8347daf5e2c930e99fb155047015bc5cfa2b33e5'
+            '434b3bb1f6fd3af31952de5c4af95eb726f4e45b077e98195f8c204732bc9754')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -60,6 +62,8 @@ prepare() {
   patch -Np1 -i "${srcdir}/0003-issue-4107.patch"
   patch -Np1 -i "${srcdir}/0004-generate-proper-pkg-config-file.patch"
   patch -Np1 -i "${srcdir}/0005-opencv-support-python-3.5.patch"
+
+  patch -Np1 -i "${srcdir}/0008-mingw-w64-cmake-lib-path.patch"
   
   cd "${srcdir}/${_realname}_contrib-${pkgver}"
   patch -Np1 -i "${srcdir}/0006-somehow-uint-not-detected.patch"


### PR DESCRIPTION
When trying to fix the ITK builds I ran into a problem with the opencv cmake files. As you can see in the patch, opencv looks for the lib path at `${OpenCV_CONFIG_PATH}/${OpenCV_ARCH}/${OpenCV_RUNTIME}/lib`. However, mingw stores the lib files under `${OpenCV_CONFIG_PATH}/lib`, where `OpenCV_CONFIG_PATH` is e.g. `/msys64/mingw64` and doesn't separate them into arch etc like the original makefile does.