### PR TITLE
Fix ITK builds.

### DIFF
--- a/FAIL_LIST.md
+++ b/FAIL_LIST.md
@@ -17,8 +17,6 @@ List of packages that currently fail to build
 
 - gtkada
 
-- itk
-
 - ldns
 
 - librocket-git

--- a/mingw-w64-itk/PKGBUILD
+++ b/mingw-w64-itk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=itk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.8.0
+pkgver=4.11.0
 pkgrel=1
 pkgdesc='An open-source C++ toolkit for medical image processing (mingw-w64)'
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 optdepends=("${MINGW_PACKAGE_PREFIX}-opencv: ITK-OpenCV bridge"
             "${MINGW_PACKAGE_PREFIX}-vtk: ITK-VTK bridge")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/InsightSoftwareConsortium/ITK/archive/v${pkgver}.tar.gz")
-sha256sums=('7b0a1fe06969c55f6a3a55cd4754b7de3662ac9e98b12b20532d3aebc082cccd')
+sha256sums=('a1857aa89f02efce3e091d102fbff7b2c53fe40c7f74580a47236bfd846c4e8b')
 
 build() {
   CFLAGS+=" ${CPPFLAGS}"
@@ -68,6 +68,7 @@ build() {
     -DITK_USE_SYSTEM_ZLIB=ON \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
+    -DITK_SKIP_PATH_LENGTH_CHECKS=1 \
     "${_extra_config[@]}" \
     "../${_realname}-${pkgver}"
 
@@ -78,11 +79,13 @@ package() {
   cd "${srcdir}/build-${CARCH}"
   make DESTDIR=${pkgdir} -j1 install
 
+  local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
+
   pushd "${pkgdir}${MINGW_PREFIX}" > /dev/null
-  sed -s "s|${MINGW_PREFIX}|\${_IMPORT_PREFIX}|g" \
+  sed -s "s|${PREFIX_DEPS}|\${_IMPORT_PREFIX}|g" \
     -i "lib/cmake/${_realname}-${pkgver%.*}/ITKTargets-release.cmake"
   find "lib/cmake/${_realname}-${pkgver%.*}" -name '*.cmake' -exec \
-    sed -s "s|${MINGW_PREFIX}|\${ITK_INSTALL_PREFIX}|g" -i {} \;
+    sed -s "s|${PREFIX_DEPS}|\${ITK_INSTALL_PREFIX}|g" -i {} \;
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "share/licenses/${_realname}/LICENSE"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/NOTICE" "share/licenses/${_realname}/NOTICE"
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/Modules/ThirdParty/KWSys/src/KWSys/Copyright.txt" \


### PR DESCRIPTION
This fixes the ITK builds.

Before this can be built however, a new package of VTK needs to be released on pacman because pacman does not have the latest build as described here: https://github.com/Alexpux/MINGW-packages/issues/1670#issuecomment-285211099.

After that OpenCV should be able to be built and there needs to be a new release of it using the fix from https://github.com/Alexpux/MINGW-packages/pull/2268.

Finally, after the VTK and OpenCV pacman packages are updated, this PR will be buildable. I tested it locally with the fixes described above applied.