### PR TITLE
mbedtls: Updated to 2.4.2 (security update)

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.0
+pkgver=2.4.2
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
@@ -20,7 +20,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha256sums=('c1c3559ed39f7a1b1550c4cf4ccb918bf239301a3311d98dda92bed8a25b7f0d'
+sha256sums=('17dd98af7478aadacc480c7e4159e447353b5b2037c1b6d48ed4fd157fb1b018'
             '5c5382ff266e5cc293f31a46e1f10782c765c5cc1476dfc21d5c4ad405f647a0'
             '89eb82f9e9fb456d0595035925d2d512aa2ca9b9e283b9c51d5524bfc8dbf996'
             '1be88267b045a8728fe4dde663faf328ad788eeefcb43915beeb364b4d2dd2e8')


### PR DESCRIPTION
Fixes CVE-2017-2784
https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2017-01