### PR TITLE
mingw-w64-libcaca: explicitly disable docs build

### DIFF
--- a/mingw-w64-libcaca/PKGBUILD
+++ b/mingw-w64-libcaca/PKGBUILD
@@ -33,12 +33,12 @@ sha256sums=('128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4'
             '41868030a0e8ec2828476c17918af6d368e84e6aa1e165338000c36cc9898f82')
 
 prepare() {
-  cd ${srcdir}/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/0001-win32-is-not-msvc-it-could-be.mingw.patch
-  patch -p1 -i ${srcdir}/0002-correct-installation-order.mingw.patch
-  patch -p1 -i ${srcdir}/0004-msc-only-please.all.patch
-  patch -p1 -i ${srcdir}/0005-ruby-paths.mingw.patch
-  patch -p1 -i ${srcdir}/0006-no-undefined.all.patch
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0001-win32-is-not-msvc-it-could-be.mingw.patch"
+  patch -p1 -i "${srcdir}/0002-correct-installation-order.mingw.patch"
+  patch -p1 -i "${srcdir}/0004-msc-only-please.all.patch"
+  patch -p1 -i "${srcdir}/0005-ruby-paths.mingw.patch"
+  patch -p1 -i "${srcdir}/0006-no-undefined.all.patch"
 
   autoreconf -fi
 }
@@ -52,6 +52,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-static \
     --enable-shared \
+    --disable-doc \
     --disable-ncurses
 
   make


### PR DESCRIPTION
The build fails if doxygen is not available. Therefore I disabled the build of docs.
There is also a minor code cleanup.