### PR TITLE
wineditline: Updates to 2.201

### DIFF
--- a/mingw-w64-wineditline/PKGBUILD
+++ b/mingw-w64-wineditline/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=wineditline
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.101
-pkgrel=4
+pkgver=2.201
+pkgrel=1
 pkgdesc="port of the NetBSD Editline library (mingw-w64)"
 arch=('any')
 license=('BSD')
@@ -15,7 +15,7 @@ source=("https://sourceforge.net/projects/mingweditline/files/${_realname}-${pkg
         '001-fix-installing.patch'
         '002-fix-exports.patch'
         '003-dont-link-with-def.patch')
-sha256sums=('854b536bfe231aba478136f5cf9f2baca0182894dae78e3fddbd83b75fe6dfc8'
+sha256sums=('df042d4766bc8cd579c3c8a10337388be64a02a9980442fec6ebbececef7c13a'
             '92987daf0c67eecdfc62702c3adaa025e0363039cda58aa9ae0a66852341a737'
             '38e779fbdebf2f29038b598920e733a4a51638834013c3cc73fb85a7d50cffd2'
             '19077726758de7780cd68f3f47d8353516fd864ede1903d55280a1fb3dbe408d')


### PR DESCRIPTION
Fixes broken download url.