### PR TITLE
mingw-w64-matio: added

### DIFF
--- a/mingw-w64-matio/PKGBUILD
+++ b/mingw-w64-matio/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Mario Emmenlauer <memmenlauer@biodataanalysis.de>
+
+_realname=matio
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.5.10
+pkgrel=1
+pkgdesc="matio is a C library for reading and writing MATLAB MAT files."
+arch=('any')
+url='https://sourceforge.net/projects/matio/'
+license=('Simplified BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-hdf5")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=('staticlibs' 'strip')
+source=(https://downloads.sourceforge.net/project/matio/matio/${pkgver}/matio-${pkgver}.7z)
+sha256sums=('ee612a40b4d86fbd44a23436bd6373989c0f71f32931a278086fb5452bf4d1a6')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  cp -rf "${_realname}-${pkgver}" "build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  chmod +x ./configure
+  ./configure \
+    --disable-debug \
+    --enable-mat73="yes" \
+    --with-default-file-ver="7.3"
+
+  make ${MAKEFLAGS}
+}
+
+check() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  # it is not clear why the following workaround is needed to
+  # execute tests, but after touching the testsuite.at, the
+  # tests work, when otherwise they fail:
+  touch ./test/testsuite.at
+
+  make check
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" -j1 install
+
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/"
+}


### PR DESCRIPTION
Added a native C++ Matlab file reader with support for Matlab files version 4, 5, and 7.3 (with hdf5).