### PR TITLE
mingw-w64-xapian-core: switched (broken) download server

### DIFF
--- a/mingw-w64-xapian-core/PKGBUILD
+++ b/mingw-w64-xapian-core/PKGBUILD
@@ -13,17 +13,17 @@ url='https://www.xapian.org/'
 license=('GPL')
 # xapian config requires libxapian.la
 options=('libtool')
-source=("http://oligarchy.co.uk/xapian/${pkgver}/${_realname}-${pkgver}.tar.xz")
+source=("${_realname}-${pkgver}.tar.xz::https://launchpad.net/ubuntu/+archive/primary/+files/${_realname}_${pkgver}.orig.tar.xz")
 sha256sums=('aec2c4352998127a2f2316218bf70f48cef0a466a87af3939f5f547c5246e1ce')
 
 prepare() {
-  cd $srcdir/${_realname}-${pkgver}
+  cd "$srcdir/${_realname}-${pkgver}"
 }
 
 build() {
-  cd "$srcdir"/${_realname}-${pkgver}
-  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  cd "$srcdir/${_realname}-${pkgver}"
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
   # FS#40614
   if [ "${CARCH}" = "i686" ]; then
     SSE2="--disable-sse"
@@ -40,6 +40,6 @@ build() {
 }
 
 package() {
-  cd "${srcdir}"/build-${CARCH}
+  cd "${srcdir}/build-${CARCH}"
   make install DESTDIR="${pkgdir}"
 }


### PR DESCRIPTION
The official download server has an expired SSL certificate and I can not get it to work.
Switched to Ubuntu mirror.
I also tried updating xapian to 1.4.3, but it has a problem (missing link against math library).
I've reported the issue upstream.