### PR TITLE
miniupnpc

### DIFF
--- a/mingw-w64-miniupnpc/PKGBUILD
+++ b/mingw-w64-miniupnpc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=miniupnpc
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=1.9.20150609
+pkgver=2.0
 pkgrel=1
 pkgdesc="A small UPnP client library/tool to access Internet Gateway Devices (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=(#"http://miniupnp.free.fr/files/${_realname}-${pkgver}.tar.gz"
         http://miniupnp.tuxfamily.org/files/${_realname}-${pkgver}.tar.gz
         001-link-libraries.patch)
-sha256sums=('86e6ccec5b660ba6889893d1f3fca21db087c6466b1a90f495a1f87ab1cd1c36'
+sha256sums=('d434ceb8986efbe199c5ca53f90ed53eab290b1e6d0530b717eb6fa49d61f93b'
             '3ac8b46b15ab48415cbbfa759d968873b315a96120d4dcbe062fbc39a909726d')
 
 prepare() {


### PR DESCRIPTION
2.0 is successfully build with 001-link-libraries.patch, but now without it
2.0.20161216 does not build