### PR TITLE
downloads.sourceforge.io -> downloads.sourceforge.net

### DIFF
--- a/mingw-w64-hyphen/PKGBUILD
+++ b/mingw-w64-hyphen/PKGBUILD
@@ -12,7 +12,7 @@ url='https://hunspell.sourceforge.io/'
 license=(GPL-2.0+ or LGPL-2.0+ or MPL-1.1+)
 makedepends=('perl')
 optdepends=('perl: for substrings.pl script')
-source=("https://downloads.sourceforge.io/hunspell/${_realname}-${pkgver}.tar.gz"
+source=("https://downloads.sourceforge.net/hunspell/${_realname}-${pkgver}.tar.gz"
         "0001-Fix_COMPOUNDHYPHENMIN_1.patch"
         "0002-Tests_COMPOUNDHYPHENMIN_1.patch")
 sha256sums=('304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705'

--- a/mingw-w64-lcov/PKGBUILD
+++ b/mingw-w64-lcov/PKGBUILD
@@ -11,7 +11,7 @@ arch=('any')
 url="https://ltp.sourceforge.io/coverage/lcov.php"
 license=('GPL')
 depends=("${MINGW_PACKAGE_PREFIX}-perl")
-source=("https://downloads.sourceforge.io/ltp/$_realname-$pkgver.tar.gz"
+source=("https://downloads.sourceforge.net/ltp/$_realname-$pkgver.tar.gz"
         "handle-equals-signs.patch"
         "fix-undef-behaviour.patch"
         "reproducible-manpage.patch"

--- a/mingw-w64-ngspice/PKGBUILD
+++ b/mingw-w64-ngspice/PKGBUILD
@@ -18,8 +18,8 @@ license=('BSD')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("https://downloads.sourceforge.io/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-${pkgver}.tar.gz"
-        "https://downloads.sourceforge.io/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-doc-${pkgver}.tar.gz")
+source=("https://downloads.sourceforge.net/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-${pkgver}.tar.gz"
+        "https://downloads.sourceforge.net/project/${_realname}/ng-spice-rework/${pkgver}/${_realname}-doc-${pkgver}.tar.gz")
 sha256sums=('51e230c8b720802d93747bc580c0a29d1fb530f3dd06f213b6a700ca9a4d0108'
             'adc722cf627ee4506ea612c3fcb79f9c73c497e328547ab2d1ea97da588459cb')
 

--- a/mingw-w64-udis86/PKGBUILD
+++ b/mingw-w64-udis86/PKGBUILD
@@ -11,7 +11,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-python2")
 options=('strip' '!libtool' 'staticlibs')
-source=("https://downloads.sourceforge.io/udis86/${_realname}-${pkgver}.tar.gz")
+source=("https://downloads.sourceforge.net/udis86/${_realname}-${pkgver}.tar.gz")
 sha256sums=('9c52ac626ac6f531e1d6828feaad7e797d0f3cce1e9f34ad4e84627022b3c2f4')
 
 build() {


### PR DESCRIPTION
sourceforge.io is for user's subdomains, not for download servers
seem that [someone](https://github.com/Alexpux/MINGW-packages/commit/92975171013db4c0c4b6298c94795ed2808bdb28) overplayed with sed :laughing: