### PR TITLE
mingw-w64-xapian-core: updated to 1.4.3

### DIFF
--- a/mingw-w64-xapian-core/0001-exp10-build-fix.patch
+++ b/mingw-w64-xapian-core/0001-exp10-build-fix.patch
@@ -1,0 +1,12 @@
+diff -Naur xapian-core-1.4.3.org/api/omenquire.cc xapian-core-1.4.3/api/omenquire.cc
+--- xapian-core-1.4.3.org/api/omenquire.cc	2017-01-25 01:41:55.000000000 +0100
++++ xapian-core-1.4.3/api/omenquire.cc	2017-03-17 09:37:35.882225800 +0100
+@@ -256,7 +256,7 @@
+ 	return e;
+     }
+ 
+-    Xapian::doccount r = Xapian::doccount(exp10(int(log10(D))) + 0.5);
++    Xapian::doccount r = Xapian::doccount(pow(10.0, (int(log10(D))) + 0.5));
+     while (r > e) r /= 10;
+ 
+     Xapian::doccount R = e / r * r;

--- a/mingw-w64-xapian-core/PKGBUILD
+++ b/mingw-w64-xapian-core/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
 epoch=1
-pkgver=1.4.2
+pkgver=1.4.3
 pkgrel=1
 pkgdesc='Open source search engine library (mingw-w64)'
 arch=('any')
@@ -13,15 +13,19 @@ url='https://www.xapian.org/'
 license=('GPL')
 # xapian config requires libxapian.la
 options=('libtool')
-source=("${_realname}-${pkgver}.tar.xz::https://launchpad.net/ubuntu/+archive/primary/+files/${_realname}_${pkgver}.orig.tar.xz")
-sha256sums=('aec2c4352998127a2f2316218bf70f48cef0a466a87af3939f5f547c5246e1ce')
+source=("http://oligarchy.co.uk/xapian/${pkgver}/${_realname}-${pkgver}.tar.xz"
+        0001-exp10-build-fix.patch)
+sha256sums=('7d5295511ca2de70463a29e75f6a2393df5dc1485bf33074b778c66e1721e475'
+            '3cf07734872d989df0cec02d707ae8691ca0c9c407b95b2334fa010d12323875')
 
 prepare() {
-  cd "$srcdir/${_realname}-${pkgver}"
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -p1 -i "${srcdir}/0001-exp10-build-fix.patch"
 }
 
 build() {
-  cd "$srcdir/${_realname}-${pkgver}"
+  cd "${srcdir}/${_realname}-${pkgver}"
   [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
   mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
   # FS#40614
@@ -32,7 +36,8 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
-    --target=${MINGW_CHOST} ${SSE2} \
+    --target=${MINGW_CHOST} \
+    ${SSE2} \
     --enable-static \
     --enable-shared
 


### PR DESCRIPTION
mingw-w64-xapian-core: updated to 1.4.3 and switched back to official download server.
Includes a patch against an exp10() missing dependency. Tested on i686 and x86_64.