### PR TITLE
mingw-w64-python3-cairo: removed msys2 python3 from makedepends

### DIFF
--- a/mingw-w64-python3-cairo/PKGBUILD
+++ b/mingw-w64-python3-cairo/PKGBUILD
@@ -10,7 +10,6 @@ url="http://www.cairographics.org/pycairo"
 arch=('any')
 license=('LGPL' 'MPL')
 depends=("${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-cairo")
-makedepends=("python3")
 source=(http://cairographics.org/releases/${_realname}-${pkgver}.tar.bz2
         'setup.py::https://cgit.freedesktop.org/pycairo/plain/setup.py?id=cd463341de185094455cf5869a442aa02b8b812e'
         0001-msys2-port-to-subprocess.check_output.patch
@@ -26,9 +25,9 @@ prepare() {
   cd "${srcdir}/pycairo-${pkgver}"
 
   cp "${srcdir}/setup.py" .
-  patch -p1 -i ${srcdir}/0001-msys2-port-to-subprocess.check_output.patch
-  patch -p0 -i ${srcdir}/setup-package-dir.patch
-  patch -p1 -i ${srcdir}/head-init.patch
+  patch -p1 -i "${srcdir}/0001-msys2-port-to-subprocess.check_output.patch"
+  patch -p0 -i "${srcdir}/setup-package-dir.patch"
+  patch -p1 -i "${srcdir}/head-init.patch"
 }
 
 build() {


### PR DESCRIPTION
msys2 python3 should not be a dependency of mingw-w64-python3-cairo, removed.
As discussed in https://github.com/Alexpux/MINGW-packages/issues/2318