### PR TITLE
python3: segfault fix in GetTickCount64

### DIFF
--- a/mingw-w64-python3/0950-mingw-w64-XP3-compat-GetProcAddress-GetTickCount64.patch
+++ b/mingw-w64-python3/0950-mingw-w64-XP3-compat-GetProcAddress-GetTickCount64.patch
@@ -30,7 +30,7 @@ diff -Naur Python-3.5.2-orig/Python/pytime.c Python-3.5.2/Python/pytime.c
 +        Py_GetTickCount64 = *(ULONGLONG (*)(void))(GetProcAddress(hKernel32,
 +                                        "GetTickCount64"));
 +    }
-+    if (Py_GetTickCount64 != (void*)-1)
++    if (Py_GetTickCount64 != (void*) NULL)
 +    {
 +        return Py_GetTickCount64();
 +    }


### PR DESCRIPTION
On Windows XP SP3 there is no GetTickCount64, current workaround for this problem has a bug: ```GetProcAddress(hKernel32, "GetTickCount64")``` returns ```NULL```, but next if compares result with ```-1``` and so it tries to call function by ```NULL``` address. This leads to segfault.