### PR TITLE
Fix #2254: libzip is missing zipconf.h header

### DIFF
--- a/mingw-w64-libzip/PKGBUILD
+++ b/mingw-w64-libzip/PKGBUILD
@@ -41,7 +41,6 @@ package() {
 
   make DESTDIR="${pkgdir}" install
 
-  # preserve old header path for compatibility
-  # ln -s ${MINGW_PREFIX}/lib/libzip/include/zipconf.h "${pkgdir}${MINGW_PREFIX}/include/zipconf.h"
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}/${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  cp "${pkgdir}${MINGW_PREFIX}/lib/libzip/include/zipconf.h" "${pkgdir}${MINGW_PREFIX}/include/zipconf.h"
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }


### PR DESCRIPTION
Copy zipconf.h to where it can be found by the main header.

Remove redundant slashes after `${pkgdir}`.