### PR TITLE
upgrade build script for chipmunk 7.0.1

### DIFF
--- a/mingw-w64-chipmunk/PKGBUILD
+++ b/mingw-w64-chipmunk/PKGBUILD
@@ -4,7 +4,8 @@ _realname=chipmunk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Please don't update chipmunk until cocos2d-x support 7.x :)
-pkgver=6.2.2
+# cocos2d-x support chipmunk 7.x now! - by ninepillars <ninepillars@gmail.com>
+pkgver=7.0.1
 pkgrel=1
 pkgdesc="A high-performance 2D rigid body physics library (mingw-w64)"
 arch=('any')
@@ -14,15 +15,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("https://github.com/slembcke/Chipmunk2D/archive/Chipmunk-${pkgver}.tar.gz"
         001-build-fix.patch
         001-fix-install-locations.patch)
-sha256sums=('c51f0e3a30770f6b940de3228bee40a871aaf7611a1b5ec546a7d2b9e1041f97'
+sha256sums=('36a8fe1f179ff54d1930adc4ad9b0fc5835283b8df3de81a22c826eae1e83606'
             '5000228fe30ed95d465a510fb002a809ecfd753341967888e3fe49a5aa773d89'
             'a941ca86cc475025c273142901d242d8845e2e6ab1e8ddec47d2b54ce41feb9b')
 options=(staticlibs !buildflags !strip)
 
 prepare() {
   cd ${srcdir}/Chipmunk2D-Chipmunk-${pkgver}
-  #patch -p1 -i ${srcdir}/001-build-fix.patch
-  patch -p1 -i ${srcdir}/001-fix-install-locations.patch
+  patch -p1 -i ${srcdir}/001-build-fix.patch
+  #patch -p1 -i ${srcdir}/001-fix-install-locations.patch
 }
 
 build() {


### PR DESCRIPTION
The newest cocos2d-x need chipmunk 7 to run.