### PR TITLE
plplot: Updated to version 5.12.0 and fixed building of package.

### DIFF
--- a/mingw-w64-plplot/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
+++ b/mingw-w64-plplot/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
@@ -1,0 +1,25 @@
+From 5b683ad7f12bb302667ce82950458f3f93c05e48 Mon Sep 17 00:00:00 2001
+From: Tim S <stahta01@users.sourceforge.net>
+Date: Wed, 5 Apr 2017 14:11:11 -0400
+Subject: [PATCH] plplot: Include "wx/msw/wrapwin.h" instead of "Windows.h".
+
+---
+ drivers/wxwidgets_comms.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/wxwidgets_comms.h b/drivers/wxwidgets_comms.h
+index dafbe9797..1da64918d 100644
+--- a/drivers/wxwidgets_comms.h
++++ b/drivers/wxwidgets_comms.h
+@@ -24,7 +24,7 @@
+ 
+ #include "plplotP.h"
+ #ifdef WIN32
+-#include <Windows.h>
++#include <wx/msw/wrapwin.h>
+ #else
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+-- 
+2.12.2.windows.1
+

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-wxWidgets"
         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-gcc-ada")
 options=('strip' 'staticlibs')

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# Contributor: Tim S. <stahta01@gmail.com>
 
 _realname=plplot
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.11.0
-pkgrel=2
+pkgver=5.12.0
+pkgrel=1
 arch=('any')
 pkgdesc="Scientific plotting software (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -26,21 +27,19 @@ options=('strip' 'staticlibs')
 license=('LGPL')
 url="https://plplot.sourceforge.io/"
 source=(https://downloads.sourceforge.net/sourceforge/plplot/${_realname}-${pkgver}.tar.gz
-        find-gd.patch)
-sha256sums=('bfa8434e6e1e7139a5651203ec1256c8581e2fac3122f907f7d8d25ed3bd5f7e'
-            'd5fbcb9369824c0f3da24bc63fcf4d764bbf70a2c727f7fec6ad3bf42edaa92f')
+        find-gd.patch
+        "Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch")
+sha256sums=('8dc5da5ef80e4e19993d4c3ef2a84a24cc0e44a5dade83201fca7160a6d352ce'
+            'd5fbcb9369824c0f3da24bc63fcf4d764bbf70a2c727f7fec6ad3bf42edaa92f'
+            '9c81879ade97eb15bdefc04c476e986e5996ac52fff2428f90c136e16d54f275')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/find-gd.patch
+  patch -p1 -i ${srcdir}/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
 }
 
 build() {
-  # cmake's FindSWIG doesn't work properly on MSYS,
-  # so we provide SWIG here
-  SWIG_DIR_U=`${MINGW_PREFIX}/bin/swig -swiglib`
-  SWIG_DIR=`cygpath -m ${SWIG_DIR_U}`
-
   # cmake may be confused if there is a Windows installation
   # of the official Python MSI. Please do the Python-enabled
   # build only, if no official Python is installed.
@@ -55,12 +54,17 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTING=OFF \
-    -DSWIG_EXECUTABLE="${SWIG_EXECUTABLE}" \
-    -DSWIG_DIR="${SWIG_DIR}" \
     -DQHULL_INCLUDE_DIR=${MINGW_PREFIX}/include \
     -DGD_INCLUDE_DIR=${MINGW_PREFIX}/include \
+    -DDEFAULT_NO_BINDINGS=ON \
+    -DENABLE_ada=ON \
+    -DENABLE_cxx=ON \
+    -DENABLE_f95=ON \
     -DENABLE_lua=ON \
     -DENABLE_python=ON \
+    -DENABLE_tcl=ON \
+    -DENABLE_tk=ON \
+    -DENABLE_wxwidgets=ON \
     ../${_realname}-${pkgver}
 
   make V=1


### PR DESCRIPTION
Changed include of "Windows.h" to "wx/msw/wrapwin.h" via patch file.
Removed "Fix CMake FindSWIG" code from package.
And, added defines:
  DEFAULT_NO_BINDINGS=ON
  ENABLE_ada=ON
  ENABLE_cxx=ON
  ENABLE_f95=ON
  ENABLE_tcl=ON
  ENABLE_tk=ON
  ENABLE_wxwidgets=ON