### PR TITLE
gdk-pixbuf2: re-enable gdiplus loaders

### DIFF
--- a/mingw-w64-gdk-pixbuf2/PKGBUILD
+++ b/mingw-w64-gdk-pixbuf2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=gdk-pixbuf2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.36.6
-pkgrel=1
+pkgrel=2
 pkgdesc="An image loading library (mingw-w64)"
 arch=('any')
 url="http://www.gtk.org"
@@ -60,8 +60,7 @@ build() {
     --enable-shared \
     --enable-introspection \
     --enable-relocations \
-    --with-included-loaders=png \
-    --without-gdiplus
+    --with-included-loaders=png,gdip-bmp,gdip-emf,gdip-gif,gdip-ico,gdip-jpeg,gdip-tiff,gdip-wmf
   make
 }
 


### PR DESCRIPTION
(they were disabled in 5b53585ec2b119eaf37517d84ab2a1940430146b)

GDI+ loaders neet to be built into gdk-pixbuf to prevent the bug described in https://bugzilla.redhat.com/show_bug.cgi?id=795152#c1 (see also https://bugs.launchpad.net/inkscape/+bug/1467103)