### PR TITLE
gtkspell: fix relocation of translations

### DIFF
--- a/mingw-w64-gtkspell/001-localedir-relocation.patch
+++ b/mingw-w64-gtkspell/001-localedir-relocation.patch
@@ -1,0 +1,16 @@
+--- gtkspell-2.0.16/gtkspell/gtkspell.c	2009-10-09 21:01:47.000000000 +0200
++++ gtkspell-2.0.16/gtkspell/gtkspell.c	2017-04-08 15:24:36.476426500 +0200
+@@ -740,7 +740,13 @@
+ 	GtkSpell *spell;
+ 
+ #ifdef ENABLE_NLS
++#ifdef G_OS_WIN32
++	gchar *dir = g_win32_get_package_installation_directory_of_module(NULL);
++	bindtextdomain(PACKAGE, g_build_filename (dir, "share", "locale", NULL));
++	g_free(dir);
++#else
+ 	bindtextdomain(PACKAGE, LOCALEDIR);
++#endif
+ 	bind_textdomain_codeset(PACKAGE, "UTF-8");
+ #endif
+ 

--- a/mingw-w64-gtkspell/PKGBUILD
+++ b/mingw-w64-gtkspell/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: Eduard Braun <eduard.braun2@gmx.de>
 
 _realname=gtkspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.16
-pkgrel=5
+pkgrel=6
 pkgdesc="Provides word-processor-style highlighting and replacement of misspelled words in a GtkTextView widget (mingw-w64)"
 arch=('any')
 url="https://gtkspell.sourceforge.io/"
@@ -18,13 +19,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-enchant")
 options=(!libtool strip staticlibs)
 source=(https://gtkspell.sourceforge.io/download/${_realname}-${pkgver}.tar.gz
-        gtkspell-no-undefined.patch)
+        gtkspell-no-undefined.patch
+        001-localedir-relocation.patch)
 sha256sums=('8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02'
-            'cb6978c914d5a20544cad2ba6b3a58096daadc420d21f99797949c7f3a02e57b')
+            'cb6978c914d5a20544cad2ba6b3a58096daadc420d21f99797949c7f3a02e57b'
+            '1b4c6400c19eef9e36cb85fcb6c9a97a49d474bdd24ba4e8bfb29f3bacefa868')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/gtkspell-no-undefined.patch
+  patch -p1 -i ${srcdir}/001-localedir-relocation.patch
 
   WANT_AUTOMAKE=latest autoreconf -fi
 }


### PR DESCRIPTION
Translations were not working because `LOCALEDIR` was an absolute path (`C:/building/msys64/mingw64/share/locale`).