### PR TITLE
mingw-w64-ptyhon-coverage - 4.3.4 - Update to latest version

### DIFF
--- a/mingw-w64-python-appdirs/PKGBUILD
+++ b/mingw-w64-python-appdirs/PKGBUILD
@@ -1,26 +1,25 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
-
-_realname=pretend
+_realname=appdirs
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.0.8
+pkgver=1.4.3
 pkgrel=1
-pkgdesc="A library for stubbing in Python (mingw-w64)"
+pkgdesc='A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir". (mingw-w64)'
 arch=('any')
-license=('BSD')
-url="https://github.com/alex/pretend"
+url="https://github.com/ActiveState/appdirs"
+license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
-source=("http://pypi.python.org/packages/source/p/pretend/pretend-$pkgver.tar.gz")
-sha256sums=('930f2c1e18503e8f8c403abe2e02166c4a881941745147e712cdd4f49f3fb964')
+source=("https://pypi.io/packages/source/a/appdirs/appdirs-$pkgver.tar.gz")
+sha256sums=('9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92')
 
 prepare() {  
-  cd "$srcdir"/  
+  cd "$srcdir"/
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
     cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }  
-
+  
 # Note that build() is sometimes skipped because it's done in 
 # the packages setup.py install for simplicity if you can do so.
 # but sometimes, you want to do a check before install which would
@@ -33,40 +32,53 @@ build() {
   done  
 }
 
-package_python3-pretend() {
+check() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} test for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"  
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done  
+}
+
+package_python3-appdirs() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
-  install -D -m644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE.rst"
+
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
 }
 
-package_python2-pretend() {
+
+package_python2-appdirs() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
   cd "${srcdir}/python2-build-${CARCH}"
+
+  rm -f ./buildutils/include_win32/stdint.h
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
 
-  install -D -m644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE.rst"
+  install -Dm644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+
 }
 
-
-package_mingw-w64-i686-python2-pretend() {
-  package_python2-pretend
+package_mingw-w64-i686-python2-appdirs() {
+  package_python2-appdirs
 }
 
-package_mingw-w64-i686-python3-pretend() {
-  package_python3-pretend
+package_mingw-w64-i686-python3-appdirs() {
+  package_python3-appdirs 
 }
 
-package_mingw-w64-x86_64-python2-pretend() {
-  package_python2-pretend
+package_mingw-w64-x86_64-python2-appdirs() {
+  package_python2-appdirs
 }
 
-package_mingw-w64-x86_64-python3-pretend() {
-  package_python3-pretend
+package_mingw-w64-x86_64-python3-appdirs() {
+  package_python3-appdirs
 }
+

--- a/mingw-w64-python-beautifulsoup4/PKGBUILD
+++ b/mingw-w64-python-beautifulsoup4/PKGBUILD
@@ -1,5 +1,6 @@
-_pyname=beautifulsoup4
-pkgbase=python-beautifulsoup4
+#Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+_realname=beautifulsoup4
+pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-beautifulsoup4" "${MINGW_PACKAGE_PREFIX}-python2-beautifulsoup4")
 pkgver=4.5.3
 pkgrel=1
@@ -9,13 +10,13 @@ url="http://www.crummy.com/software/BeautifulSoup/index.html"
 license=('PSF')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest" "${MINGW_PACKAGE_PREFIX}-python2-pytest")
-source=("http://www.crummy.com/software/BeautifulSoup/bs4/download/${pkgver%.*}/${pkgbase#*-}-$pkgver.tar.gz")
+source=("http://www.crummy.com/software/BeautifulSoup/bs4/download/${pkgver%.*}/${_realname#*-}-$pkgver.tar.gz")
 md5sums=('937e0df0d699a1237646f38fd567f0c6')
 
 prepare() {
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }
 

--- a/mingw-w64-python-beautifulsoup4/PKGBUILD
+++ b/mingw-w64-python-beautifulsoup4/PKGBUILD
@@ -1,0 +1,80 @@
+_pyname=beautifulsoup4
+pkgbase=python-beautifulsoup4
+pkgname=("${MINGW_PACKAGE_PREFIX}-python3-beautifulsoup4" "${MINGW_PACKAGE_PREFIX}-python2-beautifulsoup4")
+pkgver=4.5.3
+pkgrel=1
+pkgdesc="A Python HTML/XML parser designed for quick turnaround projects like screen-scraping (mingw-w64)"
+arch=('any')
+url="http://www.crummy.com/software/BeautifulSoup/index.html"
+license=('PSF')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest" "${MINGW_PACKAGE_PREFIX}-python2-pytest")
+source=("http://www.crummy.com/software/BeautifulSoup/bs4/download/${pkgver%.*}/${pkgbase#*-}-$pkgver.tar.gz")
+md5sums=('937e0df0d699a1237646f38fd567f0c6')
+
+prepare() {
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done 
+}
+
+#check() {
+#  cd "$srcdir"/python3-build-${CARCH}
+#  ${MINGW_PREFIX}/bin/py.test.exe
+
+#  cd "$srcdir"/python2-build-${CARCH}
+#  ${MINGW_PREFIX}/bin/py.test2.exe
+#}
+
+package_python3-beautifulsoup4() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-chardet: to autodetect character encodings"
+              "${MINGW_PACKAGE_PREFIX}-python3-lxml: alternative HTML parser"
+              "${MINGW_PACKAGE_PREFIX}-python3-html5lib: alternative HTML parser")
+
+ cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_python2-beautifulsoup4() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python2-chardet: to autodetect character encodings"
+              "${MINGW_PACKAGE_PREFIX}-python2-lxml: alternative HTML parser"
+              "${MINGW_PACKAGE_PREFIX}-python2-html5lib: alternative HTML parser")
+
+
+  cd "${srcdir}/python2-build-${CARCH}"
+
+  rm -f ./buildutils/include_win32/stdint.h
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_mingw-w64-i686-python2-beautifulsoup4() {
+  package_python2-beautifulsoup4
+}
+
+package_mingw-w64-i686-python3-beautifulsoup4() {
+  package_python3-beautifulsoup4
+}
+
+package_mingw-w64-x86_64-python2-beautifulsoup4() {
+  package_python2-beautifulsoup4
+}
+
+package_mingw-w64-x86_64-python3-beautifulsoup4() {
+  package_python3-beautifulsoup4
+}
+

--- a/mingw-w64-python-chardet/PKGBUILD
+++ b/mingw-w64-python-chardet/PKGBUILD
@@ -1,5 +1,4 @@
 # Maintainer : J. Peter Mugaas <jpmugaas@suddenlink.net>
-_pyname=chardet 
 _realname=chardet
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-chardet" "${MINGW_PACKAGE_PREFIX}-python2-chardet")
@@ -11,14 +10,13 @@ license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 #More comprehensive than PyPi source
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/chardet/chardet/archive/${pkgver}.tar.gz")
-#source=("https://pypi.python.org/packages/source/c/chardet/chardet-${pkgver}.tar.gz")
 sha256sums=('afb95679fb687fad167a714d929d033e3dd0d64b66d3646eecf117d350ae40cc')
 
 prepare() {
   cd "$srcdir"/  
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }
 
@@ -45,7 +43,7 @@ check() {
 
 package_python3-chardet() {
    depends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-   pkgdesc="Python3 module for character encoding auto-detection"
+   pkgdesc="Python3 module for character encoding auto-detection (mingw-w64)"
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -62,7 +60,7 @@ package_python3-chardet() {
 
 package_python2-chardet() {
    depends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools")
-   pkgdesc="Python2 module for character encoding auto-detection"
+   pkgdesc="Python2 module for character encoding auto-detection (mingw-w64)"
 
    local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
@@ -104,4 +102,3 @@ package_mingw-w64-x86_64-python2-chardet() {
 package_mingw-w64-x86_64-python3-chardet() {
   package_python3-chardet
 }
-

--- a/mingw-w64-python-chardet/PKGBUILD
+++ b/mingw-w64-python-chardet/PKGBUILD
@@ -1,0 +1,107 @@
+# Maintainer : J. Peter Mugaas <jpmugaas@suddenlink.net>
+_pyname=chardet 
+_realname=chardet
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python3-chardet" "${MINGW_PACKAGE_PREFIX}-python2-chardet")
+pkgver=2.3.0
+pkgrel=4
+arch=('any')
+url="https://github.com/chardet/chardet"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+#More comprehensive than PyPi source
+source=("https://github.com/chardet/chardet/archive/${pkgver}.tar.gz")
+#source=("https://pypi.python.org/packages/source/c/chardet/chardet-${pkgver}.tar.gz")
+sha256sums=('afb95679fb687fad167a714d929d033e3dd0d64b66d3646eecf117d350ae40cc')
+
+prepare() {
+  cd "$srcdir"/  
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} test for ${CARCH}"  
+    cd "${srcdir}/python2-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} test.py
+  done  
+}
+
+
+package_python3-chardet() {
+   depends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+   pkgdesc="Python3 module for character encoding auto-detection"
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+  done
+}
+
+package_python2-chardet() {
+   depends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+   pkgdesc="Python2 module for character encoding auto-detection"
+
+   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+
+   cd "${srcdir}/python2-build-${CARCH}"
+   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
+
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+  done
+
+  for f in chardetect; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+
+}
+
+
+package_mingw-w64-i686-python2-chardet() {
+  package_python2-chardet
+}
+
+package_mingw-w64-i686-python3-chardet() {
+  package_python3-chardet
+}
+
+package_mingw-w64-x86_64-python2-chardet() {
+  package_python2-chardet
+}
+
+package_mingw-w64-x86_64-python3-chardet() {
+  package_python3-chardet
+}
+

--- a/mingw-w64-python-chardet/PKGBUILD
+++ b/mingw-w64-python-chardet/PKGBUILD
@@ -4,13 +4,13 @@ _realname=chardet
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-chardet" "${MINGW_PACKAGE_PREFIX}-python2-chardet")
 pkgver=2.3.0
-pkgrel=4
+pkgrel=1
 arch=('any')
 url="https://github.com/chardet/chardet"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 #More comprehensive than PyPi source
-source=("https://github.com/chardet/chardet/archive/${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/chardet/chardet/archive/${pkgver}.tar.gz")
 #source=("https://pypi.python.org/packages/source/c/chardet/chardet-${pkgver}.tar.gz")
 sha256sums=('afb95679fb687fad167a714d929d033e3dd0d64b66d3646eecf117d350ae40cc')
 

--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -1,7 +1,6 @@
 # Contributor: Frederic Wang <fred.wang@free.fr>
 
-_pyname=coverage
-_realname=${_pyname}
+_realname=coverage
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.3.4
@@ -20,7 +19,7 @@ prepare() {
   cd "$srcdir"/
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 } 
 

--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -1,9 +1,10 @@
 # Contributor: Frederic Wang <fred.wang@free.fr>
 
-_realname=coverage
+_pyname=coverage
+_realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.0.3
+pkgver=4.3.4
 pkgrel=1
 pkgdesc='Code coverage measurement for Python (mingw-w64)'
 url='https://coverage.readthedocs.org/'
@@ -11,18 +12,33 @@ license=('Apache 2.0')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-source=("https://pypi.python.org/packages/source/c/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('85b1275b6d7a61ccc8024a4e9a4c9e896394776edce1a5d075ec116f91925462')
+_dtoken="6e/33/01cb50da2d0582c077299651038371dba988248058e03c7a7c4be0c84c40"
+source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('eaaefe0f6aa33de5a65f48dd0040d7fe08cac9ac6c35a56d0a7db109c3e733df')
 
-prepare() {
-  cd ${srcdir}
-  cp -r ${_realname}-${pkgver} build-python2
-  cp -r ${_realname}-${pkgver} build-python3
+prepare() {  
+  cd "$srcdir"/
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+} 
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
 }
 
+
 package_python3-coverage() {
-  cd ${srcdir}/build-python3
-  ${MINGW_PREFIX}/bin/python3 setup.py build
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
 
@@ -36,8 +52,7 @@ package_python3-coverage() {
 }
 
 package_python2-coverage() {
-  cd ${srcdir}/build-python2
-  ${MINGW_PREFIX}/bin/python2 setup.py build
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
 

--- a/mingw-w64-python-html5lib/LICENSE
+++ b/mingw-w64-python-html5lib/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/mingw-w64-python-html5lib/PKGBUILD
+++ b/mingw-w64-python-html5lib/PKGBUILD
@@ -1,0 +1,92 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+_pyname=html5lib 
+_realname=html5lib
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.999999999
+pkgrel=1
+arch=('any')
+pkgdesc="A Python HTML parser/tokenizer based on the WHATWG HTML5 spec (mingw-w64)"
+url="https://github.com/html5lib"
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-python3" 
+             "unzip" 
+             "${MINGW_PACKAGE_PREFIX}-python3-webencodings"
+             "${MINGW_PACKAGE_PREFIX}-python2-webencodings")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-six" "${MINGW_PACKAGE_PREFIX}-python2-six"
+              "${MINGW_PACKAGE_PREFIX}-python2-pytest" "${MINGW_PACKAGE_PREFIX}-python3-pytest" 
+              "${MINGW_PACKAGE_PREFIX}-python3-lxml" "${MINGW_PACKAGE_PREFIX}-python2-lxml"
+              "${MINGW_PACKAGE_PREFIX}-python3-mock" "${MINGW_PACKAGE_PREFIX}-python2-mock") 
+source=(${_realname}-$pkgver.tar.gz::https://github.com/html5lib/html5lib-python/archive/${pkgver}.tar.gz
+    LICENSE)
+sha256sums=('05c0f1ba235776060ded5093c365483d50deacdd7cabc57b6996d6e2480a4626'
+            '89807acf2309bd285f033404ee78581602f3cd9b819a16ac2f0e5f60ff4a473e')
+
+prepare() {  
+  cd "$srcdir"/
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}-python-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}  
+  
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg2 "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+#A few tests fail but most succede.
+    for pver in {2,3}; do
+      msg2 "Python ${pver} check for ${CARCH}"
+      cd ${srcdir}/python${pver}-build-${CARCH}/html5lib/tests
+      ${MINGW_PREFIX}/bin/nosetests${pver} || true
+    done
+}
+
+package_python3-html5lib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3" 
+           "${MINGW_PACKAGE_PREFIX}-python3-six" 
+           "${MINGW_PACKAGE_PREFIX}-python3-webencodings")
+    cd "${srcdir}/python3-build-${CARCH}"
+
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+    install -Dm755 $srcdir/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE  
+}
+
+package_python2-html5lib() {
+    depends=("${MINGW_PACKAGE_PREFIX}-python2" 
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-webencodings")
+    cd "${srcdir}/python2-build-${CARCH}"
+
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+    install -Dm755 $srcdir/LICENSE ${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE  
+}
+
+package_mingw-w64-i686-python2-html5lib() {
+  package_python2-html5lib
+}
+
+package_mingw-w64-i686-python3-html5lib() {
+  package_python3-html5lib
+}
+
+package_mingw-w64-x86_64-python2-html5lib() {
+  package_python2-html5lib
+}
+
+package_mingw-w64-x86_64-python3-html5lib() {
+  package_python3-html5lib
+}

--- a/mingw-w64-python-html5lib/PKGBUILD
+++ b/mingw-w64-python-html5lib/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
-_pyname=html5lib 
+
 _realname=html5lib
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -17,8 +17,8 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-six" "${MINGW_PACKAGE_PREFIX}-pyt
               "${MINGW_PACKAGE_PREFIX}-python2-pytest" "${MINGW_PACKAGE_PREFIX}-python3-pytest" 
               "${MINGW_PACKAGE_PREFIX}-python3-lxml" "${MINGW_PACKAGE_PREFIX}-python2-lxml"
               "${MINGW_PACKAGE_PREFIX}-python3-mock" "${MINGW_PACKAGE_PREFIX}-python2-mock") 
-source=(${_realname}-$pkgver.tar.gz::https://github.com/html5lib/html5lib-python/archive/${pkgver}.tar.gz
-    LICENSE)
+source=("${_realname}-$pkgver.tar.gz::https://github.com/html5lib/html5lib-python/archive/${pkgver}.tar.gz"
+        LICENSE)
 sha256sums=('05c0f1ba235776060ded5093c365483d50deacdd7cabc57b6996d6e2480a4626'
             '89807acf2309bd285f033404ee78581602f3cd9b819a16ac2f0e5f60ff4a473e')
 
@@ -26,7 +26,7 @@ prepare() {
   cd "$srcdir"/
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_pyname}-python-${pkgver}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}-python-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }  
   

--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -3,8 +3,10 @@
 
 _realname=lxml
 pkgbase=mingw-w64-python-${_realname}
-pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}" "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=3.6.0
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" 
+         "${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
+pkgver=3.7.3
 pkgrel=1
 arch=('any')
 license=('BSD' 'custom')
@@ -14,13 +16,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-libxslt"
              "${MINGW_PACKAGE_PREFIX}-python2-cssselect"
              "${MINGW_PACKAGE_PREFIX}-python3-cssselect")
-source=(https://pypi.python.org/packages/source/l/lxml/${_realname}-${pkgver}.tar.gz{,.asc}
+_dtoken="39/e8/a8e0b1fa65dd021d48fe21464f71783655f39a41f218293c1c590d54eb82"
+source=(https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz{,.asc}
         mingw-python-fix.patch
         use-distutils-get_platform.patch)
-sha256sums=('9c74ca28a7f0c30dca8872281b3c47705e21217c8bc63912d95c9e2a7cac6bdf'
+sha256sums=('aa502d78a51ee7d127b4824ff96500f0181d3c7826e6ee7b800d068be79361c7'
             'SKIP'
             '66924a961e8baaa5dac4c3d8b72e4bb956f967025301a0320575c98ae9fab1c3'
-            'e50ea7f6004596ab43fe77abbbf28db5ca3a3e9ff7936b4319799ce49362029c')
+            'd50fefc47295d8c6eecf1ca42d03af43dc79d3debb52caf8edbed3b56df2f672')
+validpgpkeys=('1737D5FB8DACC53CA96A77AB0D3D536908D3A01E')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -29,8 +33,8 @@ prepare() {
 
   cd "${srcdir}"
 
-  cp -r ${_realname}-${pkgver} build-python2
-  cp -r ${_realname}-${pkgver} build-python3
+  cp -r ${_realname}-${pkgver} build-python2-${CARCH}
+  cp -r ${_realname}-${pkgver} build-python3-${CARCH}
 }
 
 build() {
@@ -53,11 +57,11 @@ build() {
   LDFLAGS="$LDFLAGS -L${PREFIX_WIN}\\\\lib"
 
   # Build python 2 module
-  cd "${srcdir}"/build-python2
+  cd "${srcdir}"/build-python2-${CARCH}
   ${MINGW_PREFIX}/bin/python2 setup.py build --with-xslt-config=${MINGW_PREFIX}/bin/xslt-config
 
   # Build python 3 module
-  cd "${srcdir}"/build-python3
+  cd "${srcdir}"/build-python3-${CARCH}
   ${MINGW_PREFIX}/bin/python3 setup.py build --with-xslt-config=${MINGW_PREFIX}/bin/xslt-config
 }
 
@@ -67,7 +71,7 @@ package_python2-lxml() {
   optdepends=("${MINGW_PACKAGE_PREFIX}-python2-beautifulsoup3: support for parsing not well formed HTML"
       "${MINGW_PACKAGE_PREFIX}-python-lxml-docs: offline docs")
 
-  cd "${srcdir}/build-python2"
+  cd "${srcdir}/build-python2-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
 
@@ -84,7 +88,7 @@ package_python3-lxml() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-libxslt")
   optdepends=("${MINGW_PACKAGE_PREFIX}-python-lxml-docs: offline docs")
 
-  cd "${srcdir}/build-python3"
+  cd "${srcdir}/build-python3-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
 

--- a/mingw-w64-python-lxml/use-distutils-get_platform.patch
+++ b/mingw-w64-python-lxml/use-distutils-get_platform.patch
@@ -1,6 +1,6 @@
---- lxml-3.5.0b1/setupinfo.py.orig	2014-03-05 01:32:55.698960400 +0000
-+++ lxml-3.5.0b1/setupinfo.py	2014-03-05 01:47:39.983538500 +0000
-@@ -2,6 +2,7 @@
+--- lxml-3.7.3/setupinfo.py.orig	2017-04-07 15:51:34.188042100 -0400
++++ lxml-3.7.3/setupinfo.py	2017-04-07 15:53:47.887745500 -0400
+@@ -2,6 +2,7 @@ import sys, os, os.path
  from distutils.core import Extension
  from distutils.errors import CompileError, DistutilsOptionError
  from distutils.command.build_ext import build_ext as _build_ext
@@ -8,10 +8,10 @@
  from versioninfo import get_base_dir
  
  try:
-@@ -180,7 +181,7 @@
-     return result
+@@ -239,7 +240,7 @@ def libraries():
+         standard_libs.append('z')
+     standard_libs.append('m')
  
- def libraries():
 -    if sys.platform in ('win32',):
 +    if get_platform().startswith('win'):
          libs = ['libxslt', 'libexslt', 'libxml2', 'iconv']

--- a/mingw-w64-python-nose/PKGBUILD
+++ b/mingw-w64-python-nose/PKGBUILD
@@ -5,7 +5,7 @@ _realname=nose
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.3.7
-pkgrel=3
+pkgrel=4
 pkgdesc="A discovery-based unittest extension (mingw-w64)"
 arch=('any')
 license=('LGPL-2.1')
@@ -37,7 +37,16 @@ package_python3-nose() {
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
-  rm -f ${pkgdir}${MINGW_PREFIX}/bin/nosetests{.exe,-script.py,.exe.manifest}
+  for f in nosetests; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}.exe.manifest
+      sed -e "s|${f}|${f}3|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}3.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}-script.py
+  done
+
+#  rm -f ${pkgdir}${MINGW_PREFIX}/bin/nosetests{.exe,-script.py,.exe.manifest}
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
@@ -57,6 +66,15 @@ package_python2-nose() {
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+  done
+  #Create an alias so we could do nose tests in a loop with python major versions.
+  for f in nosetests; do
+    cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
   done
 }
 

--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -1,29 +1,27 @@
-# $Id$
-# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-_pyname=packaging
 _realname=packaging
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=16.8
-pkgrel=2
+pkgrel=1
 pkgdesc="Core utilities for Python packages (mingw-w64)"
 arch=('any')
 url="https://github.com/pypa/packaging"
 license=('Apache')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python3-pyparsing" "${MINGW_PACKAGE_PREFIX}-python2-pyparsing" 'git')
+             "${MINGW_PACKAGE_PREFIX}-python3-pyparsing" "${MINGW_PACKAGE_PREFIX}-python2-pyparsing")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-runner" "${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python3-pretend" "${MINGW_PACKAGE_PREFIX}-python2-pretend" 
               "${MINGW_PACKAGE_PREFIX}-python3-coverage" "${MINGW_PACKAGE_PREFIX}-python2-coverage")
-source=("git+https://github.com/pypa/packaging.git#tag=$pkgver")
-sha256sums=('SKIP')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/pypa/${_realname}/archive/${pkgver}.tar.gz")
+sha256sums=('a48230c947869b53a452bde06889de6ffeeabd252f1426564aaddca3e692f3f6')
 
 prepare() {  
   cd "$srcdir"/  
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_pyname}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}" "python${pver}-build-${CARCH}"
   done
 }  
 

--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -21,7 +21,7 @@ prepare() {
   cd "$srcdir"/  
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "${_realname}" "python${pver}-build-${CARCH}"
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }  
 

--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -1,0 +1,88 @@
+# $Id$
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+_pyname=packaging
+_realname=packaging
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=16.8
+pkgrel=2
+pkgdesc="Core utilities for Python packages (mingw-w64)"
+arch=('any')
+url="https://github.com/pypa/packaging"
+license=('Apache')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-pyparsing" "${MINGW_PACKAGE_PREFIX}-python2-pyparsing" 'git')
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest-runner" "${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
+              "${MINGW_PACKAGE_PREFIX}-python3-pretend" "${MINGW_PACKAGE_PREFIX}-python2-pretend" 
+              "${MINGW_PACKAGE_PREFIX}-python3-coverage" "${MINGW_PACKAGE_PREFIX}-python2-coverage")
+source=("git+https://github.com/pypa/packaging.git#tag=$pkgver")
+sha256sums=('SKIP')
+
+prepare() {  
+  cd "$srcdir"/  
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}" "python${pver}-build-${CARCH}"
+  done
+}  
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} test for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"  
+    ${MINGW_PREFIX}/bin/python${pver} setup.py ptr
+  done  
+}
+
+
+package_python3-packaging() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
+}
+
+package_python2-packaging() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+}
+
+package_mingw-w64-i686-python2-packaging() {
+  package_python2-packaging
+}
+
+package_mingw-w64-i686-python3-packaging() {
+  package_python3-packaging
+}
+
+package_mingw-w64-x86_64-python2-packaging() {
+  package_python2-packaging
+}
+
+package_mingw-w64-x86_64-python3-packaging() {
+  package_python3-packaging
+}

--- a/mingw-w64-python-pbr/PKGBUILD
+++ b/mingw-w64-python-pbr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pbr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.10.0
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="Python Build Reasonableness (mingw-w64)"
 url="https://launchpad.net/pbr"
@@ -13,9 +13,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-six"
              "${MINGW_PACKAGE_PREFIX}-python3-six")
-_dtoken="63275fab26a0fd8cadafca71a3623e4d0f0ee8ed7124a5bb128853d178a7"
-source=("https://pypi.python.org/packages/c3/2c/${_dtoken}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('186428c270309e6fdfe2d5ab0949ab21ae5f7dea831eab96701b86bd666af39c')
+_dtoken="35/a5/3d1beff9fc149b3da814419369a8c24ecf0d1410637fc91002989f433a1a"
+source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('0ccd2db529afd070df815b1521f01401d43de03941170f8a800e7531faba265d')
 
 prepare() {
   cd ${srcdir}

--- a/mingw-w64-python-pretend/PKGBUILD
+++ b/mingw-w64-python-pretend/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_pyname=pretend
+_realname=pretend
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.0.8
+pkgrel=1
+pkgdesc="A library for stubbing in Python (mingw-w64)"
+arch=('any')
+license=('BSD')
+url="https://github.com/alex/pretend"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=("http://pypi.python.org/packages/source/p/pretend/pretend-$pkgver.tar.gz")
+sha256sums=('930f2c1e18503e8f8c403abe2e02166c4a881941745147e712cdd4f49f3fb964')
+
+prepare() {  
+  cd "$srcdir"/  
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}  
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+package_python3-pretend() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+  install -D -m644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE.rst"
+}
+
+package_python2-pretend() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -D -m644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/${pkgname}/LICENSE.rst"
+}
+
+
+package_mingw-w64-i686-python2-pretend() {
+  package_python2-pretend
+}
+
+package_mingw-w64-i686-python3-pretend() {
+  package_python3-pretend
+}
+
+package_mingw-w64-x86_64-python2-pretend() {
+  package_python2-pretend
+}
+
+package_mingw-w64-x86_64-python3-pretend() {
+  package_python3-pretend
+}

--- a/mingw-w64-python-py/PKGBUILD
+++ b/mingw-w64-python-py/PKGBUILD
@@ -4,7 +4,7 @@ _pyname=py
 _realname=py
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.4.31
+pkgver=1.4.33
 pkgrel=1
 pkgdesc='library with cross-python path, ini-parsing, io, code, log facilities (mingw-w64)'
 arch=('any')
@@ -17,8 +17,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest")
 options=('staticlibs' 'strip' '!debug')
-source=("https://pypi.python.org/packages/source/p/${_realname}/${_realname}-$pkgver.tar.gz")
-sha256sums=('a6501963c725fc2554dabfece8ae9a8fb5e149c0ac0a42fd2b02c5c1c57fc114')
+_dtoken="2a/a5/139ca93a9ffffd9fc1d3f14be375af3085f53cc490c508cf1c988b886baa"
+source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('1f9a981438f2acc20470b301a07a496375641f902320f70e31916fe3377385a9')
 
 prepare() {  
   cd "$srcdir"/  
@@ -26,16 +27,29 @@ prepare() {
   tar xf ${_realname}-$pkgver.tar.gz || true
   cp ${_realname}-$pkgver/LICENSE ${_realname}-$pkgver/py/LICENSE
   rm -rf $builddir | true
-  for builddir in python{2,3}-build; do  
+  for builddir in python{2,3}-build-${CARCH}; do  
     rm -rf $builddir | true
     cp -r "${_pyname}-${pkgver}" "${builddir}"
   done  
-}  
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
   
 check() {  
   for pver in {2,3}; do  
     msg "Python ${pver} test for ${CARCH}"  
-    cd "${srcdir}/python${pver}-build"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"  
     ${MINGW_PREFIX}/bin/python${pver} setup.py check 
   done  
 }
@@ -43,10 +57,10 @@ check() {
 package_python3-py() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
-  cd "${srcdir}/python3-build"
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1
+    --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
 }
@@ -54,10 +68,10 @@ package_python3-py() {
 package_python2-py() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
-  cd "${srcdir}/python2-build"
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
-    --root="${pkgdir}" --optimize=1
+    --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-pyparsing/PKGBUILD
+++ b/mingw-w64-python-pyparsing/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyparsing
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.1.10
+pkgver=2.2.0
 pkgrel=1
 pkgdesc='General parsing module for Python (mingw-w64)'
 arch=('any')
@@ -12,7 +12,7 @@ license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python2")
 source=("https://downloads.sourceforge.net/pyparsing/pyparsing-${pkgver}.tar.gz")
-sha256sums=('811c3e7b0031021137fc83e051795025fcb98674d07eb8fe922ba4de53d39188')
+sha256sums=('0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04')
 
 prepare() {
   cd "$srcdir"/

--- a/mingw-w64-python-webencodings/PKGBUILD
+++ b/mingw-w64-python-webencodings/PKGBUILD
@@ -1,7 +1,5 @@
-# Maintainer: Jelle van der Waa <jelle@vdwaa.nl>
-# Contributor: Jelle van der Waa <jelle@vdwaa.nl>
+#Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-_pyname=webencodings 
 _realname=webencodings
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
@@ -12,14 +10,14 @@ pkgdesc="This is a Python implementation of the WHATWG Encoding standard. (mingw
 url="https://github.com/gsnedders/python-webencodings"
 license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
-source=(https://github.com/gsnedders/python-webencodings/archive/v$pkgver.tar.gz)
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/gsnedders/python-webencodings/archive/v$pkgver.tar.gz")
 sha256sums=('082367f568a7812aa5f6922ffe3d9d027cd83829dc32bcaac4c874eeed618000')
 
 prepare() {  
   cd "$srcdir"/  
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH} | true
-    cp -r "python-${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+    cp -r "python-${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
 }  
 

--- a/mingw-w64-python-webencodings/PKGBUILD
+++ b/mingw-w64-python-webencodings/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Jelle van der Waa <jelle@vdwaa.nl>
+# Contributor: Jelle van der Waa <jelle@vdwaa.nl>
+
+_pyname=webencodings 
+_realname=webencodings
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.5.1
+pkgrel=1
+arch=('any')
+pkgdesc="This is a Python implementation of the WHATWG Encoding standard. (mingw-w64)"
+url="https://github.com/gsnedders/python-webencodings"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-python3-setuptools" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=(https://github.com/gsnedders/python-webencodings/archive/v$pkgver.tar.gz)
+sha256sums=('082367f568a7812aa5f6922ffe3d9d027cd83829dc32bcaac4c874eeed618000')
+
+prepare() {  
+  cd "$srcdir"/  
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "python-${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}  
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.  
+build() {  
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+
+check() {
+  for pver in {2,3}; do
+    cd "${srcdir}/python${pver}-build-${CARCH}/build/lib/webencodings/"
+    ${MINGW_PREFIX}/bin/nosetests${pver} 
+  done
+}
+
+package_python3-webencodings() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --skip-build
+}
+
+package_python2-webencodings() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --skip-build
+}
+
+package_mingw-w64-i686-python2-webencodings() {
+  package_python2-webencodings
+}
+
+package_mingw-w64-i686-python3-webencodings() {
+  package_python3-webencodings
+}
+
+package_mingw-w64-x86_64-python2-webencodings() {
+  package_python2-webencodings
+}
+
+package_mingw-w64-x86_64-python3-webencodings() {
+  package_python3-webencodings
+}


### PR DESCRIPTION
mingw-w64-python-lxml  - 3.7.3 - Update to latest version, update patch
mingw-w64-python-nose - 1.3.7 - make aliases (nosetests2 and nosetest3 to faciltate upgrading python to 3.6)
mingw-w64-python-pbr - 2.0.0 - Update to latest version
mingw-w64-python-py - 1.4.33 - Update to latest version
mingw-w64-python-pyparsing - 2.2.0 Update to latest version
mingw-w64-python-beautifulsoup4 - 4.5.3 - New Package
mingw-w64-python-chardet - 2.3.0 - New Package
mingw-w64-python-html5lib - 0.9999999 - New Package
mingw-w64-python-packaging - 16.0 - New Package
mingw-w64-python-pretend - 1.0.0 - New Package
mingw-w64-python-webencodings - 0.5.1 - New Package