### PR TITLE
Updated GNU libmicrohttpd to latest upstream version (0.9.53)

### DIFF
--- a/mingw-w64-libmicrohttpd/PKGBUILD
+++ b/mingw-w64-libmicrohttpd/PKGBUILD
@@ -18,8 +18,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libgcrypt")
-source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz")
-sha256sums=('9b15ec2d381f44936323adfd4f989fa35add517cccbbfa581896b02a393c2cc4')
+source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz"{,.sig})
+validpgpkeys=('D8423BCB326C7907033929C7939E6BE1E29FC3CC'  # Christian Grothoff <christian@grothoff.org>
+              '289FE99E138CF6D473A3F0CFBF7AC4A5EAC2BAF4') # Karlson2k (Evgeny Grin) <k2k@narod.ru>
+sha256sums=('9b15ec2d381f44936323adfd4f989fa35add517cccbbfa581896b02a393c2cc4'
+            'SKIP')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}

--- a/mingw-w64-libmicrohttpd/PKGBUILD
+++ b/mingw-w64-libmicrohttpd/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=libmicrohttpd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.50
-pkgrel=4
+pkgver=0.9.53
+pkgrel=1
 pkgdesc="GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/libmicrohttpd"
@@ -19,12 +19,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-gnutls"
          "${MINGW_PACKAGE_PREFIX}-libgcrypt")
 source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz")
-sha256sums=('d1b6385068abded29b6470e383287aa7705de05ae3c08ad0bf5747ac4dc6ebd7')
+sha256sums=('9b15ec2d381f44936323adfd4f989fa35add517cccbbfa581896b02a393c2cc4')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
-  CFLAGS+=" -DWINVER=0x0600 -D_WIN32_WINNT=0x0600 -D_POSIX_C_SOURCE"
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Restored compatibility with WinXP