### PR TITLE
mypaint-git: upstream has switched to setuptools.

### DIFF
--- a/mingw-w64-mypaint-git/PKGBUILD
+++ b/mingw-w64-mypaint-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mypaint
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=1.3.0alpha.d20161023.g427c7e5
+pkgver=1.3.0alpha.d20170416.g64e90976
 pkgrel=1
 provides=(
     "${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -32,7 +32,7 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-pkg-config"
     "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
     "${MINGW_PACKAGE_PREFIX}-python2"
-    "scons"
+    "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
     "swig"
 )
 options=('!strip' 'debug' 'staticlibs')
@@ -57,20 +57,28 @@ prepare() {
 }
 
 build() {
-    cd "${srcdir}"
-    [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
-    cp -a "${_realname}" "build-${MINGW_CHOST}"
-    cd "build-${MINGW_CHOST}"
-    scons prefix="${MINGW_PREFIX}"
+    cd "${srcdir}/${_realname}"
+    ${MINGW_PREFIX}/bin/python2 setup.py clean --all
+    ${MINGW_PREFIX}/bin/python2 setup.py build
 }
 
 package() {
-    cd "${srcdir}/build-${MINGW_CHOST}"
+    cd "${srcdir}/${_realname}"
     echo "prefix: ${MINGW_PREFIX}"
-    echo "sandbox: ${pkgdir}"
-    echo "target: ${pkgdir}${MINGW_PREFIX}"
-    scons prefix="${MINGW_PREFIX}" --install-sandbox="${pkgdir}" \
-        "${pkgdir}${MINGW_PREFIX}"
+    echo "root: ${pkgdir}"
+
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install \
+	--prefix=${MINGW_PREFIX} --root="${pkgdir}" \
+	--optimize=1 \
+	--skip-build
+
+    # Fix Python #! to not refer to Windows paths (C:\mymsys32\...)
+    local PREFIX_WIN=$(cygpath -wm "${MINGW_PREFIX}")
+    for script in "${pkgdir}${MINGW_PREFIX}/bin"/mypaint*; do
+        sed -e "s|^\(#!.*\)${PREFIX_WIN}/bin/|\1/usr/bin/env |g" -i "$script"
+    done
+
     install -Dm644 COPYING \
         "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
     install -Dm644 Licenses.md \


### PR DESCRIPTION
MyPaint now uses setuptools for installation. No more SCons! Although build needs to be a clean build currently, because of silly layout reasons.

https://github.com/mypaint/mypaint/projects/4