### PR TITLE
mingw-w64-thrift: use newer than WinXP as default build target

### DIFF
--- a/mingw-w64-thrift/0001-thrift-build-option-defines.patch
+++ b/mingw-w64-thrift/0001-thrift-build-option-defines.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/cpp/src/thrift/windows/config.h b/lib/cpp/src/thrift/windows/config.h
+index bc4aa42..174e8c1 100644
+--- a/lib/cpp/src/thrift/windows/config.h
++++ b/lib/cpp/src/thrift/windows/config.h
+@@ -44,9 +44,11 @@
+ #define HAVE_STDINT_H 1
+ #endif
+ 
++#ifndef __MINGW32__
+ #ifndef TARGET_WIN_XP
+ #define TARGET_WIN_XP 1
+ #endif
++#endif
+ 
+ #if TARGET_WIN_XP
+ #ifndef WINVER

--- a/mingw-w64-thrift/PKGBUILD
+++ b/mingw-w64-thrift/PKGBUILD
@@ -4,7 +4,7 @@ _realname=thrift
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=1.0.0.3db41fa
-pkgrel=1
+pkgrel=2
 pkgdesc="Apache Thrift is a software framework for scalable cross-language services development (mingw-w64)"
 arch=('any')
 url='https://thrift.apache.org/'
@@ -20,11 +20,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "flex"
              "git")
 options=('strip')
-source=(git+https://github.com/apache/thrift.git#commit=3db41fa)
-sha256sums=('SKIP')
+source=(git+https://github.com/apache/thrift.git#commit=3db41fa
+        0001-thrift-build-option-defines.patch)
+sha256sums=('SKIP'
+            '5819422f02da692faee26837256e27a8d70cd8a3bb6580872bfdc6d56a37527e')
 
 prepare() {
   cd "${srcdir}/${_realname}"
+
+  patch -p1 -i "${srcdir}/0001-thrift-build-option-defines.patch"
 }
 
 build() {


### PR DESCRIPTION
Use newer than WinXP as default build target