### PR TITLE
Update fox toolkit to 1.6.54

### DIFF
--- a/mingw-w64-fox/PKGBUILD
+++ b/mingw-w64-fox/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fox
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.6.53
+pkgver=1.6.54
 pkgrel=1
 pkgdesc="C++ user interface toolkit (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ options=('strip')
 source=("http://ftp.fox-toolkit.org/pub/${_realname}-${pkgver}.tar.gz"
         fox-1-rdynamic.patch
         fox-2-FXTrayIcon.patch)
-sha256sums=('1fe3d53691dad766f91e288fc7ec0f10ae735127766ed17298c3519591d83806'
+sha256sums=('960f16a8a69d41468f841039e83c2f58f3cb32622fc283a69f20381abb355219'
             '98394112211e360046745040de7f6203fd4c8141bf99f9e10d34d848585a8368'
             '200e604581b20bfaa35a8747c293d43e3024ce554b23c47c466b3ca11341b209')
 


### PR DESCRIPTION
This fixes segfaults in FXString.vformat() on Windows-10.

See discussion here:
https://sourceforge.net/p/foxgui/mailman/message/35797127/