### PR TITLE
Update git-lfs to v2.0.2

### DIFF
--- a/mingw-w64-git-lfs/0001-Translate-git-paths-from-msys-to-windows.patch
+++ b/mingw-w64-git-lfs/0001-Translate-git-paths-from-msys-to-windows.patch
@@ -1,79 +1,15 @@
-From 46ade92e68e3041f315867afd4b157258a1981b5 Mon Sep 17 00:00:00 2001
-Message-Id: <46ade92e68e3041f315867afd4b157258a1981b5.1483358798.git-series.abdo.roig@gmail.com>
-From: Abdo Roig-Maranges <abdo.roig@gmail.com>
-Date: Fri, 19 Aug 2016 13:46:27 +0200
-Subject: [PATCH] Translate git paths from msys to windows
-
----
- git/git.go | 26 ++++++++++++++++++++++----
- 1 file changed, 22 insertions(+), 4 deletions(-)
-
-diff --git a/git/git.go b/git/git.go
-index 72ab9c7..c66048c 100644
---- a/git/git.go
-+++ b/git/git.go
-@@ -574,6 +574,20 @@ func GetCommitSummary(commit string) (*CommitSummary, error) {
- 	}
- }
- 
-+func CygpathWindowsAbsolute(path string) (string, error) {
-+	cmd := subprocess.ExecCommand("cygpath", "-w", strings.TrimSpace(path))
-+	buf := &bytes.Buffer{}
-+	cmd.Stderr = buf
-+
-+	out, err := cmd.Output()
-+	output := strings.TrimSpace(string(out))
-+	if err != nil {
-+		return "", fmt.Errorf("Failed to call cygpath -w: %q", buf.String())
-+	}
-+
-+	return filepath.Abs(output)
-+}
-+
- func GitAndRootDirs() (string, string, error) {
- 	cmd := subprocess.ExecCommand("git", "rev-parse", "--git-dir", "--show-toplevel")
- 	buf := &bytes.Buffer{}
-@@ -592,7 +606,7 @@ func GitAndRootDirs() (string, string, error) {
- 		return "", "", fmt.Errorf("Bad git rev-parse output: %q", output)
+diff -rupN old/tools/cygwin_windows.go new/tools/cygwin_windows.go
+--- old/tools/cygwin_windows.go	2017-04-21 22:27:30.893330900 -0500
++++ new/tools/cygwin_windows.go	2017-04-21 22:35:24.320047700 -0500
+@@ -43,7 +43,10 @@ func isCygwin() bool {
+ 		return false
  	}
  
--	absGitDir, err := filepath.Abs(paths[0])
-+	absGitDir, err := CygpathWindowsAbsolute(paths[0])
- 	if err != nil {
- 		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[0], err)
- 	}
-@@ -601,7 +615,11 @@ func GitAndRootDirs() (string, string, error) {
- 		return absGitDir, "", nil
- 	}
- 
--	absRootDir := paths[1]
-+	absRootDir, err := CygpathWindowsAbsolute(paths[1])
-+	if err != nil {
-+		return "", "", fmt.Errorf("Error converting %q to absolute: %s", paths[1], err)
-+	}
-+
- 	return absGitDir, absRootDir, nil
- }
- 
-@@ -614,7 +632,7 @@ func RootDir() (string, error) {
- 
- 	path := strings.TrimSpace(string(out))
- 	if len(path) > 0 {
--		return filepath.Abs(path)
-+		return CygpathWindowsAbsolute(path)
- 	}
- 	return "", nil
- 
-@@ -628,7 +646,7 @@ func GitDir() (string, error) {
- 	}
- 	path := strings.TrimSpace(string(out))
- 	if len(path) > 0 {
--		return filepath.Abs(path)
-+		return CygpathWindowsAbsolute(path)
- 	}
- 	return "", nil
- }
-
-base-commit: 71b637f1dfa4ea5f200465536190c290f190f58d
--- 
-git-series 0.9.0
+-	if bytes.Contains(out, []byte("CYGWIN")) {
++	if bytes.Contains(out, []byte("CYGWIN")) ||
++	   bytes.Contains(out, []byte("MINGW64_NT")) ||
++	   bytes.Contains(out, []byte("MINGW32_NT")) ||
++	   bytes.Contains(out, []byte("MYS_NT")) {
+ 		cygwinState = cygwinStateEnabled
+ 	} else {
+ 		cygwinState = cygwinStateDisabled

--- a/mingw-w64-git-lfs/PKGBUILD
+++ b/mingw-w64-git-lfs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=git-lfs
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.5.4
+pkgver=2.0.2
 pkgrel=1
 arch=("any")
 pkgdesc="An open source Git extension for versioning large files (mingw-w64)"
@@ -11,13 +11,13 @@ url="https://git-lfs.github.com/"
 license=('MIT')
 options=('!strip')
 depends=("git")
-makedepends=("${MINGW_PACKAGE_PREFIX}-go")
+makedepends=("${MINGW_PACKAGE_PREFIX}-go" "${MINGW_PACKAGE_PREFIX}-ruby")
 
 source=(${_realname}-${pkgver}.zip::"https://github.com/github/git-lfs/archive/v${pkgver}.zip"
         "0001-Translate-git-paths-from-msys-to-windows.patch")
 
-sha256sums=('95e64dbc6ce6acfd014e789030f8f2c0b5fae0e7005a9760d0c917535fa29e65'
-            '9f991fae2f0439b747b8cac577fe22924f963a6e15a27df6310b0d50c7f4a899')
+sha256sums=('3d1c43411727d17557c602d4e6f9b935564dc22c0f3b3fd0bd348debd5ad9c3c'
+            '3ff65cb1b2dc13630a65ff694813854dc6dbb5ebfae3800aacd3fbb768c69bb9')
 
 prepare() {
   # apply patches
@@ -32,17 +32,20 @@ prepare() {
   cp -R "$srcdir/git-lfs-$pkgver/" "$srcdir/src/github.com/git-lfs/git-lfs"
 
   # Fetch dependencies
+  . ${MINGW_PREFIX}/etc/profile.d/go.sh
   GOPATH="$srcdir" go get -v -d
+  gem install ronn
 }
 
 build() {
   cd "${srcdir}/git-lfs-${pkgver}"
 
   # build
+  . ${MINGW_PREFIX}/etc/profile.d/go.sh
   GOPATH="$srcdir" go run script/*.go -cmd build
 
   # The man pages need ronn, which needs a bunch of missing ruby dependencies.
-  # ronn docs/man/*.ronn
+  ronn docs/man/*.ronn
 }
 
 package() {
@@ -50,7 +53,7 @@ package() {
   install -Dm755 "bin/git-lfs" "${pkgdir}${MINGW_PREFIX}/bin/git-lfs"
 
   # man page
-  # install -d "${pkgdir}${MINGW_PREFIX}/share/man/man1"
-  # install -Dm644 docs/man/*.1 "${pkgdir}${MINGW_PREFIX}/share/man/man1"
+  install -d "${pkgdir}${MINGW_PREFIX}/share/man/man1"
+  install -Dm644 docs/man/*.1 "${pkgdir}${MINGW_PREFIX}/share/man/man1"
 }
 


### PR DESCRIPTION
Some problems:
 * ~~bsdtar chokes on the zip. Switching to the tar.gz release doesn't help. I can unzip it fine with the bsdtar on my Arch box, so it might be a problem with MSYS2 or a bug that was fixed in newer versions. As a workaround you can simply run makepkg-mingw twice, for some reason it only chokes on the zip when operating in a clean directory. I might try upgrading the libarchive PKGBUILD later to see if that helps.~~ (Resolved by Alexpux/MSYS2-packages#880)
 * GOROOT is set via a /mingwXX/etc/profile.d script, but makepkg-mingw doesn't pull them in. To get that environment variable I have to manually source the script, but the right fix might be to modify either makepkg-mingw or change how GOROOT is set.
 * We can now build man pages, I just had to install the ronn gem to the build system. I'm not sure if it's ok for a PKGBUILD to have side effects like that, so some input would be appreciated.
