### PR TITLE
qemu: Update to 2.9.0 , add missing dependency, and enable libusb feature again

### DIFF
--- a/mingw-w64-qemu/PKGBUILD
+++ b/mingw-w64-qemu/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=qemu
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.8.0
+pkgver=2.9.0
 pkgrel=1
 pkgdesc="A generic and open source processor emulator (mingw-w64)"
 arch=('any')
@@ -19,13 +19,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
-         #"${MINGW_PACKAGE_PREFIX}-libusb"
+         "${MINGW_PACKAGE_PREFIX}-libusb"
          "${MINGW_PACKAGE_PREFIX}-lzo2"
          "${MINGW_PACKAGE_PREFIX}-pixman"
          "${MINGW_PACKAGE_PREFIX}-snappy"
-         "${MINGW_PACKAGE_PREFIX}-SDL")
+         "${MINGW_PACKAGE_PREFIX}-SDL"
+         "${MINGW_PACKAGE_PREFIX}-usbredir")
 source=(http://wiki.qemu.org/download/${_realname}-${pkgver}.tar.bz2)
-sha256sums=('dafd5d7f649907b6b617b822692f4c82e60cf29bc0fc58bc2036219b591e5e62')
+sha256sums=('00bfb217b1bb03c7a6c3261b819cfccbfb5a58e3e2ceff546327d271773c6c14')
 options=('!strip' 'debug')
 _pkgfqn="${_realname}-${pkgver}"
 noextract=(${_pkgfqn}.tar.bz2)
@@ -74,7 +75,6 @@ build() {
     --disable-xen \
     --disable-vnc-sasl \
     --disable-kvm \
-    --disable-libusb \
     --disable-bluez \
     --disable-spice \
     "${extra_config[@]}"


### PR DESCRIPTION
Fixes #1407.

Tbh I'm not sure if enabling libusb is correct. The [commit disabling](https://github.com/Alexpux/MINGW-packages/commit/1be509d7aaef5deede76a3632e926ea26ed97799) it only said it was disabled to fix build issues. At least on my setup I can build with it enabled (and also with the other disabled features enabled).