### PR TITLE
wxwidgets: Updated version to "3.0.3".

### DIFF
--- a/mingw-w64-wxwidgets/PKGBUILD
+++ b/mingw-w64-wxwidgets/PKGBUILD
@@ -2,18 +2,18 @@
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
 # Contributor: Zach Bacon <11doctorwhocanada@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
+# Contributor: Tim S <stahta01@gmail.com>
 
 _realname=wxWidgets
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgbase=mingw-w64-${_realname}
-pkgver=3.0.2
-pkgrel=17
+pkgver=3.0.3
+pkgrel=1
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
 url="https://www.wxwidgets.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-cppunit"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng"
@@ -22,30 +22,22 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-zlib"
         )
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-python2")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-cppunit")
 options=('strip' 'staticlibs' 'buildflags')
-source=(https://downloads.sourceforge.net/wxwindows/wxWidgets-${pkgver}.tar.bz2
+source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWidgets-${pkgver}.tar.bz2
         "wxWidgets-3.0.0-gcc-codelight.patch"
-        "wxWidgets-3.0.2-msw-dc-orientation-fix.patch"
         "wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
-        "wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
-        "wxWidgets-3.0.2-windows-version.patch"
-        "wxWidgets-3.0.2-gcc6-abs.patch")
-sha256sums=('346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d'
+        "wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch")
+sha256sums=('08c8033f48ec1b23520f036cde37b5ae925a6a65f137ded665633ca159b9307b'
             'd30e32efbb334ff473e8d8c37152281b19b78a36bd5c766ed9781c7581ee92c2'
-            '12f9f474aceb39e5e978e5abbd4288a0ab62d1bcd2ea4a1899c0641fbee8abe1'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
-            '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
-            'c73911b55371554f071b0c547630b6fa5b03eec8307e6fb0ae7587833ea96c0e'
-            '35baeefa14a4b3b60c580337c96887ea439bbfe052dae236bfce109cf43d1031')
+            '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  patch -p1 -i "${srcdir}"/wxWidgets-3.0.0-gcc-codelight.patch
-  patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-msw-dc-orientation-fix.patch
+  #patch -p1 -i "${srcdir}"/wxWidgets-3.0.0-gcc-codelight.patch
   patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch
   patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch
-  patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-windows-version.patch
-  patch -p1 -i "${srcdir}"/wxWidgets-3.0.2-gcc6-abs.patch
 }
 
 build() {
@@ -70,7 +62,13 @@ build() {
     --disable-mslu \
     --disable-precomp-headers \
     --with-msw \
-    --with-opengl
+    --with-opengl \
+    --with-libpng=sys \
+    --with-libjpeg=sys \
+    --with-libtiff=sys \
+    --with-zlib=sys \
+    --with-expat=sys \
+    --with-regex=builtin
 
   make #VERBOSE=1
 
@@ -96,7 +94,13 @@ build() {
     --disable-mslu \
     --disable-precomp-headers \
     --with-msw \
-    --with-opengl
+    --with-opengl \
+    --with-libpng=sys \
+    --with-libjpeg=sys \
+    --with-libtiff=sys \
+    --with-zlib=sys \
+    --with-expat=sys \
+    --with-regex=builtin
 
   make #VERBOSE=1
 }


### PR DESCRIPTION
Changed download URL to "https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWidgets-${pkgver}.tar.bz2".
Moved "${MINGW_PACKAGE_PREFIX}-cppunit" to checkdepends.
Added more "--with-libs" to configure command.
Deleted patch files that no longer worked.
Commented out out the applying of "wxWidgets-3.0.0-gcc-codelight.patch".
I believe the codelight patch is no longer needed.