### PR TITLE
1. Fix to build angleproject using newest git checkout by linking to …

### DIFF
--- a/mingw-w64-angleproject-git/0000-build-fix.patch
+++ b/mingw-w64-angleproject-git/0000-build-fix.patch
@@ -71,13 +71,13 @@ index bda8a0530e..14dc69d4df 100644
                          [
                              '<@(util_win32_sources)',
                          ],
-+						'link_settings':
-+						{
-+							'libraries':
-+							[
-+								'-lgdi32',
-+							]
-+						},
+                        'link_settings':
+                        {
+                            'libraries':
+                            [
+                               '-lgdi32',
+                            ]
+                        },
                      }],
                      ['OS=="win" and angle_build_winrt==1',
                      {

--- a/mingw-w64-angleproject-git/0000-build-fix.patch
+++ b/mingw-w64-angleproject-git/0000-build-fix.patch
@@ -38,18 +38,6 @@ index e096b1a..716aeb6 100644
  
  namespace gl
  {
-diff --git a/src/libANGLE/renderer/d3d/d3d11/Blit11.cpp b/src/libANGLE/renderer/d3d/d3d11/Blit11.cpp
-index cdf3b8e..59aacb8 100644
---- a/src/libANGLE/renderer/d3d/d3d11/Blit11.cpp
-+++ b/src/libANGLE/renderer/d3d/d3d11/Blit11.cpp
-@@ -55,6 +55,7 @@
- #include "libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlef2darrayps.h"
- #include "libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzlei2darrayps.h"
- #include "libANGLE/renderer/d3d/d3d11/shaders/compiled/swizzleui2darrayps.h"
-+#include <float.h>
- 
- namespace rx
- {
 diff --git a/src/libANGLE/renderer/d3d/d3d11/RenderStateCache.cpp b/src/libANGLE/renderer/d3d/d3d11/RenderStateCache.cpp
 index ae42f36..0f1fed8 100644
 --- a/src/libANGLE/renderer/d3d/d3d11/RenderStateCache.cpp
@@ -75,3 +63,21 @@ index c4b79ee..f22609b 100644
  typedef BOOL(WINAPI *PFNWGLMAKECURRENTPROC)(HDC, HGLRC);
  typedef BOOL(WINAPI *PFNWGLSHARELISTSPROC)(HGLRC, HGLRC);
  typedef BOOL(WINAPI *PFNWGLUSEFONTBITMAPSAPROC)(HDC, DWORD, DWORD, DWORD);
+diff --git a/util/util.gyp b/util/util.gyp
+index bda8a0530e..14dc69d4df 100644
+--- a/util/util.gyp
++++ b/util/util.gyp
+@@ -118,6 +118,13 @@
+                         [
+                             '<@(util_win32_sources)',
+                         ],
++						'link_settings':
++						{
++							'libraries':
++							[
++								'-lgdi32',
++							]
++						},
+                     }],
+                     ['OS=="win" and angle_build_winrt==1',
+                     {

--- a/mingw-w64-angleproject-git/0001-static-build-workaround.patch
+++ b/mingw-w64-angleproject-git/0001-static-build-workaround.patch
@@ -1,0 +1,38 @@
+diff --git a/include/export.h b/include/export.h
+index cf144f92a5..892e10d2dd 100644
+--- a/include/export.h
++++ b/include/export.h
+@@ -10,14 +10,14 @@
+ #define LIBGLESV2_EXPORT_H_
+ 
+ #if !defined(ANGLE_EXPORT)
+-#if defined(_WIN32)
++#if defined(_WIN32) && !defined(ANGLE_STATIC)
+ #if defined(LIBGLESV2_IMPLEMENTATION) || defined(LIBANGLE_IMPLEMENTATION) || \
+     defined(LIBANGLE_UTIL_IMPLEMENTATION)
+ #       define ANGLE_EXPORT __declspec(dllexport)
+ #   else
+ #       define ANGLE_EXPORT __declspec(dllimport)
+ #   endif
+-#elif defined(__GNUC__)
++#elif defined(__GNUC__) && !defined(ANGLE_STATIC)
+ #if defined(LIBGLESV2_IMPLEMENTATION) || defined(LIBANGLE_IMPLEMENTATION) || \
+     defined(LIBANGLE_UTIL_IMPLEMENTATION)
+ #       define ANGLE_EXPORT __attribute__((visibility ("default")))
+
+diff --git a/include/KHR/khrplatform.h b/include/KHR/khrplatform.h
+index 68fca48271..bc5b299a97 100755
+--- a/include/KHR/khrplatform.h
++++ b/include/KHR/khrplatform.h
+@@ -97,9 +97,9 @@
+  *-------------------------------------------------------------------------
+  * This precedes the return type of the function in the function prototype.
+  */
+-#if defined(_WIN32) && !defined(__SCITECH_SNAP__)
++#if defined(_WIN32) && !defined(__SCITECH_SNAP__) && !defined(ANGLE_STATIC)
+ #   define KHRONOS_APICALL __declspec(dllimport)
+-#elif defined (__SYMBIAN32__)
++#elif defined (__SYMBIAN32__) && !defined(ANGLE_STATIC)
+ #   define KHRONOS_APICALL IMPORT_C
+ #elif defined(__ANDROID__)
+ #   include <sys/cdefs.h>

--- a/mingw-w64-angleproject-git/0002-redist.patch
+++ b/mingw-w64-angleproject-git/0002-redist.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/version.h b/src/common/version.h
+index e7ffa7cab3..b653ae39c9 100644
+--- a/src/common/version.h
++++ b/src/common/version.h
+@@ -7,7 +7,7 @@
+ #ifndef COMMON_VERSION_H_
+ #define COMMON_VERSION_H_
+ 
+-#include "id/commit.h"
++#include "commit.h"
+ 
+ #define ANGLE_MAJOR_VERSION 2
+ #define ANGLE_MINOR_VERSION 1

--- a/mingw-w64-angleproject-git/PKGBUILD
+++ b/mingw-w64-angleproject-git/PKGBUILD
@@ -10,7 +10,7 @@ pkgdesc='ANGLE project built from git source (mingw-w64)'
 arch=('any')
 url='https://chromium.googlesource.com/angle/angle'
 license=('LGPLv2+')
-depends=()
+depends=('python2' 'python2-setuptools')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" 'gyp-git' 'git')
 provides=("${MINGW_PACKAGE_PREFIX}-angleproject")
 conflicts=("${MINGW_PACKAGE_PREFIX}-angleproject")
@@ -20,15 +20,15 @@ source=("angleproject"::git+https://chromium.googlesource.com/angle/angle
         angleproject-include-import-library-and-use-def-file.patch
         libEGL_mingw32.def
         libGLESv2_mingw32.def
-		0001-static-build-workaround.patch
-		0002-redist.patch)
+        0001-static-build-workaround.patch
+        0002-redist.patch)
 sha256sums=('SKIP'
-            'c156847f5fc5032bd827ef266358c3f1ca8b04f520b5f6e05d9b6b60ca74e722'
+            'e8b3833a3bb88459c05236695a0206a12d2f206fbbc7c33b9c6f1f8ef7274dab'
             '5652d020d68bd0a6c618306c553684ab65af9428c1f44d86490c60226987bb7d'
             'fb04f30b904760d32c4c0b733d0a0b44359855db1fde9e7f5ca7d0b8b1be3e56'
             'a3551bc289ab345f2195507d7c5ff784a64fa658a5390dabdb04898841675bd5'
-			'b97815e789fd012775f869e5c1720dacb92144546526b0c66240d773e307b926'
-			'deb1dc2915ae72f4688ee658f5be8dd04766de3f4f7f9817ebb6cd26a3dd00ff')
+            'b97815e789fd012775f869e5c1720dacb92144546526b0c66240d773e307b926'
+            'deb1dc2915ae72f4688ee658f5be8dd04766de3f4f7f9817ebb6cd26a3dd00ff')
 pkgver() {
   cd "${srcdir}"/${_realname}
   local _major=$(head -n 14 src/common/version.h | grep 'ANGLE_MAJOR_VERSION' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
@@ -91,9 +91,6 @@ package() {
   install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/out/Debug/lib.target/libGLESv2.dll "${pkgdir}/${MINGW_PREFIX}"/bin/libGLESv2.dll
   install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/out/Debug/lib.target/libEGL.dll "${pkgdir}/${MINGW_PREFIX}"/bin/libEGL.dll
   ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}/${MINGW_PREFIX}"/bin/*.dll
-
-  #install libGLESv2.a "${pkgdir}/${MINGW_PREFIX}"/lib/
-  #install libEGL.a "${pkgdir}/${MINGW_PREFIX}"/lib/
 
   install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/libEGL.dll.a "${pkgdir}/${MINGW_PREFIX}"/lib/
   install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/libGLESv2.dll.a "${pkgdir}/${MINGW_PREFIX}"/lib/

--- a/mingw-w64-angleproject-git/PKGBUILD
+++ b/mingw-w64-angleproject-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=angleproject
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=2.1.r5864
+pkgver=2.1.r6839
 pkgrel=1
 pkgdesc='ANGLE project built from git source (mingw-w64)'
 arch=('any')
@@ -19,14 +19,18 @@ source=("angleproject"::git+https://chromium.googlesource.com/angle/angle
         0000-build-fix.patch
         angleproject-include-import-library-and-use-def-file.patch
         libEGL_mingw32.def
-        libGLESv2_mingw32.def)
+        libGLESv2_mingw32.def
+		0001-static-build-workaround.patch
+		0002-redist.patch)
 sha256sums=('SKIP'
-            '80f1dc27536181e6cce98089de36f2829a525b1e134e733bbe4083607ace45e5'
-            'cce1a41325ef893c4ff42aa7cba3d32ae0e675f9d012879c6eef002b2e5ee637'
+            'c156847f5fc5032bd827ef266358c3f1ca8b04f520b5f6e05d9b6b60ca74e722'
+            '5652d020d68bd0a6c618306c553684ab65af9428c1f44d86490c60226987bb7d'
             'fb04f30b904760d32c4c0b733d0a0b44359855db1fde9e7f5ca7d0b8b1be3e56'
-            '9bcb144037483dd1985ba6034a9c3a06101bf9441ccaeda7018538070b8cfba5')
+            'a3551bc289ab345f2195507d7c5ff784a64fa658a5390dabdb04898841675bd5'
+			'b97815e789fd012775f869e5c1720dacb92144546526b0c66240d773e307b926'
+			'deb1dc2915ae72f4688ee658f5be8dd04766de3f4f7f9817ebb6cd26a3dd00ff')
 pkgver() {
-  cd "$srcdir/angleproject"
+  cd "${srcdir}"/${_realname}
   local _major=$(head -n 14 src/common/version.h | grep 'ANGLE_MAJOR_VERSION' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   local _minor=$(head -n 14 src/common/version.h | grep 'ANGLE_MINOR_VERSION' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
   printf "%s.%s.r%s" "$_major" "$_minor" "$(git rev-list --count HEAD)"
@@ -45,17 +49,17 @@ prepare() {
   # Make sure an import library is created and the correct .def file is used during the build
   patch -p1 -i ${srcdir}/angleproject-include-import-library-and-use-def-file.patch
 
-  #echo "" > src/copy_compiler_dll.bat
-  #chmod +x src/copy_compiler_dll.bat
-}
+  # Static build workaround
+  patch -p1 -i ${srcdir}/0001-static-build-workaround.patch
+  
+  #Out of source directory fix
+  patch -p1 -i ${srcdir}/0002-redist.patch
+  }
 
 build() {
-  cd "${srcdir}"/angleproject
-
+# Set ar/compiler and architecture specific compiler flags
+  cd "${srcdir}"/${_realname}
   export PYTHON=/usr/bin/python2
-
-  #export CFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4"
-  #export CXXFLAGS="-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4"
 
   sed -i -e 's_python _python2 _g' -e 's_"python"_"python2"_g' -e "s_'python'_'python2'_g" -e 's_/usr/bin/python_/usr/bin/python2_g' $(find -not \( -path "./.git*" -prune \) -type f)
 
@@ -64,32 +68,38 @@ build() {
   else
     _target="win64"
   fi
+  
+  mkdir -p "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared
+  mkdir -p "${srcdir}"/${_realname}/build-${MINGW_CHOST}-static
 
-  gyp -D angle_enable_vulkan=0 -D use_ozone=0 -D OS=win -D MSVS_VERSION="" -D TARGET=${_target} --format make --depth . -I gyp/common.gypi src/angle.gyp
+#Build shared libraries
+  gyp -D angle_enable_vulkan=0 -D use_ozone=0 -D OS=win -D MSVS_VERSION="" -D TARGET=${_target} --format make --generator-output="${srcdir}/${_realname}/build-${MINGW_CHOST}-shared" --depth . -I "${srcdir}/${_realname}/gyp/common.gypi" "${srcdir}/${_realname}/src/angle.gyp"
+  
+  gyp -D angle_enable_vulkan=0 -D use_ozone=0 -D OS=win -D MSVS_VERSION="" -D TARGET=${_target} --format make --generator-output="${srcdir}/${_realname}/build-${MINGW_CHOST}-static" --depth . -I "${srcdir}/${_realname}/gyp/common.gypi" "${srcdir}/${_realname}/src/angle.gyp" -D angle_gl_library_type=static_library
 
-  # Make sure the correct libraries are linked in
-  #sed -i s@'^LIBS :='@'LIBS := -ld3d9 -ldxguid'@ ../src/libGLESv2.target.mk
-  #sed -i s@'^LIBS :='@'LIBS := -ld3d9 -ldxguid -L. -lGLESv2'@ ../src/libEGL.target.mk
-
-  # LINK=g++ is to prevent using flock to serialize linking.
-  LINK=g++ make -j1 V=1 CXXFLAGS="-std=c++14 -msse2 -DUNICODE -D_UNICODE"
+  LINK=g++ make -C "${srcdir}/${_realname}/build-${MINGW_CHOST}-shared" -j$(($(nproc)+1)) V=1 CXXFLAGS="-O2 -g -pipe -Wall -std=c++14 -msse2 -DUNICODE -D_UNICODE"
+cd "${srcdir}"/${_realname}  
+  LINK=g++ make -C "${srcdir}/${_realname}/build-${MINGW_CHOST}-static" -j$(($(nproc)+1)) V=1 CXXFLAGS="-O2 -g -pipe -Wall -std=c++14 -msse2 -DUNICODE -D_UNICODE"
+  
 }
 
 package() {
-  cd "${srcdir}"/angleproject
+  cd "${srcdir}"/${_realname}
 
-  mkdir -p "${pkgdir}${MINGW_PREFIX}"/{bin,lib,include}
+  mkdir -p "${pkgdir}/${MINGW_PREFIX}"/{bin,lib,include}
 
-  install out/Debug/lib.target/libGLESv2.dll "${pkgdir}${MINGW_PREFIX}"/bin/libGLESv2.dll
-  install out/Debug/lib.target/libEGL.dll "${pkgdir}${MINGW_PREFIX}"/bin/libEGL.dll
-  ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}${MINGW_PREFIX}"/bin/*.dll
+  install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/out/Debug/lib.target/libGLESv2.dll "${pkgdir}/${MINGW_PREFIX}"/bin/libGLESv2.dll
+  install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/out/Debug/lib.target/libEGL.dll "${pkgdir}/${MINGW_PREFIX}"/bin/libEGL.dll
+  ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}/${MINGW_PREFIX}"/bin/*.dll
 
-  #install libGLESv2.a "${pkgdir}${MINGW_PREFIX}"/lib/
-  #install libEGL.a "${pkgdir}${MINGW_PREFIX}"/lib/
+  #install libGLESv2.a "${pkgdir}/${MINGW_PREFIX}"/lib/
+  #install libEGL.a "${pkgdir}/${MINGW_PREFIX}"/lib/
 
-  install libEGL.dll.a "${pkgdir}${MINGW_PREFIX}"/lib/
-  install libGLESv2.dll.a "${pkgdir}${MINGW_PREFIX}"/lib/
-  ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}${MINGW_PREFIX}"/lib/*.dll.a
-
-  cp -Rv include/* "${pkgdir}${MINGW_PREFIX}"/include/
+  install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/libEGL.dll.a "${pkgdir}/${MINGW_PREFIX}"/lib/
+  install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-shared/libGLESv2.dll.a "${pkgdir}/${MINGW_PREFIX}"/lib/
+  ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}/${MINGW_PREFIX}"/lib/*.dll.a
+  
+  install "${srcdir}"/${_realname}/build-${MINGW_CHOST}-static/out/Debug/obj.target/src/{libGLESv2.a,libEGL.a} "${pkgdir}/${MINGW_PREFIX}"/lib/
+  ${MINGW_PREFIX}/bin/strip --strip-unneeded "${pkgdir}/${MINGW_PREFIX}"/lib/{libGLESv2.a,libEGL.a}
+  cp -Rv include/* "${pkgdir}/${MINGW_PREFIX}"/include/
 }

--- a/mingw-w64-angleproject-git/angleproject-include-import-library-and-use-def-file.patch
+++ b/mingw-w64-angleproject-git/angleproject-include-import-library-and-use-def-file.patch
@@ -5,14 +5,14 @@
                      'msvs_requires_importlibrary' : 'true',
                  }],
 +                ['TARGET=="win32"', {
-+                    'ldflags': [ '-Wl,--out-implib,libEGL.dll.a ./src/libEGL/libEGL_mingw32.def' ],
++                    'ldflags': [ '-Wl,--out-implib,libEGL.dll.a ../src/libEGL/libEGL_mingw32.def' ],
 +                }],
 +                ['TARGET=="win64"', {
-+                    'ldflags': [ '-Wl,--out-implib,libEGL.dll.a ./src/libEGL/libEGL.def' ],
++                    'ldflags': [ '-Wl,--out-implib,libEGL.dll.a ../src/libEGL/libEGL.def' ],
 +                }],
              ],
 +            'libraries': [
-+                '-ldxguid -ld3d9 -lgdi32'
++                '-ldxguid -ld3d9 -lgdi32 -lsetupapi'
 +            ]
          },
      ],
@@ -33,14 +33,14 @@
                      'msvs_enable_winphone' : '1',
                  }],
 +                ['TARGET=="win32"', {
-+                    'ldflags': [ '-Wl,--out-implib,libGLESv2.dll.a ./src/libGLESv2/libGLESv2_mingw32.def' ],
++                    'ldflags': [ '-Wl,--out-implib,libGLESv2.dll.a ../src/libGLESv2/libGLESv2_mingw32.def' ],
 +                }],
 +                ['TARGET=="win64"', {
-+                    'ldflags': [ '-Wl,--out-implib,libGLESv2.dll.a ./src/libGLESv2/libGLESv2.def' ],
++                    'ldflags': [ '-Wl,--out-implib,libGLESv2.dll.a ../src/libGLESv2/libGLESv2.def' ],
 +                }],
              ],
 +            'libraries': [
-+                '-ldxguid -ld3d9 -lgdi32'
++                '-ldxguid -ld3d9 -lgdi32 -lsetupapi'
 +            ]
          },
      ],

--- a/mingw-w64-angleproject-git/libGLESv2_mingw32.def
+++ b/mingw-w64-angleproject-git/libGLESv2_mingw32.def
@@ -308,3 +308,8 @@ EXPORTS
     glTexStorage2D@20                        @281
     glTexStorage3D@24                        @282
     glGetInternalformativ@20                 @283
+
+    ; ANGLE Platform Implementation
+    ANGLEPlatformCurrent                     @290
+    ANGLEPlatformInitialize                  @291
+    ANGLEPlatformShutdown                    @292


### PR DESCRIPTION
1. Fix to build angleproject using newest git checkout by linking to -lsetupapi
2. Add small patch to build outside of the source directory
3. Build static libraries after building shared libraries
