### PR TITLE
improve vcs protocols

### DIFF
--- a/mingw-w64-binutils-git/PKGBUILD
+++ b/mingw-w64-binutils-git/PKGBUILD
@@ -20,7 +20,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-libiconv" "${MINGW_PACKAGE_PREFIX}-zlib" "git")
 options=('staticlibs' '!distcc' '!ccache' 'debug' '!strip')
 #install=binutils.install
-source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git#branch=${_realname}-${_base_ver//./_}-branch"
+source=("${_realname}"::"git+https://sourceware.org/git/binutils-gdb.git#branch=${_realname}-${_base_ver//./_}-branch"
         0001-MinGW-w64-Two-fixes-for-unusual-files.patch
         0002-MinGW-w64-Fix-libiberty-makefile.patch
         0003-MinGW-w64-Fix-libibery-configure.patch

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -39,9 +39,9 @@ options=('staticlibs' '!emptydirs' '!strip' 'debug')
 #_branch=gcc-5-branch
 #_branch=gcc-6-branch
 _branch=gcc-7-branch
-_realpkgver="$(git archive --remote=git://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
+_realpkgver="$(git archive --remote=https://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
 
-source=("git://gcc.gnu.org/git/gcc.git#branch=${_branch}"
+source=("git+https://gcc.gnu.org/git/gcc.git#branch=${_branch}"
         "0001-gcc-5-branch-gfortran-incorrect-reading-of-values-fr.patch"
         "0002-Relocate-libintl.patch"
         "0003-Windows-Follow-Posix-dir-exists-semantics-more-close.patch"

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -26,7 +26,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
              "${MINGW_PACKAGE_PREFIX}-xz"
              "git")
 options=('staticlibs' '!distcc' '!ccache' 'debug' '!strip')
-source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git#branch=master"
+source=("${_realname}"::"git+https://sourceware.org/git/binutils-gdb.git#branch=master"
         gdbinit
         0001-MinGW-w64-Two-fixes-for-unusual-files.patch
         0002-MinGW-w64-Fix-libibery-configure.patch


### PR DESCRIPTION
Use encrypted Git protocol for gcc.gnu.org and sourceware.org VCS servers.
