### PR TITLE
mingw-w64-gcc-git: Fix patch 0017 and PKGBUILD.

### DIFF
--- a/mingw-w64-gcc-git/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
+++ b/mingw-w64-gcc-git/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
@@ -1,13 +1,17 @@
-From 27208a3ff2592c1b4cd5baa44acf22c7137de76c Mon Sep 17 00:00:00 2001
+From fad1e9b6a448a27f1f37e43faf9a824ef5bf41de Mon Sep 17 00:00:00 2001
 From: niXman <github.nixman@protonmail.com>
-Date: Wed, 10 May 2017 14:02:32 +0800
+Date: Wed, 10 May 2017 20:29:02 +0800
 Subject: [PATCH] Enable std::experimental::filesystem.
 
 ---
- libstdc++-v3/src/filesystem/dir.cc  | 24 +++++-----
- libstdc++-v3/src/filesystem/ops.cc  | 91 ++++++++++++++++++++++---------------
- libstdc++-v3/src/filesystem/path.cc |  2 +-
- 3 files changed, 69 insertions(+), 48 deletions(-)
+ libstdc++-v3/src/filesystem/dir.cc     | 24 +++++----
+ libstdc++-v3/src/filesystem/fs-posix.h | 49 ++++++++++++++++++
+ libstdc++-v3/src/filesystem/fs-win32.h | 64 ++++++++++++++++++++++++
+ libstdc++-v3/src/filesystem/ops.cc     | 91 ++++++++++++++++++++--------------
+ libstdc++-v3/src/filesystem/path.cc    |  2 +-
+ 5 files changed, 182 insertions(+), 48 deletions(-)
+ create mode 100644 libstdc++-v3/src/filesystem/fs-posix.h
+ create mode 100644 libstdc++-v3/src/filesystem/fs-win32.h
 
 diff --git a/libstdc++-v3/src/filesystem/dir.cc b/libstdc++-v3/src/filesystem/dir.cc
 index c8457bde102..ac4dda465d2 100644
@@ -94,6 +98,131 @@ index c8457bde102..ac4dda465d2 100644
      {
        auto sp = std::make_shared<_Dir_stack>();
        sp->push(_Dir{ dirp, p });
+diff --git a/libstdc++-v3/src/filesystem/fs-posix.h b/libstdc++-v3/src/filesystem/fs-posix.h
+new file mode 100644
+index 00000000000..08768c59c97
+--- /dev/null
++++ b/libstdc++-v3/src/filesystem/fs-posix.h
+@@ -0,0 +1,49 @@
++
++// Copyright (C) 2014-2017 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++#ifndef _GLIBCXX_EXPERIMENTAL_FS_POSIX_H
++#define _GLIBCXX_EXPERIMENTAL_FS_POSIX_H 1
++
++#define os_DIR_t DIR
++#define os_dirent_t dirent
++#define os_open open
++#define os_opendir opendir
++#define os_closedir closedir
++#define os_readdir readdir
++#define os_stat stat
++#define os_stat_t stat
++#define os_chmod chmod
++#define os_mkdir mkdir
++#define os_getcwd getcwd
++#define os_chdir chdir
++#define os_utimbuf_t utimbuf
++#define os_utime utime
++#define os_remove remove
++#define os_rename rename
++#define os_truncate truncate
++
++#define os_utime utime
++
++#define _WS(x) x
++
++#endif // _GLIBCXX_EXPERIMENTAL_FS_POSIX_H
+diff --git a/libstdc++-v3/src/filesystem/fs-win32.h b/libstdc++-v3/src/filesystem/fs-win32.h
+new file mode 100644
+index 00000000000..23053343fc0
+--- /dev/null
++++ b/libstdc++-v3/src/filesystem/fs-win32.h
+@@ -0,0 +1,64 @@
++
++// Copyright (C) 2014-2017 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++#ifndef _GLIBCXX_EXPERIMENTAL_FS_WIN32_H
++#define _GLIBCXX_EXPERIMENTAL_FS_WIN32_H 1
++
++#define os_DIR_t _WDIR
++#define os_dirent_t _wdirent
++#define os_open _wopen
++#define os_opendir _wopendir
++#define os_closedir _wclosedir
++#define os_readdir _wreaddir
++#define os_stat _wstat
++#define os_stat_t _stat
++#define os_chmod _wchmod
++#define os_mkdir _wmkdir
++#define os_getcwd _wgetcwd
++#define os_chdir _wchdir
++#define os_utimbuf_t _utimbuf
++#define os_utime _wutime
++#define os_remove _wremove
++#define os_rename _wrename
++
++#include <unistd.h>
++#include <fcntl.h>
++#include <errno.h>
++
++inline int _wtruncate(const wchar_t *fname, _off64_t size) {
++  int fd = ::os_open(fname, _O_BINARY|_O_RDWR);
++  if (fd == -1) return fd;
++  int ret = ::ftruncate64(fd, size), err=0;
++  _get_errno(&err);
++  _close(fd);
++  _set_errno(err);
++  return ret;
++}
++
++#define os_truncate _wtruncate
++
++#define os_utime _wutime
++
++#define _WS(x) L##x
++
++#endif // _GLIBCXX_EXPERIMENTAL_FS_WIN32_H
 diff --git a/libstdc++-v3/src/filesystem/ops.cc b/libstdc++-v3/src/filesystem/ops.cc
 index c711de16f06..f60e3517d9a 100644
 --- a/libstdc++-v3/src/filesystem/ops.cc

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -39,7 +39,7 @@ options=('staticlibs' '!emptydirs' '!strip' 'debug')
 #_branch=gcc-5-branch
 #_branch=gcc-6-branch
 _branch=gcc-7-branch
-_realpkgver="$(git archive --remote=https://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
+_realpkgver="$(git archive --remote=git://gcc.gnu.org/git/gcc.git refs/heads/${_branch}:gcc/ BASE-VER | tar -xO)"
 
 source=("git+https://gcc.gnu.org/git/gcc.git#branch=${_branch}"
         "0001-gcc-5-branch-gfortran-incorrect-reading-of-values-fr.patch"
@@ -89,7 +89,7 @@ sha256sums=('SKIP'
             '60a58ed41389691a68ef4b7d47a0328df4d28d26e6c680a6b06b31191481ca65'
             '262c6fb0f6c9951d69e4c2dcc27949aa8f2cca8e672faf66740a7dbba4a4cd2c'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
-            '6341b1c237a0ff48fce563ce95a2accdf04c03c2369303585e8ba2c7f95f695f'
+            '4c190efddb73a3e0a7163653e60f299e66dfb172f4d0f2f775fdd80713c1b845'
             'a82eadfbb6a182b1ffeb860e89c89f46373a8b891594280b2268ecac8d7bac88')
 
 _threads="posix"


### PR DESCRIPTION
  1. Fix patch for std::experimental::filesystem for gcc-7-branch.
  2. `git archive` seems not supporting HTTPS. Revert to the GIT protocol.