### PR TITLE
gtk3: Update to 3.22.13

### DIFF
--- a/mingw-w64-gtk3/0001-Revert-clipboard-Try-the-mimetype-first.patch
+++ b/mingw-w64-gtk3/0001-Revert-clipboard-Try-the-mimetype-first.patch
@@ -1,0 +1,42 @@
+From 01e4134cb464128b7c8169b8cf71c9d6df529fbb Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <creiter@src.gnome.org>
+Date: Wed, 10 May 2017 17:56:33 +0200
+Subject: [PATCH] Revert "clipboard: Try the mimetype first"
+
+This reverts commit 7d9450fb60b03dcead85a462f30f24e60119c520.
+---
+ gtk/gtkclipboard.c | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/gtk/gtkclipboard.c b/gtk/gtkclipboard.c
+index 7de4f60099..06a8a39f93 100644
+--- a/gtk/gtkclipboard.c
++++ b/gtk/gtkclipboard.c
+@@ -1042,14 +1042,7 @@ request_text_received_func (GtkClipboard     *clipboard,
+        */
+       GdkAtom target = gtk_selection_data_get_target (selection_data);
+ 
+-      if (target == gdk_atom_intern_static_string ("text/plain;charset=utf-8"))
+-        {
+-          gtk_clipboard_request_contents (clipboard,
+-                                          gdk_atom_intern_static_string ("UTF8_TEXT"),
+-                                          request_text_received_func, info);
+-          return;
+-        }
+-      else if (target == gdk_atom_intern_static_string ("UTF8_STRING"))
++      if (target == gdk_atom_intern_static_string ("UTF8_STRING"))
+ 	{
+ 	  gtk_clipboard_request_contents (clipboard,
+ 					  gdk_atom_intern_static_string ("COMPOUND_TEXT"), 
+@@ -1100,7 +1093,7 @@ gtk_clipboard_request_text (GtkClipboard                *clipboard,
+   info->callback = callback;
+   info->user_data = user_data;
+ 
+-  gtk_clipboard_request_contents (clipboard, gdk_atom_intern_static_string ("text/plain;charset=utf-8"),
++  gtk_clipboard_request_contents (clipboard, gdk_atom_intern_static_string ("UTF8_STRING"),
+ 				  request_text_received_func,
+ 				  info);
+ }
+-- 
+2.11.0
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.22.10
+pkgver=3.22.13
 pkgrel=1
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
@@ -28,11 +28,18 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
-source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz")
-sha256sums=('352a90b3d09256d597cb2768ee5d685285ccc284ff22adf19df16753a829c554')
+source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
+        "gtk3-sassc-fix.patch"
+        "0001-Revert-clipboard-Try-the-mimetype-first.patch")
+sha256sums=('575f45571fc7c0081ede9ba745b752514cd883c3b5f69cf5bee0a5ee11c6bee6'
+            '22be41ac786132470d4f4beb4f0c6feca287a4fa86268994e65fefb7ed70277e'
+            'de855c36be849e82a497d18810406cd360f9568f6d53e35e029d6df302360eb4')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
+
+  patch -p1 -i "${srcdir}"/gtk3-sassc-fix.patch
+  patch -p1 -i "${srcdir}"/0001-Revert-clipboard-Try-the-mimetype-first.patch
 
   autoreconf -i
 }

--- a/mingw-w64-gtk3/gtk3-sassc-fix.patch
+++ b/mingw-w64-gtk3/gtk3-sassc-fix.patch
@@ -1,0 +1,27 @@
+From 1a489831b39d0c1583bd4d5e8583f65c1ba880e0 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Wed, 10 May 2017 14:31:09 +0100
+Subject: build: Fix the check on sassc's presence
+
+If sassc is not available we do not want to include the rules to
+regenerate the CSS out of the SCSS files.
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 05fdf4e..4e68e2d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1821,7 +1821,7 @@ AC_SUBST(GDK_HIDDEN_VISIBILITY_CFLAGS)
+ 
+ AC_PATH_PROG([SASSC], [sassc])
+ AC_ARG_VAR(SASSC)
+-AM_CONDITIONAL([REBUILD_SCSS], [test "xSASSC" != x])
++AM_CONDITIONAL([REBUILD_SCSS], [test "x$SASSC" != x])
+ 
+ ##################################################
+ # Output commands
+-- 
+cgit v0.12
+


### PR DESCRIPTION
This release fixes DnD images being stuck in the top left screen corner:
https://bugzilla.gnome.org/show_bug.cgi?id=781737

Requires two patches:

A small build fix commited right after the release:
https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=1a489831b39d0c1583bd4d5e8583f65c1ba880e0

A revert of the following:
https://git.gnome.org/browse/gtk+/commit/?h=gtk-3-22&id=7d9450fb60b03dcead85a462f30f24e60119c520
because it causes pasting to break, see https://bugzilla.gnome.org/show_bug.cgi?id=782453