### PR TITLE
Add libsass and sassc

### DIFF
--- a/mingw-w64-libsass/PKGBUILD
+++ b/mingw-w64-libsass/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=libsass
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.4.4
+pkgrel=1
+pkgdesc="C implementation of Sass CSS preprocessor (library) (mingw-w64)"
+arch=('any')
+url="http://libsass.org/"
+license=("MIT")
+options=('strip' 'staticlibs')
+source=("$_realname-$pkgver.tar.gz::https://github.com/sass/$_realname/archive/$pkgver.tar.gz")
+sha256sums=('1dc4d49a9a53b891b7e98935709e625f1d68782d87aef4304a41e6d590abb480')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  autoreconf -vfi
+}
+
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-sassc/PKGBUILD
+++ b/mingw-w64-sassc/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=sassc
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.4.2
+pkgrel=1
+pkgdesc="C implementation of Sass CSS preprocessor (mingw-w64)"
+arch=('any')
+url="http://libsass.org/"
+license=("MIT")
+depends=("${MINGW_PACKAGE_PREFIX}-libsass")
+source=("$_realname-$pkgver.tar.gz::https://github.com/sass/$_realname/archive/$pkgver.tar.gz")
+sha256sums=('ad805f2d404d17cf2980c8079a7413cd58d2f2085120167997b85420a722e079')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  autoreconf -vfi
+}
+
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  make DESTDIR="${pkgdir}" install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+}


### PR DESCRIPTION
See http://sass-lang.com and http://libsass.org

sassc is needed for working on the Adwaita theme in GTK+ and also is
an optional build dependency there (upstream includes the generated css
in tree atm)