### PR TITLE
mingw-w64-gcc: Add a patch to fix the __in/__out name collision.

### DIFF
--- a/mingw-w64-gcc/0130-libstdc++-in-out.patch
+++ b/mingw-w64-gcc/0130-libstdc++-in-out.patch
@@ -1,0 +1,2982 @@
+Microsoft-style code uses __in and __out to annotate function
+parameters, which causes compilation in libstdc++ headers where they
+try to use __in and __out as variable names.
+
+This patch fixes the issue by adding one more underscore to the
+problematic variable names in libstdc++.
+
+The changes for this patch were generated with this command:
+
+sed -ri 's/\b(__in|__out)\b/_&/g' $(egrep -rl '\b(__in|__out)\b' libstdc++-v3/{include,config})
+
+The GCC maintainers have been notified:
+
+https://gcc.gnu.org/ml/gcc-help/2017-05/msg00121.html
+
+
+diff -ur gcc-6.3.0-orig/libstdc++-v3/config/locale/dragonfly/c_locale.h gcc-6.3.0/libstdc++-v3/config/locale/dragonfly/c_locale.h
+--- gcc-6.3.0-orig/libstdc++-v3/config/locale/dragonfly/c_locale.h	2017-05-14 09:37:13.366674666 -0700
++++ gcc-6.3.0/libstdc++-v3/config/locale/dragonfly/c_locale.h	2017-05-14 09:56:41.230007999 -0700
+@@ -55,7 +55,7 @@
+   // fall back to the unsafe vsprintf which, in general, can be dangerous
+   // and should be avoided.
+   inline int
+-  __convert_from_v(const __c_locale& __cloc, char* __out,
++  __convert_from_v(const __c_locale& __cloc, char* ___out,
+ 		   const int __size __attribute__ ((__unused__)),
+ 		   const char* __fmt, ...)
+   {
+@@ -65,9 +65,9 @@
+     __builtin_va_start(__args, __fmt);
+ 
+ #if _GLIBCXX_USE_C99_STDIO
+-    const int __ret = __builtin_vsnprintf(__out, __size, __fmt, __args);
++    const int __ret = __builtin_vsnprintf(___out, __size, __fmt, __args);
+ #else
+-    const int __ret = __builtin_vsprintf(__out, __fmt, __args);
++    const int __ret = __builtin_vsprintf(___out, __fmt, __args);
+ #endif
+ 
+     __builtin_va_end(__args);
+diff -ur gcc-6.3.0-orig/libstdc++-v3/config/locale/generic/c_locale.h gcc-6.3.0/libstdc++-v3/config/locale/generic/c_locale.h
+--- gcc-6.3.0-orig/libstdc++-v3/config/locale/generic/c_locale.h	2017-05-14 09:37:13.366674666 -0700
++++ gcc-6.3.0/libstdc++-v3/config/locale/generic/c_locale.h	2017-05-14 09:56:41.230007999 -0700
+@@ -53,7 +53,7 @@
+   // fall back to the unsafe vsprintf which, in general, can be dangerous
+   // and should be avoided.
+   inline int
+-  __convert_from_v(const __c_locale&, char* __out, 
++  __convert_from_v(const __c_locale&, char* ___out, 
+ 		   const int __size __attribute__((__unused__)),
+ 		   const char* __fmt, ...)
+   {
+@@ -71,9 +71,9 @@
+     __builtin_va_start(__args, __fmt);
+ 
+ #if _GLIBCXX_USE_C99_STDIO
+-    const int __ret = __builtin_vsnprintf(__out, __size, __fmt, __args);
++    const int __ret = __builtin_vsnprintf(___out, __size, __fmt, __args);
+ #else
+-    const int __ret = __builtin_vsprintf(__out, __fmt, __args);
++    const int __ret = __builtin_vsprintf(___out, __fmt, __args);
+ #endif
+ 
+     __builtin_va_end(__args);
+diff -ur gcc-6.3.0-orig/libstdc++-v3/config/locale/gnu/c_locale.h gcc-6.3.0/libstdc++-v3/config/locale/gnu/c_locale.h
+--- gcc-6.3.0-orig/libstdc++-v3/config/locale/gnu/c_locale.h	2017-05-14 09:37:13.366674666 -0700
++++ gcc-6.3.0/libstdc++-v3/config/locale/gnu/c_locale.h	2017-05-14 09:56:41.230007999 -0700
+@@ -67,7 +67,7 @@
+   // and should be avoided.
+   inline int
+   __convert_from_v(const __c_locale& __cloc __attribute__ ((__unused__)),
+-		   char* __out,
++		   char* ___out,
+ 		   const int __size __attribute__ ((__unused__)),
+ 		   const char* __fmt, ...)
+   {
+@@ -89,9 +89,9 @@
+     __builtin_va_start(__args, __fmt);
+ 
+ #if _GLIBCXX_USE_C99_STDIO
+-    const int __ret = __builtin_vsnprintf(__out, __size, __fmt, __args);
++    const int __ret = __builtin_vsnprintf(___out, __size, __fmt, __args);
+ #else
+-    const int __ret = __builtin_vsprintf(__out, __fmt, __args);
++    const int __ret = __builtin_vsprintf(___out, __fmt, __args);
+ #endif
+ 
+     __builtin_va_end(__args);
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/basic_string.h gcc-6.3.0/libstdc++-v3/include/bits/basic_string.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/basic_string.h	2017-05-14 09:37:13.596674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/basic_string.h	2017-05-14 09:56:41.210007999 -0700
+@@ -5384,13 +5384,13 @@
+ 
+   template<>
+     basic_istream<char>&
+-    getline(basic_istream<char>& __in, basic_string<char>& __str,
++    getline(basic_istream<char>& ___in, basic_string<char>& __str,
+ 	    char __delim);
+ 
+ #ifdef _GLIBCXX_USE_WCHAR_T
+   template<>
+     basic_istream<wchar_t>&
+-    getline(basic_istream<wchar_t>& __in, basic_string<wchar_t>& __str,
++    getline(basic_istream<wchar_t>& ___in, basic_string<wchar_t>& __str,
+ 	    wchar_t __delim);
+ #endif  
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/basic_string.tcc gcc-6.3.0/libstdc++-v3/include/bits/basic_string.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/basic_string.tcc	2017-05-14 09:37:13.593341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/basic_string.tcc	2017-05-14 09:56:41.210007999 -0700
+@@ -1434,7 +1434,7 @@
+   // 21.3.7.9 basic_string::getline and operators
+   template<typename _CharT, typename _Traits, typename _Alloc>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in,
++    operator>>(basic_istream<_CharT, _Traits>& ___in,
+ 	       basic_string<_CharT, _Traits, _Alloc>& __str)
+     {
+       typedef basic_istream<_CharT, _Traits>		__istream_type;
+@@ -1447,7 +1447,7 @@
+ 
+       __size_type __extracted = 0;
+       typename __ios_base::iostate __err = __ios_base::goodbit;
+-      typename __istream_type::sentry __cerb(__in, false);
++      typename __istream_type::sentry __cerb(___in, false);
+       if (__cerb)
+ 	{
+ 	  __try
+@@ -1456,12 +1456,12 @@
+ 	      __str.erase();
+ 	      _CharT __buf[128];
+ 	      __size_type __len = 0;	      
+-	      const streamsize __w = __in.width();
++	      const streamsize __w = ___in.width();
+ 	      const __size_type __n = __w > 0 ? static_cast<__size_type>(__w)
+ 		                              : __str.max_size();
+-	      const __ctype_type& __ct = use_facet<__ctype_type>(__in.getloc());
++	      const __ctype_type& __ct = use_facet<__ctype_type>(___in.getloc());
+ 	      const __int_type __eof = _Traits::eof();
+-	      __int_type __c = __in.rdbuf()->sgetc();
++	      __int_type __c = ___in.rdbuf()->sgetc();
+ 
+ 	      while (__extracted < __n
+ 		     && !_Traits::eq_int_type(__c, __eof)
+@@ -1475,17 +1475,17 @@
+ 		    }
+ 		  __buf[__len++] = _Traits::to_char_type(__c);
+ 		  ++__extracted;
+-		  __c = __in.rdbuf()->snextc();
++		  __c = ___in.rdbuf()->snextc();
+ 		}
+ 	      __str.append(__buf, __len);
+ 
+ 	      if (_Traits::eq_int_type(__c, __eof))
+ 		__err |= __ios_base::eofbit;
+-	      __in.width(0);
++	      ___in.width(0);
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+@@ -1493,20 +1493,20 @@
+ 	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
+ 	      // 91. Description of operator>> and getline() for string<>
+ 	      // might cause endless loop
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	    }
+ 	}
+       // 211.  operator>>(istream&, string&) doesn't set failbit
+       if (!__extracted)
+ 	__err |= __ios_base::failbit;
+       if (__err)
+-	__in.setstate(__err);
+-      return __in;
++	___in.setstate(__err);
++      return ___in;
+     }
+ 
+   template<typename _CharT, typename _Traits, typename _Alloc>
+     basic_istream<_CharT, _Traits>&
+-    getline(basic_istream<_CharT, _Traits>& __in,
++    getline(basic_istream<_CharT, _Traits>& ___in,
+ 	    basic_string<_CharT, _Traits, _Alloc>& __str, _CharT __delim)
+     {
+       typedef basic_istream<_CharT, _Traits>		__istream_type;
+@@ -1518,7 +1518,7 @@
+       __size_type __extracted = 0;
+       const __size_type __n = __str.max_size();
+       typename __ios_base::iostate __err = __ios_base::goodbit;
+-      typename __istream_type::sentry __cerb(__in, true);
++      typename __istream_type::sentry __cerb(___in, true);
+       if (__cerb)
+ 	{
+ 	  __try
+@@ -1526,7 +1526,7 @@
+ 	      __str.erase();
+ 	      const __int_type __idelim = _Traits::to_int_type(__delim);
+ 	      const __int_type __eof = _Traits::eof();
+-	      __int_type __c = __in.rdbuf()->sgetc();
++	      __int_type __c = ___in.rdbuf()->sgetc();
+ 
+ 	      while (__extracted < __n
+ 		     && !_Traits::eq_int_type(__c, __eof)
+@@ -1534,7 +1534,7 @@
+ 		{
+ 		  __str += _Traits::to_char_type(__c);
+ 		  ++__extracted;
+-		  __c = __in.rdbuf()->snextc();
++		  __c = ___in.rdbuf()->snextc();
+ 		}
+ 
+ 	      if (_Traits::eq_int_type(__c, __eof))
+@@ -1542,14 +1542,14 @@
+ 	      else if (_Traits::eq_int_type(__c, __idelim))
+ 		{
+ 		  ++__extracted;		  
+-		  __in.rdbuf()->sbumpc();
++		  ___in.rdbuf()->sbumpc();
+ 		}
+ 	      else
+ 		__err |= __ios_base::failbit;
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+@@ -1557,14 +1557,14 @@
+ 	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
+ 	      // 91. Description of operator>> and getline() for string<>
+ 	      // might cause endless loop
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	    }
+ 	}
+       if (!__extracted)
+ 	__err |= __ios_base::failbit;
+       if (__err)
+-	__in.setstate(__err);
+-      return __in;
++	___in.setstate(__err);
++      return ___in;
+     }
+ 
+   // Inhibit implicit instantiations for required instantiations,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/istream.tcc gcc-6.3.0/libstdc++-v3/include/bits/istream.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/istream.tcc	2017-05-14 09:37:13.593341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/istream.tcc	2017-05-14 09:56:41.213341333 -0700
+@@ -44,20 +44,20 @@
+ 
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>::sentry::
+-    sentry(basic_istream<_CharT, _Traits>& __in, bool __noskip) : _M_ok(false)
++    sentry(basic_istream<_CharT, _Traits>& ___in, bool __noskip) : _M_ok(false)
+     {
+       ios_base::iostate __err = ios_base::goodbit;
+-      if (__in.good())
++      if (___in.good())
+ 	{
+-	  if (__in.tie())
+-	    __in.tie()->flush();
+-	  if (!__noskip && bool(__in.flags() & ios_base::skipws))
++	  if (___in.tie())
++	    ___in.tie()->flush();
++	  if (!__noskip && bool(___in.flags() & ios_base::skipws))
+ 	    {
+ 	      const __int_type __eof = traits_type::eof();
+-	      __streambuf_type* __sb = __in.rdbuf();
++	      __streambuf_type* __sb = ___in.rdbuf();
+ 	      __int_type __c = __sb->sgetc();
+ 
+-	      const __ctype_type& __ct = __check_facet(__in._M_ctype);
++	      const __ctype_type& __ct = __check_facet(___in._M_ctype);
+ 	      while (!traits_type::eq_int_type(__c, __eof)
+ 		     && __ct.is(ctype_base::space, 
+ 				traits_type::to_char_type(__c)))
+@@ -71,12 +71,12 @@
+ 	    }
+ 	}
+ 
+-      if (__in.good() && __err == ios_base::goodbit)
++      if (___in.good() && __err == ios_base::goodbit)
+ 	_M_ok = true;
+       else
+ 	{
+ 	  __err |= ios_base::failbit;
+-	  __in.setstate(__err);
++	  ___in.setstate(__err);
+ 	}
+     }
+ 
+@@ -920,18 +920,18 @@
+   // 27.6.1.2.3 Character extraction templates
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in, _CharT& __c)
++    operator>>(basic_istream<_CharT, _Traits>& ___in, _CharT& __c)
+     {
+       typedef basic_istream<_CharT, _Traits>		__istream_type;
+       typedef typename __istream_type::int_type         __int_type;
+ 
+-      typename __istream_type::sentry __cerb(__in, false);
++      typename __istream_type::sentry __cerb(___in, false);
+       if (__cerb)
+ 	{
+ 	  ios_base::iostate __err = ios_base::goodbit;
+ 	  __try
+ 	    {
+-	      const __int_type __cb = __in.rdbuf()->sbumpc();
++	      const __int_type __cb = ___in.rdbuf()->sbumpc();
+ 	      if (!_Traits::eq_int_type(__cb, _Traits::eof()))
+ 		__c = _Traits::to_char_type(__cb);
+ 	      else
+@@ -939,20 +939,20 @@
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(ios_base::badbit);
++	      ___in._M_setstate(ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+-	    { __in._M_setstate(ios_base::badbit); }
++	    { ___in._M_setstate(ios_base::badbit); }
+ 	  if (__err)
+-	    __in.setstate(__err);
++	    ___in.setstate(__err);
+ 	}
+-      return __in;
++      return ___in;
+     }
+ 
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in, _CharT* __s)
++    operator>>(basic_istream<_CharT, _Traits>& ___in, _CharT* __s)
+     {
+       typedef basic_istream<_CharT, _Traits>		__istream_type;
+       typedef basic_streambuf<_CharT, _Traits>          __streambuf_type;
+@@ -962,20 +962,20 @@
+ 
+       streamsize __extracted = 0;
+       ios_base::iostate __err = ios_base::goodbit;
+-      typename __istream_type::sentry __cerb(__in, false);
++      typename __istream_type::sentry __cerb(___in, false);
+       if (__cerb)
+ 	{
+ 	  __try
+ 	    {
+ 	      // Figure out how many characters to extract.
+-	      streamsize __num = __in.width();
++	      streamsize __num = ___in.width();
+ 	      if (__num <= 0)
+ 		__num = __gnu_cxx::__numeric_traits<streamsize>::__max;
+ 
+-	      const __ctype_type& __ct = use_facet<__ctype_type>(__in.getloc());
++	      const __ctype_type& __ct = use_facet<__ctype_type>(___in.getloc());
+ 
+ 	      const int_type __eof = _Traits::eof();
+-	      __streambuf_type* __sb = __in.rdbuf();
++	      __streambuf_type* __sb = ___in.rdbuf();
+ 	      int_type __c = __sb->sgetc();
+ 
+ 	      while (__extracted < __num - 1
+@@ -993,36 +993,36 @@
+ 	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
+ 	      // 68.  Extractors for char* should store null at end
+ 	      *__s = char_type();
+-	      __in.width(0);
++	      ___in.width(0);
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(ios_base::badbit);
++	      ___in._M_setstate(ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+-	    { __in._M_setstate(ios_base::badbit); }
++	    { ___in._M_setstate(ios_base::badbit); }
+ 	}
+       if (!__extracted)
+ 	__err |= ios_base::failbit;
+       if (__err)
+-	__in.setstate(__err);
+-      return __in;
++	___in.setstate(__err);
++      return ___in;
+     }
+ 
+   // 27.6.1.4 Standard basic_istream manipulators
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>&
+-    ws(basic_istream<_CharT, _Traits>& __in)
++    ws(basic_istream<_CharT, _Traits>& ___in)
+     {
+       typedef basic_istream<_CharT, _Traits>		__istream_type;
+       typedef basic_streambuf<_CharT, _Traits>          __streambuf_type;
+       typedef typename __istream_type::int_type		__int_type;
+       typedef ctype<_CharT>				__ctype_type;
+ 
+-      const __ctype_type& __ct = use_facet<__ctype_type>(__in.getloc());
++      const __ctype_type& __ct = use_facet<__ctype_type>(___in.getloc());
+       const __int_type __eof = _Traits::eof();
+-      __streambuf_type* __sb = __in.rdbuf();
++      __streambuf_type* __sb = ___in.rdbuf();
+       __int_type __c = __sb->sgetc();
+ 
+       while (!_Traits::eq_int_type(__c, __eof)
+@@ -1030,8 +1030,8 @@
+ 	__c = __sb->snextc();
+ 
+        if (_Traits::eq_int_type(__c, __eof))
+-	 __in.setstate(ios_base::eofbit);
+-      return __in;
++	 ___in.setstate(ios_base::eofbit);
++      return ___in;
+     }
+ 
+   // Inhibit implicit instantiations for required instantiations,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/locale_conv.h gcc-6.3.0/libstdc++-v3/include/bits/locale_conv.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/locale_conv.h	2017-05-14 09:37:13.596674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/locale_conv.h	2017-05-14 09:56:41.216674666 -0700
+@@ -246,10 +246,10 @@
+       {
+ 	if (!_M_with_cvtstate)
+ 	  _M_state = state_type();
+-	wide_string __out{ _M_wide_err_string.get_allocator() };
+-	if (__str_codecvt_in(__first, __last, __out, *_M_cvt, _M_state,
++	wide_string ___out{ _M_wide_err_string.get_allocator() };
++	if (__str_codecvt_in(__first, __last, ___out, *_M_cvt, _M_state,
+ 			     _M_count))
+-	  return __out;
++	  return ___out;
+ 	if (_M_with_strings)
+ 	  return _M_wide_err_string;
+ 	__throw_range_error("wstring_convert::from_bytes");
+@@ -282,10 +282,10 @@
+       {
+ 	if (!_M_with_cvtstate)
+ 	  _M_state = state_type();
+-	byte_string __out{ _M_byte_err_string.get_allocator() };
+-	if (__str_codecvt_out(__first, __last, __out, *_M_cvt, _M_state,
++	byte_string ___out{ _M_byte_err_string.get_allocator() };
++	if (__str_codecvt_out(__first, __last, ___out, *_M_cvt, _M_state,
+ 			      _M_count))
+-	  return __out;
++	  return ___out;
+ 	if (_M_with_strings)
+ 	  return _M_byte_err_string;
+ 	__throw_range_error("wstring_convert::to_bytes");
+@@ -375,13 +375,13 @@
+       { return _M_buf && _M_conv_put() && _M_buf->pubsync() ? 0 : -1; }
+ 
+       typename _Wide_streambuf::int_type
+-      overflow(typename _Wide_streambuf::int_type __out)
++      overflow(typename _Wide_streambuf::int_type ___out)
+       {
+ 	if (!_M_buf || !_M_conv_put())
+ 	  return _Tr::eof();
+-	else if (!_Tr::eq_int_type(__out, _Tr::eof()))
+-	  return this->sputc(__out);
+-	return _Tr::not_eof(__out);
++	else if (!_Tr::eq_int_type(___out, _Tr::eof()))
++	  return this->sputc(___out);
++	return _Tr::not_eof(___out);
+       }
+ 
+       typename _Wide_streambuf::int_type
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/locale_facets.h gcc-6.3.0/libstdc++-v3/include/bits/locale_facets.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/locale_facets.h	2017-05-14 09:37:13.593341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/locale_facets.h	2017-05-14 09:56:41.213341333 -0700
+@@ -1984,7 +1984,7 @@
+        *  except if the value is 1, sets @a v to true, if the value is 0, sets
+        *  @a v to false, and otherwise set err to ios_base::failbit.
+        *
+-       *  @param  __in  Start of input stream.
++       *  @param  ___in  Start of input stream.
+        *  @param  __end  End of input stream.
+        *  @param  __io  Source of locale and flags.
+        *  @param  __err  Error flags to set.
+@@ -1992,9 +1992,9 @@
+        *  @return  Iterator after reading.
+       */
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, bool& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       //@{
+       /**
+@@ -2021,7 +2021,7 @@
+        *  Otherwise, sets err to ios_base::failbit and leaves @a v unaltered.
+        *  Sets err to ios_base::eofbit if the stream is emptied.
+        *
+-       *  @param  __in  Start of input stream.
++       *  @param  ___in  Start of input stream.
+        *  @param  __end  End of input stream.
+        *  @param  __io  Source of locale and flags.
+        *  @param  __err  Error flags to set.
+@@ -2029,35 +2029,35 @@
+        *  @return  Iterator after reading.
+       */
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, long& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, unsigned short& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, unsigned int& __v)   const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, unsigned long& __v)  const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+ #ifdef _GLIBCXX_USE_LONG_LONG
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, long long& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, unsigned long long& __v)  const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ #endif
+       //@}
+ 
+@@ -2081,7 +2081,7 @@
+        *  Otherwise, sets err to ios_base::failbit and leaves @a v unaltered.
+        *  Sets err to ios_base::eofbit if the stream is emptied.
+        *
+-       *  @param  __in  Start of input stream.
++       *  @param  ___in  Start of input stream.
+        *  @param  __end  End of input stream.
+        *  @param  __io  Source of locale and flags.
+        *  @param  __err  Error flags to set.
+@@ -2089,19 +2089,19 @@
+        *  @return  Iterator after reading.
+       */
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, float& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, double& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, long double& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+       //@}
+ 
+       /**
+@@ -2124,7 +2124,7 @@
+        *  Otherwise, sets err to ios_base::failbit and leaves @a v unaltered.
+        *  Sets err to ios_base::eofbit if the stream is emptied.
+        *
+-       *  @param  __in  Start of input stream.
++       *  @param  ___in  Start of input stream.
+        *  @param  __end  End of input stream.
+        *  @param  __io  Source of locale and flags.
+        *  @param  __err  Error flags to set.
+@@ -2132,9 +2132,9 @@
+        *  @return  Iterator after reading.
+       */
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, void*& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+ 
+     protected:
+       /// Destructor.
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/ostream_insert.h gcc-6.3.0/libstdc++-v3/include/bits/ostream_insert.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/ostream_insert.h	2017-05-14 09:37:13.596674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/ostream_insert.h	2017-05-14 09:56:41.220007999 -0700
+@@ -41,31 +41,31 @@
+ 
+   template<typename _CharT, typename _Traits>
+     inline void
+-    __ostream_write(basic_ostream<_CharT, _Traits>& __out,
++    __ostream_write(basic_ostream<_CharT, _Traits>& ___out,
+ 		    const _CharT* __s, streamsize __n)
+     {
+       typedef basic_ostream<_CharT, _Traits>       __ostream_type;      
+       typedef typename __ostream_type::ios_base    __ios_base;
+ 
+-      const streamsize __put = __out.rdbuf()->sputn(__s, __n);
++      const streamsize __put = ___out.rdbuf()->sputn(__s, __n);
+       if (__put != __n)
+-	__out.setstate(__ios_base::badbit);
++	___out.setstate(__ios_base::badbit);
+     }
+ 
+   template<typename _CharT, typename _Traits>
+     inline void
+-    __ostream_fill(basic_ostream<_CharT, _Traits>& __out, streamsize __n)
++    __ostream_fill(basic_ostream<_CharT, _Traits>& ___out, streamsize __n)
+     {
+       typedef basic_ostream<_CharT, _Traits>       __ostream_type;      
+       typedef typename __ostream_type::ios_base    __ios_base;
+ 
+-      const _CharT __c = __out.fill();
++      const _CharT __c = ___out.fill();
+       for (; __n > 0; --__n)
+ 	{
+-	  const typename _Traits::int_type __put = __out.rdbuf()->sputc(__c);
++	  const typename _Traits::int_type __put = ___out.rdbuf()->sputc(__c);
+ 	  if (_Traits::eq_int_type(__put, _Traits::eof()))
+ 	    {
+-	      __out.setstate(__ios_base::badbit);
++	      ___out.setstate(__ios_base::badbit);
+ 	      break;
+ 	    }
+ 	}
+@@ -73,43 +73,43 @@
+ 
+   template<typename _CharT, typename _Traits>
+     basic_ostream<_CharT, _Traits>&
+-    __ostream_insert(basic_ostream<_CharT, _Traits>& __out,
++    __ostream_insert(basic_ostream<_CharT, _Traits>& ___out,
+ 		     const _CharT* __s, streamsize __n)
+     {
+       typedef basic_ostream<_CharT, _Traits>       __ostream_type;
+       typedef typename __ostream_type::ios_base    __ios_base;
+ 
+-      typename __ostream_type::sentry __cerb(__out);
++      typename __ostream_type::sentry __cerb(___out);
+       if (__cerb)
+ 	{
+ 	  __try
+ 	    {
+-	      const streamsize __w = __out.width();
++	      const streamsize __w = ___out.width();
+ 	      if (__w > __n)
+ 		{
+-		  const bool __left = ((__out.flags()
++		  const bool __left = ((___out.flags()
+ 					& __ios_base::adjustfield)
+ 				       == __ios_base::left);
+ 		  if (!__left)
+-		    __ostream_fill(__out, __w - __n);
+-		  if (__out.good())
+-		    __ostream_write(__out, __s, __n);
+-		  if (__left && __out.good())
+-		    __ostream_fill(__out, __w - __n);
++		    __ostream_fill(___out, __w - __n);
++		  if (___out.good())
++		    __ostream_write(___out, __s, __n);
++		  if (__left && ___out.good())
++		    __ostream_fill(___out, __w - __n);
+ 		}
+ 	      else
+-		__ostream_write(__out, __s, __n);
+-	      __out.width(0);
++		__ostream_write(___out, __s, __n);
++	      ___out.width(0);
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __out._M_setstate(__ios_base::badbit);
++	      ___out._M_setstate(__ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+-	    { __out._M_setstate(__ios_base::badbit); }
++	    { ___out._M_setstate(__ios_base::badbit); }
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   // Inhibit implicit instantiations for required instantiations,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/ostream.tcc gcc-6.3.0/libstdc++-v3/include/bits/ostream.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/ostream.tcc	2017-05-14 09:37:13.593341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/ostream.tcc	2017-05-14 09:56:41.203341332 -0700
+@@ -318,10 +318,10 @@
+ 
+   template<typename _CharT, typename _Traits>
+     basic_ostream<_CharT, _Traits>&
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, const char* __s)
+     {
+       if (!__s)
+-	__out.setstate(ios_base::badbit);
++	___out.setstate(ios_base::badbit);
+       else
+ 	{
+ 	  // _GLIBCXX_RESOLVE_LIB_DEFECTS
+@@ -339,18 +339,18 @@
+ 
+ 	      _CharT *__ws = __pg.__get();
+ 	      for (size_t  __i = 0; __i < __clen; ++__i)
+-		__ws[__i] = __out.widen(__s[__i]);
+-	      __ostream_insert(__out, __ws, __clen);
++		__ws[__i] = ___out.widen(__s[__i]);
++	      __ostream_insert(___out, __ws, __clen);
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __out._M_setstate(ios_base::badbit);
++	      ___out._M_setstate(ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+-	    { __out._M_setstate(ios_base::badbit); }
++	    { ___out._M_setstate(ios_base::badbit); }
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   // Inhibit implicit instantiations for required instantiations,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/regex.h gcc-6.3.0/libstdc++-v3/include/bits/regex.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/regex.h	2017-05-14 09:37:13.593341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/regex.h	2017-05-14 09:56:41.220007999 -0700
+@@ -1777,7 +1777,7 @@
+        */
+       template<typename _Out_iter>
+ 	_Out_iter
+-	format(_Out_iter __out, const char_type* __fmt_first,
++	format(_Out_iter ___out, const char_type* __fmt_first,
+ 	       const char_type* __fmt_last,
+ 	       match_flag_type __flags = regex_constants::format_default) const;
+ 
+@@ -1786,10 +1786,10 @@
+        */
+       template<typename _Out_iter, typename _St, typename _Sa>
+ 	_Out_iter
+-	format(_Out_iter __out, const basic_string<char_type, _St, _Sa>& __fmt,
++	format(_Out_iter ___out, const basic_string<char_type, _St, _Sa>& __fmt,
+ 	       match_flag_type __flags = regex_constants::format_default) const
+ 	{
+-	  return format(__out, __fmt.data(), __fmt.data() + __fmt.size(),
++	  return format(___out, __fmt.data(), __fmt.data() + __fmt.size(),
+ 			__flags);
+ 	}
+ 
+@@ -2277,46 +2277,46 @@
+   /**
+    * @brief Search for a regular expression within a range for multiple times,
+    and replace the matched parts through filling a format string.
+-   * @param __out   [OUT] The output iterator.
++   * @param ___out   [OUT] The output iterator.
+    * @param __first [IN]  The start of the string to search.
+    * @param __last  [IN]  One-past-the-end of the string to search.
+    * @param __e     [IN]  The regular expression to search for.
+    * @param __fmt   [IN]  The format string.
+    * @param __flags [IN]  Search and replace policy flags.
+    *
+-   * @returns __out
++   * @returns ___out
+    * @throws an exception of type regex_error.
+    */
+   template<typename _Out_iter, typename _Bi_iter,
+ 	   typename _Rx_traits, typename _Ch_type,
+ 	   typename _St, typename _Sa>
+     inline _Out_iter
+-    regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
++    regex_replace(_Out_iter ___out, _Bi_iter __first, _Bi_iter __last,
+ 		  const basic_regex<_Ch_type, _Rx_traits>& __e,
+ 		  const basic_string<_Ch_type, _St, _Sa>& __fmt,
+ 		  regex_constants::match_flag_type __flags
+ 		  = regex_constants::match_default)
+     {
+-      return regex_replace(__out, __first, __last, __e, __fmt.c_str(), __flags);
++      return regex_replace(___out, __first, __last, __e, __fmt.c_str(), __flags);
+     }
+ 
+   /**
+    * @brief Search for a regular expression within a range for multiple times,
+    and replace the matched parts through filling a format C-string.
+-   * @param __out   [OUT] The output iterator.
++   * @param ___out   [OUT] The output iterator.
+    * @param __first [IN]  The start of the string to search.
+    * @param __last  [IN]  One-past-the-end of the string to search.
+    * @param __e     [IN]  The regular expression to search for.
+    * @param __fmt   [IN]  The format C-string.
+    * @param __flags [IN]  Search and replace policy flags.
+    *
+-   * @returns __out
++   * @returns ___out
+    * @throws an exception of type regex_error.
+    */
+   template<typename _Out_iter, typename _Bi_iter,
+ 	   typename _Rx_traits, typename _Ch_type>
+     _Out_iter
+-    regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
++    regex_replace(_Out_iter ___out, _Bi_iter __first, _Bi_iter __last,
+ 		  const basic_regex<_Ch_type, _Rx_traits>& __e,
+ 		  const _Ch_type* __fmt,
+ 		  regex_constants::match_flag_type __flags
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/bits/regex.tcc gcc-6.3.0/libstdc++-v3/include/bits/regex.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/bits/regex.tcc	2017-05-14 09:37:13.596674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/bits/regex.tcc	2017-05-14 09:56:41.203341332 -0700
+@@ -357,7 +357,7 @@
+   template<typename _Bi_iter, typename _Alloc>
+   template<typename _Out_iter>
+     _Out_iter match_results<_Bi_iter, _Alloc>::
+-    format(_Out_iter __out,
++    format(_Out_iter ___out,
+ 	   const match_results<_Bi_iter, _Alloc>::char_type* __fmt_first,
+ 	   const match_results<_Bi_iter, _Alloc>::char_type* __fmt_last,
+ 	   match_flag_type __flags) const
+@@ -372,7 +372,7 @@
+ 	{
+ 	  auto& __sub = (*this)[__idx];
+ 	  if (__sub.matched)
+-	    __out = std::copy(__sub.first, __sub.second, __out);
++	    ___out = std::copy(__sub.first, __sub.second, ___out);
+ 	};
+ 
+       if (__flags & regex_constants::format_sed)
+@@ -389,10 +389,10 @@
+ 		    && __fctyp.is(__ctype_type::digit, *__fmt_first))
+ 		  __output(__traits.value(*__fmt_first++, 10));
+ 		else
+-		  *__out++ = '\\';
++		  *___out++ = '\\';
+ 	      }
+ 	    else
+-	      *__out++ = *__fmt_first++;
++	      *___out++ = *__fmt_first++;
+ 	}
+       else
+ 	{
+@@ -402,7 +402,7 @@
+ 	      if (__next == __fmt_last)
+ 		break;
+ 
+-	      __out = std::copy(__fmt_first, __next, __out);
++	      ___out = std::copy(__fmt_first, __next, ___out);
+ 
+ 	      auto __eat = [&](char __ch) -> bool
+ 		{
+@@ -415,22 +415,22 @@
+ 		};
+ 
+ 	      if (++__next == __fmt_last)
+-		*__out++ = '$';
++		*___out++ = '$';
+ 	      else if (__eat('$'))
+-		*__out++ = '$';
++		*___out++ = '$';
+ 	      else if (__eat('&'))
+ 		__output(0);
+ 	      else if (__eat('`'))
+ 		{
+ 		  auto& __sub = _M_prefix();
+ 		  if (__sub.matched)
+-		    __out = std::copy(__sub.first, __sub.second, __out);
++		    ___out = std::copy(__sub.first, __sub.second, ___out);
+ 		}
+ 	      else if (__eat('\''))
+ 		{
+ 		  auto& __sub = _M_suffix();
+ 		  if (__sub.matched)
+-		    __out = std::copy(__sub.first, __sub.second, __out);
++		    ___out = std::copy(__sub.first, __sub.second, ___out);
+ 		}
+ 	      else if (__fctyp.is(__ctype_type::digit, *__next))
+ 		{
+@@ -445,18 +445,18 @@
+ 		    __output(__num);
+ 		}
+ 	      else
+-		*__out++ = '$';
++		*___out++ = '$';
+ 	      __fmt_first = __next;
+ 	    }
+-	  __out = std::copy(__fmt_first, __fmt_last, __out);
++	  ___out = std::copy(__fmt_first, __fmt_last, ___out);
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   template<typename _Out_iter, typename _Bi_iter,
+ 	   typename _Rx_traits, typename _Ch_type>
+     _Out_iter
+-    regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
++    regex_replace(_Out_iter ___out, _Bi_iter __first, _Bi_iter __last,
+ 		  const basic_regex<_Ch_type, _Rx_traits>& __e,
+ 		  const _Ch_type* __fmt,
+ 		  regex_constants::match_flag_type __flags)
+@@ -467,7 +467,7 @@
+       if (__i == __end)
+ 	{
+ 	  if (!(__flags & regex_constants::format_no_copy))
+-	    __out = std::copy(__first, __last, __out);
++	    ___out = std::copy(__first, __last, ___out);
+ 	}
+       else
+ 	{
+@@ -476,17 +476,17 @@
+ 	  for (; __i != __end; ++__i)
+ 	    {
+ 	      if (!(__flags & regex_constants::format_no_copy))
+-		__out = std::copy(__i->prefix().first, __i->prefix().second,
+-				  __out);
+-	      __out = __i->format(__out, __fmt, __fmt + __len, __flags);
++		___out = std::copy(__i->prefix().first, __i->prefix().second,
++				  ___out);
++	      ___out = __i->format(___out, __fmt, __fmt + __len, __flags);
+ 	      __last = __i->suffix();
+ 	      if (__flags & regex_constants::format_first_only)
+ 		break;
+ 	    }
+ 	  if (!(__flags & regex_constants::format_no_copy))
+-	    __out = std::copy(__last.first, __last.second, __out);
++	    ___out = std::copy(__last.first, __last.second, ___out);
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   template<typename _Bi_iter,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/experimental/algorithm gcc-6.3.0/libstdc++-v3/include/experimental/algorithm
+--- gcc-6.3.0-orig/libstdc++-v3/include/experimental/algorithm	2017-05-14 09:37:13.580007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/experimental/algorithm	2017-05-14 09:56:41.230007999 -0700
+@@ -60,7 +60,7 @@
+            typename _Size, typename _UniformRandomNumberGenerator>
+     _RandomAccessIterator
+     __sample(_InputIterator __first, _InputIterator __last, input_iterator_tag,
+-	     _RandomAccessIterator __out, random_access_iterator_tag,
++	     _RandomAccessIterator ___out, random_access_iterator_tag,
+ 	     _Size __n, _UniformRandomNumberGenerator&& __g)
+     {
+       using __distrib_type = std::uniform_int_distribution<_Size>;
+@@ -69,7 +69,7 @@
+       _Size __sample_sz = 0;
+       while (__first != __last && __sample_sz != __n)
+ 	{
+-	  __out[__sample_sz++] = *__first;
++	  ___out[__sample_sz++] = *__first;
+ 	  ++__first;
+ 	}
+       for (auto __pop_sz = __sample_sz; __first != __last;
+@@ -77,9 +77,9 @@
+ 	{
+ 	  const auto __k = __d(__g, __param_type{0, __pop_sz});
+ 	  if (__k < __n)
+-	    __out[__k] = *__first;
++	    ___out[__k] = *__first;
+ 	}
+-      return __out + __sample_sz;
++      return ___out + __sample_sz;
+     }
+ 
+   /// Selection sampling algorithm.
+@@ -88,7 +88,7 @@
+     _OutputIterator
+     __sample(_ForwardIterator __first, _ForwardIterator __last,
+ 	     forward_iterator_tag,
+-	     _OutputIterator __out, _Cat,
++	     _OutputIterator ___out, _Cat,
+ 	     _Size __n, _UniformRandomNumberGenerator&& __g)
+     {
+       using __distrib_type = std::uniform_int_distribution<_Size>;
+@@ -98,10 +98,10 @@
+       for (__n = std::min(__n, __unsampled_sz); __n != 0; ++__first)
+ 	if (__d(__g, __param_type{0, --__unsampled_sz}) < __n)
+ 	  {
+-	    *__out++ = *__first;
++	    *___out++ = *__first;
+ 	    --__n;
+ 	  }
+-      return __out;
++      return ___out;
+     }
+ 
+   /// Take a random sample from a population.
+@@ -109,7 +109,7 @@
+            typename _Distance, typename _UniformRandomNumberGenerator>
+     _SampleIterator
+     sample(_PopulationIterator __first, _PopulationIterator __last,
+-	   _SampleIterator __out, _Distance __n,
++	   _SampleIterator ___out, _Distance __n,
+ 	   _UniformRandomNumberGenerator&& __g)
+     {
+       using __pop_cat = typename
+@@ -128,7 +128,7 @@
+ 
+       typename iterator_traits<_PopulationIterator>::difference_type __d = __n;
+       return std::experimental::__sample(
+-	  __first, __last, __pop_cat{}, __out, __samp_cat{},
++	  __first, __last, __pop_cat{}, ___out, __samp_cat{},
+ 	  __d, std::forward<_UniformRandomNumberGenerator>(__g));
+     }
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/ext/algorithm gcc-6.3.0/libstdc++-v3/include/ext/algorithm
+--- gcc-6.3.0-orig/libstdc++-v3/include/ext/algorithm	2017-05-14 09:37:13.590007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/ext/algorithm	2017-05-14 09:56:41.196674666 -0700
+@@ -265,7 +265,7 @@
+ 	   typename _Distance>
+     _OutputIterator
+     random_sample_n(_ForwardIterator __first, _ForwardIterator __last,
+-                    _OutputIterator __out, const _Distance __n)
++                    _OutputIterator ___out, const _Distance __n)
+     {
+       // concept requirements
+       __glibcxx_function_requires(_ForwardIteratorConcept<_ForwardIterator>)
+@@ -280,14 +280,14 @@
+ 	{
+ 	  if ((std::rand() % __remaining) < __m)
+ 	    {
+-	      *__out = *__first;
+-	      ++__out;
++	      *___out = *__first;
++	      ++___out;
+ 	      --__m;
+ 	    }
+ 	  --__remaining;
+ 	  ++__first;
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   /**
+@@ -299,7 +299,7 @@
+ 	   typename _Distance, typename _RandomNumberGenerator>
+     _OutputIterator
+     random_sample_n(_ForwardIterator __first, _ForwardIterator __last,
+-                   _OutputIterator __out, const _Distance __n,
++                   _OutputIterator ___out, const _Distance __n,
+ 		   _RandomNumberGenerator& __rand)
+     {
+       // concept requirements
+@@ -317,44 +317,44 @@
+ 	{
+ 	  if (__rand(__remaining) < __m)
+ 	    {
+-	      *__out = *__first;
+-	      ++__out;
++	      *___out = *__first;
++	      ++___out;
+ 	      --__m;
+ 	    }
+ 	  --__remaining;
+ 	  ++__first;
+ 	}
+-      return __out;
++      return ___out;
+     }
+ 
+   template<typename _InputIterator, typename _RandomAccessIterator,
+ 	   typename _Distance>
+     _RandomAccessIterator
+     __random_sample(_InputIterator __first, _InputIterator __last,
+-		    _RandomAccessIterator __out,
++		    _RandomAccessIterator ___out,
+ 		    const _Distance __n)
+     {
+       _Distance __m = 0;
+       _Distance __t = __n;
+       for ( ; __first != __last && __m < __n; ++__m, ++__first)
+-	__out[__m] = *__first;
++	___out[__m] = *__first;
+ 
+       while (__first != __last)
+ 	{
+ 	  ++__t;
+ 	  _Distance __M = std::rand() % (__t);
+ 	  if (__M < __n)
+-	    __out[__M] = *__first;
++	    ___out[__M] = *__first;
+ 	  ++__first;
+ 	}
+-      return __out + __m;
++      return ___out + __m;
+     }
+ 
+   template<typename _InputIterator, typename _RandomAccessIterator,
+ 	   typename _RandomNumberGenerator, typename _Distance>
+     _RandomAccessIterator
+     __random_sample(_InputIterator __first, _InputIterator __last,
+-		    _RandomAccessIterator __out,
++		    _RandomAccessIterator ___out,
+ 		    _RandomNumberGenerator& __rand,
+ 		    const _Distance __n)
+     {
+@@ -365,17 +365,17 @@
+       _Distance __m = 0;
+       _Distance __t = __n;
+       for ( ; __first != __last && __m < __n; ++__m, ++__first)
+-	__out[__m] = *__first;
++	___out[__m] = *__first;
+ 
+       while (__first != __last)
+ 	{
+ 	  ++__t;
+ 	  _Distance __M = __rand(__t);
+ 	  if (__M < __n)
+-	    __out[__M] = *__first;
++	    ___out[__M] = *__first;
+ 	  ++__first;
+ 	}
+-      return __out + __m;
++      return ___out + __m;
+     }
+ 
+   /**
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp gcc-6.3.0/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp
+--- gcc-6.3.0-orig/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2017-05-14 09:37:13.586674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/ext/pb_ds/detail/debug_map_base.hpp	2017-05-14 09:56:41.196674666 -0700
+@@ -57,9 +57,9 @@
+     // Need std::pair ostream extractor.
+     template<typename _CharT, typename _Traits, typename _Tp1, typename _Tp2>
+     inline std::basic_ostream<_CharT, _Traits>&
+-    operator<<(std::basic_ostream<_CharT, _Traits>& __out,
++    operator<<(std::basic_ostream<_CharT, _Traits>& ___out,
+ 	       const std::pair<_Tp1, _Tp2>& p)
+-    { return (__out << '(' << p.first << ',' << p.second << ')'); }
++    { return (___out << '(' << p.first << ',' << p.second << ')'); }
+ 
+ #define PB_DS_CLASS_T_DEC \
+     template<typename Key, typename Eq_Fn, typename Const_Key_Reference>
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/ext/random.tcc gcc-6.3.0/libstdc++-v3/include/ext/random.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/ext/random.tcc	2017-05-14 09:37:13.586674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/ext/random.tcc	2017-05-14 09:56:41.193341333 -0700
+@@ -207,38 +207,38 @@
+   namespace {
+ 
+     template<size_t __shift>
+-      inline void __rshift(uint32_t *__out, const uint32_t *__in)
++      inline void __rshift(uint32_t *___out, const uint32_t *___in)
+       {
+-	uint64_t __th = ((static_cast<uint64_t>(__in[3]) << 32)
+-			 | static_cast<uint64_t>(__in[2]));
+-	uint64_t __tl = ((static_cast<uint64_t>(__in[1]) << 32)
+-			 | static_cast<uint64_t>(__in[0]));
++	uint64_t __th = ((static_cast<uint64_t>(___in[3]) << 32)
++			 | static_cast<uint64_t>(___in[2]));
++	uint64_t __tl = ((static_cast<uint64_t>(___in[1]) << 32)
++			 | static_cast<uint64_t>(___in[0]));
+ 
+ 	uint64_t __oh = __th >> (__shift * 8);
+ 	uint64_t __ol = __tl >> (__shift * 8);
+ 	__ol |= __th << (64 - __shift * 8);
+-	__out[1] = static_cast<uint32_t>(__ol >> 32);
+-	__out[0] = static_cast<uint32_t>(__ol);
+-	__out[3] = static_cast<uint32_t>(__oh >> 32);
+-	__out[2] = static_cast<uint32_t>(__oh);
++	___out[1] = static_cast<uint32_t>(__ol >> 32);
++	___out[0] = static_cast<uint32_t>(__ol);
++	___out[3] = static_cast<uint32_t>(__oh >> 32);
++	___out[2] = static_cast<uint32_t>(__oh);
+       }
+ 
+ 
+     template<size_t __shift>
+-      inline void __lshift(uint32_t *__out, const uint32_t *__in)
++      inline void __lshift(uint32_t *___out, const uint32_t *___in)
+       {
+-	uint64_t __th = ((static_cast<uint64_t>(__in[3]) << 32)
+-			 | static_cast<uint64_t>(__in[2]));
+-	uint64_t __tl = ((static_cast<uint64_t>(__in[1]) << 32)
+-			 | static_cast<uint64_t>(__in[0]));
++	uint64_t __th = ((static_cast<uint64_t>(___in[3]) << 32)
++			 | static_cast<uint64_t>(___in[2]));
++	uint64_t __tl = ((static_cast<uint64_t>(___in[1]) << 32)
++			 | static_cast<uint64_t>(___in[0]));
+ 
+ 	uint64_t __oh = __th << (__shift * 8);
+ 	uint64_t __ol = __tl << (__shift * 8);
+ 	__oh |= __tl >> (64 - __shift * 8);
+-	__out[1] = static_cast<uint32_t>(__ol >> 32);
+-	__out[0] = static_cast<uint32_t>(__ol);
+-	__out[3] = static_cast<uint32_t>(__oh >> 32);
+-	__out[2] = static_cast<uint32_t>(__oh);
++	___out[1] = static_cast<uint32_t>(__ol >> 32);
++	___out[0] = static_cast<uint32_t>(__ol);
++	___out[3] = static_cast<uint32_t>(__oh >> 32);
++	___out[2] = static_cast<uint32_t>(__oh);
+       }
+ 
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/ext/vstring.tcc gcc-6.3.0/libstdc++-v3/include/ext/vstring.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/ext/vstring.tcc	2017-05-14 09:37:13.590007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/ext/vstring.tcc	2017-05-14 09:56:41.193341333 -0700
+@@ -549,7 +549,7 @@
+   template<typename _CharT, typename _Traits, typename _Alloc,
+            template <typename, typename, typename> class _Base>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in,
++    operator>>(basic_istream<_CharT, _Traits>& ___in,
+ 	       __gnu_cxx::__versa_string<_CharT, _Traits,
+ 	                                 _Alloc, _Base>& __str)
+     {
+@@ -564,7 +564,7 @@
+ 
+       __size_type __extracted = 0;
+       typename __ios_base::iostate __err = __ios_base::goodbit;
+-      typename __istream_type::sentry __cerb(__in, false);
++      typename __istream_type::sentry __cerb(___in, false);
+       if (__cerb)
+ 	{
+ 	  __try
+@@ -573,12 +573,12 @@
+ 	      __str.erase();
+ 	      _CharT __buf[128];
+ 	      __size_type __len = 0;
+-	      const streamsize __w = __in.width();
++	      const streamsize __w = ___in.width();
+ 	      const __size_type __n = __w > 0 ? static_cast<__size_type>(__w)
+ 		                              : __str.max_size();
+-	      const __ctype_type& __ct = use_facet<__ctype_type>(__in.getloc());
++	      const __ctype_type& __ct = use_facet<__ctype_type>(___in.getloc());
+ 	      const __int_type __eof = _Traits::eof();
+-	      __int_type __c = __in.rdbuf()->sgetc();
++	      __int_type __c = ___in.rdbuf()->sgetc();
+ 
+ 	      while (__extracted < __n
+ 		     && !_Traits::eq_int_type(__c, __eof)
+@@ -592,17 +592,17 @@
+ 		    }
+ 		  __buf[__len++] = _Traits::to_char_type(__c);
+ 		  ++__extracted;
+-		  __c = __in.rdbuf()->snextc();
++		  __c = ___in.rdbuf()->snextc();
+ 		}
+ 	      __str.append(__buf, __len);
+ 
+ 	      if (_Traits::eq_int_type(__c, __eof))
+ 		__err |= __ios_base::eofbit;
+-	      __in.width(0);
++	      ___in.width(0);
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+@@ -610,21 +610,21 @@
+ 	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
+ 	      // 91. Description of operator>> and getline() for string<>
+ 	      // might cause endless loop
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	    }
+ 	}
+       // 211.  operator>>(istream&, string&) doesn't set failbit
+       if (!__extracted)
+ 	__err |= __ios_base::failbit;
+       if (__err)
+-	__in.setstate(__err);
+-      return __in;
++	___in.setstate(__err);
++      return ___in;
+     }      
+ 
+   template<typename _CharT, typename _Traits, typename _Alloc,
+            template <typename, typename, typename> class _Base>
+     basic_istream<_CharT, _Traits>&
+-    getline(basic_istream<_CharT, _Traits>& __in,
++    getline(basic_istream<_CharT, _Traits>& ___in,
+ 	    __gnu_cxx::__versa_string<_CharT, _Traits, _Alloc, _Base>& __str,
+ 	    _CharT __delim)
+     {
+@@ -638,7 +638,7 @@
+       __size_type __extracted = 0;
+       const __size_type __n = __str.max_size();
+       typename __ios_base::iostate __err = __ios_base::goodbit;
+-      typename __istream_type::sentry __cerb(__in, true);
++      typename __istream_type::sentry __cerb(___in, true);
+       if (__cerb)
+ 	{
+ 	  __try
+@@ -649,7 +649,7 @@
+ 	      __size_type __len = 0;
+ 	      const __int_type __idelim = _Traits::to_int_type(__delim);
+ 	      const __int_type __eof = _Traits::eof();
+-	      __int_type __c = __in.rdbuf()->sgetc();
++	      __int_type __c = ___in.rdbuf()->sgetc();
+ 
+ 	      while (__extracted < __n
+ 		     && !_Traits::eq_int_type(__c, __eof)
+@@ -662,7 +662,7 @@
+ 		    }
+ 		  __buf[__len++] = _Traits::to_char_type(__c);
+ 		  ++__extracted;
+-		  __c = __in.rdbuf()->snextc();
++		  __c = ___in.rdbuf()->snextc();
+ 		}
+ 	      __str.append(__buf, __len);
+ 
+@@ -671,14 +671,14 @@
+ 	      else if (_Traits::eq_int_type(__c, __idelim))
+ 		{
+ 		  ++__extracted;		  
+-		  __in.rdbuf()->sbumpc();
++		  ___in.rdbuf()->sbumpc();
+ 		}
+ 	      else
+ 		__err |= __ios_base::failbit;
+ 	    }
+ 	  __catch(__cxxabiv1::__forced_unwind&)
+ 	    {
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	      __throw_exception_again;
+ 	    }
+ 	  __catch(...)
+@@ -686,14 +686,14 @@
+ 	      // _GLIBCXX_RESOLVE_LIB_DEFECTS
+ 	      // 91. Description of operator>> and getline() for string<>
+ 	      // might cause endless loop
+-	      __in._M_setstate(__ios_base::badbit);
++	      ___in._M_setstate(__ios_base::badbit);
+ 	    }
+ 	}
+       if (!__extracted)
+ 	__err |= __ios_base::failbit;
+       if (__err)
+-	__in.setstate(__err);
+-      return __in;
++	___in.setstate(__err);
++      return ___in;
+     }      
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/parallel/algo.h gcc-6.3.0/libstdc++-v3/include/parallel/algo.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/parallel/algo.h	2017-05-14 09:37:13.576674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/parallel/algo.h	2017-05-14 09:56:41.226674666 -0700
+@@ -300,48 +300,48 @@
+   // Sequential fallback
+   template<typename _IIter, typename _OutputIterator>
+     inline _OutputIterator
+-    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator __out,
++    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator ___out,
+                 __gnu_parallel::sequential_tag)
+-    { return _GLIBCXX_STD_A::unique_copy(__begin1, __end1, __out); }
++    { return _GLIBCXX_STD_A::unique_copy(__begin1, __end1, ___out); }
+ 
+   // Sequential fallback
+   template<typename _IIter, typename _OutputIterator,
+            typename _Predicate>
+     inline _OutputIterator
+-    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator __out,
++    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator ___out,
+                 _Predicate __pred, __gnu_parallel::sequential_tag)
+-    { return _GLIBCXX_STD_A::unique_copy(__begin1, __end1, __out, __pred); }
++    { return _GLIBCXX_STD_A::unique_copy(__begin1, __end1, ___out, __pred); }
+ 
+   // Sequential fallback for input iterator case
+   template<typename _IIter, typename _OutputIterator,
+            typename _Predicate, typename _IteratorTag1, typename _IteratorTag2>
+     inline _OutputIterator
+     __unique_copy_switch(_IIter __begin, _IIter __last, 
+-                       _OutputIterator __out, _Predicate __pred, 
++                       _OutputIterator ___out, _Predicate __pred, 
+                        _IteratorTag1, _IteratorTag2)
+-    { return _GLIBCXX_STD_A::unique_copy(__begin, __last, __out, __pred); }
++    { return _GLIBCXX_STD_A::unique_copy(__begin, __last, ___out, __pred); }
+ 
+   // Parallel unique_copy for random access iterators
+   template<typename _RAIter, typename RandomAccessOutputIterator,
+            typename _Predicate>
+     RandomAccessOutputIterator
+     __unique_copy_switch(_RAIter __begin, _RAIter __last, 
+-                       RandomAccessOutputIterator __out, _Predicate __pred, 
++                       RandomAccessOutputIterator ___out, _Predicate __pred, 
+                        random_access_iterator_tag, random_access_iterator_tag)
+     {
+       if (_GLIBCXX_PARALLEL_CONDITION(
+             static_cast<__gnu_parallel::_SequenceIndex>(__last - __begin)
+             > __gnu_parallel::_Settings::get().unique_copy_minimal_n))
+         return __gnu_parallel::__parallel_unique_copy(
+-                 __begin, __last, __out, __pred);
++                 __begin, __last, ___out, __pred);
+       else
+-        return _GLIBCXX_STD_A::unique_copy(__begin, __last, __out, __pred);
++        return _GLIBCXX_STD_A::unique_copy(__begin, __last, ___out, __pred);
+     }
+ 
+   // Public interface
+   template<typename _IIter, typename _OutputIterator>
+     inline _OutputIterator
+-    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator __out)
++    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator ___out)
+     {
+       typedef std::iterator_traits<_IIter> _IIterTraits;
+       typedef std::iterator_traits<_OutputIterator> _OIterTraits;
+@@ -350,14 +350,14 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __unique_copy_switch(
+-               __begin1, __end1, __out, equal_to<_ValueType>(),
++               __begin1, __end1, ___out, equal_to<_ValueType>(),
+                _IIteratorCategory(), _OIterCategory());
+     }
+ 
+   // Public interface
+   template<typename _IIter, typename _OutputIterator, typename _Predicate>
+     inline _OutputIterator
+-    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator __out,
++    unique_copy(_IIter __begin1, _IIter __end1, _OutputIterator ___out,
+                 _Predicate __pred)
+     {
+       typedef std::iterator_traits<_IIter> _IIterTraits;
+@@ -366,7 +366,7 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __unique_copy_switch(
+-               __begin1, __end1, __out, __pred,
++               __begin1, __end1, ___out, __pred,
+                _IIteratorCategory(), _OIterCategory());
+     }
+ 
+@@ -376,9 +376,9 @@
+     inline _OutputIterator
+     set_union(_IIter1 __begin1, _IIter1 __end1,
+               _IIter2 __begin2, _IIter2 __end2,
+-              _OutputIterator __out, __gnu_parallel::sequential_tag)
++              _OutputIterator ___out, __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_union(
+-               __begin1, __end1, __begin2, __end2, __out); }
++               __begin1, __end1, __begin2, __end2, ___out); }
+ 
+   // Sequential fallback
+   template<typename _IIter1, typename _IIter2,
+@@ -386,10 +386,10 @@
+     inline _OutputIterator
+     set_union(_IIter1 __begin1, _IIter1 __end1,
+               _IIter2 __begin2, _IIter2 __end2,
+-              _OutputIterator __out, _Predicate __pred,
++              _OutputIterator ___out, _Predicate __pred,
+               __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_union(__begin1, __end1,
+-                                       __begin2, __end2, __out, __pred); }
++                                       __begin2, __end2, ___out, __pred); }
+ 
+   // Sequential fallback for input iterator case
+   template<typename _IIter1, typename _IIter2, typename _Predicate,
+@@ -430,7 +430,7 @@
+            typename _OutputIterator>
+     inline _OutputIterator 
+     set_union(_IIter1 __begin1, _IIter1 __end1,
+-              _IIter2 __begin2, _IIter2 __end2, _OutputIterator __out)
++              _IIter2 __begin2, _IIter2 __end2, _OutputIterator ___out)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -444,7 +444,7 @@
+       typedef typename _IIterTraits2::value_type _ValueType2;
+ 
+       return __set_union_switch(
+-               __begin1, __end1, __begin2, __end2, __out,
++               __begin1, __end1, __begin2, __end2, ___out,
+                __gnu_parallel::_Less<_ValueType1, _ValueType2>(),
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+@@ -455,7 +455,7 @@
+     inline _OutputIterator 
+     set_union(_IIter1 __begin1, _IIter1 __end1,
+               _IIter2 __begin2, _IIter2 __end2,
+-              _OutputIterator __out, _Predicate __pred)
++              _OutputIterator ___out, _Predicate __pred)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -467,7 +467,7 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __set_union_switch(
+-               __begin1, __end1, __begin2, __end2, __out, __pred,
++               __begin1, __end1, __begin2, __end2, ___out, __pred,
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+ 
+@@ -477,9 +477,9 @@
+     inline _OutputIterator
+     set_intersection(_IIter1 __begin1, _IIter1 __end1,
+                      _IIter2 __begin2, _IIter2 __end2,
+-                     _OutputIterator __out, __gnu_parallel::sequential_tag)
++                     _OutputIterator ___out, __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_intersection(__begin1, __end1,
+-                                              __begin2, __end2, __out); }
++                                              __begin2, __end2, ___out); }
+ 
+   // Sequential fallback.
+   template<typename _IIter1, typename _IIter2,
+@@ -487,10 +487,10 @@
+     inline _OutputIterator
+     set_intersection(_IIter1 __begin1, _IIter1 __end1,
+                      _IIter2 __begin2, _IIter2 __end2,
+-                     _OutputIterator __out, _Predicate __pred, 
++                     _OutputIterator ___out, _Predicate __pred, 
+                      __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_intersection(
+-               __begin1, __end1, __begin2, __end2, __out, __pred); }
++               __begin1, __end1, __begin2, __end2, ___out, __pred); }
+ 
+   // Sequential fallback for input iterator case
+   template<typename _IIter1, typename _IIter2,
+@@ -537,7 +537,7 @@
+     inline _OutputIterator 
+     set_intersection(_IIter1 __begin1, _IIter1 __end1, 
+                      _IIter2 __begin2, _IIter2 __end2, 
+-                     _OutputIterator __out)
++                     _OutputIterator ___out)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -551,7 +551,7 @@
+       typedef typename _IIterTraits2::value_type _ValueType2;
+ 
+       return __set_intersection_switch(
+-               __begin1, __end1, __begin2, __end2, __out,
++               __begin1, __end1, __begin2, __end2, ___out,
+                __gnu_parallel::_Less<_ValueType1, _ValueType2>(),
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+@@ -561,7 +561,7 @@
+     inline _OutputIterator 
+     set_intersection(_IIter1 __begin1, _IIter1 __end1,
+                      _IIter2 __begin2, _IIter2 __end2,
+-                     _OutputIterator __out, _Predicate __pred)
++                     _OutputIterator ___out, _Predicate __pred)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -573,7 +573,7 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __set_intersection_switch(
+-               __begin1, __end1, __begin2, __end2, __out, __pred,
++               __begin1, __end1, __begin2, __end2, ___out, __pred,
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+ 
+@@ -583,10 +583,10 @@
+     inline _OutputIterator
+     set_symmetric_difference(_IIter1 __begin1, _IIter1 __end1,
+                              _IIter2 __begin2, _IIter2 __end2,
+-                             _OutputIterator __out,
++                             _OutputIterator ___out,
+                              __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_symmetric_difference(
+-               __begin1, __end1, __begin2, __end2, __out); }
++               __begin1, __end1, __begin2, __end2, ___out); }
+ 
+   // Sequential fallback
+   template<typename _IIter1, typename _IIter2,
+@@ -594,10 +594,10 @@
+     inline _OutputIterator
+     set_symmetric_difference(_IIter1 __begin1, _IIter1 __end1,
+                              _IIter2 __begin2, _IIter2 __end2,
+-                             _OutputIterator __out, _Predicate __pred,
++                             _OutputIterator ___out, _Predicate __pred,
+                              __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_symmetric_difference(
+-               __begin1, __end1, __begin2, __end2, __out, __pred); }
++               __begin1, __end1, __begin2, __end2, ___out, __pred); }
+ 
+   // Sequential fallback for input iterator case
+   template<typename _IIter1, typename _IIter2,
+@@ -644,7 +644,7 @@
+     inline _OutputIterator 
+     set_symmetric_difference(_IIter1 __begin1, _IIter1 __end1,
+                              _IIter2 __begin2, _IIter2 __end2,
+-                             _OutputIterator __out)
++                             _OutputIterator ___out)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -658,7 +658,7 @@
+       typedef typename _IIterTraits2::value_type _ValueType2;
+ 
+       return __set_symmetric_difference_switch(
+-               __begin1, __end1, __begin2, __end2, __out,
++               __begin1, __end1, __begin2, __end2, ___out,
+                __gnu_parallel::_Less<_ValueType1, _ValueType2>(),
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+@@ -669,7 +669,7 @@
+     inline _OutputIterator 
+     set_symmetric_difference(_IIter1 __begin1, _IIter1 __end1,
+                              _IIter2 __begin2, _IIter2 __end2,
+-                             _OutputIterator __out, _Predicate __pred)
++                             _OutputIterator ___out, _Predicate __pred)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -681,7 +681,7 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __set_symmetric_difference_switch(
+-               __begin1, __end1, __begin2, __end2, __out, __pred,
++               __begin1, __end1, __begin2, __end2, ___out, __pred,
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+ 
+@@ -691,9 +691,9 @@
+     inline _OutputIterator
+     set_difference(_IIter1 __begin1, _IIter1 __end1, 
+                    _IIter2 __begin2, _IIter2 __end2, 
+-                   _OutputIterator __out, __gnu_parallel::sequential_tag)
++                   _OutputIterator ___out, __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_difference(
+-               __begin1,__end1, __begin2, __end2, __out); }
++               __begin1,__end1, __begin2, __end2, ___out); }
+ 
+   // Sequential fallback.
+   template<typename _IIter1, typename _IIter2,
+@@ -701,10 +701,10 @@
+     inline _OutputIterator
+     set_difference(_IIter1 __begin1, _IIter1 __end1, 
+                    _IIter2 __begin2, _IIter2 __end2, 
+-                   _OutputIterator __out, _Predicate __pred, 
++                   _OutputIterator ___out, _Predicate __pred, 
+                    __gnu_parallel::sequential_tag)
+     { return _GLIBCXX_STD_A::set_difference(__begin1, __end1,
+-                                            __begin2, __end2, __out, __pred); }
++                                            __begin2, __end2, ___out, __pred); }
+ 
+   // Sequential fallback for input iterator case.
+   template<typename _IIter1, typename _IIter2, typename _Predicate,
+@@ -749,7 +749,7 @@
+     inline _OutputIterator
+     set_difference(_IIter1 __begin1, _IIter1 __end1, 
+                    _IIter2 __begin2, _IIter2 __end2, 
+-                   _OutputIterator __out)
++                   _OutputIterator ___out)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -763,7 +763,7 @@
+       typedef typename _IIterTraits2::value_type _ValueType2;
+ 
+       return __set_difference_switch(
+-               __begin1, __end1, __begin2, __end2, __out,
++               __begin1, __end1, __begin2, __end2, ___out,
+                __gnu_parallel::_Less<_ValueType1, _ValueType2>(),
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+@@ -774,7 +774,7 @@
+     inline _OutputIterator
+     set_difference(_IIter1 __begin1, _IIter1 __end1, 
+                    _IIter2 __begin2, _IIter2 __end2, 
+-                   _OutputIterator __out, _Predicate __pred)
++                   _OutputIterator ___out, _Predicate __pred)
+     {
+       typedef std::iterator_traits<_IIter1> _IIterTraits1;
+       typedef std::iterator_traits<_IIter2> _IIterTraits2;
+@@ -786,7 +786,7 @@
+       typedef typename _OIterTraits::iterator_category _OIterCategory;
+ 
+       return __set_difference_switch(
+-               __begin1, __end1, __begin2, __end2, __out, __pred,
++               __begin1, __end1, __begin2, __end2, ___out, __pred,
+                _IIterCategory1(), _IIterCategory2(), _OIterCategory());
+     }
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/parallel/multiway_merge.h gcc-6.3.0/libstdc++-v3/include/parallel/multiway_merge.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/parallel/multiway_merge.h	2017-05-14 09:37:13.580007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/parallel/multiway_merge.h	2017-05-14 09:56:41.230007999 -0700
+@@ -1372,7 +1372,7 @@
+    *     for (int __j = 0; __i < 10; ++__j)
+    *       sequences[__i][__j] = __j;
+    *
+-   *   int __out[33];
++   *   int ___out[33];
+    *   std::vector<std::pair<int*> > seqs;
+    *   for (int __i = 0; __i < 10; ++__i)
+    *     { seqs.push(std::make_pair<int*>(sequences[__i],
+@@ -1733,7 +1733,7 @@
+    *     for (int __j = 0; __i < 11; ++__j)
+    *       sequences[__i][__j] = __j; // __last one is sentinel!
+    *
+-   *   int __out[33];
++   *   int ___out[33];
+    *   std::vector<std::pair<int*> > seqs;
+    *   for (int __i = 0; __i < 10; ++__i)
+    *     { seqs.push(std::make_pair<int*>(sequences[__i],
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/parallel/set_operations.h gcc-6.3.0/libstdc++-v3/include/parallel/set_operations.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/parallel/set_operations.h	2017-05-14 09:37:13.576674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/parallel/set_operations.h	2017-05-14 09:56:41.226674666 -0700
+@@ -130,12 +130,12 @@
+       }
+ 
+       _OutputIterator
+-      __first_empty(_IIter __c, _IIter __d, _OutputIterator __out) const
+-      { return std::copy(__c, __d, __out); }
++      __first_empty(_IIter __c, _IIter __d, _OutputIterator ___out) const
++      { return std::copy(__c, __d, ___out); }
+ 
+       _OutputIterator
+-      __second_empty(_IIter __a, _IIter __b, _OutputIterator __out) const
+-      { return std::copy(__a, __b, __out); }
++      __second_empty(_IIter __a, _IIter __b, _OutputIterator ___out) const
++      { return std::copy(__a, __b, ___out); }
+     };
+ 
+ 
+@@ -198,12 +198,12 @@
+       }
+ 
+       _OutputIterator
+-      __first_empty(_IIter, _IIter, _OutputIterator __out) const
+-      { return __out; }
++      __first_empty(_IIter, _IIter, _OutputIterator ___out) const
++      { return ___out; }
+ 
+       _OutputIterator
+-      __second_empty(_IIter __a, _IIter __b, _OutputIterator __out) const
+-      { return std::copy(__a, __b, __out); }
++      __second_empty(_IIter __a, _IIter __b, _OutputIterator ___out) const
++      { return std::copy(__a, __b, ___out); }
+     };
+ 
+ 
+@@ -265,12 +265,12 @@
+       }
+ 
+       _OutputIterator
+-      __first_empty(_IIter, _IIter, _OutputIterator __out) const
+-      { return __out; }
++      __first_empty(_IIter, _IIter, _OutputIterator ___out) const
++      { return ___out; }
+ 
+       _OutputIterator
+-      __second_empty(_IIter, _IIter, _OutputIterator __out) const
+-      { return __out; }
++      __second_empty(_IIter, _IIter, _OutputIterator ___out) const
++      { return ___out; }
+     };
+ 
+   template<class _IIter, class _OutputIterator, class _Compare>
+@@ -335,12 +335,12 @@
+       }
+ 
+       _OutputIterator
+-      __first_empty(_IIter __c, _IIter __d, _OutputIterator __out) const
+-      { return std::copy(__c, __d, __out); }
++      __first_empty(_IIter __c, _IIter __d, _OutputIterator ___out) const
++      { return std::copy(__c, __d, ___out); }
+ 
+       _OutputIterator
+-      __second_empty(_IIter __a, _IIter __b, _OutputIterator __out) const
+-      { return std::copy(__a, __b, __out); }
++      __second_empty(_IIter __a, _IIter __b, _OutputIterator ___out) const
++      { return std::copy(__a, __b, ___out); }
+     };
+ 
+   template<typename _IIter,
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/parallel/unique_copy.h gcc-6.3.0/libstdc++-v3/include/parallel/unique_copy.h
+--- gcc-6.3.0-orig/libstdc++-v3/include/parallel/unique_copy.h	2017-05-14 09:37:13.580007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/parallel/unique_copy.h	2017-05-14 09:56:41.230007999 -0700
+@@ -85,7 +85,7 @@
+ 	// Check for length without duplicates
+ 	// Needed for position in output
+ 	_DifferenceType __i = 0;
+-	_OutputIterator __out = __result;
++	_OutputIterator ___out = __result;
+ 
+ 	if (__iam == 0)
+           {
+@@ -93,7 +93,7 @@
+             __end = __borders[__iam + 1];
+ 
+             ++__i;
+-            *__out++ = *__first;
++            *___out++ = *__first;
+ 
+             for (_IIter __iter = __first + __begin; __iter < __first + __end;
+ 		 ++__iter)
+@@ -101,7 +101,7 @@
+         	if (!__binary_pred(*__iter, *(__iter - 1)))
+                   {
+                     ++__i;
+-                    *__out++ = *__iter;
++                    *___out++ = *__iter;
+                   }
+               }
+           }
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/std/istream gcc-6.3.0/libstdc++-v3/include/std/istream
+--- gcc-6.3.0-orig/libstdc++-v3/include/std/istream	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/std/istream	2017-05-14 09:56:41.200008000 -0700
+@@ -738,7 +738,7 @@
+   //@{
+   /**
+    *  @brief  Character extractors
+-   *  @param  __in  An input stream.
++   *  @param  ___in  An input stream.
+    *  @param  __c  A character reference.
+    *  @return  in
+    *
+@@ -749,25 +749,25 @@
+   */
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in, _CharT& __c);
++    operator>>(basic_istream<_CharT, _Traits>& ___in, _CharT& __c);
+ 
+   template<class _Traits>
+     inline basic_istream<char, _Traits>&
+-    operator>>(basic_istream<char, _Traits>& __in, unsigned char& __c)
+-    { return (__in >> reinterpret_cast<char&>(__c)); }
++    operator>>(basic_istream<char, _Traits>& ___in, unsigned char& __c)
++    { return (___in >> reinterpret_cast<char&>(__c)); }
+ 
+   template<class _Traits>
+     inline basic_istream<char, _Traits>&
+-    operator>>(basic_istream<char, _Traits>& __in, signed char& __c)
+-    { return (__in >> reinterpret_cast<char&>(__c)); }
++    operator>>(basic_istream<char, _Traits>& ___in, signed char& __c)
++    { return (___in >> reinterpret_cast<char&>(__c)); }
+   //@}
+ 
+   //@{
+   /**
+    *  @brief  Character string extractors
+-   *  @param  __in  An input stream.
++   *  @param  ___in  An input stream.
+    *  @param  __s  A pointer to a character array.
+-   *  @return  __in
++   *  @return  ___in
+    *
+    *  Behaves like one of the formatted arithmetic extractors described in
+    *  std::basic_istream.  After constructing a sentry object with good
+@@ -791,22 +791,22 @@
+   */
+   template<typename _CharT, typename _Traits>
+     basic_istream<_CharT, _Traits>&
+-    operator>>(basic_istream<_CharT, _Traits>& __in, _CharT* __s);
++    operator>>(basic_istream<_CharT, _Traits>& ___in, _CharT* __s);
+ 
+   // Explicit specialization declaration, defined in src/istream.cc.
+   template<>
+     basic_istream<char>&
+-    operator>>(basic_istream<char>& __in, char* __s);
++    operator>>(basic_istream<char>& ___in, char* __s);
+ 
+   template<class _Traits>
+     inline basic_istream<char, _Traits>&
+-    operator>>(basic_istream<char, _Traits>& __in, unsigned char* __s)
+-    { return (__in >> reinterpret_cast<char*>(__s)); }
++    operator>>(basic_istream<char, _Traits>& ___in, unsigned char* __s)
++    { return (___in >> reinterpret_cast<char*>(__s)); }
+ 
+   template<class _Traits>
+     inline basic_istream<char, _Traits>&
+-    operator>>(basic_istream<char, _Traits>& __in, signed char* __s)
+-    { return (__in >> reinterpret_cast<char*>(__s)); }
++    operator>>(basic_istream<char, _Traits>& ___in, signed char* __s)
++    { return (___in >> reinterpret_cast<char*>(__s)); }
+   //@}
+ 
+   /**
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/std/ostream gcc-6.3.0/libstdc++-v3/include/std/ostream
+--- gcc-6.3.0-orig/libstdc++-v3/include/std/ostream	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/std/ostream	2017-05-14 09:56:41.200008000 -0700
+@@ -479,14 +479,14 @@
+   //@{
+   /**
+    *  @brief  Character inserters
+-   *  @param  __out  An output stream.
++   *  @param  ___out  An output stream.
+    *  @param  __c  A character.
+    *  @return  out
+    *
+    *  Behaves like one of the formatted arithmetic inserters described in
+    *  std::basic_ostream.  After constructing a sentry object with good
+    *  status, this function inserts a single character and any required
+-   *  padding (as determined by [22.2.2.2.2]).  @c __out.width(0) is then
++   *  padding (as determined by [22.2.2.2.2]).  @c ___out.width(0) is then
+    *  called.
+    *
+    *  If @p __c is of type @c char and the character type of the stream is not
+@@ -494,36 +494,36 @@
+   */
+   template<typename _CharT, typename _Traits>
+     inline basic_ostream<_CharT, _Traits>&
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
+-    { return __ostream_insert(__out, &__c, 1); }
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, _CharT __c)
++    { return __ostream_insert(___out, &__c, 1); }
+ 
+   template<typename _CharT, typename _Traits>
+     inline basic_ostream<_CharT, _Traits>&
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
+-    { return (__out << __out.widen(__c)); }
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, char __c)
++    { return (___out << ___out.widen(__c)); }
+ 
+   // Specialization
+   template <class _Traits>
+     inline basic_ostream<char, _Traits>&
+-    operator<<(basic_ostream<char, _Traits>& __out, char __c)
+-    { return __ostream_insert(__out, &__c, 1); }
++    operator<<(basic_ostream<char, _Traits>& ___out, char __c)
++    { return __ostream_insert(___out, &__c, 1); }
+ 
+   // Signed and unsigned
+   template<class _Traits>
+     inline basic_ostream<char, _Traits>&
+-    operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
+-    { return (__out << static_cast<char>(__c)); }
++    operator<<(basic_ostream<char, _Traits>& ___out, signed char __c)
++    { return (___out << static_cast<char>(__c)); }
+ 
+   template<class _Traits>
+     inline basic_ostream<char, _Traits>&
+-    operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
+-    { return (__out << static_cast<char>(__c)); }
++    operator<<(basic_ostream<char, _Traits>& ___out, unsigned char __c)
++    { return (___out << static_cast<char>(__c)); }
+   //@}
+ 
+   //@{
+   /**
+    *  @brief  String inserters
+-   *  @param  __out  An output stream.
++   *  @param  ___out  An output stream.
+    *  @param  __s  A character string.
+    *  @return  out
+    *  @pre  @p __s must be a non-NULL pointer
+@@ -532,47 +532,47 @@
+    *  std::basic_ostream.  After constructing a sentry object with good
+    *  status, this function inserts @c traits::length(__s) characters starting
+    *  at @p __s, widened if necessary, followed by any required padding (as
+-   *  determined by [22.2.2.2.2]).  @c __out.width(0) is then called.
++   *  determined by [22.2.2.2.2]).  @c ___out.width(0) is then called.
+   */
+   template<typename _CharT, typename _Traits>
+     inline basic_ostream<_CharT, _Traits>&
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, const _CharT* __s)
+     {
+       if (!__s)
+-	__out.setstate(ios_base::badbit);
++	___out.setstate(ios_base::badbit);
+       else
+-	__ostream_insert(__out, __s,
++	__ostream_insert(___out, __s,
+ 			 static_cast<streamsize>(_Traits::length(__s)));
+-      return __out;
++      return ___out;
+     }
+ 
+   template<typename _CharT, typename _Traits>
+     basic_ostream<_CharT, _Traits> &
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s);
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, const char* __s);
+ 
+   // Partial specializations
+   template<class _Traits>
+     inline basic_ostream<char, _Traits>&
+-    operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
++    operator<<(basic_ostream<char, _Traits>& ___out, const char* __s)
+     {
+       if (!__s)
+-	__out.setstate(ios_base::badbit);
++	___out.setstate(ios_base::badbit);
+       else
+-	__ostream_insert(__out, __s,
++	__ostream_insert(___out, __s,
+ 			 static_cast<streamsize>(_Traits::length(__s)));
+-      return __out;
++      return ___out;
+     }
+ 
+   // Signed and unsigned
+   template<class _Traits>
+     inline basic_ostream<char, _Traits>&
+-    operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
+-    { return (__out << reinterpret_cast<const char*>(__s)); }
++    operator<<(basic_ostream<char, _Traits>& ___out, const signed char* __s)
++    { return (___out << reinterpret_cast<const char*>(__s)); }
+ 
+   template<class _Traits>
+     inline basic_ostream<char, _Traits> &
+-    operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
+-    { return (__out << reinterpret_cast<const char*>(__s)); }
++    operator<<(basic_ostream<char, _Traits>& ___out, const unsigned char* __s)
++    { return (___out << reinterpret_cast<const char*>(__s)); }
+   //@}
+ 
+   // Standard basic_ostream manipulators
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/std/thread gcc-6.3.0/libstdc++-v3/include/std/thread
+--- gcc-6.3.0-orig/libstdc++-v3/include/std/thread	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/std/thread	2017-05-14 09:56:41.200008000 -0700
+@@ -107,7 +107,7 @@
+ 
+       template<class _CharT, class _Traits>
+ 	friend basic_ostream<_CharT, _Traits>&
+-	operator<<(basic_ostream<_CharT, _Traits>& __out, thread::id __id);
++	operator<<(basic_ostream<_CharT, _Traits>& ___out, thread::id __id);
+     };
+ 
+   private:
+@@ -259,12 +259,12 @@
+ 
+   template<class _CharT, class _Traits>
+     inline basic_ostream<_CharT, _Traits>&
+-    operator<<(basic_ostream<_CharT, _Traits>& __out, thread::id __id)
++    operator<<(basic_ostream<_CharT, _Traits>& ___out, thread::id __id)
+     {
+       if (__id == thread::id())
+-	return __out << "thread::id of a non-executing thread";
++	return ___out << "thread::id of a non-executing thread";
+       else
+-	return __out << __id._M_thread;
++	return ___out << __id._M_thread;
+     }
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/std/tuple gcc-6.3.0/libstdc++-v3/include/std/tuple
+--- gcc-6.3.0-orig/libstdc++-v3/include/std/tuple	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/std/tuple	2017-05-14 09:56:41.196674666 -0700
+@@ -215,23 +215,23 @@
+       constexpr _Tuple_impl(const _Tuple_impl&) = default;
+ 
+       constexpr
+-      _Tuple_impl(_Tuple_impl&& __in)
++      _Tuple_impl(_Tuple_impl&& ___in)
+       noexcept(__and_<is_nothrow_move_constructible<_Head>,
+ 	              is_nothrow_move_constructible<_Inherited>>::value)
+-      : _Inherited(std::move(_M_tail(__in))), 
+-	_Base(std::forward<_Head>(_M_head(__in))) { }
++      : _Inherited(std::move(_M_tail(___in))), 
++	_Base(std::forward<_Head>(_M_head(___in))) { }
+ 
+       template<typename... _UElements>
+-        constexpr _Tuple_impl(const _Tuple_impl<_Idx, _UElements...>& __in)
+-	: _Inherited(_Tuple_impl<_Idx, _UElements...>::_M_tail(__in)),
+-	  _Base(_Tuple_impl<_Idx, _UElements...>::_M_head(__in)) { }
++        constexpr _Tuple_impl(const _Tuple_impl<_Idx, _UElements...>& ___in)
++	: _Inherited(_Tuple_impl<_Idx, _UElements...>::_M_tail(___in)),
++	  _Base(_Tuple_impl<_Idx, _UElements...>::_M_head(___in)) { }
+ 
+       template<typename _UHead, typename... _UTails>
+-        constexpr _Tuple_impl(_Tuple_impl<_Idx, _UHead, _UTails...>&& __in)
++        constexpr _Tuple_impl(_Tuple_impl<_Idx, _UHead, _UTails...>&& ___in)
+ 	: _Inherited(std::move
+-		     (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(__in))),
++		     (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(___in))),
+ 	  _Base(std::forward<_UHead>
+-		(_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(__in))) { }
++		(_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(___in))) { }
+ 
+       template<typename _Alloc>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a)
+@@ -255,81 +255,81 @@
+ 
+       template<typename _Alloc>
+         _Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            const _Tuple_impl& __in)
+-	: _Inherited(__tag, __a, _M_tail(__in)), 
+-          _Base(__use_alloc<_Head, _Alloc, _Head>(__a), _M_head(__in)) { }
++	            const _Tuple_impl& ___in)
++	: _Inherited(__tag, __a, _M_tail(___in)), 
++          _Base(__use_alloc<_Head, _Alloc, _Head>(__a), _M_head(___in)) { }
+ 
+       template<typename _Alloc>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            _Tuple_impl&& __in)
+-	: _Inherited(__tag, __a, std::move(_M_tail(__in))), 
++	            _Tuple_impl&& ___in)
++	: _Inherited(__tag, __a, std::move(_M_tail(___in))), 
+ 	  _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
+-	        std::forward<_Head>(_M_head(__in))) { }
++	        std::forward<_Head>(_M_head(___in))) { }
+ 
+       template<typename _Alloc, typename... _UElements>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            const _Tuple_impl<_Idx, _UElements...>& __in)
++	            const _Tuple_impl<_Idx, _UElements...>& ___in)
+ 	: _Inherited(__tag, __a,
+-		     _Tuple_impl<_Idx, _UElements...>::_M_tail(__in)),
++		     _Tuple_impl<_Idx, _UElements...>::_M_tail(___in)),
+ 	  _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
+-		_Tuple_impl<_Idx, _UElements...>::_M_head(__in)) { }
++		_Tuple_impl<_Idx, _UElements...>::_M_head(___in)) { }
+ 
+       template<typename _Alloc, typename _UHead, typename... _UTails>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            _Tuple_impl<_Idx, _UHead, _UTails...>&& __in)
++	            _Tuple_impl<_Idx, _UHead, _UTails...>&& ___in)
+ 	: _Inherited(__tag, __a, std::move
+-		     (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(__in))),
++		     (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(___in))),
+ 	  _Base(__use_alloc<_Head, _Alloc, _UHead>(__a),
+                 std::forward<_UHead>
+-		(_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(__in))) { }
++		(_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(___in))) { }
+ 
+       _Tuple_impl&
+-      operator=(const _Tuple_impl& __in)
++      operator=(const _Tuple_impl& ___in)
+       {
+-	_M_head(*this) = _M_head(__in);
+-	_M_tail(*this) = _M_tail(__in);
++	_M_head(*this) = _M_head(___in);
++	_M_tail(*this) = _M_tail(___in);
+ 	return *this;
+       }
+ 
+       _Tuple_impl&
+-      operator=(_Tuple_impl&& __in)
++      operator=(_Tuple_impl&& ___in)
+       noexcept(__and_<is_nothrow_move_assignable<_Head>,
+ 	              is_nothrow_move_assignable<_Inherited>>::value)
+       {
+-	_M_head(*this) = std::forward<_Head>(_M_head(__in));
+-	_M_tail(*this) = std::move(_M_tail(__in));
++	_M_head(*this) = std::forward<_Head>(_M_head(___in));
++	_M_tail(*this) = std::move(_M_tail(___in));
+ 	return *this;
+       }
+ 
+       template<typename... _UElements>
+         _Tuple_impl&
+-        operator=(const _Tuple_impl<_Idx, _UElements...>& __in)
++        operator=(const _Tuple_impl<_Idx, _UElements...>& ___in)
+         {
+-	  _M_head(*this) = _Tuple_impl<_Idx, _UElements...>::_M_head(__in);
+-	  _M_tail(*this) = _Tuple_impl<_Idx, _UElements...>::_M_tail(__in);
++	  _M_head(*this) = _Tuple_impl<_Idx, _UElements...>::_M_head(___in);
++	  _M_tail(*this) = _Tuple_impl<_Idx, _UElements...>::_M_tail(___in);
+ 	  return *this;
+ 	}
+ 
+       template<typename _UHead, typename... _UTails>
+         _Tuple_impl&
+-        operator=(_Tuple_impl<_Idx, _UHead, _UTails...>&& __in)
++        operator=(_Tuple_impl<_Idx, _UHead, _UTails...>&& ___in)
+         {
+ 	  _M_head(*this) = std::forward<_UHead>
+-	    (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(__in));
++	    (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_head(___in));
+ 	  _M_tail(*this) = std::move
+-	    (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(__in));
++	    (_Tuple_impl<_Idx, _UHead, _UTails...>::_M_tail(___in));
+ 	  return *this;
+ 	}
+ 
+     protected:
+       void
+-      _M_swap(_Tuple_impl& __in)
++      _M_swap(_Tuple_impl& ___in)
+       noexcept(__is_nothrow_swappable<_Head>::value
+-               && noexcept(_M_tail(__in)._M_swap(_M_tail(__in))))
++               && noexcept(_M_tail(___in)._M_swap(_M_tail(___in))))
+       {
+ 	using std::swap;
+-	swap(_M_head(*this), _M_head(__in));
+-	_Inherited::_M_swap(_M_tail(__in));
++	swap(_M_head(*this), _M_head(___in));
++	_Inherited::_M_swap(_M_tail(___in));
+       }
+     };
+ 
+@@ -363,17 +363,17 @@
+       constexpr _Tuple_impl(const _Tuple_impl&) = default;
+ 
+       constexpr
+-      _Tuple_impl(_Tuple_impl&& __in)
++      _Tuple_impl(_Tuple_impl&& ___in)
+       noexcept(is_nothrow_move_constructible<_Head>::value)
+-      : _Base(std::forward<_Head>(_M_head(__in))) { }
++      : _Base(std::forward<_Head>(_M_head(___in))) { }
+ 
+       template<typename _UHead>
+-        constexpr _Tuple_impl(const _Tuple_impl<_Idx, _UHead>& __in)
+-	: _Base(_Tuple_impl<_Idx, _UHead>::_M_head(__in)) { }
++        constexpr _Tuple_impl(const _Tuple_impl<_Idx, _UHead>& ___in)
++	: _Base(_Tuple_impl<_Idx, _UHead>::_M_head(___in)) { }
+ 
+       template<typename _UHead>
+-        constexpr _Tuple_impl(_Tuple_impl<_Idx, _UHead>&& __in)
+-	: _Base(std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(__in)))
++        constexpr _Tuple_impl(_Tuple_impl<_Idx, _UHead>&& ___in)
++	: _Base(std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(___in)))
+ 	{ }
+ 
+       template<typename _Alloc>
+@@ -393,67 +393,67 @@
+ 
+       template<typename _Alloc>
+         _Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            const _Tuple_impl& __in)
+-	: _Base(__use_alloc<_Head, _Alloc, _Head>(__a), _M_head(__in)) { }
++	            const _Tuple_impl& ___in)
++	: _Base(__use_alloc<_Head, _Alloc, _Head>(__a), _M_head(___in)) { }
+ 
+       template<typename _Alloc>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            _Tuple_impl&& __in)
++	            _Tuple_impl&& ___in)
+ 	: _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
+-	        std::forward<_Head>(_M_head(__in))) { }
++	        std::forward<_Head>(_M_head(___in))) { }
+ 
+       template<typename _Alloc, typename _UHead>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            const _Tuple_impl<_Idx, _UHead>& __in)
++	            const _Tuple_impl<_Idx, _UHead>& ___in)
+ 	: _Base(__use_alloc<_Head, _Alloc, _Head>(__a),
+-		_Tuple_impl<_Idx, _UHead>::_M_head(__in)) { }
++		_Tuple_impl<_Idx, _UHead>::_M_head(___in)) { }
+ 
+       template<typename _Alloc, typename _UHead>
+ 	_Tuple_impl(allocator_arg_t __tag, const _Alloc& __a,
+-	            _Tuple_impl<_Idx, _UHead>&& __in)
++	            _Tuple_impl<_Idx, _UHead>&& ___in)
+ 	: _Base(__use_alloc<_Head, _Alloc, _UHead>(__a),
+-                std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(__in)))
++                std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(___in)))
+ 	{ }
+ 
+       _Tuple_impl&
+-      operator=(const _Tuple_impl& __in)
++      operator=(const _Tuple_impl& ___in)
+       {
+-	_M_head(*this) = _M_head(__in);
++	_M_head(*this) = _M_head(___in);
+ 	return *this;
+       }
+ 
+       _Tuple_impl&
+-      operator=(_Tuple_impl&& __in)
++      operator=(_Tuple_impl&& ___in)
+       noexcept(is_nothrow_move_assignable<_Head>::value)
+       {
+-	_M_head(*this) = std::forward<_Head>(_M_head(__in));
++	_M_head(*this) = std::forward<_Head>(_M_head(___in));
+ 	return *this;
+       }
+ 
+       template<typename _UHead>
+         _Tuple_impl&
+-        operator=(const _Tuple_impl<_Idx, _UHead>& __in)
++        operator=(const _Tuple_impl<_Idx, _UHead>& ___in)
+         {
+-	  _M_head(*this) = _Tuple_impl<_Idx, _UHead>::_M_head(__in);
++	  _M_head(*this) = _Tuple_impl<_Idx, _UHead>::_M_head(___in);
+ 	  return *this;
+ 	}
+ 
+       template<typename _UHead>
+         _Tuple_impl&
+-        operator=(_Tuple_impl<_Idx, _UHead>&& __in)
++        operator=(_Tuple_impl<_Idx, _UHead>&& ___in)
+         {
+ 	  _M_head(*this)
+-	    = std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(__in));
++	    = std::forward<_UHead>(_Tuple_impl<_Idx, _UHead>::_M_head(___in));
+ 	  return *this;
+ 	}
+ 
+     protected:
+       void
+-      _M_swap(_Tuple_impl& __in)
++      _M_swap(_Tuple_impl& ___in)
+       noexcept(__is_nothrow_swappable<_Head>::value)
+       {
+ 	using std::swap;
+-	swap(_M_head(*this), _M_head(__in));
++	swap(_M_head(*this), _M_head(___in));
+       }
+     };
+ 
+@@ -667,8 +667,8 @@
+                   && _TNTC<_Dummy>::template
+                     _NonNestedTuple<const tuple<_UElements...>&>(),
+         bool>::type=true>
+-        constexpr tuple(const tuple<_UElements...>& __in)
+-        : _Inherited(static_cast<const _Tuple_impl<0, _UElements...>&>(__in))
++        constexpr tuple(const tuple<_UElements...>& ___in)
++        : _Inherited(static_cast<const _Tuple_impl<0, _UElements...>&>(___in))
+         { }
+ 
+       template<typename... _UElements, typename _Dummy = void, typename
+@@ -679,8 +679,8 @@
+                   && _TNTC<_Dummy>::template
+                     _NonNestedTuple<const tuple<_UElements...>&>(),
+         bool>::type=false>
+-        explicit constexpr tuple(const tuple<_UElements...>& __in)
+-        : _Inherited(static_cast<const _Tuple_impl<0, _UElements...>&>(__in))
++        explicit constexpr tuple(const tuple<_UElements...>& ___in)
++        : _Inherited(static_cast<const _Tuple_impl<0, _UElements...>&>(___in))
+         { }
+ 
+       template<typename... _UElements, typename _Dummy = void, typename
+@@ -691,8 +691,8 @@
+                   && _TNTC<_Dummy>::template
+                     _NonNestedTuple<tuple<_UElements...>&&>(),
+         bool>::type=true>
+-        constexpr tuple(tuple<_UElements...>&& __in)
+-        : _Inherited(static_cast<_Tuple_impl<0, _UElements...>&&>(__in)) { }
++        constexpr tuple(tuple<_UElements...>&& ___in)
++        : _Inherited(static_cast<_Tuple_impl<0, _UElements...>&&>(___in)) { }
+ 
+       template<typename... _UElements, typename _Dummy = void, typename
+         enable_if<_TMC<_UElements...>::template
+@@ -702,8 +702,8 @@
+                   && _TNTC<_Dummy>::template
+                     _NonNestedTuple<tuple<_UElements...>&&>(),
+         bool>::type=false>
+-        explicit constexpr tuple(tuple<_UElements...>&& __in)
+-        : _Inherited(static_cast<_Tuple_impl<0, _UElements...>&&>(__in)) { }
++        explicit constexpr tuple(tuple<_UElements...>&& ___in)
++        : _Inherited(static_cast<_Tuple_impl<0, _UElements...>&&>(___in)) { }
+ 
+       // Allocator-extended constructors.
+ 
+@@ -756,12 +756,12 @@
+         { }
+ 
+       template<typename _Alloc>
+-	tuple(allocator_arg_t __tag, const _Alloc& __a, const tuple& __in)
+-	: _Inherited(__tag, __a, static_cast<const _Inherited&>(__in)) { }
++	tuple(allocator_arg_t __tag, const _Alloc& __a, const tuple& ___in)
++	: _Inherited(__tag, __a, static_cast<const _Inherited&>(___in)) { }
+ 
+       template<typename _Alloc>
+-	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple&& __in)
+-	: _Inherited(__tag, __a, static_cast<_Inherited&&>(__in)) { }
++	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple&& ___in)
++	: _Inherited(__tag, __a, static_cast<_Inherited&&>(___in)) { }
+ 
+       template<typename _Alloc, typename... _UElements, typename
+         enable_if<_TMC<_UElements...>::template
+@@ -770,9 +770,9 @@
+                     _ImplicitlyConvertibleTuple<_UElements...>(),
+         bool>::type=true>
+ 	tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const tuple<_UElements...>& __in)
++	      const tuple<_UElements...>& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<const _Tuple_impl<0, _UElements...>&>(__in))
++	             static_cast<const _Tuple_impl<0, _UElements...>&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename... _UElements, typename
+@@ -782,9 +782,9 @@
+                     _ImplicitlyConvertibleTuple<_UElements...>(),
+         bool>::type=false>
+ 	explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const tuple<_UElements...>& __in)
++	      const tuple<_UElements...>& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<const _Tuple_impl<0, _UElements...>&>(__in))
++	             static_cast<const _Tuple_impl<0, _UElements...>&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename... _UElements, typename
+@@ -794,9 +794,9 @@
+                     _ImplicitlyMoveConvertibleTuple<_UElements...>(),
+         bool>::type=true>
+ 	tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      tuple<_UElements...>&& __in)
++	      tuple<_UElements...>&& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<_Tuple_impl<0, _UElements...>&&>(__in))
++	             static_cast<_Tuple_impl<0, _UElements...>&&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename... _UElements, typename
+@@ -806,23 +806,23 @@
+                     _ImplicitlyMoveConvertibleTuple<_UElements...>(),
+         bool>::type=false>
+ 	explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      tuple<_UElements...>&& __in)
++	      tuple<_UElements...>&& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<_Tuple_impl<0, _UElements...>&&>(__in))
++	             static_cast<_Tuple_impl<0, _UElements...>&&>(___in))
+ 	{ }
+ 
+       tuple&
+-      operator=(const tuple& __in)
++      operator=(const tuple& ___in)
+       {
+-	static_cast<_Inherited&>(*this) = __in;
++	static_cast<_Inherited&>(*this) = ___in;
+ 	return *this;
+       }
+ 
+       tuple&
+-      operator=(tuple&& __in)
++      operator=(tuple&& ___in)
+       noexcept(is_nothrow_move_assignable<_Inherited>::value)
+       {
+-	static_cast<_Inherited&>(*this) = std::move(__in);
++	static_cast<_Inherited&>(*this) = std::move(___in);
+ 	return *this;
+       }
+ 
+@@ -830,9 +830,9 @@
+ 	       enable_if<sizeof...(_UElements)
+ 			 == sizeof...(_Elements)>::type>
+         tuple&
+-        operator=(const tuple<_UElements...>& __in)
++        operator=(const tuple<_UElements...>& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = __in;
++	  static_cast<_Inherited&>(*this) = ___in;
+ 	  return *this;
+ 	}
+ 
+@@ -840,16 +840,16 @@
+ 	       enable_if<sizeof...(_UElements)
+ 			 == sizeof...(_Elements)>::type>
+         tuple&
+-        operator=(tuple<_UElements...>&& __in)
++        operator=(tuple<_UElements...>&& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = std::move(__in);
++	  static_cast<_Inherited&>(*this) = std::move(___in);
+ 	  return *this;
+ 	}
+ 
+       void
+-      swap(tuple& __in)
+-      noexcept(noexcept(__in._M_swap(__in)))
+-      { _Inherited::_M_swap(__in); }
++      swap(tuple& ___in)
++      noexcept(noexcept(___in._M_swap(___in)))
++      { _Inherited::_M_swap(___in); }
+     };
+ 
+   // Explicit specialization, zero-element tuple.
+@@ -947,8 +947,8 @@
+                   && _TMC::template
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-        constexpr tuple(const tuple<_U1, _U2>& __in)
+-	: _Inherited(static_cast<const _Tuple_impl<0, _U1, _U2>&>(__in)) { }
++        constexpr tuple(const tuple<_U1, _U2>& ___in)
++	: _Inherited(static_cast<const _Tuple_impl<0, _U1, _U2>&>(___in)) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -956,8 +956,8 @@
+                   && !_TMC::template
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+-        explicit constexpr tuple(const tuple<_U1, _U2>& __in)
+-	: _Inherited(static_cast<const _Tuple_impl<0, _U1, _U2>&>(__in)) { }
++        explicit constexpr tuple(const tuple<_U1, _U2>& ___in)
++	: _Inherited(static_cast<const _Tuple_impl<0, _U1, _U2>&>(___in)) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -965,8 +965,8 @@
+                   && _TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-        constexpr tuple(tuple<_U1, _U2>&& __in)
+-	: _Inherited(static_cast<_Tuple_impl<0, _U1, _U2>&&>(__in)) { }
++        constexpr tuple(tuple<_U1, _U2>&& ___in)
++	: _Inherited(static_cast<_Tuple_impl<0, _U1, _U2>&&>(___in)) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -974,8 +974,8 @@
+                   && !_TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+-        explicit constexpr tuple(tuple<_U1, _U2>&& __in)
+-	: _Inherited(static_cast<_Tuple_impl<0, _U1, _U2>&&>(__in)) { }
++        explicit constexpr tuple(tuple<_U1, _U2>&& ___in)
++	: _Inherited(static_cast<_Tuple_impl<0, _U1, _U2>&&>(___in)) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -983,8 +983,8 @@
+                   && _TMC::template
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-        constexpr tuple(const pair<_U1, _U2>& __in)
+-	: _Inherited(__in.first, __in.second) { }
++        constexpr tuple(const pair<_U1, _U2>& ___in)
++	: _Inherited(___in.first, ___in.second) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -992,8 +992,8 @@
+                   && !_TMC::template
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+-        explicit constexpr tuple(const pair<_U1, _U2>& __in)
+-	: _Inherited(__in.first, __in.second) { }
++        explicit constexpr tuple(const pair<_U1, _U2>& ___in)
++	: _Inherited(___in.first, ___in.second) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1001,9 +1001,9 @@
+                   && _TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-        constexpr tuple(pair<_U1, _U2>&& __in)
+-	: _Inherited(std::forward<_U1>(__in.first),
+-		     std::forward<_U2>(__in.second)) { }
++        constexpr tuple(pair<_U1, _U2>&& ___in)
++	: _Inherited(std::forward<_U1>(___in.first),
++		     std::forward<_U2>(___in.second)) { }
+ 
+       template<typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1011,9 +1011,9 @@
+                   && !_TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+-        explicit constexpr tuple(pair<_U1, _U2>&& __in)
+-	: _Inherited(std::forward<_U1>(__in.first),
+-		     std::forward<_U2>(__in.second)) { }
++        explicit constexpr tuple(pair<_U1, _U2>&& ___in)
++	: _Inherited(std::forward<_U1>(___in.first),
++		     std::forward<_U2>(___in.second)) { }
+ 
+       // Allocator-extended constructors.
+ 
+@@ -1067,12 +1067,12 @@
+ 	             std::forward<_U2>(__a2)) { }
+ 
+       template<typename _Alloc>
+-	tuple(allocator_arg_t __tag, const _Alloc& __a, const tuple& __in)
+-	: _Inherited(__tag, __a, static_cast<const _Inherited&>(__in)) { }
++	tuple(allocator_arg_t __tag, const _Alloc& __a, const tuple& ___in)
++	: _Inherited(__tag, __a, static_cast<const _Inherited&>(___in)) { }
+ 
+       template<typename _Alloc>
+-	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple&& __in)
+-	: _Inherited(__tag, __a, static_cast<_Inherited&&>(__in)) { }
++	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple&& ___in)
++	: _Inherited(__tag, __a, static_cast<_Inherited&&>(___in)) { }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1081,9 +1081,9 @@
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+ 	tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const tuple<_U1, _U2>& __in)
++	      const tuple<_U1, _U2>& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<const _Tuple_impl<0, _U1, _U2>&>(__in))
++	             static_cast<const _Tuple_impl<0, _U1, _U2>&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+@@ -1093,9 +1093,9 @@
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+ 	explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const tuple<_U1, _U2>& __in)
++	      const tuple<_U1, _U2>& ___in)
+ 	: _Inherited(__tag, __a,
+-	             static_cast<const _Tuple_impl<0, _U1, _U2>&>(__in))
++	             static_cast<const _Tuple_impl<0, _U1, _U2>&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+@@ -1104,8 +1104,8 @@
+                   && _TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple<_U1, _U2>&& __in)
+-	: _Inherited(__tag, __a, static_cast<_Tuple_impl<0, _U1, _U2>&&>(__in))
++	tuple(allocator_arg_t __tag, const _Alloc& __a, tuple<_U1, _U2>&& ___in)
++	: _Inherited(__tag, __a, static_cast<_Tuple_impl<0, _U1, _U2>&&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+@@ -1115,8 +1115,8 @@
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+ 	explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-                       tuple<_U1, _U2>&& __in)
+-	: _Inherited(__tag, __a, static_cast<_Tuple_impl<0, _U1, _U2>&&>(__in))
++                       tuple<_U1, _U2>&& ___in)
++	: _Inherited(__tag, __a, static_cast<_Tuple_impl<0, _U1, _U2>&&>(___in))
+ 	{ }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+@@ -1126,8 +1126,8 @@
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+         tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const pair<_U1, _U2>& __in)
+-	: _Inherited(__tag, __a, __in.first, __in.second) { }
++	      const pair<_U1, _U2>& ___in)
++	: _Inherited(__tag, __a, ___in.first, ___in.second) { }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1136,8 +1136,8 @@
+                     _ImplicitlyConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-	      const pair<_U1, _U2>& __in)
+-	: _Inherited(__tag, __a, __in.first, __in.second) { }
++	      const pair<_U1, _U2>& ___in)
++	: _Inherited(__tag, __a, ___in.first, ___in.second) { }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1145,9 +1145,9 @@
+                   && _TMC::template
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = true>
+-        tuple(allocator_arg_t __tag, const _Alloc& __a, pair<_U1, _U2>&& __in)
+-	: _Inherited(__tag, __a, std::forward<_U1>(__in.first),
+-		     std::forward<_U2>(__in.second)) { }
++        tuple(allocator_arg_t __tag, const _Alloc& __a, pair<_U1, _U2>&& ___in)
++	: _Inherited(__tag, __a, std::forward<_U1>(___in.first),
++		     std::forward<_U2>(___in.second)) { }
+ 
+       template<typename _Alloc, typename _U1, typename _U2, typename
+         enable_if<_TMC::template
+@@ -1156,63 +1156,63 @@
+                     _ImplicitlyMoveConvertibleTuple<_U1, _U2>(),
+ 	bool>::type = false>
+         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
+-                       pair<_U1, _U2>&& __in)
+-	: _Inherited(__tag, __a, std::forward<_U1>(__in.first),
+-		     std::forward<_U2>(__in.second)) { }
++                       pair<_U1, _U2>&& ___in)
++	: _Inherited(__tag, __a, std::forward<_U1>(___in.first),
++		     std::forward<_U2>(___in.second)) { }
+ 
+       tuple&
+-      operator=(const tuple& __in)
++      operator=(const tuple& ___in)
+       {
+-	static_cast<_Inherited&>(*this) = __in;
++	static_cast<_Inherited&>(*this) = ___in;
+ 	return *this;
+       }
+ 
+       tuple&
+-      operator=(tuple&& __in)
++      operator=(tuple&& ___in)
+       noexcept(is_nothrow_move_assignable<_Inherited>::value)
+       {
+-	static_cast<_Inherited&>(*this) = std::move(__in);
++	static_cast<_Inherited&>(*this) = std::move(___in);
+ 	return *this;
+       }
+ 
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(const tuple<_U1, _U2>& __in)
++        operator=(const tuple<_U1, _U2>& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = __in;
++	  static_cast<_Inherited&>(*this) = ___in;
+ 	  return *this;
+ 	}
+ 
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(tuple<_U1, _U2>&& __in)
++        operator=(tuple<_U1, _U2>&& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = std::move(__in);
++	  static_cast<_Inherited&>(*this) = std::move(___in);
+ 	  return *this;
+ 	}
+ 
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(const pair<_U1, _U2>& __in)
++        operator=(const pair<_U1, _U2>& ___in)
+         {
+-	  this->_M_head(*this) = __in.first;
+-	  this->_M_tail(*this)._M_head(*this) = __in.second;
++	  this->_M_head(*this) = ___in.first;
++	  this->_M_tail(*this)._M_head(*this) = ___in.second;
+ 	  return *this;
+ 	}
+ 
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(pair<_U1, _U2>&& __in)
++        operator=(pair<_U1, _U2>&& ___in)
+         {
+-	  this->_M_head(*this) = std::forward<_U1>(__in.first);
+-	  this->_M_tail(*this)._M_head(*this) = std::forward<_U2>(__in.second);
++	  this->_M_head(*this) = std::forward<_U1>(___in.first);
++	  this->_M_tail(*this)._M_head(*this) = std::forward<_U2>(___in.second);
+ 	  return *this;
+ 	}
+ 
+       void
+-      swap(tuple& __in)
+-      noexcept(noexcept(__in._M_swap(__in)))
+-      { _Inherited::_M_swap(__in); }
++      swap(tuple& ___in)
++      noexcept(noexcept(___in._M_swap(___in)))
++      { _Inherited::_M_swap(___in); }
+     };
+ 
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/std/utility gcc-6.3.0/libstdc++-v3/include/std/utility
+--- gcc-6.3.0-orig/libstdc++-v3/include/std/utility	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/std/utility	2017-05-14 09:56:41.196674666 -0700
+@@ -199,18 +199,18 @@
+ 
+   template<std::size_t _Int, class _Tp1, class _Tp2>
+     constexpr typename tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
+-    get(std::pair<_Tp1, _Tp2>& __in) noexcept
+-    { return __pair_get<_Int>::__get(__in); }
++    get(std::pair<_Tp1, _Tp2>& ___in) noexcept
++    { return __pair_get<_Int>::__get(___in); }
+ 
+   template<std::size_t _Int, class _Tp1, class _Tp2>
+     constexpr typename tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&&
+-    get(std::pair<_Tp1, _Tp2>&& __in) noexcept
+-    { return __pair_get<_Int>::__move_get(std::move(__in)); }
++    get(std::pair<_Tp1, _Tp2>&& ___in) noexcept
++    { return __pair_get<_Int>::__move_get(std::move(___in)); }
+ 
+   template<std::size_t _Int, class _Tp1, class _Tp2>
+     constexpr const typename tuple_element<_Int, std::pair<_Tp1, _Tp2>>::type&
+-    get(const std::pair<_Tp1, _Tp2>& __in) noexcept
+-    { return __pair_get<_Int>::__const_get(__in); }
++    get(const std::pair<_Tp1, _Tp2>& ___in) noexcept
++    { return __pair_get<_Int>::__const_get(___in); }
+ 
+ #if __cplusplus > 201103L
+ 
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/tr1/regex gcc-6.3.0/libstdc++-v3/include/tr1/regex
+--- gcc-6.3.0-orig/libstdc++-v3/include/tr1/regex	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/tr1/regex	2017-05-14 09:56:41.223341333 -0700
+@@ -2008,7 +2008,7 @@
+        */
+       template<typename _Out_iter>
+         _Out_iter
+-        format(_Out_iter __out, const string_type& __fmt,
++        format(_Out_iter ___out, const string_type& __fmt,
+ 	       regex_constants::match_flag_type __flags
+ 	       = regex_constants::format_default) const;
+ 
+@@ -2404,7 +2404,7 @@
+   template<typename _Out_iter, typename _Bi_iter,
+ 	   typename _Rx_traits, typename _Ch_type>
+     inline _Out_iter
+-    regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
++    regex_replace(_Out_iter ___out, _Bi_iter __first, _Bi_iter __last,
+ 		  const basic_regex<_Ch_type, _Rx_traits>& __e,
+ 		  const basic_string<_Ch_type>& __fmt,
+ 		  regex_constants::match_flag_type __flags
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/tr1/tuple gcc-6.3.0/libstdc++-v3/include/tr1/tuple
+--- gcc-6.3.0-orig/libstdc++-v3/include/tr1/tuple	2017-05-14 09:37:13.580007999 -0700
++++ gcc-6.3.0/libstdc++-v3/include/tr1/tuple	2017-05-14 09:56:41.220007999 -0700
+@@ -102,26 +102,26 @@
+       : _Inherited(__tail...), _M_head(__head) { }
+ 
+       template<typename... _UElements>
+-      _Tuple_impl(const _Tuple_impl<_Idx, _UElements...>& __in)
+-      : _Inherited(__in._M_tail()), _M_head(__in._M_head) { }
++      _Tuple_impl(const _Tuple_impl<_Idx, _UElements...>& ___in)
++      : _Inherited(___in._M_tail()), _M_head(___in._M_head) { }
+ 
+-      _Tuple_impl(const _Tuple_impl& __in)
+-      : _Inherited(__in._M_tail()), _M_head(__in._M_head) { }
++      _Tuple_impl(const _Tuple_impl& ___in)
++      : _Inherited(___in._M_tail()), _M_head(___in._M_head) { }
+      
+       template<typename... _UElements>
+         _Tuple_impl&
+-        operator=(const _Tuple_impl<_Idx, _UElements...>& __in)
++        operator=(const _Tuple_impl<_Idx, _UElements...>& ___in)
+         {
+-	  _M_head = __in._M_head;
+-	  _M_tail() = __in._M_tail();
++	  _M_head = ___in._M_head;
++	  _M_tail() = ___in._M_tail();
+ 	  return *this;
+ 	}
+ 
+       _Tuple_impl&
+-      operator=(const _Tuple_impl& __in)
++      operator=(const _Tuple_impl& ___in)
+       {
+-	_M_head = __in._M_head;
+-	_M_tail() = __in._M_tail();
++	_M_head = ___in._M_head;
++	_M_tail() = ___in._M_tail();
+ 	return *this;
+       }
+     };
+@@ -139,24 +139,24 @@
+       : _Inherited(__elements...) { }
+ 
+       template<typename... _UElements>
+-        tuple(const tuple<_UElements...>& __in)
+-	: _Inherited(__in) { }
++        tuple(const tuple<_UElements...>& ___in)
++	: _Inherited(___in) { }
+ 
+-      tuple(const tuple& __in)
+-      : _Inherited(__in) { }
++      tuple(const tuple& ___in)
++      : _Inherited(___in) { }
+ 
+       template<typename... _UElements>
+         tuple&
+-        operator=(const tuple<_UElements...>& __in)
++        operator=(const tuple<_UElements...>& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = __in;
++	  static_cast<_Inherited&>(*this) = ___in;
+ 	  return *this;
+ 	}
+ 
+       tuple&
+-      operator=(const tuple& __in)
++      operator=(const tuple& ___in)
+       {
+-	static_cast<_Inherited&>(*this) = __in;
++	static_cast<_Inherited&>(*this) = ___in;
+ 	return *this;
+       }
+     };
+@@ -178,41 +178,41 @@
+       : _Inherited(__a1, __a2) { }
+ 
+       template<typename _U1, typename _U2>
+-        tuple(const tuple<_U1, _U2>& __in)
+-	: _Inherited(__in) { }
++        tuple(const tuple<_U1, _U2>& ___in)
++	: _Inherited(___in) { }
+ 
+-      tuple(const tuple& __in)
+-      : _Inherited(__in) { }
++      tuple(const tuple& ___in)
++      : _Inherited(___in) { }
+ 
+       template<typename _U1, typename _U2>
+-        tuple(const pair<_U1, _U2>& __in)
++        tuple(const pair<_U1, _U2>& ___in)
+ 	: _Inherited(_Tuple_impl<0, 
+ 		     typename __add_c_ref<_U1>::type,
+-		     typename __add_c_ref<_U2>::type>(__in.first, 
+-						      __in.second))
++		     typename __add_c_ref<_U2>::type>(___in.first, 
++						      ___in.second))
+         { }
+   
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(const tuple<_U1, _U2>& __in)
++        operator=(const tuple<_U1, _U2>& ___in)
+         {
+-	  static_cast<_Inherited&>(*this) = __in;
++	  static_cast<_Inherited&>(*this) = ___in;
+ 	  return *this;
+ 	}
+ 
+       tuple&
+-      operator=(const tuple& __in)
++      operator=(const tuple& ___in)
+       {
+-	static_cast<_Inherited&>(*this) = __in;
++	static_cast<_Inherited&>(*this) = ___in;
+ 	return *this;
+       }
+ 
+       template<typename _U1, typename _U2>
+         tuple&
+-        operator=(const pair<_U1, _U2>& __in)
++        operator=(const pair<_U1, _U2>& ___in)
+         {
+-	  this->_M_head = __in.first;
+-	  this->_M_tail()._M_head = __in.second;
++	  this->_M_head = ___in.first;
++	  this->_M_tail()._M_head = ___in.second;
+ 	  return *this;
+ 	}
+     };
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/tr1/utility gcc-6.3.0/libstdc++-v3/include/tr1/utility
+--- gcc-6.3.0-orig/libstdc++-v3/include/tr1/utility	2017-05-14 09:37:13.583341333 -0700
++++ gcc-6.3.0/libstdc++-v3/include/tr1/utility	2017-05-14 09:56:41.220007999 -0700
+@@ -93,13 +93,13 @@
+ 
+   template<int _Int, class _Tp1, class _Tp2>
+     inline typename tuple_element<_Int, std::pair<_Tp1, _Tp2> >::type&
+-    get(std::pair<_Tp1, _Tp2>& __in)
+-    { return __pair_get<_Int>::__get(__in); }
++    get(std::pair<_Tp1, _Tp2>& ___in)
++    { return __pair_get<_Int>::__get(___in); }
+ 
+   template<int _Int, class _Tp1, class _Tp2>
+     inline const typename tuple_element<_Int, std::pair<_Tp1, _Tp2> >::type&
+-    get(const std::pair<_Tp1, _Tp2>& __in)
+-    { return __pair_get<_Int>::__const_get(__in); }
++    get(const std::pair<_Tp1, _Tp2>& ___in)
++    { return __pair_get<_Int>::__const_get(___in); }
+ 
+ _GLIBCXX_END_NAMESPACE_VERSION
+ }
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/tr2/bool_set gcc-6.3.0/libstdc++-v3/include/tr2/bool_set
+--- gcc-6.3.0-orig/libstdc++-v3/include/tr2/bool_set	2017-05-14 09:37:13.576674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/tr2/bool_set	2017-05-14 09:56:41.200008000 -0700
+@@ -131,18 +131,18 @@
+ 
+     template<typename CharT, typename Traits>
+       friend std::basic_ostream<CharT, Traits>&
+-      operator<<(std::basic_ostream<CharT, Traits>& __out, bool_set __b)
++      operator<<(std::basic_ostream<CharT, Traits>& ___out, bool_set __b)
+       {
+ 	int __a = __b._M_b;
+-	__out << __a;
++	___out << __a;
+       }
+ 
+     template<typename CharT, typename Traits>
+       friend std::basic_istream<CharT, Traits>&
+-      operator>>(std::basic_istream<CharT, Traits>& __in, bool_set& __b)
++      operator>>(std::basic_istream<CharT, Traits>& ___in, bool_set& __b)
+       {
+ 	long __c;
+-	__in >> __c;
++	___in >> __c;
+ 	if (__c >= _S_false && __c < _S_empty)
+ 	  __b._M_b = static_cast<_Bool_set_val>(__c);
+       }
+diff -ur gcc-6.3.0-orig/libstdc++-v3/include/tr2/bool_set.tcc gcc-6.3.0/libstdc++-v3/include/tr2/bool_set.tcc
+--- gcc-6.3.0-orig/libstdc++-v3/include/tr2/bool_set.tcc	2017-05-14 09:37:13.576674666 -0700
++++ gcc-6.3.0/libstdc++-v3/include/tr2/bool_set.tcc	2017-05-14 09:56:41.200008000 -0700
+@@ -100,9 +100,9 @@
+        *  @param  v  Value to format and insert.
+        *  @return  Iterator after reading.
+       iter_type
+-      get(iter_type __in, iter_type __end, ios_base& __io,
++      get(iter_type ___in, iter_type __end, ios_base& __io,
+ 	  ios_base::iostate& __err, bool& __v) const
+-      { return this->do_get(__in, __end, __io, __err, __v); }
++      { return this->do_get(___in, __end, __io, __err, __v); }
+        */
+ /*
+   template<typename _CharT, typename _InIter>

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -56,6 +56,7 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}/${_realname}-${pkgve
         "0018-PR-77333-Set-clone-call-fntype-to-callee-type.patch"
         "0100-gcc-4.8-libstdc++export.patch"
         "0110-gcc-4.7-stdthreads.patch"
+        "0130-libstdc++-in-out.patch"
         "gcc7-pr79665.patch")
 sha256sums=('f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
@@ -79,6 +80,7 @@ sha256sums=('f06ae7f3f790fbf0f018f6d40e844451e6bc3b7bc96e128e63b09825c1f8b29f'
             '62dccf1e2e85068ee1060af24162c760ca5d76b0d9690efa62fac9d959b6aac6'
             '21191b4fd57ce5f230fcc97b4d9ae31bdc387d7c7c8e39436aa7e4268d278d3d'
             '5e0fc1437ce0b357e78d440692e3a30a7905a5f360a67928a95b14ec8d45365b'
+            '0e24c6955f53a6c84cca9a8c9a372054bd90d5b1a2c6c3f29e36cb350f973b5d'
             '24524102ba4a4360881e45aea4c0b8fd2f97969f00c0df05e714a9ee6c6b913d')
 
 _threads="posix"
@@ -108,6 +110,8 @@ prepare() {
 
   #patch -p1 -i ${srcdir}/0100-gcc-4.8-libstdc++export.patch
   #patch -p1 -i ${srcdir}/0110-gcc-4.7-stdthreads.patch
+
+  patch -p1 -i ${srcdir}/0130-libstdc++-in-out.patch
 
   # do not expect $prefix/mingw symlink - this should be superceded by
   # 0004-Windows-Don-t-ignore-native-system-header-dir.patch .. but isn't!


### PR DESCRIPTION
In C/C++ code, the names `__in` and `__out` have a special meaning in Microsoft-style code, and a recent commit to mingw-w64 (b7f44b677f43c3bb5f771ff5a430206de040c48c) made those definitions be more visible, causing compilation errors in libstdc++ headers which try to use `__in` and `__out` as variable names.  For what it's worth, this pull request adds a patch to mingw-w64-gcc (but not mingw-w64-gcc-git) which should fix the issue, but the mingw-w64-gcc package is not currently compiling so I was unable to really test this pull request.  I usually don't make a pull request if I can't build the package in question, and I would personally prefer to use `sed` instead of a 3000-line patch, but Alexey asked for this.