### PR TITLE
cmake: patch cm_codecvt (fix #2462)

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -31,7 +31,8 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0005-Do-not-install-Qt-bundle-in-cmake-gui.patch"
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
-        "0008-Output-line-numbers-in-callstacks.patch")
+        "0008-Output-line-numbers-in-callstacks.patch"
+        "cm_codecvt.patch")
 sha256sums=('ce5d9161396e06501b00e52933783150a87c33080d4bdcef461b5b7fd24ac228'
             '0d8557d7964a624d00c64ce390a4440d6d82119b45c1cd24ddeae3ee028dcf87'
             'cfffe9d255dd5d78f8d029878bb46f7adfb60ac4ec9564e8d478b5b6a52231b8'
@@ -40,7 +41,8 @@ sha256sums=('ce5d9161396e06501b00e52933783150a87c33080d4bdcef461b5b7fd24ac228'
             'f8886078cb61e2b3d2cb6d7fe9325290206e006d7a1f1423425078bd35b0023f'
             'c230783cdd1a32ddd3d0d938c63d70a24e23bc6947f90f22770d85be5af54c6a'
             'a3541d1272805fa11de0bb7cb19b37f55f2e0664410247c5cfab4ee93d2637a5'
-            '9dc604b25b97ff612723c8955b27ab015d22af3e762851a01a934a656c8b80c5')
+            '9dc604b25b97ff612723c8955b27ab015d22af3e762851a01a934a656c8b80c5'
+            '2d3e54836f93f0391fe805dfc9a895477ed7a304b9148bc8baf49062f117958d')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -52,6 +54,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch
   patch -Np1 -i "${srcdir}"/0007-Do-not-generate-import-libs-for-exes.patch
   patch -Np1 -i "${srcdir}"/0008-Output-line-numbers-in-callstacks.patch
+  patch -Np1 -i "${srcdir}"/cm_codecvt.patch
 }
 
 build() {

--- a/mingw-w64-cmake/cm_codecvt.patch
+++ b/mingw-w64-cmake/cm_codecvt.patch
@@ -1,0 +1,11 @@
+--- a/Source/cm_codecvt.cxx	2017-05-02 12:59:43.000000000 +0000
++++ b/Source/cm_codecvt.cxx	2017-05-17 00:09:09.492859300 +0000
+@@ -58,7 +58,7 @@
+   unsigned int& stateId = reinterpret_cast<unsigned int&>(state);
+   if (count == 0) {
+     return codecvt::ok;
+-  } else if (count == 1) {
++  } else if (count >= 1) {
+     if (stateId == 0) {
+       // decode first byte for UTF-8
+       if ((*from & 0xF8) == 0xF0 || // 1111 0xxx; 4 bytes for codepoint


### PR DESCRIPTION
perform conversion for more than one character in cm_codecvt

codecvt::do_out returned std::codecvt::error when called for more than 1 char
the Ninja (and NMake) generator use this codecvt and therefore failed when writing files

since this works in the official CMake binary release
i’d infer that msvc calls this function ? one char at a time ?

i’m not sure this patch is correct, but it seems to work

upstream bugreport https://gitlab.kitware.com/cmake/cmake/issues/16893