### PR TITLE
cppunit: Update to 1.14.0

### DIFF
--- a/mingw-w64-cppunit/PKGBUILD
+++ b/mingw-w64-cppunit/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cppunit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.13.2
-pkgrel=5
+pkgver=1.14.0
+pkgrel=0
 pkgdesc="A C++ unit testing framework (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/cppunit"
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("http://dev-www.libreoffice.org/src/${_realname}-${pkgver}.tar.gz")
-sha256sums=('3f47d246e3346f2ba4d7c9e882db3ad9ebd3fcbd2e8b732f946e0e3eeb9f429f')
+sha256sums=('3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
@@ -23,7 +23,8 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static
+    --enable-static \
+    --disable-werror
 
   make
 }


### PR DESCRIPTION
Explicitly disable Werror to prevent the build from failing

In this release cppunit-config was removed in favor of pkg-config.