### PR TITLE
python-colorama: Update to 0.3.9

### DIFF
--- a/mingw-w64-python-colorama/PKGBUILD
+++ b/mingw-w64-python-colorama/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=colorama
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.3.7
+pkgver=0.3.9
 pkgrel=1
 pkgdesc="Python API for cross-platform colored terminal text (mingw-w64)"
 arch=('any')
@@ -12,11 +12,9 @@ license=('BSD')
 url="https://pypi.python.org/pypi/colorama"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose"
-              "${MINGW_PACKAGE_PREFIX}-python3-nose")
 options=('staticlibs')
-source=(https://pypi.python.org/packages/source/c/colorama/colorama-${pkgver}.tar.gz)
-sha256sums=('e043c8d32527607223652021ff648fbb394d5e19cba9f1a698670b338c9d782b')
+source=("https://pypi.org/packages/source/c/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1')
 
 prepare() {
   cd ${srcdir}
@@ -29,15 +27,6 @@ build() {
   for builddir in python{2,3}-build; do
     pushd ${builddir}
     ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
-    popd
-  done
-}
-
-check() {
-  cd "${srcdir}"
-  for builddir in python{2,3}-build; do
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} py.test
     popd
   done
 }


### PR DESCRIPTION
Also remove the check() target. colorama doesn't ship tests in the
tarball and the check() is broken anyway.