### PR TITLE
nasm: update to 2.13.01

### DIFF
--- a/mingw-w64-nasm/PKGBUILD
+++ b/mingw-w64-nasm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.12.02
+pkgver=2.13.01
 pkgrel=1
 pkgdesc="An 80x86 assembler designed for portability and modularity (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' '!libtool' 'staticlibs' '!makeflags')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=(http://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('4c866b60c0b1c4ebc715205d007b4640ff4e36af637c9a7deb87b2900e544321')
+sha256sums=('aa0213008f0433ecbe07bb628506a5c4be8079be20fc3532a5031fd639db9a5e')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
Required for x264 git AVX-512 instructions support.