### PR TITLE
portaudio: include static library. Fixes #2317

### DIFF
--- a/mingw-w64-portaudio/PKGBUILD
+++ b/mingw-w64-portaudio/PKGBUILD
@@ -4,28 +4,50 @@ _realname=portaudio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=190600_20161030
-pkgrel=1
+pkgrel=2
 pkgdesc="A free, cross-platform, open source, audio I/O library (mingw-w64)"
 arch=('any')
 url="http://www.portaudio.com"
 license=("custom")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-options=(!libtool strip !makeflags staticlibs)
-source=("http://www.portaudio.com/archives/pa_stable_v${pkgver}.tgz")
-sha256sums=('f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513')
+options=(!libtool strip staticlibs)
+source=("http://www.portaudio.com/archives/pa_stable_v${pkgver}.tgz"
+        "fix-build.patch")
+sha256sums=('f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513'
+            '77e8438d482ad03baa5c23afbe293e8cbdb95287ff6a489515bde61231e78525')
 
 prepare() {
   cd ${srcdir}/${_realname}
+
+  patch -p0 -i ${srcdir}/fix-build.patch
 
   autoconf
 }
 
 build() {
   export lt_cv_deplibs_check_method='pass_all'
-  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  [[ -d "build-static-${MINGW_CHOST}" ]] && rm -rf "build-static-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-static-${MINGW_CHOST}"
+  cd "${srcdir}/build-static-${MINGW_CHOST}"
+
+  ../${_realname}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-shared \
+    --enable-static \
+    --with-dxdir=${MINGW_PREFIX}/${MINGW_CHOST} \
+    --with-winapi=wmme,directx
+
+  make
+
+  [[ -d "build-shared-${MINGW_CHOST}" ]] && rm -rf "build-shared-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-shared-${MINGW_CHOST}"
+  cd "${srcdir}/build-shared-${MINGW_CHOST}"
+
   ../${_realname}/configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
@@ -39,6 +61,9 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-static-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+
+  cd "${srcdir}/build-shared-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
 }

--- a/mingw-w64-portaudio/fix-build.patch
+++ b/mingw-w64-portaudio/fix-build.patch
@@ -1,0 +1,12 @@
+--- Makefile.in.orig	2017-05-23 11:54:39.381395400 +0200
++++ Makefile.in	2017-05-23 11:55:16.248260300 +0200
+@@ -56,8 +56,7 @@
+ 	src/common/pa_front.o \
+ 	src/common/pa_process.o \
+ 	src/common/pa_stream.o \
+-	src/common/pa_trace.o \
+-	src/hostapi/skeleton/pa_hostapi_skeleton.o
++	src/common/pa_trace.o
+ 
+ LOOPBACK_OBJS = \
+ 	qa/loopback/src/audio_analyzer.o \


### PR DESCRIPTION
For some reason it either builds a static or a shared one.
Just build it twice and install both.