### PR TITLE
cmake: fix regression

### DIFF
--- a/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
@@ -113,20 +113,21 @@ index 825eba0e1d..61652b80b1 100644
  }
  
  static void GetCompileDefinitionsAndDirectories(
-@@ -742,7 +802,13 @@ void cmQtAutoGeneratorInitializer::InitializeAutogenTarget(
+@@ -733,7 +793,14 @@ void cmQtAutoGeneratorInitializer::InitializeAutogenTarget(
+     if (target->GetPropertyAsBool("AUTORCC")) {
+       toolNames.push_back("RCC");
      }
-     if (toolNames.size() == 1) {
-       tools += " and " + toolNames[0];
-+    } else if (toolNames.size() == 0) {
+ 
++    if (toolNames.empty()) {
 +      /* AUTOSTATICPLUGINS .cpp files are created at cmake execution time,
 +       * and not at build time, so in that case it is possible to get here
 +       * with no toolNames. */
 +      return;
-     }
++    }
 +
-     autogenComment = "Automatic " + tools + " for target " + target->GetName();
-   }
- 
+     std::string tools = toolNames[0];
+     toolNames.erase(toolNames.begin());
+     while (toolNames.size() > 1) {
 @@ -894,7 +960,9 @@ void cmQtAutoGeneratorInitializer::SetupAutoGenerateTarget(
  
    if (target->GetPropertyAsBool("AUTOMOC") ||

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.8.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -37,7 +37,7 @@ sha256sums=('ce5d9161396e06501b00e52933783150a87c33080d4bdcef461b5b7fd24ac228'
             '0d8557d7964a624d00c64ce390a4440d6d82119b45c1cd24ddeae3ee028dcf87'
             'cfffe9d255dd5d78f8d029878bb46f7adfb60ac4ec9564e8d478b5b6a52231b8'
             '6845069dc9428e09d837b0f260ec3dd477533f8b19812b6d44eb29e8f4561c29'
-            'b3b9c83e55e29f39bc4bb0a8db476e898d85bb7aaf3e27cde433a7f9eae776bb'
+            'ab9fa86d0014b076fa58effb3bf14a01bde9a8e462405edef412c19b8618e351'
             'f8886078cb61e2b3d2cb6d7fe9325290206e006d7a1f1423425078bd35b0023f'
             'c230783cdd1a32ddd3d0d938c63d70a24e23bc6947f90f22770d85be5af54c6a'
             'a3541d1272805fa11de0bb7cb19b37f55f2e0664410247c5cfab4ee93d2637a5'


### PR DESCRIPTION
hunk was incorrectly rebased

removed 1 working autogen if present
and crashed when no additional autogen was used