### PR TITLE
Added new package: fmt

### DIFF
--- a/mingw-w64-fmt/PKGBUILD
+++ b/mingw-w64-fmt/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: melak47 <melak47@gmail.com>
+
+_realname=fmt
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.0.1
+pkgrel=1
+pkgdesc="Small, safe and fast formatting library (mingw-w64)"
+arch=('any')
+url="http://fmtlib.net"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+options=('staticlibs')
+source=("https://github.com/fmtlib/${_realname}/archive/${pkgver}.tar.gz")
+sha256sums=('dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad')
+
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=OFF \
+    ../${_realname}-${pkgver}
+
+  make -j1 # parallel jobs break build
+}
+
+check() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  ctest
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.rst
+}

--- a/mingw-w64-fmt/PKGBUILD
+++ b/mingw-w64-fmt/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs')
-source=("https://github.com/fmtlib/${_realname}/archive/${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/fmtlib/${_realname}/archive/${pkgver}.tar.gz")
 sha256sums=('dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad')
 
 build() {


### PR DESCRIPTION
I'd like to add this recipe for fmt (formerly fmtlib).
Tests seem to pass locally.

The library ships with some `.cc` files in `include/fmt` (for header-only usage), I hope that's alright.