### PR TITLE
gstreamer: Update to 1.12.0

### DIFF
--- a/mingw-w64-gst-editing-services/PKGBUILD
+++ b/mingw-w64-gst-editing-services/PKGBUILD
@@ -4,7 +4,7 @@ _srcname=gstreamer-editing-services
 _realname=gst-editing-services
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer Editing Services (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_srcname}-${pkgver}.tar.xz
         0002-add-cflags-for-gir.patch)
-sha256sums=('f2ad6d02dc9d12e899059796e8de03a662f41e4d732797fb4b5ecbc973582144'
+sha256sums=('993372f80cafd5395e90a4bc8bf28733513949a2ae4df987ab0dcc99fc5bab66'
             '9d4c26c60c6a1b2ef4430c82ff5fcbf06f1aae61572ec005b387bb5419564e78')
 
 prepare() {

--- a/mingw-w64-gst-libav/PKGBUILD
+++ b/mingw-w64-gst-libav/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gst-libav
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer libav (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('6ca0feca75e3d48315e07f20ec37cf6260ed1e9dde58df355febd5016246268b')
+sha256sums=('39d1477f642ee980b008e78d716b16801eec9a6e5958c5a6cdc0cb04ab0750c4')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-gst-plugins-bad/0002-fix-link-order.patch
+++ b/mingw-w64-gst-plugins-bad/0002-fix-link-order.patch
@@ -1,6 +1,6 @@
---- gst-plugins-bad-1.10.2/ext/gl/Makefile.am.orig	2017-01-16 08:25:10.131688300 +0300
-+++ gst-plugins-bad-1.10.2/ext/gl/Makefile.am	2017-01-16 08:25:29.154329000 +0300
-@@ -144,14 +144,14 @@
+--- gst-plugins-bad-1.12.0/ext/gl/Makefile.am.orig	2017-05-29 08:07:16.185403600 +0200
++++ gst-plugins-bad-1.12.0/ext/gl/Makefile.am	2017-05-29 08:08:44.628462200 +0200
+@@ -149,6 +149,7 @@
  	$(top_builddir)/gst-libs/gst/gl/libgstgl-$(GST_API_VERSION).la \
  	$(top_builddir)/gst-libs/gst/base/libgstbadbase-$(GST_API_VERSION).la \
  	$(top_builddir)/gst-libs/gst/video/libgstbadvideo-$(GST_API_VERSION).la \
@@ -8,6 +8,7 @@
  	$(GST_BASE_LIBS) \
  	$(GST_PLUGINS_BASE_LIBS) -lgstvideo-$(GST_API_VERSION) \
  	-lgstpbutils-$(GST_API_VERSION) \
+@@ -156,8 +157,7 @@
  	$(GL_LIBS) \
  	$(LIBPNG_LIBS) \
  	$(JPEG_LIBS) \

--- a/mingw-w64-gst-plugins-bad/PKGBUILD
+++ b/mingw-w64-gst-plugins-bad/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=gst-plugins-bad
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer Multimedia Framework Bad Plugins (mingw-w64)"
 arch=('any')
@@ -33,7 +33,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-celt"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libgme"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
-         "${MINGW_PACKAGE_PREFIX}-libmimic"
          "${MINGW_PACKAGE_PREFIX}-libmodplug"
          "${MINGW_PACKAGE_PREFIX}-libmpeg2"
          "${MINGW_PACKAGE_PREFIX}-libpng"
@@ -41,13 +40,11 @@ depends=("${MINGW_PACKAGE_PREFIX}-celt"
          "${MINGW_PACKAGE_PREFIX}-libsrtp"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-mpg123"
          "${MINGW_PACKAGE_PREFIX}-nettle"
          "${MINGW_PACKAGE_PREFIX}-openal"
          "${MINGW_PACKAGE_PREFIX}-opencv"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
-         "${MINGW_PACKAGE_PREFIX}-opus"
          "${MINGW_PACKAGE_PREFIX}-orc"
          "${MINGW_PACKAGE_PREFIX}-schroedinger"
          "${MINGW_PACKAGE_PREFIX}-soundtouch"
@@ -59,8 +56,8 @@ source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz
         0002-fix-link-order.patch
         0005-Include-glext-h.patch
         0006-No-X11-on-_WIN32.patch)
-sha256sums=('23ddae506b3a223b94869a0d3eea3e9a12e847f94d2d0e0b97102ce13ecd6966'
-            '8a64a800fe9721055e0b36fbde000c8fbd35f105c5c6556319594ae0af976540'
+sha256sums=('11b73cfff1b315a8e9be1756435ea84937e7cb90afbab0e8e6975367dbfb8534'
+            'd9433cbe0eba170e9228632883a9fe1634354e4e31c2261e5e2dcedca9b0ed6a'
             '439436d02724c07af95f509647238f271f4717958dcf42dc5adb5a8e6a2108e7'
             'da9b9c1cf8ce5ee77f7963a6ffecc2abfbc8d0e3c4ea88a49646c0c98a480e46')
 

--- a/mingw-w64-gst-plugins-base/PKGBUILD
+++ b/mingw-w64-gst-plugins-base/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gst-plugins-base
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer Multimedia Framework Base Plugins (mingw-w64)"
 arch=('any')
@@ -16,14 +16,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-libvorbis"
          "${MINGW_PACKAGE_PREFIX}-libtheora"
          "${MINGW_PACKAGE_PREFIX}-libvorbisidec"
+         "${MINGW_PACKAGE_PREFIX}-opus"
          "${MINGW_PACKAGE_PREFIX}-pango"
          #"${MINGW_PACKAGE_PREFIX}-libvisual"
          #"${MINGW_PACKAGE_PREFIX}-cdparanoia"
          "${MINGW_PACKAGE_PREFIX}-gstreamer"
          "${MINGW_PACKAGE_PREFIX}-orc")
 options=(!libtool strip staticlibs)
+conflicts=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad<1.12.0")
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('f6d245b6b3d4cb733f81ebb021074c525ece83db0c10e932794b339b8d935eb7')
+sha256sums=('345fc6877f54b8b6e97aacf2996be37a51a0e369f53fc2cf83108af9f764364d')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-gst-plugins-good/PKGBUILD
+++ b/mingw-w64-gst-plugins-good/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=gst-plugins-good
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
-pkgrel=2
+pkgver=1.12.0
+pkgrel=1
 pkgdesc="GStreamer Multimedia Framework Base Plugins (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
@@ -27,7 +27,7 @@ options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz
         0001-directsoundsink-Fix-corner-case-causing-large-CPU-us.patch
         0002-directsoundsink-Use-GstClock-API-instead-of-Sleep-fo.patch)
-sha256sums=('8a86c61434a8c44665365bd0b3557a040937d1f44bf69caee4e9ea816ce74d7e'
+sha256sums=('8a1d734db7338e00c28b794a7f0a5a9e67d1c5c8b0074075b50638207d372ebc'
             '8a3165af84bdd800899e99ea01149ce3a7188b1dabc365423234bd7b5717e458'
             '61c9a7104b0c1ecb40bc98a08e1137cefb555d53246a751c07d326320b1bfaee')
 

--- a/mingw-w64-gst-plugins-ugly/PKGBUILD
+++ b/mingw-w64-gst-plugins-ugly/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gst-plugins-ugly
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer Multimedia Framework Ugly Plugins (mingw-w64)"
 arch=('any')
@@ -15,8 +15,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
          "${MINGW_PACKAGE_PREFIX}-lame"
+         "${MINGW_PACKAGE_PREFIX}-mpg123"
          "${MINGW_PACKAGE_PREFIX}-libdvdread"
-         "${MINGW_PACKAGE_PREFIX}-libmad"
          "${MINGW_PACKAGE_PREFIX}-libmpeg2"
          "${MINGW_PACKAGE_PREFIX}-libcdio"
          "${MINGW_PACKAGE_PREFIX}-opencore-amr"
@@ -24,7 +24,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          "${MINGW_PACKAGE_PREFIX}-x264")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('6386c77ca8459cba431ed0b63da780c7062c7cc48055d222024d8eaf198ffa59')
+sha256sums=('5e68ba5046e83ee87b17d7a13931e6091466fd771e1338c5b929ee0944d40ad6')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-gst-python/PKGBUILD
+++ b/mingw-w64-gst-python/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gst-python
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer GObject Introspection overrides for Python 3 (mingw-w64)"
 arch=('any')
@@ -20,7 +20,7 @@ source=(https://gstreamer.freedesktop.org/src/gst-python/${_realname}-${pkgver}.
         '0002-msys2-fix-linking-errors.patch'
         '0004-add-overrides.patch'
         '0005-unix-override-dir.patch')
-sha256sums=('59508174b8bc86c05290aa9a7c5d480ac556a6f36306ddbc1d0eacf4f7868212'
+sha256sums=('be33de6b9f21e95f677ef91b142e5249e71c8d7e894a5a4a53e19cf18d5d9c07'
             '836cf2e9e713705e5fd0f09d4e38d3de839a3c663eb6fa85f0a3f9a5f0b224ee'
             'dc4cd0f1890d82e5d09e667763b6a7c1731864e3ddfe4f0ff42d3e83de4def20'
             '04f94d86379280d6a4d7970dd149f31ef9ea04f5151dc6f9be474069570366ac'

--- a/mingw-w64-gst-rtsp-server/PKGBUILD
+++ b/mingw-w64-gst-rtsp-server/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gst-rtsp-server
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer RTSP server library (mingw-w64)"
 arch=('any')
@@ -26,7 +26,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('2f6e12fd4e3568ee190dc24e57e4c3a878971c3a3fb6904a9674404fac256de6')
+sha256sums=('85ae6bbe173b365ddf4859967144f1999b436531ecbe09935914bfa9f6b37652')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-gstreamer/PKGBUILD
+++ b/mingw-w64-gstreamer/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gstreamer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.4
+pkgver=1.12.0
 pkgrel=1
 pkgdesc="GStreamer Multimedia Framework (mingw-w64)"
 arch=('any')
@@ -23,8 +23,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-gsl")
 options=(!libtool strip staticlibs)
+conflicts=("${MINGW_PACKAGE_PREFIX}-gst-plugins-bad<1.12.0")
 source=("${url}/src/gstreamer/gstreamer-${pkgver}.tar.xz")
-sha256sums=('50c2f5af50a6cc6c0a3f3ed43bdd8b5e2bff00bacfb766d4be139ec06d8b5218')
+sha256sums=('14d5eef8297d2bf2a728d38fa43cd92cc267a0ad260cf83d770215212aff4302')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
I've added some conflicts to prevent upgrade errors for plugins moving between packages. I'm not sure if that's desirable.

Release notes: https://gstreamer.freedesktop.org/releases/1.12/

All in all GStreamer no longer depends on libmimic and libmad.