### PR TITLE
appveyor: Set shorter clone folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+clone_folder: C:\M
+
 environment:
     DEPLOY_PROVIDER: bintray
     BINTRAY_ACCOUNT: alexpux


### PR DESCRIPTION
This saves 22 characters on absolute paths during building

I think this should help with GStreamer builds