### PR TITLE
opencv: Add some missing dependencies. Fixes #2420

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
@@ -17,6 +17,7 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
          #"${MINGW_PACKAGE_PREFIX}-qt5"
          #"${MINGW_PACKAGE_PREFIX}-gtkglext"
          #"${MINGW_PACKAGE_PREFIX}-gtk2"
@@ -27,11 +28,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ffmpeg"
              "${MINGW_PACKAGE_PREFIX}-python2-numpy"
              "${MINGW_PACKAGE_PREFIX}-python3-numpy"
+             "${MINGW_PACKAGE_PREFIX}-tesseract-ocr"
+             "${MINGW_PACKAGE_PREFIX}-hdf5"
              "${MINGW_PACKAGE_PREFIX}-vtk")
 optdepends=("${MINGW_PACKAGE_PREFIX}-eigen3"
             "${MINGW_PACKAGE_PREFIX}-ffmpeg: support to read and write video files"
             "${MINGW_PACKAGE_PREFIX}-python2-numpy: Python 2.x interface"
             "${MINGW_PACKAGE_PREFIX}-python3-numpy: Python 3.x interface"
+            "${MINGW_PACKAGE_PREFIX}-hdf5: opencv_hdf module"
+            "${MINGW_PACKAGE_PREFIX}-tesseract-ocr: opencv_text module"
             "${MINGW_PACKAGE_PREFIX}-vtk: opencv_viz module")
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archive/${pkgver}.tar.gz
         "${_realname}_contrib-${pkgver}.tar.gz"::https://github.com/opencv/opencv_contrib/archive/${pkgver}.tar.gz


### PR DESCRIPTION
It currently links agains a missing libwebp-6.dll and needs a rebuild.

* libopencv_hdf320.dll depends on libhdf5
* libopencv_imgcodecs320.dll depends on libwebp
* libopencv_text320.dll depends on libtesseract