### PR TITLE
Add libwebp as runtime dependency to opencv.

### DIFF
--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -4,7 +4,7 @@ _realname=opencv
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Open Source Computer Vision Library (mingw-w64)"
 arch=('any')
 url="http://opencv.org/"
@@ -15,6 +15,7 @@ depends=(#"${MINGW_PACKAGE_PREFIX}-gst-plugins-base
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
          "${MINGW_PACKAGE_PREFIX}-libpng"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
+         "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          #"${MINGW_PACKAGE_PREFIX}-qt5"


### PR DESCRIPTION
The current binary package "mingw-w64-x86_64-opencv-3.2.0-3-any.pkg.tar.xz"
links to the outdated DLL "libwebp-6.dll" but doesn't specify libwebp as a dependency.

Since libwebp is updated in the meanwhile to "libwebp-7.dll", it isn't sufficient to install the package.

Rebuilding opencv with webp dependency fixes this issue.
