### PR TITLE
mingw-w64 headers, tools, crt, libmangle, winstorecompat, winpthreads…

### DIFF
--- a/mingw-w64-crt-git/PKGBUILD
+++ b/mingw-w64-crt-git/PKGBUILD
@@ -4,11 +4,11 @@ _realname=crt
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
-pkgver=5.0.0.4834.33ee6cab
+pkgver=5.0.0.4839.da76aa7c
 pkgrel=1
 pkgdesc='MinGW-w64 CRT for Windows'
 arch=('any')
-url='https://mingw-w64.sourceforge.io/'
+url='http://mingw-w64.sourceforge.net'
 license=('custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-headers-git")
@@ -18,7 +18,7 @@ makedepends=("git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' 'staticlibs' '!buildflags' '!emptydirs')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64"
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64"
         "0003-dxgi-Add-missing-dxgi-1.2-structs-and-interfaces.patch"
         "0004-d3d11-Add-missing-d3d11-1.1-structs-and-interfaces.patch"
         "0005-handle-ctor_list-internally.patch")

--- a/mingw-w64-headers-git/PKGBUILD
+++ b/mingw-w64-headers-git/PKGBUILD
@@ -5,17 +5,17 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 pkgdesc="MinGW-w64 headers for Windows"
-pkgver=5.0.0.4836.670da35c
+pkgver=5.0.0.4841.1ff9caf4
 pkgrel=1
 arch=('any')
-url="https://mingw-w64.sourceforge.io/"
+url="http://mingw-w64.sourceforge.net"
 license=('custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=('git' "${MINGW_PACKAGE_PREFIX}-tools")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!strip' '!libtool' '!emptydirs')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64"
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64"
         "0003-dxgi-Add-missing-dxgi-1.2-structs-and-interfaces.patch"
         "0004-d3d11-Add-missing-d3d11-1.1-structs-and-interfaces.patch"
         "0005-bessel_complex.patch"

--- a/mingw-w64-libmangle-git/PKGBUILD
+++ b/mingw-w64-libmangle-git/PKGBUILD
@@ -6,11 +6,11 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.0.0.4760.d3089b5
+pkgver=5.0.0.4837.b33fcd03
 pkgrel=1
 pkgdesc="MinGW-w64 libmangle"
 arch=('any')
-url="https://mingw-w64.sourceforge.io/"
+url="http://mingw-w64.sourceforge.net"
 license=('custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("git"
@@ -19,7 +19,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-crt-git"
              "${MINGW_PACKAGE_PREFIX}-headers-git")
 options=('strip' 'staticlibs' '!emptydirs')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64")
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64")
 sha256sums=('SKIP')
 
 pkgver() {

--- a/mingw-w64-tools-git/0001-add-genstubsdll.patch
+++ b/mingw-w64-tools-git/0001-add-genstubsdll.patch
@@ -1,0 +1,52 @@
+--- mingw-w64/mingw-w64-tools/genstubdll-old/Makefile.am	1969-12-31 19:00:00 
++++ mingw-w64/mingw-w64-tools/genstubdll/Makefile.am	2017-05-31 05:36:00 -0400
+@@ -0,0 +1,7 @@
++bin_PROGRAMS = genstubdll
++genstubdll_SOURCES = src/token.h src/lexdef.c src/output.c
++genstubdll_CPPFLAGS = -Isrc
++genstubdll_CFLAGS = $(AM_CFLAGS) -O3 -g -Wall -Wextra
++
++EXTRA_DIST = $(srcdir)/COPYING
++DISTCHECK_CONFIGURE_FLAGS = --host=$(host)
+--- mingw-w64/mingw-w64-tools/genstubdll-old/configure.ac	1969-12-31 19:00:00 
++++ mingw-w64/mingw-w64-tools/genstubdll/configure.ac	2017-05-31 04:46:50 -0400
+@@ -0,0 +1,39 @@
++#                                               -*- Autoconf -*-
++# Process this file with autoconf to produce a configure script.
++
++AC_PREREQ([2.69])
++AC_INIT([mingw-w64-genstubdll],[1.0],[mingw-w64-public@lists.sourceforge.net])
++AC_CONFIG_AUX_DIR([build-aux])
++AC_CONFIG_SRCDIR([src/output.c])
++AC_CONFIG_HEADERS([config.h])
++
++AM_INIT_AUTOMAKE([foreign subdir-objects])
++AM_MAINTAINER_MODE
++
++AC_CANONICAL_HOST
++
++# Checks for programs.
++AC_PROG_CC
++
++# Checks for libraries.
++
++# Checks for header files.
++AC_CHECK_HEADERS([malloc.h memory.h stdint.h stdlib.h string.h])
++
++# Checks for typedefs, structures, and compiler characteristics.
++AC_TYPE_INT16_T
++AC_TYPE_INT32_T
++AC_TYPE_INT64_T
++AC_TYPE_SIZE_T
++AC_TYPE_UINT16_T
++AC_TYPE_UINT32_T
++AC_TYPE_UINT64_T
++
++# Checks for library functions.
++AC_FUNC_MALLOC
++AC_FUNC_REALLOC
++AC_CHECK_FUNCS([memset strchr strdup strrchr strstr])
++
++AC_CONFIG_FILES([Makefile])
++AC_OUTPUT
++

--- a/mingw-w64-tools-git/PKGBUILD
+++ b/mingw-w64-tools-git/PKGBUILD
@@ -7,19 +7,21 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-svn")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.0.0.4760.d3089b5
+pkgver=5.0.0.4837.b33fcd03
 pkgrel=1
 pkgdesc="MinGW-w64 tools"
 arch=('any')
-url="https://mingw-w64.sourceforge.io/"
+url="http://mingw-w64.sourceforge.net"
 license=('custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("git" "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-libmangle")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' '!emptydirs')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64")
-sha256sums=('SKIP')
-_tools="gendef genlib genidl genpeimg widl" # genstubdll
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64"
+        "0001-add-genstubsdll.patch")
+sha256sums=('SKIP'
+            '139d0fb571ebcf60b7ac0a4031acaeed7dedf72bfb7e917e251fb53e96e90ba6')
+_tools="gendef genlib genidl genpeimg widl genstubdll"
 
 pkgver() {
   cd "${srcdir}/mingw-w64"
@@ -29,9 +31,35 @@ pkgver() {
   printf "%s.%s.%s.%s.%s" ${_major} ${_minor} ${_rev} "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  msg2 "Applying $1"
+  patch -Nbp1 -i "${srcdir}"/$1
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+
 prepare() {
   cd "${srcdir}/mingw-w64"
   #git am "${srcdir}/0001-widl-Relocate-DEFAULT_INCLUDE_DIR.patch"
+
+#genstubdll does not have it's own configure, configure.ac, and Makefile.in
+
+  del_file_exists ${srcdir}/mingw-w64/mingw-w64-tools/genstubdll/configure.ac ${srcdir}/mingw-w64/mingw-w64-tools/genstubdll/Makefile.am
+
+  apply_patch_with_msg 0001-add-genstubsdll.patch
+  pushd ${srcdir}/mingw-w64/mingw-w64-tools/genstubdll
+  autoreconf -fiv
+  popd
 }
 
 build() {

--- a/mingw-w64-winpthreads-git/PKGBUILD
+++ b/mingw-w64-winpthreads-git/PKGBUILD
@@ -5,10 +5,10 @@
 _realname=winpthreads
 pkgbase=mingw-w64-${_realname}-git
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git" "${MINGW_PACKAGE_PREFIX}-libwinpthread-git")
-pkgver=5.0.0.4833.f057c525
+pkgver=5.0.0.4838.011a3917
 pkgrel=1
 pkgdesc="MinGW-w64 winpthreads library"
-url="https://mingw-w64.sourceforge.io/"
+url="http://mingw-w64.sourceforge.net"
 # The main license of `winpthreads' is MIT, but parts of this library are
 # derived from the "POSIX Threads for Microsoft Windows" library, which is
 # licensed under BSD [1].
@@ -21,7 +21,7 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-crt-git"
              "${MINGW_PACKAGE_PREFIX}-headers-git")
 options=('strip' '!buildflags' 'staticlibs' '!emptydirs' '!debug')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64"
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64"
         "0001-Define-__-de-register_frame_info-in-fake-libgcc_s.patch")
 sha256sums=('SKIP'
             'd9e8af81682d9bf70e3d87506f51156cec61260b810a234bce861cb2eb3a5919')

--- a/mingw-w64-winstorecompat-git/PKGBUILD
+++ b/mingw-w64-winstorecompat-git/PKGBUILD
@@ -3,16 +3,16 @@
 _realname=winstorecompat
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=5.0.0.4760.d3089b5
+pkgver=5.0.0.4837.b33fcd03
 pkgrel=1
 pkgdesc="MinGW-w64 winRT compat library"
 arch=('any')
-url="https://mingw-w64.sourceforge.io/"
+url="http://mingw-w64.sourceforge.net"
 license=('custom')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
 makedepends=("git" "${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-binutils" "${MINGW_PACKAGE_PREFIX}-crt" "${MINGW_PACKAGE_PREFIX}-headers")
 options=('strip' '!buildflags' 'staticlibs' '!emptydirs' '!debug')
-source=("mingw-w64"::"git+https://git.code.sf.net/p/mingw-w64/mingw-w64")
+source=("mingw-w64"::"git://git.code.sf.net/p/mingw-w64/mingw-w64")
 sha256sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
… - Update to latest git versions and add genstubsdll using a patch.