### PR TITLE
mingw-w64-cling-git/PKGBUILD: several minor build improvements

### DIFF
--- a/mingw-w64-cling-git/PKGBUILD
+++ b/mingw-w64-cling-git/PKGBUILD
@@ -37,31 +37,34 @@ sha256sums=('SKIP'
             '25074103748b8f2ca531fcaddc24ec705c485649d3f0ea7cd672466cc1f6de9a')
 
 pkgver() {
-  cd "$srcdir/cling"
+  cd "$srcdir/../cling/"
   local ver="$(git rev-parse HEAD)"
   printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 prepare() {
+  cd "${srcdir}/"
+  cp -par ../cling ./
+  cp -par ../clang-cern ./
 
   #cd ${srcdir}/clang
   #patch -p1 -i ${srcdir}/0001-Add-SEH-exceptions-to-the-clang-frontend.patch
 
-  cd ${srcdir}/cling
+  cd "${srcdir}/cling/"
   git checkout 39c7e56
-  git am ${srcdir}/0001-change-all-WIN32-defines-to-_WIN32-as-it-is-a-compil.patch
-  git am ${srcdir}/0002-Invoke-bash-when-looking-for-gcc-includes.patch
-  git am ${srcdir}/0003-use-size_t-for-void-pointer-cast.patch
-  git am ${srcdir}/0004-Hack-around-missing-functions.patch
+  git am "${srcdir}/0001-change-all-WIN32-defines-to-_WIN32-as-it-is-a-compil.patch"
+  git am "${srcdir}/0002-Invoke-bash-when-looking-for-gcc-includes.patch"
+  git am "${srcdir}/0003-use-size_t-for-void-pointer-cast.patch"
+  git am "${srcdir}/0004-Hack-around-missing-functions.patch"
 
-  cd ${srcdir}
-  mv ${srcdir}/clang-cern ${srcdir}/llvm-cern/tools/clang
-  mv ${srcdir}/cling ${srcdir}/llvm-cern/tools/cling
+  cd "${srcdir}"
+  mv "${srcdir}/clang-cern" "${srcdir}/llvm-cern/tools/clang"
+  mv "${srcdir}/cling" "${srcdir}/llvm-cern/tools/cling"
 }
 
 build() {
-  mkdir -p ${srcdir}/llvm-cern/build-${MINGW_CHOST}
-  cd ${srcdir}/llvm-cern/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}/llvm-cern/build-${MINGW_CHOST}"
+  cd "${srcdir}/llvm-cern/build-${MINGW_CHOST}/"
   echo 'ac_cv_have_decl_strerror_s=${ac_cv_have_decl_strerror_s=no}' > config.cache
 
   # Include location of libffi headers in CPPFLAGS
@@ -69,10 +72,10 @@ build() {
 
   ../configure \
     -C \
-    --prefix=${MINGW_PREFIX} \
-    --build=${MINGW_CHOST} \
-    --host=${MINGW_CHOST} \
-    --with-sysroot=${MINGW_PREFIX} \
+    --prefix="${MINGW_PREFIX}" \
+    --build="${MINGW_CHOST}" \
+    --host="${MINGW_CHOST}" \
+    --with-sysroot="${MINGW_PREFIX}" \
     --enable-targets=x86,x86_64,cpp \
     --enable-optimized \
     --disable-assertions \
@@ -88,13 +91,13 @@ package_clang(){
   depends=("${MINGW_PACKAGE_PREFIX}-llvm-cern-git")
   provides=("${MINGW_PACKAGE_PREFIX}-clang")
   conflicts=("${MINGW_PACKAGE_PREFIX}-clang")
-  cd ${srcdir}/llvm-cern/tools/clang
+  cd "${srcdir}/llvm-cern/tools/clang"
   local ver="$(git rev-parse HEAD)"
   pkgver="r$(git rev-list --count HEAD)"
 
   cd "${srcdir}/llvm-cern/build-${MINGW_CHOST}/tools/clang"
-    make -j1 DESTDIR="$pkgdir" install
-  rm -r ${pkgdir}${MINGW_PREFIX}/docs
+  make -j1 DESTDIR="$pkgdir" install
+  rm -r "${pkgdir}${MINGW_PREFIX}/docs"
 }
 
 package_cling(){
@@ -102,7 +105,7 @@ package_cling(){
   depends=("${MINGW_PACKAGE_PREFIX}-llvm-cern-git" "${MINGW_PACKAGE_PREFIX}-clang-cern-git")
   provides=("${MINGW_PACKAGE_PREFIX}-cling")
   conflicts=("${MINGW_PACKAGE_PREFIX}-cling")
-  cd ${srcdir}/llvm-cern/tools/cling
+  cd "${srcdir}/llvm-cern/tools/cling"
   local ver="$(git rev-parse HEAD)"
   pkgver="r$(git rev-list --count HEAD)"
 
@@ -110,7 +113,7 @@ package_cling(){
   make -j1 DESTDIR="$pkgdir" install
 
   # map hack
-  nm "${srcdir}/llvm-cern/build-${MINGW_CHOST}"/Release/bin/cling.exe > "${pkgdir}${MINGW_PREFIX}"/bin/cling_func.map
+  nm "${srcdir}/llvm-cern/build-${MINGW_CHOST}/Release/bin/cling.exe" > "${pkgdir}${MINGW_PREFIX}/bin/cling_func.map"
 }
 
 
@@ -133,12 +136,12 @@ package_llvm(){
   mv "${srcdir}/clang-${MINGW_CHOST}" "${srcdir}/llvm-cern/build-${MINGW_CHOST}/tools/clang"
   mv "${srcdir}/cling" "${srcdir}/llvm-cern/tools/cling"
   mv "${srcdir}/cling-${MINGW_CHOST}" "${srcdir}/llvm-cern/build-${MINGW_CHOST}/tools/cling"
-  rm -r ${pkgdir}${MINGW_PREFIX}/docs
+  rm -r "${pkgdir}${MINGW_PREFIX}/docs"
 
   # Install CMake stuff
   install -d "${pkgdir}${MINGW_PREFIX}"/share/llvm/cmake/{modules,platforms}
-  install -Dm644 $srcdir/llvm-cern/cmake/modules/*.cmake "${pkgdir}${MINGW_PREFIX}"/share/llvm/cmake/modules/
-  install -Dm644 $srcdir/llvm-cern/cmake/platforms/*.cmake "${pkgdir}${MINGW_PREFIX}"/share/llvm/cmake/platforms/
+  install -Dm644 $srcdir/llvm-cern/cmake/modules/*.cmake "${pkgdir}${MINGW_PREFIX}/share/llvm/cmake/modules/"
+  install -Dm644 $srcdir/llvm-cern/cmake/platforms/*.cmake "${pkgdir}${MINGW_PREFIX}/share/llvm/cmake/platforms/"
 }
 
 package_clang-analyzer() {
@@ -147,7 +150,7 @@ package_clang-analyzer() {
   depends=("${MINGW_PACKAGE_PREFIX}-clang-cern-git" "${MINGW_PACKAGE_PREFIX}-python2")
   provides=("${MINGW_PACKAGE_PREFIX}-clang-analyzer")
   conflicts=("${MINGW_PACKAGE_PREFIX}-clang-analyzer")
-  cd ${srcdir}/llvm-cern/tools/clang
+  cd "${srcdir}/llvm-cern/tools/clang"
   local ver="$(git rev-parse HEAD)"
   pkgver="r$(git rev-list --count HEAD)"
 


### PR DESCRIPTION
Fixes a basic build error with wrong paths relative to srcdir. After pulling the sources with git, most sources are in `$srcdir/../` and not `$srcdir/`. We make a copy into `$srcdir/` so the rest of the build can progress.

This PR does not make cling build successfully. But it removes a simple blocker problem very early on.

I also added better quoting in several places.