### PR TITLE
mingw-w64-libtiff/PKGBUILD: enable the tiff-cxx library

### DIFF
--- a/mingw-w64-libtiff/PKGBUILD
+++ b/mingw-w64-libtiff/PKGBUILD
@@ -24,15 +24,16 @@ sha256sums=('9f43a2cfb9589e5cecaa66e16bf87f814c945f22df7ba600d63aac4632c4f019'
 
 prepare() {
   cd tiff-${pkgver}
-  patch -Nbp1 -i ${srcdir}/fix-hylafax.patch
+
+  patch -Nbp1 -i "${srcdir}/fix-hylafax.patch"
 }
 
 build() {
   export CFLAGS+=" -fno-strict-aliasing"
   export CXXFLAGS+=" -fno-strict-aliasing"
 
-  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
-  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
   ../tiff-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -41,6 +42,7 @@ build() {
     --target=${MINGW_CHOST} \
     --enable-static \
     --enable-shared \
+    --enable-cxx \
     --disable-jbig \
     --without-x
 
@@ -56,10 +58,10 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
 
-  cp ${srcdir}/tiff-${pkgver}/libtiff/{tiffiop,tif_dir}.h ${pkgdir}${MINGW_PREFIX}/include/
-  cp libtiff/tif_config.h ${pkgdir}${MINGW_PREFIX}/include/
+  cp ${srcdir}/tiff-${pkgver}/libtiff/{tiffiop,tif_dir}.h "${pkgdir}${MINGW_PREFIX}/include/"
+  cp "libtiff/tif_config.h" "${pkgdir}${MINGW_PREFIX}/include/"
 
   # License
   # See https://fedoraproject.org/wiki/Licensing:MIT#Hylafax_Variant
-  install -Dm644 ${srcdir}/tiff-${pkgver}/COPYRIGHT "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT"
+  install -Dm644 "${srcdir}/tiff-${pkgver}/COPYRIGHT" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYRIGHT"
 }


### PR DESCRIPTION
enable the tiff-cxx library in configure. This PR also adds a few minor improvements in quoting paths.