### PR TITLE
fontconfig: add an upstream patch to fix the cache update. Fixes #2550

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -5,7 +5,7 @@ _realname=fontconfig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.12.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 url="https://wiki.freedesktop.org/www/Software/fontconfig/"
@@ -19,12 +19,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip')
 install=${_realname}-${CARCH}.install
 source=("https://www.freedesktop.org/software/fontconfig/release/fontconfig-${pkgver}.tar.bz2"
+        fix-cache-update.patch
         0001-fix-config-linking.all.patch
         0002-fix-mkdir.mingw.patch
         0004-fix-mkdtemp.mingw.patch
         0005-fix-setenv.mingw.patch
         0007-pkgconfig.mingw.patch)
 sha256sums=('b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3'
+            'f0d9cab1cc7f6c45303f1ff31c6c52641a2101b4b3c4788fe89c2748ffa48621'
             '1266d4bbd8270f013fee2401c890f0251babf50a175a69d681d3a6af5003c899'
             '0d950eb8a19858bff1f0b26e4a560f589e79e7eb7f22f723267748dfe55e0b63'
             '57ff8420dbf62873b6fcb38b52fb7b37e0e278425a9125e15dccba54668c8ab9'
@@ -33,6 +35,7 @@ sha256sums=('b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3'
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/fix-cache-update.patch
   patch -p1 -i ${srcdir}/0001-fix-config-linking.all.patch
   patch -p1 -i ${srcdir}/0002-fix-mkdir.mingw.patch
   patch -p1 -i ${srcdir}/0004-fix-mkdtemp.mingw.patch

--- a/mingw-w64-fontconfig/fix-cache-update.patch
+++ b/mingw-w64-fontconfig/fix-cache-update.patch
@@ -1,0 +1,59 @@
+From 79058f4e911487275323e93146e1e93ad15afcd8 Mon Sep 17 00:00:00 2001
+From: Masamichi Hosoda <trueroad@trueroad.jp>
+Date: Wed, 11 Jan 2017 20:42:56 +0900
+Subject: Bug 99360 - Fix cache file update on MinGW
+
+On Windows, opened or locked files cannot be removed.
+Since fontconfig locked an old cache file while updating the file,
+fontconfig failed to replace the file with updated file on Windows.
+
+This patch makes fontconfig does not lock the old cache file
+while updating it on Windows.
+
+diff --git a/src/fcdir.c b/src/fcdir.c
+index fd62a34..c8aaf54 100644
+--- a/src/fcdir.c
++++ b/src/fcdir.c
+@@ -362,7 +362,9 @@ FcDirCacheScan (const FcChar8 *dir, FcConfig *config)
+     if (!dirs)
+ 	goto bail1;
+ 
++#ifndef _WIN32
+     fd = FcDirCacheLock (dir, config);
++#endif
+     /*
+      * Scan the dir
+      */
+@@ -382,7 +384,9 @@ FcDirCacheScan (const FcChar8 *dir, FcConfig *config)
+     FcDirCacheWrite (cache, config);
+ 
+  bail2:
++#ifndef _WIN32
+     FcDirCacheUnlock (fd);
++#endif
+     FcStrSetDestroy (dirs);
+  bail1:
+     FcFontSetDestroy (set);
+@@ -417,7 +421,9 @@ FcDirCacheRescan (const FcChar8 *dir, FcConfig *config)
+     if (!dirs)
+ 	goto bail;
+ 
++#ifndef _WIN32
+     fd = FcDirCacheLock (dir, config);
++#endif
+     /*
+      * Scan the dir
+      */
+@@ -436,7 +442,9 @@ FcDirCacheRescan (const FcChar8 *dir, FcConfig *config)
+     FcDirCacheWrite (new, config);
+ 
+ bail1:
++#ifndef _WIN32
+     FcDirCacheUnlock (fd);
++#endif
+     FcStrSetDestroy (dirs);
+ bail:
+     if (d)
+-- 
+cgit v0.10.2
+


### PR DESCRIPTION
See https://cgit.freedesktop.org/fontconfig/commit/?id=79058f4e911487275323e9314