### PR TITLE
mingw-w64-icu - 58.2 - added export  CXXFLAGS+=" -D_WIN32_WINNT=0x601…

### DIFF
--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -10,7 +10,7 @@ _realname=icu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-libs")
 pkgver=58.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="International Components for Unicode library (mingw-w64)"
 arch=('any')
@@ -83,6 +83,7 @@ prepare() {
 
 build() {
   local -a extra_config
+  export CXXFLAGS+=" -D_WIN32_WINNT=0x601"
   cd "${srcdir}/icu/"
   # For ICU we ignore the options for debug above and always
   # build both debug and release (and static and shared).


### PR DESCRIPTION
…" to prevent build failures on some systems.