### PR TITLE
ag: Update to 2.0.0 and support detecting mintty

### DIFF
--- a/mingw-w64-ag/0001-lang-Allow-both-extensions-and-full-filenames.patch
+++ b/mingw-w64-ag/0001-lang-Allow-both-extensions-and-full-filenames.patch
@@ -1,7 +1,7 @@
-From 1ede87c906fc1f9cab44f351c3eadf0080f75cf4 Mon Sep 17 00:00:00 2001
+From bacedeb21cd30101b787838d003d686ae3036838 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Feb 2015 21:46:45 +0000
-Subject: [PATCH 1/6] lang: Allow both extensions and full filenames
+Subject: [PATCH 1/7] lang: Allow both extensions and full filenames
 
 Because many filetypes (e.g. make) are not indicated by the
 file extension but instead by the full filename (Makefile).
@@ -16,10 +16,10 @@ are indicated by prefixing the pattern with a '^'.
  3 files changed, 60 insertions(+), 47 deletions(-)
 
 diff --git a/src/lang.c b/src/lang.c
-index 96d6be0..37d61ac 100644
+index 5ccd860..17783ae 100644
 --- a/src/lang.c
 +++ b/src/lang.c
-@@ -109,20 +109,27 @@ size_t get_lang_count() {
+@@ -115,20 +115,27 @@ size_t get_lang_count() {
      return sizeof(langs) / sizeof(lang_spec_t);
  }
  
@@ -55,7 +55,7 @@ index 96d6be0..37d61ac 100644
              regex_capacity *= 2;
              regex = ag_realloc(regex, regex_capacity);
          }
-@@ -131,8 +138,12 @@ char *make_lang_regex(char *ext_array, size_t num_exts) {
+@@ -137,8 +144,12 @@ char *make_lang_regex(char *ext_array, size_t num_exts) {
          } else {
              subsequent = 1;
          }
@@ -70,7 +70,7 @@ index 96d6be0..37d61ac 100644
      }
  
      regex[regex_length++] = ')';
-@@ -141,29 +152,29 @@ char *make_lang_regex(char *ext_array, size_t num_exts) {
+@@ -147,29 +158,29 @@ char *make_lang_regex(char *ext_array, size_t num_exts) {
      return regex;
  }
  
@@ -165,10 +165,10 @@ index d0007f9..202da4b 100644
 +size_t combine_file_patterns(size_t *pattern_index, size_t len, char **pats);
  #endif
 diff --git a/src/options.c b/src/options.c
-index 67567eb..1e7648e 100644
+index dbe3e24..b8da938 100644
 --- a/src/options.c
 +++ b/src/options.c
-@@ -212,9 +212,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -224,9 +224,9 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
      size_t longopts_len, full_len;
      option_t *longopts;
      char *lang_regex = NULL;
@@ -181,7 +181,7 @@ index 67567eb..1e7648e 100644
  
      init_options();
  
-@@ -318,8 +318,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -332,8 +332,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
      full_len = (longopts_len + lang_count + 1);
      longopts = ag_malloc(full_len * sizeof(option_t));
      memcpy(longopts, base_longopts, sizeof(base_longopts));
@@ -192,7 +192,7 @@ index 67567eb..1e7648e 100644
  
      for (i = 0; i < lang_count; i++) {
          option_t opt = { langs[i].name, no_argument, NULL, 0 };
-@@ -561,7 +561,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -580,7 +580,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
                  for (i = 0; i < lang_count; i++) {
                      if (strcmp(longopts[opt_index].name, langs[i].name) == 0) {
                          has_filetype = 1;
@@ -201,7 +201,7 @@ index 67567eb..1e7648e 100644
                          break;
                      }
                  }
-@@ -595,15 +595,15 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -614,15 +614,15 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
      }
  
      if (has_filetype) {
@@ -222,7 +222,7 @@ index 67567eb..1e7648e 100644
      if (lang_regex) {
          free(lang_regex);
      }
-@@ -644,8 +644,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -663,8 +663,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
          for (lang_index = 0; lang_index < lang_count; lang_index++) {
              printf("  --%s\n    ", langs[lang_index].name);
              int j;
@@ -234,5 +234,5 @@ index 67567eb..1e7648e 100644
              printf("\n\n");
          }
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/0002-win32-Detect-Cygwin-MSYS-PTY.patch
+++ b/mingw-w64-ag/0002-win32-Detect-Cygwin-MSYS-PTY.patch
@@ -1,0 +1,357 @@
+From d7dfee733c29dae96984be373db934298d4ac53f Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Thu, 1 Jun 2017 22:19:25 +0900
+Subject: [PATCH 2/7] win32: Detect Cygwin/MSYS PTY
+
+When running Win32 version of Ag on mintty or other Cygwin/MSYS terminal
+emulators, Ag cannot detect Cygwin/MSYS pty and it causes some problems.
+E.g.
+https://github.com/ggreer/the_silver_searcher/issues/535#issuecomment-70944218
+https://github.com/Alexpux/MSYS2-packages/pull/491
+
+Import a check routine from https://github.com/k-takata/ptycheck .
+---
+ Makefile.am     |   2 +-
+ Makefile.w32    |   5 +-
+ configure.ac    |   1 +
+ src/iscygpty.c  | 185 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/iscygpty.h  |  41 +++++++++++++
+ src/options.c   |   5 +-
+ src/print_w32.c |   2 +
+ 7 files changed, 236 insertions(+), 5 deletions(-)
+ create mode 100644 src/iscygpty.c
+ create mode 100644 src/iscygpty.h
+
+diff --git a/Makefile.am b/Makefile.am
+index 93aac08..29ad4bd 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,7 +1,7 @@
+ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS}
+ 
+ bin_PROGRAMS = ag
+-ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c
++ag_SOURCES = src/ignore.c src/ignore.h src/log.c src/log.h src/options.c src/options.h src/print.c src/print_w32.c src/print.h src/scandir.c src/scandir.h src/search.c src/search.h src/lang.c src/lang.h src/util.c src/util.h src/decompress.c src/decompress.h src/uthash.h src/main.c src/iscygpty.c src/iscygpty.h
+ ag_LDADD = ${PCRE_LIBS} ${LZMA_LIBS} ${ZLIB_LIBS} $(PTHREAD_LIBS)
+ 
+ dist_man_MANS = doc/ag.1
+diff --git a/Makefile.w32 b/Makefile.w32
+index 2794651..9688bba 100644
+--- a/Makefile.w32
++++ b/Makefile.w32
+@@ -15,10 +15,11 @@ SRCS = \
+ 	src/scandir.c \
+ 	src/search.c \
+ 	src/util.c \
+-	src/print_w32.c
++	src/print_w32.c \
++	src/iscygpty.c
+ OBJS = $(subst .c,.o,$(SRCS))
+ 
+-CFLAGS = -O2 -Isrc/win32 -DPACKAGE_VERSION=\"$(VERSION)\"
++CFLAGS = -O2 -Isrc/win32 -DPACKAGE_VERSION=\"$(VERSION)\" -D_WIN32_WINNT=0x0600
+ LIBS = -lz -lpthread -lpcre -llzma -lshlwapi
+ TARGET = ag.exe
+ 
+diff --git a/configure.ac b/configure.ac
+index 3fa9c98..8808c69 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -36,6 +36,7 @@ LDFLAGS="$LDFLAGS"
+ case $host in
+ *mingw*)
+     AC_CHECK_LIB(shlwapi, main,, AC_MSG_ERROR(libshlwapi missing))
++    CFLAGS="$CFLAGS -D_WIN32_WINNT=0x0600"
+ esac
+ 
+ LIBS="$PTHREAD_LIBS $LIBS"
+diff --git a/src/iscygpty.c b/src/iscygpty.c
+new file mode 100644
+index 0000000..6a0d63e
+--- /dev/null
++++ b/src/iscygpty.c
+@@ -0,0 +1,185 @@
++/*
++ * iscygpty.c -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifdef _WIN32
++
++#include <ctype.h>
++#include <io.h>
++#include <wchar.h>
++#include <windows.h>
++
++#ifdef USE_FILEEXTD
++/* VC 7.1 or earlier doesn't support SAL. */
++# if !defined(_MSC_VER) || (_MSC_VER < 1400)
++#  define __out
++#  define __in
++#  define __in_opt
++# endif
++/* Win32 FileID API Library:
++ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
++ * Needed for WinXP. */
++# include <fileextd.h>
++#else /* USE_FILEEXTD */
++/* VC 8 or earlier. */
++# if defined(_MSC_VER) && (_MSC_VER < 1500)
++#  ifdef ENABLE_STUB_IMPL
++#   define STUB_IMPL
++#  else
++#   error "Win32 FileID API Library is required for VC2005 or earlier."
++#  endif
++# endif
++#endif /* USE_FILEEXTD */
++
++
++#include "iscygpty.h"
++
++//#define USE_DYNFILEID
++#ifdef USE_DYNFILEID
++typedef BOOL (WINAPI *pfnGetFileInformationByHandleEx)(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++);
++static pfnGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
++
++# ifndef USE_FILEEXTD
++static BOOL WINAPI stub_GetFileInformationByHandleEx(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++		)
++{
++	return FALSE;
++}
++# endif
++
++static void setup_fileid_api(void)
++{
++	if (pGetFileInformationByHandleEx != NULL) {
++		return;
++	}
++	pGetFileInformationByHandleEx = (pfnGetFileInformationByHandleEx)
++		GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
++				"GetFileInformationByHandleEx");
++	if (pGetFileInformationByHandleEx == NULL) {
++# ifdef USE_FILEEXTD
++		pGetFileInformationByHandleEx = GetFileInformationByHandleEx;
++# else
++		pGetFileInformationByHandleEx = stub_GetFileInformationByHandleEx;
++# endif
++	}
++}
++#else
++# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
++# define setup_fileid_api()
++#endif
++
++
++#define is_wprefix(s, prefix) \
++	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
++
++/* Check if the fd is a cygwin/msys's pty. */
++int is_cygpty(int fd)
++{
++#ifdef STUB_IMPL
++	return 0;
++#else
++	HANDLE h;
++	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * MAX_PATH;
++	FILE_NAME_INFO *nameinfo;
++	WCHAR *p = NULL;
++
++	setup_fileid_api();
++
++	h = (HANDLE) _get_osfhandle(fd);
++	if (h == INVALID_HANDLE_VALUE) {
++		return 0;
++	}
++	/* Cygwin/msys's pty is a pipe. */
++	if (GetFileType(h) != FILE_TYPE_PIPE) {
++		return 0;
++	}
++	nameinfo = malloc(size);
++	if (nameinfo == NULL) {
++		return 0;
++	}
++	/* Check the name of the pipe:
++	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
++	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
++		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
++		p = nameinfo->FileName;
++		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
++			p += 8;
++		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
++			p += 6;
++		} else {
++			p = NULL;
++		}
++		if (p != NULL) {
++			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
++				++p;
++			if (is_wprefix(p, L"-pty")) {
++				p += 4;
++			} else {
++				p = NULL;
++			}
++		}
++		if (p != NULL) {
++			while (*p && isdigit(*p))	/* Skip pty number. */
++				++p;
++			if (is_wprefix(p, L"-from-master")) {
++				//p += 12;
++			} else if (is_wprefix(p, L"-to-master")) {
++				//p += 10;
++			} else {
++				p = NULL;
++			}
++		}
++	}
++	free(nameinfo);
++	return (p != NULL);
++#endif /* STUB_IMPL */
++}
++
++/* Check if at least one cygwin/msys pty is used. */
++int is_cygpty_used(void)
++{
++	int fd, ret = 0;
++
++	for (fd = 0; fd < 3; fd++) {
++		ret |= is_cygpty(fd);
++	}
++	return ret;
++}
++
++#endif /* _WIN32 */
++
++/* vim: set ts=4 sw=4: */
+diff --git a/src/iscygpty.h b/src/iscygpty.h
+new file mode 100644
+index 0000000..82fd0af
+--- /dev/null
++++ b/src/iscygpty.h
+@@ -0,0 +1,41 @@
++/*
++ * iscygpty.h -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifndef _ISCYGPTY_H
++#define _ISCYGPTY_H
++
++#ifdef _WIN32
++int is_cygpty(int fd);
++int is_cygpty_used(void);
++#else
++#define is_cygpty(fd)		0
++#define is_cygpty_used()	0
++#endif
++
++#endif /* _ISCYGPTY_H */
+diff --git a/src/options.c b/src/options.c
+index b8da938..83152c5 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -10,6 +10,7 @@
+ 
+ #include "config.h"
+ #include "ignore.h"
++#include "iscygpty.h"
+ #include "lang.h"
+ #include "log.h"
+ #include "options.h"
+@@ -350,7 +351,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+ 
+     rv = fstat(fileno(stdin), &statbuf);
+     if (rv == 0) {
+-        if (S_ISFIFO(statbuf.st_mode) || S_ISREG(statbuf.st_mode)) {
++        if ((S_ISFIFO(statbuf.st_mode) || S_ISREG(statbuf.st_mode)) && !is_cygpty(fileno(stdin))) {
+             opts.search_stream = 1;
+         }
+     }
+@@ -359,7 +360,7 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+         * turn off colors
+         * print filenames on every line
+      */
+-    if (!isatty(fileno(stdout))) {
++    if (!isatty(fileno(stdout)) && !is_cygpty(fileno(stdout))) {
+         opts.color = 0;
+         group = 0;
+ 
+diff --git a/src/print_w32.c b/src/print_w32.c
+index a1fd387..f0a8de6 100644
+--- a/src/print_w32.c
++++ b/src/print_w32.c
+@@ -1,5 +1,6 @@
+ #ifdef _WIN32
+ 
++#include "iscygpty.h"
+ #include "print.h"
+ #include <io.h>
+ #include <stdarg.h>
+@@ -47,6 +48,7 @@ int fprintf_w32(FILE *fp, const char *format, ...) {
+     // the user just prefers ansi, do plain passthrough.
+     BOOL passthrough =
+         g_use_ansi ||
++        is_cygpty(fileno(fp)) ||
+         !isatty(fileno(fp)) ||
+         INVALID_HANDLE_VALUE == (stdo = (HANDLE)_get_osfhandle(fileno(fp))) ||
+         !GetConsoleScreenBufferInfo(stdo, &csbi);
+-- 
+2.12.1
+

--- a/mingw-w64-ag/0003-options-Fix-ordering-problems-with-color.patch
+++ b/mingw-w64-ag/0003-options-Fix-ordering-problems-with-color.patch
@@ -1,7 +1,7 @@
-From ac70e920d375b271adfeaedba68d8d086d36b7d1 Mon Sep 17 00:00:00 2001
+From ff4e9c3db5b42541494764ad921c80250733e84a Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Feb 2015 22:12:15 +0000
-Subject: [PATCH 2/6] options: Fix ordering problems with --color
+Subject: [PATCH 3/7] options: Fix ordering problems with --color
 
 Moved around the logic of setting opts.color so that:
 
@@ -18,15 +18,15 @@ Moved around the logic of setting opts.color so that:
 
 4. Default color to TRUE if MSYSCON env. var = mintty.exe
 ---
- src/options.c | 150 +++++++++++++++++++++++++++++++++++-----------------------
+ src/options.c | 145 +++++++++++++++++++++++++++++++++++-----------------------
  src/options.h |  10 ++++
- 2 files changed, 102 insertions(+), 58 deletions(-)
+ 2 files changed, 97 insertions(+), 58 deletions(-)
 
 diff --git a/src/options.c b/src/options.c
-index 1e7648e..8d86e39 100644
+index 83152c5..ca94126 100644
 --- a/src/options.c
 +++ b/src/options.c
-@@ -140,8 +140,16 @@ void print_version(void) {
+@@ -146,8 +146,16 @@ void print_version(void) {
  void init_options(void) {
      memset(&opts, 0, sizeof(opts));
      opts.casing = CASE_DEFAULT;
@@ -44,8 +44,8 @@ index 1e7648e..8d86e39 100644
 +
      opts.max_matches_per_file = 0;
      opts.max_search_depth = DEFAULT_MAX_SEARCH_DEPTH;
-     opts.mmap = TRUE;
-@@ -228,11 +236,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+ #if defined(__APPLE__) || defined(__MACH__)
+@@ -241,11 +249,11 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
          { "before", optional_argument, NULL, 'B' },
          { "break", no_argument, &opts.print_break, 1 },
          { "case-sensitive", no_argument, NULL, 's' },
@@ -59,7 +59,7 @@ index 1e7648e..8d86e39 100644
          { "column", no_argument, &opts.column, 1 },
          { "context", optional_argument, NULL, 'C' },
          { "count", no_argument, NULL, 'c' },
-@@ -265,8 +273,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -279,8 +287,8 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
          { "noaffinity", no_argument, &opts.use_thread_affinity, 0 },
          { "no-break", no_argument, &opts.print_break, 0 },
          { "nobreak", no_argument, &opts.print_break, 0 },
@@ -70,7 +70,7 @@ index 1e7648e..8d86e39 100644
          { "no-filename", no_argument, NULL, 0 },
          { "nofilename", no_argument, NULL, 0 },
          { "no-follow", no_argument, &opts.follow_symlinks, 0 },
-@@ -341,22 +349,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -356,22 +364,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
          }
      }
  
@@ -78,7 +78,7 @@ index 1e7648e..8d86e39 100644
 -        * turn off colors
 -        * print filenames on every line
 -     */
--    if (!isatty(fileno(stdout))) {
+-    if (!isatty(fileno(stdout)) && !is_cygpty(fileno(stdout))) {
 -        opts.color = 0;
 -        group = 0;
 -
@@ -93,7 +93,7 @@ index 1e7648e..8d86e39 100644
      char *file_search_regex = NULL;
      while ((ch = getopt_long(argc, argv, "A:aB:C:cDG:g:FfHhiLlm:nop:QRrSsvVtuUwW:z0", longopts, &opt_index)) != -1) {
          switch (ch) {
-@@ -707,42 +699,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+@@ -727,42 +719,6 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
          opts.after = opts.context;
      }
  
@@ -134,9 +134,9 @@ index 1e7648e..8d86e39 100644
 -    }
 -
      if (accepts_query && argc > 0) {
-         // use the provided query
-         opts.query = ag_strdup(argv[0]);
-@@ -806,6 +762,84 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
+         if (!needs_query && strlen(argv[0]) == 0) {
+             // use default query
+@@ -842,6 +798,79 @@ void parse_options(int argc, char **argv, char **base_paths[], char **paths[]) {
      (*paths)[i] = NULL;
      (*base_paths)[i] = NULL;
  
@@ -144,7 +144,7 @@ index 1e7648e..8d86e39 100644
 +        * turn off colors
 +        * print filenames on every line
 +     */
-+    if (!isatty(fileno(stdout))) {
++    if (!isatty(fileno(stdout)) && !is_cygpty(fileno(stdout))) {
 +        /* Don't search the file that stdout is redirected to */
 +        rv = fstat(fileno(stdout), &statbuf);
 +        if (rv != 0) {
@@ -153,16 +153,11 @@ index 1e7648e..8d86e39 100644
 +        opts.stdout_inode = statbuf.st_ino;
 +        /* Assume the user knows best */
 +        if (opts.color != COLOR_EXPLICIT_TRUE) {
-+         /* On Windows redirection to regular file *can* br detected via
++         /* On Windows redirection to regular file *can* be detected via
 +            statbuf.st_mode & S_IFREG (while statbuf.st_ino is always 0) */
 +            if (statbuf.st_ino != 0
 +             || statbuf.st_mode & S_IFREG
-+#if !defined(_WIN32)
-+                /* On Windows bash.exe pipes cannot be distinguished from cmd.exe
-+                   pipes or mintty.exe console output (statbuf.st_mode & S_IFIFO)
-+                   so its best not to disable color output here. */
 +             || statbuf.st_mode & S_IFIFO
-+#endif
 +            ) {
 +                opts.color = COLOR_DEFAULT_FALSE;
 +                group = 0;
@@ -222,7 +217,7 @@ index 1e7648e..8d86e39 100644
      windows_use_ansi(opts.color_win_ansi);
  #endif
 diff --git a/src/options.h b/src/options.h
-index 273bb9a..a617a11 100644
+index db3e896..990ce6a 100644
 --- a/src/options.h
 +++ b/src/options.h
 @@ -26,6 +26,16 @@ enum path_print_behavior {
@@ -243,5 +238,5 @@ index 273bb9a..a617a11 100644
      int ackmate;
      pcre *ackmate_dir_filter;
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/0004-lang-Add-autotools-ac-am-in-m4-pc.patch
+++ b/mingw-w64-ag/0004-lang-Add-autotools-ac-am-in-m4-pc.patch
@@ -1,14 +1,14 @@
-From d08c1df938db1b002c8bb2880ef302795214d008 Mon Sep 17 00:00:00 2001
+From b266b48b70a736927a8ee585fc888f270005973b Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Feb 2015 22:16:54 +0000
-Subject: [PATCH 3/6] lang: Add autotools (ac, am, in, m4, pc)
+Subject: [PATCH 4/7] lang: Add autotools (ac, am, in, m4, pc)
 
 ---
  src/lang.c | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/src/lang.c b/src/lang.c
-index 37d61ac..b0f4aec 100644
+index 17783ae..df58f77 100644
 --- a/src/lang.c
 +++ b/src/lang.c
 @@ -8,6 +8,7 @@ lang_spec_t langs[] = {
@@ -20,5 +20,5 @@ index 37d61ac..b0f4aec 100644
      { "bitbake", { "bb", "bbappend", "bbclass", "inc" } },
      { "bro", { "bro", "bif" } },
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/0005-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch
+++ b/mingw-w64-ag/0005-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch
@@ -1,7 +1,7 @@
-From e38826920ff1f2927b63f6c51663197fa147fd0e Mon Sep 17 00:00:00 2001
+From 1ce3c7f6347a86f210cfa2578444fcb09a5aaa6c Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Feb 2015 22:18:27 +0000
-Subject: [PATCH 4/6] lang: Add to make (^Makefile, ^Makefile.Debug,
+Subject: [PATCH 5/7] lang: Add to make (^Makefile, ^Makefile.Debug,
  ^Makefile.Release, *.make)
 
 All but one addition are full filename patterns. The
@@ -12,11 +12,11 @@ one is used by CMake.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/lang.c b/src/lang.c
-index b0f4aec..ec39d61 100644
+index df58f77..ca40be6 100644
 --- a/src/lang.c
 +++ b/src/lang.c
-@@ -50,7 +50,7 @@ lang_spec_t langs[] = {
-     { "lisp", { "lisp", "lsp" } },
+@@ -54,7 +54,7 @@ lang_spec_t langs[] = {
+     { "log", { "log" } },
      { "lua", { "lua" } },
      { "m4", { "m4" } },
 -    { "make", { "Makefiles", "mk", "mak" } },
@@ -25,5 +25,5 @@ index b0f4aec..ec39d61 100644
      { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
      { "mason", { "mas", "mhtml", "mpl", "mtxt" } },
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/0006-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch
+++ b/mingw-w64-ag/0006-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch
@@ -1,7 +1,7 @@
-From 9a33ddf551f8421fd8d73bc473a6298922f5af09 Mon Sep 17 00:00:00 2001
+From add99f2fab7f6015e5a414c33248c3a8b3b20fe6 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Feb 2015 22:21:26 +0000
-Subject: [PATCH 5/6] lang: Add makepkg (^PKGBUILD, diff, patch, in, install)
+Subject: [PATCH 6/7] lang: Add makepkg (^PKGBUILD, diff, patch, in, install)
 
 Used by the makepkg build system of ArchLinux and MSYS2
 ---
@@ -9,10 +9,10 @@ Used by the makepkg build system of ArchLinux and MSYS2
  1 file changed, 1 insertion(+)
 
 diff --git a/src/lang.c b/src/lang.c
-index ec39d61..90637ed 100644
+index ca40be6..0848fb1 100644
 --- a/src/lang.c
 +++ b/src/lang.c
-@@ -51,6 +51,7 @@ lang_spec_t langs[] = {
+@@ -55,6 +55,7 @@ lang_spec_t langs[] = {
      { "lua", { "lua" } },
      { "m4", { "m4" } },
      { "make", { "^Makefile", "^Makefile.Debug", "^Makefile.Release", "Makefiles", "mk", "mak", "make" } },
@@ -21,5 +21,5 @@ index ec39d61..90637ed 100644
      { "markdown", { "markdown", "mdown", "mdwn", "mkdn", "mkd", "md" } },
      { "mason", { "mas", "mhtml", "mpl", "mtxt" } },
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/0007-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch
+++ b/mingw-w64-ag/0007-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch
@@ -1,7 +1,7 @@
-From 9dd0f2868112d2715925cc44ec49b045e050b8ae Mon Sep 17 00:00:00 2001
+From e7ff323818bfd2bbf7d00a885e5a28da9b36f64b Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 12 Dec 2015 19:55:47 +0000
-Subject: [PATCH 6/6] lang: Add cmake (^CMakeLists.txt, ^CMakeCache.txt ..
+Subject: [PATCH 7/7] lang: Add cmake (^CMakeLists.txt, ^CMakeCache.txt ..
 
 .. ^CMakeError.log, ^CMakeOutput.log, cmake)
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 6/6] lang: Add cmake (^CMakeLists.txt, ^CMakeCache.txt ..
  1 file changed, 1 insertion(+)
 
 diff --git a/src/lang.c b/src/lang.c
-index 90637ed..bf41d4f 100644
+index 0848fb1..b608180 100644
 --- a/src/lang.c
 +++ b/src/lang.c
 @@ -16,6 +16,7 @@ lang_spec_t langs[] = {
@@ -21,5 +21,5 @@ index 90637ed..bf41d4f 100644
      { "cpp", { "cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx", "tpp" } },
      { "crystal", { "cr", "ecr" } },
 -- 
-2.10.1
+2.12.1
 

--- a/mingw-w64-ag/PKGBUILD
+++ b/mingw-w64-ag/PKGBUILD
@@ -5,7 +5,7 @@ _realname=ag
 _longname=the_silver_searcher
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.1.r1830.d48fa88
+pkgver=2.0.0.r1912.54ecc7d
 pkgrel=1
 pkgdesc="The Silver Searcher: An attempt to make something better than ack, which itself is better than grep (mingw-w64)"
 arch=('any')
@@ -20,18 +20,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-pcre"
 options=('staticlibs') # '!strip' 'debug')
 source=("${_realname}"::"git+https://github.com/ggreer/the_silver_searcher.git"
         "0001-lang-Allow-both-extensions-and-full-filenames.patch"
-        "0002-options-Fix-ordering-problems-with-color.patch"
-        "0003-lang-Add-autotools-ac-am-in-m4-pc.patch"
-        "0004-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch"
-        "0005-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch"
-        "0006-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch")
+        "0002-win32-Detect-Cygwin-MSYS-PTY.patch"
+        "0003-options-Fix-ordering-problems-with-color.patch"
+        "0004-lang-Add-autotools-ac-am-in-m4-pc.patch"
+        "0005-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch"
+        "0006-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch"
+        "0007-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch")
 sha256sums=('SKIP'
-            'f4c06e982f0465febd70237fec85eb52ae8308bd0931c8c38784c2b57ffb0d59'
-            '0ed184b58980f13670d7a58c37fbe24a6834c50985d85050643178f0021712d8'
-            'f27611170b05d809d3580bcd2d44cf7f5a4cd3c1c8e5111be340e85c7a2647d8'
-            '03ae0a003b1420ab94f645a42f6255d07f8493f1a4f19bdc8a20974b38a78784'
-            'c9234420ac2069fcb1864fa3389f402a201967b308ec25656aaaa62055ee5bd2'
-            '75d3a7eb3d6bd1b4d8d28349fead8da94bd233e42b2d8e1cb8af6611f0f0aeff')
+            '9a3c1cc11547219f699e953e05c53b779f396b3d54d1410ae78a62f7550ca7c7'
+            '53bf2bb511f55e3969ad471fdeb954126a404d041b7c7b34b01f95641d6edb59'
+            '63ded2c4bf859faa8dc33cbda89c4bbdb047b014d7b3b4d3f77f9dfb5d1a0ee4'
+            '54cfef09f429c7913c1a18e74946444ccddcbd9634bc243a268766eb4802b4e9'
+            'fada103d58911e876af36e76675793764c4019e009351d615dede9c3ba7618d1'
+            'b80e3efd854425e0e5df29cdf585b5132b5ab19e93c06713a4f4f0653bed5f84'
+            '82e7e4262b1579efa95bef8ab3f1ec3e2c87ead687fe8d5ac26e716a29cd1d47')
 
 pkgver() {
   cd ${srcdir}/${_realname}
@@ -42,11 +44,12 @@ pkgver() {
 prepare() {
   cd "${srcdir}"/${_realname}
   git am "${srcdir}"/0001-lang-Allow-both-extensions-and-full-filenames.patch
-  git am "${srcdir}"/0002-options-Fix-ordering-problems-with-color.patch
-  git am "${srcdir}"/0003-lang-Add-autotools-ac-am-in-m4-pc.patch
-  git am "${srcdir}"/0004-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch
-  git am "${srcdir}"/0005-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch
-  git am "${srcdir}"/0006-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch
+  git am "${srcdir}"/0002-win32-Detect-Cygwin-MSYS-PTY.patch
+  git am "${srcdir}"/0003-options-Fix-ordering-problems-with-color.patch
+  git am "${srcdir}"/0004-lang-Add-autotools-ac-am-in-m4-pc.patch
+  git am "${srcdir}"/0005-lang-Add-to-make-Makefile-Makefile.Debug-Makefile.Re.patch
+  git am "${srcdir}"/0006-lang-Add-makepkg-PKGBUILD-diff-patch-in-install.patch
+  git am "${srcdir}"/0007-lang-Add-cmake-CMakeLists.txt-CMakeCache.txt.patch
 
   # configure.ac forces -O2, so force it to -O0 if debugging.
   if check_option "debug" "y"; then


### PR DESCRIPTION
* Update to 2.0.0.
* Import a patch to detect mintty from ggreer/the_silver_searcher#1099.
  This fixes a well known problem which has been reported many times:
  #431, Alexpux/MSYS2-packages#491, Alexpux/MSYS2-packages#730, etc.

A few days ago, I created a PR on the ag repository: ggreer/the_silver_searcher#1099.
I believe this is very useful for MSYS2 users, but I'm not sure it will be merged soon.
So I create this PR.