### PR TITLE
pygobject: Update to 3.25.1

### DIFF
--- a/mingw-w64-pygobject/PKGBUILD
+++ b/mingw-w64-pygobject/PKGBUILD
@@ -3,26 +3,26 @@
 _realname=pygobject
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-gobject" "${MINGW_PACKAGE_PREFIX}-python3-gobject" "${MINGW_PACKAGE_PREFIX}-pygobject-devel")
-pkgver=3.24.1
+pkgver=3.25.1
 pkgrel=1
-pkgdesc="Allows you to load glade interface files in a program at runtime (mingw-w64)"
+pkgdesc="Python Bindings for GLib/GObject/GIO/GTK+ (mingw-w64)"
 arch=(any)
-url="http://www.pygtk.org"
+url="https://git.gnome.org/browse/pygobject"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-python3-cairo"
              "${MINGW_PACKAGE_PREFIX}-python2-cairo"
-             "${MINGW_PACKAGE_PREFIX}-gnome-common")
+             "autoconf-archive")
 options=('staticlibs' 'strip')
 source=(https://download.gnome.org/sources/pygobject/${pkgver%.*}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('a628a95aa0909e13fb08230b1b98fc48adef10b220932f76d62f6821b3fdbffd')
+sha256sums=('8728bb27078f7ee45c431ccbc237a58fb6d6eb1b7a0668bbe29eb107267bd736')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
-  autoreconf -fi
-  #WANT_AUTOMAKE=latest ./autogen.sh
+
+  NOCONFIGURE=1 ./autogen.sh
 }
 
 build() {


### PR DESCRIPTION
While this is an unstable release, I've pushed various Windows related
fixes upstream. No need to wait until September for 3.26...