### PR TITLE
qt5: Static build fixes.

### DIFF
--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -467,11 +467,14 @@ build() {
     configure_opts+=("-static")
     configure_opts+=("-openssl-linked")
     configure_opts+=("-no-fontconfig")
+    configure_opts+=("-no-icu")
     configure_opts+=("-qt-zlib")
     configure_opts+=("-qt-pcre")
     configure_opts+=("-qt-libpng")
     configure_opts+=("-qt-libjpeg")
     configure_opts+=("-qt-harfbuzz")
+    configure_opts+=("-qt-freetype")
+    configure_opts+=("-skip" "qtimageformats")
   else
     configure_opts+=("-shared")
     if [ "$_with_fontconfig" == "no" ]; then


### PR DESCRIPTION
Uses "-no-icu" and "-qt-freetype".
And, skips "qtimageformats" because it has an build error.

Fixed at least some of the build problems for static library.
It has been building for over 8 hours; but, it has NOT yet finished.
So, there might be some more errors to fix in static builds.

Tim S.