### PR TITLE
ffmpeg: Update to 3.3.2

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=ffmpeg
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.1
-pkgrel=2
+pkgver=3.3.2
+pkgrel=1
 pkgdesc="Complete and free Internet live audio and video broadcasting solution (mingw-w64)"
 arch=('any')
 url="https://ffmpeg.org/"
@@ -43,7 +43,7 @@ depends=(
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-yasm")
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz{,.asc})
 validpgpkeys=('FCF986EA15E6E293A5644F10B4322F04D67658D8')
-sha256sums=('b702a7fc656ac23e276b8c823a2f646e4e6f6309bb2788435a708e69bea98f2f'
+sha256sums=('1998de1ab32616cbf2ff86efc3f1f26e76805ec5dc51e24c041c79edd8262785'
             'SKIP')
 
 prepare() {
@@ -54,11 +54,6 @@ build() {
   [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
-
-  local opt_conf="--enable-libopenjpeg"
-  if [ "${CARCH}" = "i686" ]; then
-    opt_conf=""
-  fi
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \
@@ -82,7 +77,7 @@ build() {
     --enable-libmp3lame \
     --enable-libopencore_amrnb \
     --enable-libopencore_amrwb \
-    ${opt_conf} \
+    --enable-libopenjpeg \
     --enable-libopus \
     --enable-librtmp \
     --enable-libschroedinger \
@@ -107,7 +102,7 @@ build() {
     --disable-doc
     #--enable-pthreads
 
-  make -j1
+  make
 }
 
 check() {


### PR DESCRIPTION
Remove workaround for --enable-libopenjpeg and parallel make.
It seems to build fine here without those changes.