### PR TITLE
fontconfig: Update to 2.12.3

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=fontconfig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.12.1
-pkgrel=2
+pkgver=2.12.3
+pkgrel=1
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 url="https://wiki.freedesktop.org/www/Software/fontconfig/"
@@ -25,7 +25,7 @@ source=("https://www.freedesktop.org/software/fontconfig/release/fontconfig-${pk
         0004-fix-mkdtemp.mingw.patch
         0005-fix-setenv.mingw.patch
         0007-pkgconfig.mingw.patch)
-sha256sums=('b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3'
+sha256sums=('bd24bf6602731a11295c025909d918180e98385625182d3b999fd6f1ab34f8bd'
             'f0d9cab1cc7f6c45303f1ff31c6c52641a2101b4b3c4788fe89c2748ffa48621'
             '1266d4bbd8270f013fee2401c890f0251babf50a175a69d681d3a6af5003c899'
             '0d950eb8a19858bff1f0b26e4a560f589e79e7eb7f22f723267748dfe55e0b63'
@@ -47,9 +47,9 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cp -rf "${srcdir}"/${_realname}-${pkgver} "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
-  ../${_realname}-${pkgver}/configure \
+  ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \


### PR DESCRIPTION
This changes the build to a srcdir=builddir build.
srcdir!=builddir was broken upstream and I reported it at
https://bugs.freedesktop.org/show_bug.cgi?id=101280 but the provided patches didn't help.