### PR TITLE
Update gtest to 1.8.0

### DIFF
--- a/mingw-w64-gtest/0000-Fix-compilation-of-googletest-with-MinGW-using-Win32-threads.patch
+++ b/mingw-w64-gtest/0000-Fix-compilation-of-googletest-with-MinGW-using-Win32-threads.patch
@@ -1,0 +1,81 @@
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 777b91e..8878dc1 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -46,7 +46,9 @@ endmacro()
+ # Google Mock.  You can tweak these definitions to suit your need.  A
+ # variable's value is empty before it's explicitly assigned to.
+ macro(config_compiler_and_linker)
+-  if (NOT gtest_disable_pthreads)
++  # Note: pthreads on MinGW is not supported, even if available
++  # instead, we use windows threading primitives
++  if (NOT gtest_disable_pthreads AND NOT MINGW)
+     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
+     find_package(Threads)
+   endif()
+diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
+index 0094ed5..92f4c11 100644
+--- a/googletest/include/gtest/internal/gtest-port.h
++++ b/googletest/include/gtest/internal/gtest-port.h
+@@ -396,10 +396,16 @@
+ #  include <io.h>
+ # endif
+ // In order to avoid having to include <windows.h>, use forward declaration
+-// assuming CRITICAL_SECTION is a typedef of _RTL_CRITICAL_SECTION.
++#if GTEST_OS_WINDOWS_MINGW
++// MinGW defined _CRITICAL_SECTION and _RTL_CRITICAL_SECTION as two
++// separate (equivalent) structs, instead of using typedef
++typedef struct _CRITICAL_SECTION GTEST_CRITICAL_SECTION;
++#else
++// Assume CRITICAL_SECTION is a typedef of _RTL_CRITICAL_SECTION.
+ // This assumption is verified by
+ // WindowsTypesTest.CRITICAL_SECTIONIs_RTL_CRITICAL_SECTION.
+-struct _RTL_CRITICAL_SECTION;
++typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
++#endif
+ #else
+ // This assumes that non-Windows OSes provide unistd.h. For OSes where this
+ // is not the case, we need to include headers that provide the functions
+@@ -1693,7 +1699,7 @@ class GTEST_API_ Mutex {
+   // by the linker.
+   MutexType type_;
+   long critical_section_init_phase_;  // NOLINT
+-  _RTL_CRITICAL_SECTION* critical_section_;
++  GTEST_CRITICAL_SECTION* critical_section_;
+ 
+   GTEST_DISALLOW_COPY_AND_ASSIGN_(Mutex);
+ };
+diff --git a/googletest/test/gtest-port_test.cc b/googletest/test/gtest-port_test.cc
+index 6ea607b..05f8821 100644
+--- a/googletest/test/gtest-port_test.cc
++++ b/googletest/test/gtest-port_test.cc
+@@ -1295,9 +1295,16 @@ TEST(WindowsTypesTest, HANDLEIsVoidStar) {
+   StaticAssertTypeEq<HANDLE, void*>();
+ }
+ 
++#if GTEST_OS_WINDOWS_MINGW
++TEST(WindowsTypesTest, _CRITICAL_SECTIONIs_CRITICAL_SECTION) {
++  StaticAssertTypeEq<CRITICAL_SECTION, _CRITICAL_SECTION>();
++}
++#else
+ TEST(WindowsTypesTest, CRITICAL_SECTIONIs_RTL_CRITICAL_SECTION) {
+   StaticAssertTypeEq<CRITICAL_SECTION, _RTL_CRITICAL_SECTION>();
+ }
++#endif
++
+ #endif  // GTEST_OS_WINDOWS
+ 
+ }  // namespace internal
+diff --git a/googletest/test/gtest_unittest.cc b/googletest/test/gtest_unittest.cc
+index 88e9413..97fcd5a 100644
+--- a/googletest/test/gtest_unittest.cc
++++ b/googletest/test/gtest_unittest.cc
+@@ -442,7 +442,7 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
+     // tzset() distinguishes between the TZ variable being present and empty
+     // and not being present, so we have to consider the case of time_zone
+     // being NULL.
+-#if _MSC_VER
++#if _MSC_VER || GTEST_OS_WINDOWS_MINGW
+     // ...Unless it's MSVC, whose standard library's _putenv doesn't
+     // distinguish between an empty and a missing variable.
+     const std::string env_var =

--- a/mingw-w64-gtest/0001-Fix-Mingw-w64-build.patch
+++ b/mingw-w64-gtest/0001-Fix-Mingw-w64-build.patch
@@ -1,0 +1,26 @@
+diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
+index 92f4c11..860aaaf 100644
+--- a/googletest/include/gtest/internal/gtest-port.h
++++ b/googletest/include/gtest/internal/gtest-port.h
+@@ -396,7 +396,7 @@
+ #  include <io.h>
+ # endif
+ // In order to avoid having to include <windows.h>, use forward declaration
+-#if GTEST_OS_WINDOWS_MINGW
++#if GTEST_OS_WINDOWS_MINGW && !defined(__MINGW64_VERSION_MAJOR)
+ // MinGW defined _CRITICAL_SECTION and _RTL_CRITICAL_SECTION as two
+ // separate (equivalent) structs, instead of using typedef
+ typedef struct _CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+diff --git a/googletest/test/gtest-port_test.cc b/googletest/test/gtest-port_test.cc
+index 05f8821..c5067a4 100644
+--- a/googletest/test/gtest-port_test.cc
++++ b/googletest/test/gtest-port_test.cc
+@@ -1295,7 +1295,7 @@ TEST(WindowsTypesTest, HANDLEIsVoidStar) {
+   StaticAssertTypeEq<HANDLE, void*>();
+ }
+ 
+-#if GTEST_OS_WINDOWS_MINGW
++#if GTEST_OS_WINDOWS_MINGW && !defined(__MINGW64_VERSION_MAJOR)
+ TEST(WindowsTypesTest, _CRITICAL_SECTIONIs_CRITICAL_SECTION) {
+   StaticAssertTypeEq<CRITICAL_SECTION, _CRITICAL_SECTION>();
+ }

--- a/mingw-w64-gtest/PKGBUILD
+++ b/mingw-w64-gtest/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtest
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.7.0
+pkgver=1.8.0
 pkgrel=1
 pkgdesc="Google Test (mingw-w64)"
 arch=('any')
@@ -12,35 +12,55 @@ license=('custom:BSD3')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("https://github.com/google/googletest/archive/release-${pkgver}.tar.gz")
-sha256sums=("f73a6546fdf9fce9ff93a5015e0333a8af3062a152a9ad6bcb772c96687016cc")
+source=("https://github.com/google/googletest/archive/release-${pkgver}.tar.gz"
+        0000-Fix-compilation-of-googletest-with-MinGW-using-Win32-threads.patch
+        0001-Fix-Mingw-w64-build.patch)
+sha256sums=("58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8"
+            "a17aca16f399127bf53d453f1d35e8d5e5d42d502fde0d7d100fd1e746998d74"
+            "cdfc8e63afe1510a771d2d924cb46e7f69195a60afbeb93f361247bc34cfd7e1")
+
+prepare() {
+  cd "${srcdir}/googletest-release-${pkgver}"
+  plain "Apply MinGW fixes merged after 1.8.0 release"
+  patch -p1 -i "${srcdir}"/0000-Fix-compilation-of-googletest-with-MinGW-using-Win32-threads.patch
+  patch -p1 -i "${srcdir}"/0001-Fix-Mingw-w64-build.patch
+}
 
 build() {
   cd googletest-release-$pkgver
 
   rm -rf build
-  rm -rf fused-src
+  rm -rf fused-gtest-src
+  rm -rf fused-gmock-src
   mkdir build
   cd build
 
   cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=ON -DCMAKE_SKIP_RPATH=ON ..
   make
 
-  ../scripts/fuse_gtest_files.py .. ../fused-src
+  ../googletest/scripts/fuse_gtest_files.py ../googletest ../fused-gtest-src
+  ../googlemock/scripts/fuse_gmock_files.py ../googlemock ../fused-gmock-src
 }
 
 package() {
   cd googletest-release-$pkgver
 
-  mkdir -pm 0755 "$pkgdir"/${MINGW_PREFIX}/{bin,lib,include/gtest/internal,share/licenses/$pkgname,src/gtest/src,src/gtest/cmake}
-  install -m 0644 build/libgtest{,_main}.dll "$pkgdir"/${MINGW_PREFIX}/bin
-  install -m 0644 build/libgtest{,_main}.dll.a "$pkgdir"/${MINGW_PREFIX}/lib
-  install -m 0644 include/gtest/*.h "$pkgdir"/${MINGW_PREFIX}/include/gtest
-  install -m 0644 include/gtest/internal/*.h "$pkgdir"/${MINGW_PREFIX}/include/gtest/internal/
-  install -m 0644 LICENSE "$pkgdir"/${MINGW_PREFIX}/share/licenses/$pkgname/
-  install -m 0644 fused-src/gtest/* "$pkgdir"/${MINGW_PREFIX}/src/gtest/src/
+  mkdir -pm 0755 "$pkgdir"/${MINGW_PREFIX}/{bin,lib,include/gtest/internal/custom,include/gmock/internal/custom,share/licenses/$pkgname,src/gtest/src,src/gmock/src,src/gtest/cmake}
+  install -m 0644 build/googlemock/gtest/libgtest{,_main}.dll "$pkgdir"/${MINGW_PREFIX}/bin
+  install -m 0644 build/googlemock/gtest/libgtest{,_main}.dll.a "$pkgdir"/${MINGW_PREFIX}/lib
+  install -m 0644 build/googlemock/libgmock{,_main}.dll "$pkgdir"/${MINGW_PREFIX}/bin
+  install -m 0644 build/googlemock/libgmock{,_main}.dll.a "$pkgdir"/${MINGW_PREFIX}/lib
+  install -m 0644 googletest/include/gtest/*.h "$pkgdir"/${MINGW_PREFIX}/include/gtest
+  install -m 0644 googletest/include/gtest/internal/*.h "$pkgdir"/${MINGW_PREFIX}/include/gtest/internal/
+  install -m 0644 googletest/include/gtest/internal/custom/*.h "$pkgdir"/${MINGW_PREFIX}/include/gtest/internal/custom/
+  install -m 0644 googlemock/include/gmock/*.h "$pkgdir"/${MINGW_PREFIX}/include/gmock
+  install -m 0644 googlemock/include/gmock/internal/*.h "$pkgdir"/${MINGW_PREFIX}/include/gmock/internal/
+  install -m 0644 googlemock/include/gmock/internal/custom/*.h "$pkgdir"/${MINGW_PREFIX}/include/gmock/internal/custom/
+  install -m 0644 googletest/LICENSE "$pkgdir"/${MINGW_PREFIX}/share/licenses/$pkgname/
+  install -m 0644 fused-gtest-src/gtest/* "$pkgdir"/${MINGW_PREFIX}/src/gtest/src/
+  install -m 0644 fused-gmock-src/gmock/* "$pkgdir"/${MINGW_PREFIX}/src/gmock/src/
+  install -m 0644 fused-gmock-src/*.cc "$pkgdir"/${MINGW_PREFIX}/src/gmock/src/
   install -m 0644 CMakeLists.txt "$pkgdir"/${MINGW_PREFIX}/src/gtest/
-  install -m 0644 cmake/* "$pkgdir"/${MINGW_PREFIX}/src/gtest/cmake/
+  install -m 0644 googletest/cmake/* "$pkgdir"/${MINGW_PREFIX}/src/gtest/cmake/
 }
 
-# vim: set ft=sh ts=2 sw=2 et :


### PR DESCRIPTION
Googletest merged with Googlemock after 1.7.0, so add gmock too.
Backport two commits fixing compilation on MinGW made after 1.8.0 release.