### PR TITLE
python3: Update to 3.6.2rc1

### DIFF
--- a/mingw-w64-python3/0540-mingw-semicolon-DELIM.patch
+++ b/mingw-w64-python3/0540-mingw-semicolon-DELIM.patch
@@ -37,12 +37,11 @@ diff -Naur Python-3.5.2-orig/Include/osdefs.h Python-3.5.2/Include/osdefs.h
  #endif
  
  #ifdef __cplusplus
-diff -Naur Python-3.5.2-orig/Makefile.pre.in Python-3.5.2/Makefile.pre.in
---- Python-3.5.2-orig/Makefile.pre.in	2016-07-12 14:21:14.824300700 +0300
-+++ Python-3.5.2/Makefile.pre.in	2016-07-12 14:21:54.241300700 +0300
-@@ -103,7 +103,8 @@
- # C flags used for building the interpreter object files
- PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
+--- Python-3.6.2rc1/Makefile.pre.in.orig	2017-06-18 14:53:39.660917400 +0200
++++ Python-3.6.2rc1/Makefile.pre.in	2017-06-18 14:54:31.765009000 +0200
+@@ -110,7 +110,8 @@
+ # Strict or non-strict aliasing flags used to compile dtoa.c, see above
+ CFLAGS_ALIASING=@CFLAGS_ALIASING@
  
 -
 +# ; on Windows otherwise :

--- a/mingw-w64-python3/0750-builddir-fixes.patch
+++ b/mingw-w64-python3/0750-builddir-fixes.patch
@@ -1,6 +1,6 @@
---- Python-3.6.1/Makefile.pre.in.orig	2017-06-13 18:47:49.722430000 +0200
-+++ Python-3.6.1/Makefile.pre.in	2017-06-13 18:48:21.888269700 +0200
-@@ -726,15 +726,15 @@
+--- Python-3.6.2rc1/Makefile.pre.in.orig	2017-06-18 14:44:47.870383000 +0200
++++ Python-3.6.2rc1/Makefile.pre.in	2017-06-18 14:47:43.823492600 +0200
+@@ -695,19 +695,19 @@
  
  Programs/_freeze_importlib.o: Programs/_freeze_importlib.c Makefile
  
@@ -8,20 +8,23 @@
 +Programs/_freeze_importlib$(EXE): Programs/_freeze_importlib.o $(LIBRARY_OBJS_OMIT_FROZEN)
  	$(LINKCC) $(PY_LDFLAGS) -o $@ Programs/_freeze_importlib.o $(LIBRARY_OBJS_OMIT_FROZEN) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
  
--Python/importlib_external.h: @GENERATED_COMMENT@ $(srcdir)/Lib/importlib/_bootstrap_external.py Programs/_freeze_importlib Python/marshal.c
+ .PHONY: regen-importlib
+-regen-importlib: Programs/_freeze_importlib
++regen-importlib: Programs/_freeze_importlib$(EXE)
+ 	# Regenerate Python/importlib_external.h
+ 	# from Lib/importlib/_bootstrap_external.py using _freeze_importlib
 -	./Programs/_freeze_importlib \
-+Python/importlib_external.h: @GENERATED_COMMENT@ $(srcdir)/Lib/importlib/_bootstrap_external.py Programs/_freeze_importlib$(EXE) Python/marshal.c
 +	./Programs/_freeze_importlib$(EXE) \
- 	    $(srcdir)/Lib/importlib/_bootstrap_external.py Python/importlib_external.h
- 
--Python/importlib.h: @GENERATED_COMMENT@ $(srcdir)/Lib/importlib/_bootstrap.py Programs/_freeze_importlib Python/marshal.c
+ 	    $(srcdir)/Lib/importlib/_bootstrap_external.py \
+ 	    $(srcdir)/Python/importlib_external.h
+ 	# Regenerate Python/importlib.h from Lib/importlib/_bootstrap.py
+ 	# using _freeze_importlib
 -	./Programs/_freeze_importlib \
-+Python/importlib.h: @GENERATED_COMMENT@ $(srcdir)/Lib/importlib/_bootstrap.py Programs/_freeze_importlib$(EXE) Python/marshal.c
 +	./Programs/_freeze_importlib$(EXE) \
- 	    $(srcdir)/Lib/importlib/_bootstrap.py Python/importlib.h
+ 	    $(srcdir)/Lib/importlib/_bootstrap.py \
+ 	    $(srcdir)/Python/importlib.h
  
- 
-@@ -1626,7 +1626,7 @@
+@@ -1631,7 +1631,7 @@
  	find build -name '*.py[co]' -exec rm -f {} ';' || true
  	-rm -f pybuilddir.txt
  	-rm -f Lib/lib2to3/*Grammar*.pickle

--- a/mingw-w64-python3/1600-fix-disable-blake2-sse.patch
+++ b/mingw-w64-python3/1600-fix-disable-blake2-sse.patch
@@ -1,11 +1,10 @@
---- Python-3.6.1/setup.py.orig	2017-06-13 16:41:16.611128800 +0200
-+++ Python-3.6.1/setup.py	2017-06-13 16:42:21.729853400 +0200
-@@ -942,7 +942,7 @@
-         blake2_deps.append('hashlib.h')
+--- Python-3.6.2rc1/setup.py.orig	2017-06-18 14:49:53.912121100 +0200
++++ Python-3.6.2rc1/setup.py	2017-06-18 14:51:03.769843600 +0200
+@@ -943,6 +943,7 @@
  
          blake2_macros = []
--        if not cross_compiling and os.uname().machine == "x86_64":
-+        if not cross_compiling and not host_platform.startswith(('mingw', 'win')):
-             # Every x86_64 machine has at least SSE2.
-             blake2_macros.append(('BLAKE2_USE_SSE', '1'))
- 
+         if (not cross_compiling and
++                not host_platform.startswith(('mingw', 'win')) and
+                 os.uname().machine == "x86_64" and
+                 sys.maxsize >  2**32):
+             # Every x86_64 machine has at least SSE2.  Check for sys.maxsize

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -17,7 +17,7 @@ _realname=python3
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
-pkgver=${_pybasever}.1
+pkgver=${_pybasever}.2rc1
 pkgrel=1
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -395,7 +395,7 @@ package() {
   mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe
 }
 
-sha256sums=('a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041'
+sha256sums=('16bd96ec3e26365a110d8fd9f582f9123edf9cca04a65c5304c91f524129ca05'
             '4cc654f8caef73b385a57278d4a57578941ec48a5a69bcf7f100f85a5c9e5ac0'
             '166e45a247f440df92c97d3e4392daf67c79d086b3de8ff4f4698d113bad4172'
             '9e23bd69d37db124a9765afab1c9b1809af9841f4771a352ac2412031f84975c'
@@ -439,7 +439,7 @@ sha256sums=('a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041'
             '1bcc89ed500f114be330721ad0dbb9a213a2f959ab942375ddecb08f142a196c'
             '2201e336997af02cd42dd7f052d0fd05009a1a307066e15a7d38615c8d9c0ad7'
             'ab6d2450495212d7c402bd5a9a4fc64527ee54a9509825ba62312f13e1252a8a'
-            '7ab2a3a15148a4f90d45f4dbc8181f2433e0354f25b7a0de87e4cdfc06a3ed83'
+            '5ebce8259ecfdc2bf431b72e9f13480fc154d7e531646251064533f3257ad032'
             '73db4478cc06e9944a5cb99a5091647fc6c2fc87b0ba65adee263c503d3e1457'
             'c372b651b95b5a743d9299563f79c99569a6546ac07f1c77e0c80c3d887dcf88'
             'faa3389ddc8d927eb08b447066e3cc21486376e517ccad4a5e2f0300daa9f15a'
@@ -456,7 +456,7 @@ sha256sums=('a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041'
             'faf18878d93b71c9b3034b2e0be7e75d0a105734726872f1353e2afa8664e7aa'
             '8e1a66af0edb1207a27af05c8e4250bc3b02a6dc39bae2c36a313b48fae3c4e6'
             '81a88720512c311515107607447d2c8faa8a7158ebc28232a8d19fe27b905836'
-            '706e7cd6490bd292fa52dc6bda14003913c86fd2689e0501007c6586beda5b75'
+            '2218e6c146cc2370e78a7576094f9eb843292e3ad867c37be5cb1fa0e91261f5'
             'ceea443a47860778d096a4b1c644467f61f3afb135b20c9a8019242d1fc6c175'
             'ad73f017cd61183ce8a06699940233ea66cd2d58444ebe9f0f147a16a57ed1f1'
             '389872855584a1a912f3833c99a318bd924bee25ed806f5769c0b1c7feda1cf9'
@@ -481,7 +481,7 @@ sha256sums=('a01810ddfcec216bcdb357a84bfaafdfaa0ca42bbdaa4cb7ff74f5a9961e4041'
             '5f07778f93dc2ed98b4bb10102a0fffc6670c8b264abd9d86bca01e8e1a074c8'
             '20f4a0c3d14c179cf0f14e9cfbb6b5274ddf61e59966185492161643af87e9b4'
             '66219146773e44967c1971cd6631f8f76ed2ed13c527a610c398b506d2256fa7'
-            '26fa0d034ce276269d64b89dfda112fbcc050dbcd5a4beb4e67676795a11f7db'
+            'b4bc82266ffd3491a7dcb413caa1d1d6523db97ada177a846c93ec1383f3d9d1'
             '1e8382fb438775cef36a0264ea31b76892e90725228657327eadeeec286193fd'
             'f9c46db891caad30656fa1ffda81838977616f4946a6a95ddb95f91501160815'
             '8896f4e11c17498c666251cef1c89ee0d78886814c8f227ee46807bedb4b1ad3'


### PR DESCRIPTION
This fixes the remaining problems I had with Python 3.6.1 and the faulthandler module.

3.6.2 will be released in two weeks, so if there are no plans to update the repo in the mean time feel free to ignore/close this PR and I will create a new one once the final 3.6.2 is out.