### PR TITLE
python-pytest: Add missing pluggy dependency

### DIFF
--- a/mingw-w64-python-pluggy/PKGBUILD
+++ b/mingw-w64-python-pluggy/PKGBUILD
@@ -1,0 +1,64 @@
+# Contributor: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=pluggy
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.4.0
+pkgrel=1
+pkgdesc='Plugin and hook calling mechanisms for python (mingw-w64)'
+url='https://github.com/pytest-dev/pluggy'
+license=('MIT')
+arch=('any')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+source=("https://pypi.org/packages/source/p/pluggy/pluggy-0.4.0.zip")
+sha256sums=('dd841b5d290b252cf645f75f3bd37ceecfa0f36394ab313e4f785fe68a4081a4')
+
+prepare() {
+  cd ${srcdir}
+
+  for pver in {2,3}; do
+    rm -rf python${pver}-build-${CARCH}| true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}
+
+package_python3-pluggy() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd ${srcdir}/python3-build-${CARCH}
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-pluggy() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd ${srcdir}/python2-build-${CARCH}
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-pluggy() {
+  package_python2-pluggy
+}
+
+package_mingw-w64-i686-python3-pluggy() {
+  package_python3-pluggy
+}
+
+package_mingw-w64-x86_64-python2-pluggy() {
+  package_python2-pluggy
+}
+
+package_mingw-w64-x86_64-python3-pluggy() {
+  package_python3-pluggy
+}

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pytest
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='http://pytest.org'
 license=('MIT')
@@ -34,7 +34,9 @@ prepare() {
 }
 
 package_python3-pytest() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3-py" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3-py"
+           "${MINGW_PACKAGE_PREFIX}-python3-pluggy"
+           "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 
   cd ${srcdir}/python3-build-${CARCH}
   ${MINGW_PREFIX}/bin/python3 setup.py build
@@ -51,7 +53,9 @@ package_python3-pytest() {
 }
 
 package_python2-pytest() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2-py" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2-py"
+           "${MINGW_PACKAGE_PREFIX}-python2-pluggy"
+           "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 
   cd ${srcdir}/python2-build-${CARCH}
   ${MINGW_PREFIX}/bin/python2 setup.py build


### PR DESCRIPTION
In the last update the vendored pluggy was patched out, this
adds it pack as a new package.