### PR TITLE
Move to new versions on Bintray

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ deploy:
       subject: $(BINTRAY_ACCOUNT)
       repo: $(BINTRAY_REPOSITORY)
       package: $(PACMAN_REPOSITORY_NAME)
-      version: latest
+      version: $(APPVEYOR_BUILD_VERSION)
       publish: true
       override: true
       api_key:


### PR DESCRIPTION
Just a suggestion, you could use [dynamic downloads](https://bintray.com/docs/api/#_dynamic_download). By having a link pointing to `$latest` for a specific asset and always get the latest version. Current version `latest` isn't deploying because it's static

You could also only deploy on `master` with something like this in `appveyor.yml`:
```
provider:
    on:
        branch: master
```