### PR TITLE
python3: Make multiprocessing.Queue work; Add some tests. Fixes #837

### DIFF
--- a/mingw-w64-python3/1650-expose-sem_unlink.patch
+++ b/mingw-w64-python3/1650-expose-sem_unlink.patch
@@ -1,0 +1,11 @@
+--- Python-3.6.2rc1/Modules/_multiprocessing/multiprocessing.c.orig	2017-06-22 13:35:38.307651400 +0200
++++ Python-3.6.2rc1/Modules/_multiprocessing/multiprocessing.c	2017-06-22 13:40:12.238319300 +0200
+@@ -128,7 +128,7 @@
+     {"recv", multiprocessing_recv, METH_VARARGS, ""},
+     {"send", multiprocessing_send, METH_VARARGS, ""},
+ #endif
+-#if !defined(POSIX_SEMAPHORES_NOT_ENABLED) && !defined(__ANDROID__)
++#if defined(MS_WINDOWS) || (!defined(POSIX_SEMAPHORES_NOT_ENABLED) && !defined(__ANDROID__))
+     {"sem_unlink", _PyMp_sem_unlink, METH_VARARGS, ""},
+ #endif
+     {NULL}

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
 pkgver=${_pybasever}.2rc1
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -129,7 +129,9 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1610-fix-have-wspawnv.patch
         1620-fix-signal-module-build.patch
         1630-build-winconsoleio.patch
-        1640-dont-include-consoleapi-h.patch)
+        1640-dont-include-consoleapi-h.patch
+        1650-expose-sem_unlink.patch
+        smoketests.py)
 
 prepare() {
   cd "${srcdir}/Python-${pkgver}"
@@ -244,6 +246,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/1620-fix-signal-module-build.patch
   patch -Np1 -i "${srcdir}"/1630-build-winconsoleio.patch
   patch -Np1 -i "${srcdir}"/1640-dont-include-consoleapi-h.patch
+  patch -Np1 -i "${srcdir}"/1650-expose-sem_unlink.patch
 
   autoreconf -vfi
 
@@ -267,10 +270,16 @@ prepare() {
   rm -r Modules/_ctypes/{darwin,libffi}*
 }
 
-# check() {
-#   cd "${srcdir}/build-${CARCH}"
-#   make test EXTRATESTOPTS="-v"
-# }
+check() {
+  cd "${srcdir}/build-${CARCH}"
+
+  # Some basic tests to ensure nothing major or MSYS2 specific features are
+  # broken
+  ./python.exe "${srcdir}/smoketests.py"
+  MSYSTEM= ./python.exe "${srcdir}/smoketests.py"
+
+  # make test EXTRATESTOPTS="-v"
+}
 
 build() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
@@ -485,4 +494,6 @@ sha256sums=('16bd96ec3e26365a110d8fd9f582f9123edf9cca04a65c5304c91f524129ca05'
             '1e8382fb438775cef36a0264ea31b76892e90725228657327eadeeec286193fd'
             'f9c46db891caad30656fa1ffda81838977616f4946a6a95ddb95f91501160815'
             '8896f4e11c17498c666251cef1c89ee0d78886814c8f227ee46807bedb4b1ad3'
-            '597c1c13c7f4debea71de4de3325eeb66cb9c1dc064c4961a6f27de8f07c1992')
+            '597c1c13c7f4debea71de4de3325eeb66cb9c1dc064c4961a6f27de8f07c1992'
+            '14347ddde0fb78ae9d7ae1674e24fbf8c26c5c75547de33633318d785468f49e'
+            'f4f5359b35741b703cbd22dc73438c181b8541e30b3f7614bd272f7cd2c59049')

--- a/mingw-w64-python3/smoketests.py
+++ b/mingw-w64-python3/smoketests.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright 2017 Christoph Reiter
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""The goal of this test suite is collect tests for update regressions
+and to test msys2 related modifications like for path handling.
+Feel free to extend.
+"""
+
+import os
+import unittest
+
+if "MSYSTEM" in os.environ:
+    SEP = "/"
+else:
+    SEP = "\\"
+
+
+class Tests(unittest.TestCase):
+
+    def test_sep(self):
+        self.assertEqual(os.sep, SEP)
+
+    def test_os_commonpath(self):
+        self.assertEqual(
+            os.path.commonpath(
+                [os.path.join("C:", os.sep, "foo", "bar"),
+                 os.path.join("C:", os.sep, "foo")]),
+                 os.path.join("C:", os.sep, "foo"))
+
+    def test_modules_import(self):
+        import sqlite3
+        import ssl
+
+    def test_multiprocessing_queue(self):
+        from multiprocessing import Queue
+        Queue(0)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
With non-mingw builds POSIX_SEMAPHORES_NOT_ENABLED is not defined and
sem_unlink is a no-op. Change it so that the no-op sem_unlink is also exposed under mingw.

This adds a minimal test suite which makes it easier to catch regressions
in the future for common MSYS2 related bugs.