### PR TITLE
jasper: Added patch file to fix static library link error.

### DIFF
--- a/mingw-w64-jasper/PKGBUILD
+++ b/mingw-w64-jasper/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jasper
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.0.13
-pkgrel=1
+pkgrel=2
 pkgdesc="A software-based implementation of the codec specified in the emerging JPEG-2000 Part-1 standard (mingw-w64)"
 arch=('any')
 url="https://www.ece.uvic.ca/~mdadams/jasper"
@@ -14,16 +14,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-freeglut" "${MINGW_PACKAGE_PREFIX}-libjpeg-tur
 options=('staticlibs' 'strip' '!libtool')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mdadams/jasper/archive/version-${pkgver}.tar.gz
         jasper-1.900.1-fix-filename-buffer-overflow.patch
-        001-mingw-cmake.patch)
+        001-mingw-cmake.patch
+        jasper-static-fix.patch)
 sha256sums=('b50413b41bfc82ae419298b41eadcde1aa31f362fb9dc2ac089e5cbc19f60c24'
             'f51377e9b3e4faaa6b17b2d5fcf6f6d94fe2916a65dc9c78b5a99b891f5726dc'
-            '2b261c9b40b973d0d11f7b2b6842b36aee45657cbd5e0780fa73cb184f570b65')
+            '2b261c9b40b973d0d11f7b2b6842b36aee45657cbd5e0780fa73cb184f570b65'
+            '3102b4175d714df84a63b8ebf3c0f346fc09a0a784a560917994f6074d6b1697')
 
 prepare() {
   cd "$srcdir"/${_realname}-version-${pkgver}
 
   patch -p1 -i "${srcdir}"/jasper-1.900.1-fix-filename-buffer-overflow.patch
   patch -p1 -i "${srcdir}"/001-mingw-cmake.patch
+  patch -p1 -i "${srcdir}"/jasper-static-fix.patch
 }
 
 build() {

--- a/mingw-w64-jasper/jasper-static-fix.patch
+++ b/mingw-w64-jasper/jasper-static-fix.patch
@@ -1,0 +1,23 @@
+--- a/src/libjasper/include/jasper/jas_config.h.in
++++ b/src/libjasper/include/jasper/jas_config.h.in
+@@ -0,6 +0,8 @@
+ #ifndef JAS_CONFIG_H
+ #define JAS_CONFIG_H
+ 
++#ifndef JAS_DLL
+ #cmakedefine JAS_DLL 1
++#endif
+ 
+ #include <jasper/jas_dll.h>
+ 
+--- a/src/libjasper/include/jasper/jas_dll.h
++++ b/src/libjasper/include/jasper/jas_dll.h
+@@ -0,7 +0,7 @@
+ #ifndef JAS_DLL_H
+ #define JAS_DLL_H
+ 
+-#if defined(JAS_DLL)
++#if JAS_DLL
+ 	#if defined(_WIN32)
+ 		#if defined(JAS_BUILDING_DLL)
+ 			#define JAS_DLLEXPORT __declspec(dllexport)


### PR DESCRIPTION
To use the static library you need to define JAS_DLL to zero.
-D JAS_DLL=0

I am trying to update qt5-git and I need this or another fix to enable linking to an static jasper library.

Tim S.