### PR TITLE
mbedtls: Updated to 2.5.1

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.2
+pkgver=2.5.1
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
@@ -20,7 +20,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha256sums=('17dd98af7478aadacc480c7e4159e447353b5b2037c1b6d48ed4fd157fb1b018'
+sha256sums=('559aeb8c8941262d6aad96a0286a230e7ff988ba53efbf609230ca1f81cc81f9'
             '5c5382ff266e5cc293f31a46e1f10782c765c5cc1476dfc21d5c4ad405f647a0'
             '89eb82f9e9fb456d0595035925d2d512aa2ca9b9e283b9c51d5524bfc8dbf996'
             '1be88267b045a8728fe4dde663faf328ad788eeefcb43915beeb364b4d2dd2e8')


### PR DESCRIPTION
https://tls.mbed.org/tech-updates/releases/mbedtls-2.5.1-2.1.8-and-1.3.20-released