### PR TITLE
Fix some missing -git suffixes in some git PKGBUILDS

### DIFF
--- a/mingw-w64-crypto++-git/PKGBUILD
+++ b/mingw-w64-crypto++-git/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Alexey Pavlov <Alexpux@gmail.com>
 
 _realname=crypto++
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r2334.1a17ade
-pkgrel=1
+pkgrel=2
 pkgdesc="Crypto++ Library is a free C++ class library of cryptographic schemes."
 arch=('any')
 url="http://www.cryptopp.com/"
@@ -12,6 +12,8 @@ license=('Boost Software License 1.0')
 options=('staticlibs' 'strip')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "git")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 source=(${_realname}::"git+https://github.com/weidai11/cryptopp.git")
 sha256sums=('SKIP')
 

--- a/mingw-w64-gst-rtsp-server-git/PKGBUILD
+++ b/mingw-w64-gst-rtsp-server-git/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=gst-rtsp-server
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=1.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer RTSP server library (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
@@ -19,11 +19,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-gettext"
-         "${MINGW_PACKAGE_PREFIX}-gstreamer-git"
-         "${MINGW_PACKAGE_PREFIX}-gst-plugins-base-git"
-         "${MINGW_PACKAGE_PREFIX}-gst-plugins-good-git"
-         "${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly-git"
-         "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad-git")
+         "${MINGW_PACKAGE_PREFIX}-gstreamer"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-good"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-ugly"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-bad")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('aa72a94cccdd2387ad25dc65c5c0b1f76269c3997cbde348232eec2a1565b3cd')

--- a/mingw-w64-rust-git/PKGBUILD
+++ b/mingw-w64-rust-git/PKGBUILD
@@ -2,10 +2,10 @@
 
 _realname=rust
 
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgbase=mingw-w64-${_realname}-git
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=r31923.27e8d5b
-pkgrel=1
+pkgrel=2
 pkgdesc="A safe, concurrent, practical language from Mozilla (mingw-w64)"
 arch=('any')
 url="https://www.rust-lang.org/"
@@ -18,6 +18,8 @@ makedepends=('git'
       "${MINGW_PACKAGE_PREFIX}-libffi"
       'python2'
       )
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 options=('!makeflags' 'staticlibs')
 #install=rust.install
 source=("${_realname}"::"git+https://github.com/mozilla/rust.git")


### PR DESCRIPTION
Instead of building the same name as as the non-git variant
build a -git variant and provide/conflict the normal one.
As is the case with other git packages.