### PR TITLE
qt5: Fixed static library build issues.

### DIFF
--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -404,8 +404,12 @@ build() {
   mv ${_pkgfqn} ${CARCH}
 
   export PATH="${srcdir}/${CARCH}/qtbase/bin:${srcdir}/${CARCH}/qtbase/lib:${PATH}"
-  
-  export PKG_CONFIG="${MINGW_PREFIX}/bin/pkg-config.exe"
+
+  if [ "${_variant}" = "-shared" ]; then
+    # This export breaks the static library build in 5.9.0;
+    # Causes the DBUS_LIBS setting passed to configure to be ignored.
+    export PKG_CONFIG="${MINGW_PREFIX}/bin/pkg-config.exe"
+  fi
 
   # Workaround for building QtWebkit
   #pushd ${srcdir}/${CARCH}/qtwebkit > /dev/null
@@ -465,13 +469,18 @@ build() {
 
   if [ "${_variant}" = "-static" ]; then
     configure_opts+=("-static")
+    configure_opts+=("-D" "DBUS_STATIC_BUILD")
+    configure_opts+=("-D" "JAS_DLL=0")
     configure_opts+=("-openssl-linked")
+    configure_opts+=("-dbus-linked" "DBUS_LIBS=-ldbus-1 -lws2_32 -liphlpapi")
     configure_opts+=("-no-fontconfig")
+    configure_opts+=("-no-icu")
     configure_opts+=("-qt-zlib")
     configure_opts+=("-qt-pcre")
     configure_opts+=("-qt-libpng")
     configure_opts+=("-qt-libjpeg")
     configure_opts+=("-qt-harfbuzz")
+    configure_opts+=("-qt-freetype")
   else
     configure_opts+=("-shared")
     if [ "$_with_fontconfig" == "no" ]; then


### PR DESCRIPTION
By adding configure_opts for static build.
Static build uses "-no-icu", "-dbus-linked", and "-qt-freetype".
Added defines for static build of:
  JAS_DLL=0
  DBUS_STATIC_BUILD
Added library configuration info of:
  DBUS_LIBS=-ldbus-1 -lws2_32 -liphlpapi
And, added shared guard around export of "PKG_CONFIG".

Only had enough hard disk space to test building the 64 bit static release without docs or examples.
But, it built and installed without issues.
It took me many hours to figure out the export "PKG_CONFIG" was causing the static build issue.
Tim S.