### PR TITLE
clang: update to 4.0.1

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          "${MINGW_PACKAGE_PREFIX}-polly")
-pkgver=4.0.0
+pkgver=4.0.1
 pkgrel=1
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
@@ -84,27 +84,27 @@ source=(http://llvm.org/releases/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
 #0501-0599 -> lldb
 #0601-0699 -> libunwind
 #0701-0799 -> libc++abi
-sha256sums=('8d10511df96e73b8ff9e7abbfb4d4d432edbdbe965f1f4f07afaf370b8a533be'
+sha256sums=('da783db1f82d516791179fe103c71706046561f7972b18f0049242dee6712b51'
             'SKIP'
-            'cea5f88ebddb30e296ca89130c83b9d46c2d833685e2912303c828054c4dc98a'
+            '61738a735852c23c3bdbe52d035488cdb2083013f384d67c1ba36fabebd8769b'
             'SKIP'
-            'd3f25b23bef24c305137e6b44f7e81c51bbec764c119e01512a9bd2330be3115'
+            'a3c87794334887b93b7a766c507244a7cdcce1d48b2e9249fc9a94f2c3beb440'
             'SKIP'
-            '31544baafbee0d6c652637f6dfa19ca91afe5ca577e07752f4b2c23656bc6304'
+            'ecd2e9f83f78e25b249a882745d0efa26d080296a4397a250267c3cad2337e1a'
             'SKIP'
-            '4f4d33c4ad69bf9e360eebe6b29b7b19486948b1a41decf89d4adec12473cf96'
+            '520a1171f272c9ff82f324d5d89accadcec9bc9f3c78de11f5575cdb99accc4c'
             'SKIP'
-            'dca9cb619662ad2d3a0d685c4366078345247218c3702dd35bcaaa23f63481d8'
+            '8f08178989a06c66cd19e771ff9d8ca526dd4a23d1382d63e416c04ea9fa1b33'
             'SKIP'
-            '41b7d37eb128fd362ab3431be5244cf50325bb3bb153895735c5bacede647c99'
+            '35d1e64efc108076acbe7392566a52c35df9ec19778eb9eb12245fc7d8b915b6'
             'SKIP'
-            '33e06457b9ce0563c89b11ccc7ccabf9cff71b83571985a5bf8684c9150e7502'
+            '63ce10e533276ca353941ce5ab5cc8e8dcd99dbdd9c4fa49f344a212f29d36ed'
             'SKIP'
-            '2dbd8f05c662c1c9f11270fc9d0c63b419ddc988095e0ad107ed911cf882033d'
+            '8432d2dfd86044a0fc21713e0b5c1d98e1d8aad863cf67562879f47f841ac47b'
             'SKIP'
-            '0755efa9f969373d4d543123bbed4b3f9a835f6302875c1379c5745857725973'
+            '3b072e33b764b4f9b5172698e080886d1f4d606531ab227772a7fc08d6a92555'
             'SKIP'
-            '27a5dbf95e8aa9e0bbe3d6c5d1e83c92414d734357aa0d6c16020a65dc4dcd97'
+            'b443bb9617d776a7d05970e5818aa49aa2adfb2670047be8e9f242f58e84f01a'
             'SKIP'
             '3f55d2114805110e370fab6630763c359d83b07c356f61b86afc32feb7cf7514'
             '78b6951956360a8e05fdc7020bc7e1996da75b499022f9213465070fc238529c'
@@ -336,7 +336,7 @@ package_compiler-rt() {
 package_libcxxabi() {
   pkgdesc="C++ Standard Library Support (mingw-w64)"
   url="http://libcxxabi.llvm.org/"
-  depends="${MINGW_PACKAGE_PREFIX}-libunwind"
+  #depends="${MINGW_PACKAGE_PREFIX}-libunwind"
 
   cd "${srcdir}/llvm-${pkgver}.src"
   make -C ../build-${CARCH}/projects/libcxxabi -j1 DESTDIR="${pkgdir}" install


### PR DESCRIPTION
I have disabled libunwind as per https://github.com/Alexpux/MINGW-packages/pull/2294#issuecomment-310940009
CC @martell 