### PR TITLE
mingw-w64-gdb-git: Update patches for the master branch.

### DIFF
--- a/mingw-w64-gdb-git/0001-MinGW-w64-Two-fixes-for-unusual-files.patch
+++ b/mingw-w64-gdb-git/0001-MinGW-w64-Two-fixes-for-unusual-files.patch
@@ -1,4 +1,4 @@
-From 41cd0a16753c682c380c8c29881e12a7859451b2 Mon Sep 17 00:00:00 2001
+From 5bc0c8c132c829413452f03027bb89e0ac09072c Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 31 Oct 2015 21:39:35 +0000
 Subject: [PATCH] MinGW-w64: Two fixes for 'unusual' files.
@@ -12,7 +12,7 @@ Pretend 'nul' is '/dev/null' which is necessary for libtool.
  3 files changed, 46 insertions(+), 4 deletions(-)
 
 diff --git a/binutils/bucomm.c b/binutils/bucomm.c
-index fd6f35604d..992b0429fa 100644
+index 5a0b634344..ce35712889 100644
 --- a/binutils/bucomm.c
 +++ b/binutils/bucomm.c
 @@ -586,10 +586,19 @@ off_t
@@ -35,10 +35,10 @@ index fd6f35604d..992b0429fa 100644
    if (stat (file_name, &statbuf) < 0)
      {
        if (errno == ENOENT)
-@@ -598,8 +607,15 @@ get_file_size (const char * file_name)
- 	non_fatal (_("Warning: could not locate '%s'.  reason: %s"),
- 		   file_name, strerror (errno));
+@@ -600,8 +609,15 @@ get_file_size (const char * file_name)
      }
+   else if (S_ISDIR (statbuf.st_mode))
+     non_fatal (_("Warning: '%s' is a directory"), file_name);
 -  else if (! S_ISREG (statbuf.st_mode))
 -    non_fatal (_("Warning: '%s' is not an ordinary file"), file_name);
 +  else if (! S_ISREG (statbuf.st_mode) || t > 0)
@@ -88,10 +88,10 @@ index 0c84028a29..66a9cd23ad 100644
        return 1;
      }
 diff --git a/binutils/readelf.c b/binutils/readelf.c
-index b57e1e029b..7af24ca39e 100644
+index 90af7cc39c..c25c82bb33 100644
 --- a/binutils/readelf.c
 +++ b/binutils/readelf.c
-@@ -18128,6 +18128,14 @@ process_file (char * file_name)
+@@ -18416,6 +18416,14 @@ process_file (char * file_name)
    struct stat statbuf;
    char armag[SARMAG];
    bfd_boolean ret = TRUE;
@@ -106,7 +106,7 @@ index b57e1e029b..7af24ca39e 100644
  
    if (stat (file_name, &statbuf) < 0)
      {
-@@ -18139,8 +18147,13 @@ process_file (char * file_name)
+@@ -18427,8 +18435,13 @@ process_file (char * file_name)
        return FALSE;
      }
  
@@ -122,5 +122,5 @@ index b57e1e029b..7af24ca39e 100644
        return FALSE;
      }
 -- 
-2.12.1
+2.13.0
 

--- a/mingw-w64-gdb-git/0005-Mitigate-gdb-bug-21057.patch
+++ b/mingw-w64-gdb-git/0005-Mitigate-gdb-bug-21057.patch
@@ -1,10 +1,9 @@
-From a7e625b307a3ca3225a44a47a6e8cc0f0911ac12 Mon Sep 17 00:00:00 2001
+From 63fdece7d71ca3986b78655a251b6e8adc666199 Mon Sep 17 00:00:00 2001
 From: Peter Foley <>
 Date: Sat, 18 Feb 2017 11:50:55 +0800
 Subject: [PATCH] Mitigate gdb bug 21057
 
 See https://sourceware.org/bugzilla/show_bug.cgi?id=21057.
-
 ---
  gdb/ada-exp.y  | 22 ++--------------------
  gdb/ada-lang.c |  2 +-
@@ -60,10 +59,10 @@ index 1eea454670..c318d2bfd8 100644
  
  /* The following kludge was found necessary to prevent conflicts between */
 diff --git a/gdb/ada-lang.c b/gdb/ada-lang.c
-index 2e5643bd03..15ced2eb9c 100644
+index ea60df20e7..656df62bb8 100644
 --- a/gdb/ada-lang.c
 +++ b/gdb/ada-lang.c
-@@ -14025,7 +14025,7 @@ const struct language_defn ada_language_defn = {
+@@ -13988,7 +13988,7 @@ const struct language_defn ada_language_defn = {
    ada_extensions,
    &ada_exp_descriptor,
    parse,
@@ -86,7 +85,7 @@ index 5f97a6cdcc..480366a1cd 100644
                          /* Defined in ada-typeprint.c */
  extern void ada_print_type (struct type *, const char *, struct ui_file *, int,
 diff --git a/gdb/ada-lex.l b/gdb/ada-lex.l
-index 0825290214..aa6bb2d269 100644
+index fe97352d85..fa3e1b6407 100644
 --- a/gdb/ada-lex.l
 +++ b/gdb/ada-lex.l
 @@ -39,6 +39,8 @@ OPER    ([-+*/=<>&]|"<="|">="|"**"|"/="|"and"|"or"|"xor"|"not"|"mod"|"rem"|"abs"
@@ -97,7 +96,7 @@ index 0825290214..aa6bb2d269 100644
 +
  %{
  
- #define NUMERAL_WIDTH 256
+ #include "common/diagnostics.h"
 -- 
-2.12.1
+2.13.0
 

--- a/mingw-w64-gdb-git/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
+++ b/mingw-w64-gdb-git/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
@@ -1,0 +1,46 @@
+From 8f19bff31adb8b5f7da8a0c96667cc564b3c62e6 Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Sun, 2 Jul 2017 13:44:19 +0800
+Subject: [PATCH] Disable checks using setenv() or unsetenv() as they do not
+ exist on Windows.
+
+---
+ gdb/unittests/environ-selftests.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gdb/unittests/environ-selftests.c b/gdb/unittests/environ-selftests.c
+index 28b16f828f..f916fe3b5d 100644
+--- a/gdb/unittests/environ-selftests.c
++++ b/gdb/unittests/environ-selftests.c
+@@ -28,10 +28,12 @@ namespace gdb_environ_tests {
+ static void
+ run_tests ()
+ {
++#ifndef _WIN32
+   /* Set a test environment variable.  This will be unset at the end
+      of this function.  */
+   if (setenv ("GDB_SELFTEST_ENVIRON", "1", 1) != 0)
+     error (_("Could not set environment variable for testing."));
++#endif
+ 
+   gdb_environ env;
+ 
+@@ -53,6 +55,7 @@ run_tests ()
+   /* Initialize the environment vector using the host's environ.  */
+   env = gdb_environ::from_host_environ ();
+ 
++#ifndef _WIN32
+   /* Our test environment variable should be present at the
+      vector.  */
+   SELF_CHECK (strcmp (env.get ("GDB_SELFTEST_ENVIRON"), "1") == 0);
+@@ -91,6 +94,7 @@ run_tests ()
+ 
+   /* Get rid of our test variable.  */
+   unsetenv ("GDB_SELFTEST_ENVIRON");
++#endif
+ 
+   /* Test the case when we set a variable A, then set a variable B,
+      then unset A, and make sure that we cannot find A in the environ
+-- 
+2.13.0
+

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,8 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}
-_base_ver=7.12
-pkgver=r90412.562855f732
+pkgver=r90917.2a9f9e83e5
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -32,14 +31,16 @@ source=("${_realname}"::"git://sourceware.org/git/binutils-gdb.git#branch=master
         0002-MinGW-w64-Fix-libibery-configure.patch
         0003-MinGW-w64-Use-gnu-printf.patch
         0004-GDB-performance.patch
-        0005-Mitigate-gdb-bug-21057.patch)
+        0005-Mitigate-gdb-bug-21057.patch
+        0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch)
 sha256sums=('SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
-            '8ba15f54ec589939cbaefc6c676ff30789dc995046d35ad25a33218127ba6a2c'
+            '9f02f6740fc5a8e0900e2ec0196bb5851f5a5f06a4da162434646dff7fef4e54'
             'c92183a52f53d82cb5ffddf2a18f5bddd350ccc0db01eff1e5918d98467ee8e3'
             'c8aab67618e05c31e3b60b59319d8fa3eeb7ca9dbf8de937a07c99533557dd5f'
             '4ddb55be45625efd1b2c82d2e344f4ebc9f17e362642489f21eb19fa9ec8d94b'
-            '233c0171de87b9ded34e02118380ae15bf06e5088d4393b85fc4351cbf7f2b8b')
+            '9d2aa8b97952e92973b4c306aafbf338c1cd6c1bb1f75f81bdf85751464a9750'
+            'b165d602dfbeab226ca1bee1d9b85f98c6d86d9cc5bdd8e2258f705206b63c62')
 
 pkgver() {
   cd "$srcdir/$_realname"
@@ -53,6 +54,7 @@ prepare() {
   git am "${srcdir}"/0003-MinGW-w64-Use-gnu-printf.patch
   git am "${srcdir}"/0004-GDB-performance.patch
   git am "${srcdir}"/0005-Mitigate-gdb-bug-21057.patch
+  git am "${srcdir}"/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
 }
 
 build() {


### PR DESCRIPTION
The `_base_ver` variable in `PKGBUILD` seems unused. Why was it there after all? `gdb --version` says `8.0` despite that value.