### PR TITLE
mingw-w64-vtk: update to 8.0.0, removed deprecated patches

### DIFF
--- a/mingw-w64-vtk/PKGBUILD
+++ b/mingw-w64-vtk/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=vtk
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.1.1
+pkgver=8.0.0
 pkgrel=1
 pkgdesc="A software system for 3D computer graphics, image processing and visualization (mingw-w64)"
 arch=('any')
@@ -39,18 +39,12 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-boost: InfovisBoost and InfovisBoostGraphAl
             "${MINGW_PACKAGE_PREFIX}-python2: Python bindings"
             "${MINGW_PACKAGE_PREFIX}-python2-matplotlib: Matplotlib renderer"
             "${MINGW_PACKAGE_PREFIX}-tk: TCL bindings, Python Tk widgets")
-source=(http://www.vtk.org/files/release/${pkgver%.*}/VTK-${pkgver}.tar.gz
-        "vtk-mingw-w64.patch"
-        "0002-dont-use-external-templates-mingw.patch")
-sha256sums=('2d5cdd048540144d821715c718932591418bb48f5b6bb19becdae62339efa75a'
-            'db3163012fc7d90f6ffd8300a7a306a609e7c69a88a1dcfb9cb5b5df4391e3ad'
-            '80dad2ff2d9f8148b77facee2b8e0612f16052bdd8fe81167158813af688321c')
+source=(http://www.vtk.org/files/release/${pkgver%.*}/VTK-${pkgver}.tar.gz)
+sha256sums=('c7e727706fb689fb6fd764d3b47cac8f4dc03204806ff19a10dfd406c6072a27')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
-  patch -Np1 -i "${srcdir}/vtk-mingw-w64.patch"
-  patch -Np1 -i "${srcdir}/0002-dont-use-external-templates-mingw.patch"
 }
 
 build() {
@@ -63,11 +57,12 @@ build() {
     _cmakeopts=('-DVTK_USE_64BIT_IDS=ON')
   }
 
-  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
-  mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}" && cd "${srcdir}/build-${CARCH}"
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DVTK_INSTALL_QT_PLUGIN_DIR=;-DVTK_INSTALL_TCL_DIR=" \
-  "${MINGW_PREFIX}/bin/cmake.exe" -Wno-dev \
+  "${MINGW_PREFIX}/bin/cmake.exe" \
+    -Wno-dev \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DVTK_INSTALL_QT_PLUGIN_DIR="${MINGW_PREFIX}/share/qt5/plugins/designer" \
@@ -130,7 +125,7 @@ package() {
   cd "${srcdir}/build-${CARCH}"
   make -j1 DESTDIR="${pkgdir}" install
 
-  local PREFIX_DEPS=$(cygpath -am ${MINGW_PREFIX})
+  local PREFIX_DEPS=$(cygpath -am "${MINGW_PREFIX}")
 
   pushd "${pkgdir}${MINGW_PREFIX}/lib/cmake/${_realname}-${pkgver%.*}" > /dev/null
   sed -s 's|Qt5::|Qt5|g' -i ./VTKTargets*.cmake


### PR DESCRIPTION
Updated VTK to newest 8.0.0 release. The patches are not required for building anymore. I did not perform any tests except that VTK builds.