### PR TITLE
gcc: actually apply the patches

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -12,7 +12,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
 pkgver=7.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -89,8 +89,11 @@ _threads="posix"
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
-  msg2 "Applying $1"
-  patch -Nbp1 -i "${srcdir}"/$1
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/${_patch}"
+  done
 }
 
 del_file_exists() {


### PR DESCRIPTION
I'm getting the _ITM_RU1 relocation errors again from https://github.com/Alexpux/MINGW-packages/issues/1580
Wasn't the weak references in 64-bit patch merged upstream already?

Edit: (^ It was added to master the same day of the 7.1 release, so no.)