### PR TITLE
mingw-w64-fontconfig: added python3-lxml to makedepends

### DIFF
--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -10,7 +10,9 @@ pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
 url="https://wiki.freedesktop.org/www/Software/fontconfig/"
 license=("custom")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-python3-lxml")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat>=2.1.0"
          "${MINGW_PACKAGE_PREFIX}-freetype>=2.3.11"


### PR DESCRIPTION
Added `mingw-w64-python3-lxml` to makedepends to fix https://github.com/Alexpux/MINGW-packages/issues/2602