### PR TITLE
mingw-w64-x264-git: adding nasm>=2.13 to makedepends

### DIFF
--- a/mingw-w64-x264-git/PKGBUILD
+++ b/mingw-w64-x264-git/PKGBUILD
@@ -12,7 +12,11 @@ pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
 url="https://www.videolan.org/developers/x264.html"
 license=("custom")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "yasm" "git")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "yasm"
+             "nasm>=2.13"
+             "git")
 depends=("${MINGW_PACKAGE_PREFIX}-libwinpthread"
          "${MINGW_PACKAGE_PREFIX}-l-smash")
 options=('strip' 'staticlibs')


### PR DESCRIPTION
`mingw-w64-x264-git` fails to build with error:
```
==> Starting build()...
Found no assembler
Minimum version is nasm-2.13
If you really want to compile without asm, configure with --disable-asm.
==> ERROR: A failure occurred in build().
    Aborting...
```
Added nasm>=2.13 to makedepends. I'm not sure if it still requires `yasm` so I left yasm in makedepends.