### PR TITLE
libcaca: Move cppunit to makedepends/checkdepends

### DIFF
--- a/mingw-w64-libcaca/PKGBUILD
+++ b/mingw-w64-libcaca/PKGBUILD
@@ -4,20 +4,21 @@ _realname=libcaca
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.99.beta19
-pkgrel=2
+pkgrel=3
 pkgdesc="Color AsCii Art library (mingw-w64)"
 arch=('any')
 url="http://caca.zoy.org/wiki/libcaca"
 license=("LGPL")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cppunit"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              #"${MINGW_PACKAGE_PREFIX}-ncurses"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-ruby")
-depends=("${MINGW_PACKAGE_PREFIX}-cppunit"
-         "${MINGW_PACKAGE_PREFIX}-fontconfig"
+depends=("${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-zlib")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-cppunit")
 options=(!libtool strip staticlibs)
 source=(http://libcaca.zoy.org/files/libcaca/${_realname}-${pkgver}.tar.gz
         0001-win32-is-not-msvc-it-could-be.mingw.patch
@@ -52,7 +53,8 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-static \
     --enable-shared \
-    --disable-ncurses
+    --disable-ncurses \
+    --disable-doc
 
   make
 }


### PR DESCRIPTION
Also use --disable-doc to make the build work without doxygen.