### PR TITLE
Add freetds build script

### DIFF
--- a/mingw-w64-freetds/0001-Don-t-use-MSYS2-file-libws2_32.patch
+++ b/mingw-w64-freetds/0001-Don-t-use-MSYS2-file-libws2_32.patch
@@ -1,0 +1,41 @@
+From 56e8972f66c3e948e2ad6885595c58fd23dcdb37 Mon Sep 17 00:00:00 2001
+From: Lars Kanis <kanis@comcard.de>
+Date: Thu, 6 Jul 2017 17:09:40 +0200
+Subject: [PATCH] Don't use MSYS2 file libws2_32.a for MINGW build
+
+This file is intended for MSYS2/cygwin builds and blocks OpenSSL
+detection of freetds on i686.
+---
+ configure    | 2 --
+ configure.ac | 2 --
+ 2 files changed, 4 deletions(-)
+
+diff --git a/configure b/configure
+index 9495a49..31eb01d 100644
+--- a/configure
++++ b/configure
+@@ -15915,8 +15915,6 @@ case $host in
+ 	tds_mingw=yes
+ 	if test "$host_cpu" = "x86_64"; then
+ 		LIBS="-lws2_32"
+-	elif test -r /usr/lib/w32api/libws2_32.a; then
+-		LIBS="-L/usr/lib/w32api -lws2_32"
+ 	else
+ 		LIBS="-lws2_32"
+ 	fi
+diff --git a/configure.ac b/configure.ac
+index bff51aa..1034bf7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -172,8 +172,6 @@ case $host in
+ 	tds_mingw=yes
+ 	if test "$host_cpu" = "x86_64"; then
+ 		LIBS="-lws2_32"
+-	elif test -r /usr/lib/w32api/libws2_32.a; then
+-		LIBS="-L/usr/lib/w32api -lws2_32"
+ 	else
+ 		LIBS="-lws2_32"
+ 	fi
+-- 
+2.6.2.windows.1
+

--- a/mingw-w64-freetds/0002-Enable-inet_pton-definition-in-MINGW-i686-build.patch
+++ b/mingw-w64-freetds/0002-Enable-inet_pton-definition-in-MINGW-i686-build.patch
@@ -1,0 +1,26 @@
+From ebf33922cdd5e80a3365a5387d95feef63476b5e Mon Sep 17 00:00:00 2001
+From: Lars Kanis <kanis@comcard.de>
+Date: Thu, 6 Jul 2017 18:16:25 +0200
+Subject: [PATCH] Enable inet_pton() definition in MINGW i686 build
+
+---
+ src/tds/tls.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/tds/tls.c b/src/tds/tls.c
+index a44ac6c..0003291 100644
+--- a/src/tds/tls.c
++++ b/src/tds/tls.c
+@@ -20,6 +20,9 @@
+ 
+ #include <config.h>
+ 
++/* enabled some additional definitions for inet_pton */
++#define _WIN32_WINNT 0x601
++
+ #include <stdio.h>
+ 
+ #if HAVE_ERRNO_H
+-- 
+2.6.2.windows.1
+

--- a/mingw-w64-freetds/PKGBUILD
+++ b/mingw-w64-freetds/PKGBUILD
@@ -1,0 +1,52 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Lars Kanis <lars@greiz-reinsdorf.de>
+
+_realname=freetds
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.00.48
+pkgrel=1
+pkgdesc="A free implementation of Sybase's DB-Library, CT-Library and ODBC libraries."
+arch=('any')
+url="http://www.freetds.org/"
+license=(LGPL2)
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-libiconv")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-libtool")
+options=('strip' '!libtool' 'staticlibs')
+source=(ftp://ftp.freetds.org/pub/freetds/stable/freetds-${pkgver}.tar.bz2
+        0001-Don-t-use-MSYS2-file-libws2_32.patch
+        0002-Enable-inet_pton-definition-in-MINGW-i686-build.patch )
+sha256sums=('fdda4c744072d9a8c2d1553c96ad2cf506993b873ff637a1b23d82c7714c29b4'
+            '27e97c6bab28f00d5f6b00cb4a2f604e9c1919d08ee9fbd12b244461aff9f2d4'
+            'f0ac77b00b14db339fb772730ca36c97e8ff69ccfed2fe4291cad6daba47c586')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/0001-Don-t-use-MSYS2-file-libws2_32.patch
+  patch -p1 -i ${srcdir}/0002-Enable-inet_pton-definition-in-MINGW-i686-build.patch
+}
+
+build() {
+  [[ -d "${srcdir}/build-${CARCH}" ]] && rm -rf "${srcdir}/build-${CARCH}"
+  mkdir -p "${srcdir}/build-${CARCH}"
+  cd "${srcdir}/build-${CARCH}"
+
+  ../freetds-${pkgver}/configure \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --enable-static \
+    --enable-shared \
+    --with-openssl \
+    --enable-sspi
+
+  make
+}
+
+package () {
+  cd "${srcdir}/build-${CARCH}"
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
This adds a build script for [FreeTDS](http://www.freetds.org/). I'll open a pull request for the required patch.

I tested the package by using `tsql.exe` (which is part of the resulting package) and by building and running [tiny_tds](https://github.com/rails-sqlserver/tiny_tds) against the installed libraries.