### PR TITLE
python3: Use is_cygpty() to detect a terminal; disable readline with …

### DIFF
--- a/mingw-w64-python3/1700-cygpty-isatty-disable-readline.patch
+++ b/mingw-w64-python3/1700-cygpty-isatty-disable-readline.patch
@@ -1,0 +1,382 @@
+diff -Nur Python-3.6.2rc1/Include/iscygpty.h Python-3.6.2rc1_pty/Include/iscygpty.h
+--- Python-3.6.2rc1/Include/iscygpty.h	1970-01-01 01:00:00.000000000 +0100
++++ Python-3.6.2rc1_pty/Include/iscygpty.h	2017-06-01 15:06:06.000000000 +0200
+@@ -0,0 +1,41 @@
++/*
++ * iscygpty.h -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifndef _ISCYGPTY_H
++#define _ISCYGPTY_H
++
++#ifdef _WIN32
++int is_cygpty(int fd);
++int is_cygpty_used(void);
++#else
++#define is_cygpty(fd)		0
++#define is_cygpty_used()	0
++#endif
++
++#endif /* _ISCYGPTY_H */
+diff -Nur Python-3.6.2rc1/Makefile.pre.in Python-3.6.2rc1_pty/Makefile.pre.in
+--- Python-3.6.2rc1/Makefile.pre.in	2017-07-07 15:33:14.892371300 +0200
++++ Python-3.6.2rc1_pty/Makefile.pre.in	2017-07-07 14:39:37.110324600 +0200
+@@ -106,7 +106,7 @@
+ # Extra C flags added for building the interpreter object files.
+ CFLAGSFORSHARED=@CFLAGSFORSHARED@
+ # C flags used for building the interpreter object files
+-PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
++PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE -D_WIN32_WINNT=0x0600
+ # Strict or non-strict aliasing flags used to compile dtoa.c, see above
+ CFLAGS_ALIASING=@CFLAGS_ALIASING@
+ 
+@@ -343,6 +343,7 @@
+ 		Python/graminit.o \
+ 		Python/import.o \
+ 		Python/importdl.o \
++		Python/iscygpty.o \
+ 		Python/marshal.o \
+ 		Python/modsupport.o \
+ 		Python/mystrtoul.o \
+@@ -953,6 +954,7 @@
+ 		$(srcdir)/Include/genobject.h \
+ 		$(srcdir)/Include/import.h \
+ 		$(srcdir)/Include/intrcheck.h \
++		$(srcdir)/Include/iscygpty.h \
+ 		$(srcdir)/Include/iterobject.h \
+ 		$(srcdir)/Include/listobject.h \
+ 		$(srcdir)/Include/longintrepr.h \
+diff -Nur Python-3.6.2rc1/Modules/_io/fileio.c Python-3.6.2rc1_pty/Modules/_io/fileio.c
+--- Python-3.6.2rc1/Modules/_io/fileio.c	2017-07-07 15:33:04.837796200 +0200
++++ Python-3.6.2rc1_pty/Modules/_io/fileio.c	2017-07-07 14:38:31.805589400 +0200
+@@ -17,6 +17,7 @@
+ #endif
+ #include <stddef.h> /* For offsetof */
+ #include "_iomodule.h"
++#include "iscygpty.h"
+ 
+ /*
+  * Known likely problems:
+@@ -1116,7 +1117,7 @@
+         return err_closed();
+     Py_BEGIN_ALLOW_THREADS
+     _Py_BEGIN_SUPPRESS_IPH
+-    res = isatty(self->fd);
++    res = isatty(self->fd) || is_cygpty(self->fd);
+     _Py_END_SUPPRESS_IPH
+     Py_END_ALLOW_THREADS
+     return PyBool_FromLong(res);
+diff -Nur Python-3.6.2rc1/Modules/posixmodule.c Python-3.6.2rc1_pty/Modules/posixmodule.c
+--- Python-3.6.2rc1/Modules/posixmodule.c	2017-07-07 15:33:02.160643000 +0200
++++ Python-3.6.2rc1_pty/Modules/posixmodule.c	2017-07-07 14:40:46.610299800 +0200
+@@ -31,6 +31,7 @@
+ #else
+ #include "winreparse.h"
+ #endif
++#include "iscygpty.h"
+ 
+ /* On android API level 21, 'AT_EACCESS' is not declared although
+  * HAVE_FACCESSAT is defined. */
+@@ -8357,7 +8358,7 @@
+ {
+     int return_value;
+     _Py_BEGIN_SUPPRESS_IPH
+-    return_value = isatty(fd);
++    return_value = isatty(fd) || is_cygpty(fd);
+     _Py_END_SUPPRESS_IPH
+     return return_value;
+ }
+diff -Nur Python-3.6.2rc1/Modules/readline.c Python-3.6.2rc1_pty/Modules/readline.c
+--- Python-3.6.2rc1/Modules/readline.c	2017-07-07 15:32:52.081066500 +0200
++++ Python-3.6.2rc1_pty/Modules/readline.c	2017-07-07 15:30:59.697638600 +0200
+@@ -6,6 +6,7 @@
+ 
+ /* Standard definitions */
+ #include "Python.h"
++#include "iscygpty.h"
+ #include <stddef.h>
+ #include <setjmp.h>
+ #include <signal.h>
+@@ -1404,6 +1405,11 @@
+     PyObject *m;
+     readlinestate *mod_state;
+ 
++    if (!is_cygpty(STDOUT_FILENO)) {
++        PyErr_SetString(PyExc_ImportError, "Not a cygwin terminal");
++        return NULL;
++    }
++
+ #ifdef __APPLE__
+     if (strncmp(rl_library_version, libedit_version_tag, strlen(libedit_version_tag)) == 0) {
+         using_libedit_emulation = 1;
+diff -Nur Python-3.6.2rc1/Python/frozenmain.c Python-3.6.2rc1_pty/Python/frozenmain.c
+--- Python-3.6.2rc1/Python/frozenmain.c	2017-07-07 15:33:11.848197100 +0200
++++ Python-3.6.2rc1_pty/Python/frozenmain.c	2017-07-07 14:32:32.147018100 +0200
+@@ -3,6 +3,7 @@
+ 
+ #include "Python.h"
+ #include <locale.h>
++#include "iscygpty.h"
+ 
+ #ifdef MS_WINDOWS
+ extern void PyWinFreeze_ExeInit(void);
+@@ -93,7 +94,7 @@
+     else
+         sts = 0;
+ 
+-    if (inspect && isatty((int)fileno(stdin)))
++    if (inspect && (isatty((int)fileno(stdin)) || is_cygpty((int)fileno(stdin))))
+         sts = PyRun_AnyFile(stdin, "<stdin>") != 0;
+ 
+ #ifdef MS_WINDOWS
+diff -Nur Python-3.6.2rc1/Python/iscygpty.c Python-3.6.2rc1_pty/Python/iscygpty.c
+--- Python-3.6.2rc1/Python/iscygpty.c	1970-01-01 01:00:00.000000000 +0100
++++ Python-3.6.2rc1_pty/Python/iscygpty.c	2017-07-07 14:26:41.145942000 +0200
+@@ -0,0 +1,185 @@
++/*
++ * iscygpty.c -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifdef _WIN32
++
++#include <ctype.h>
++#include <io.h>
++#include <wchar.h>
++#include <windows.h>
++
++#ifdef USE_FILEEXTD
++/* VC 7.1 or earlier doesn't support SAL. */
++# if !defined(_MSC_VER) || (_MSC_VER < 1400)
++#  define __out
++#  define __in
++#  define __in_opt
++# endif
++/* Win32 FileID API Library:
++ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
++ * Needed for WinXP. */
++# include <fileextd.h>
++#else /* USE_FILEEXTD */
++/* VC 8 or earlier. */
++# if defined(_MSC_VER) && (_MSC_VER < 1500)
++#  ifdef ENABLE_STUB_IMPL
++#   define STUB_IMPL
++#  else
++#   error "Win32 FileID API Library is required for VC2005 or earlier."
++#  endif
++# endif
++#endif /* USE_FILEEXTD */
++
++
++#include "iscygpty.h"
++
++//#define USE_DYNFILEID
++#ifdef USE_DYNFILEID
++typedef BOOL (WINAPI *pfnGetFileInformationByHandleEx)(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++);
++static pfnGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
++
++# ifndef USE_FILEEXTD
++static BOOL WINAPI stub_GetFileInformationByHandleEx(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++		)
++{
++	return FALSE;
++}
++# endif
++
++static void setup_fileid_api(void)
++{
++	if (pGetFileInformationByHandleEx != NULL) {
++		return;
++	}
++	pGetFileInformationByHandleEx = (pfnGetFileInformationByHandleEx)
++		GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
++				"GetFileInformationByHandleEx");
++	if (pGetFileInformationByHandleEx == NULL) {
++# ifdef USE_FILEEXTD
++		pGetFileInformationByHandleEx = GetFileInformationByHandleEx;
++# else
++		pGetFileInformationByHandleEx = stub_GetFileInformationByHandleEx;
++# endif
++	}
++}
++#else
++# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
++# define setup_fileid_api()
++#endif
++
++
++#define is_wprefix(s, prefix) \
++	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
++
++/* Check if the fd is a cygwin/msys's pty. */
++int is_cygpty(int fd)
++{
++#ifdef STUB_IMPL
++	return 0;
++#else
++	HANDLE h;
++	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * MAX_PATH;
++	FILE_NAME_INFO *nameinfo;
++	WCHAR *p = NULL;
++
++	setup_fileid_api();
++
++	h = (HANDLE) _get_osfhandle(fd);
++	if (h == INVALID_HANDLE_VALUE) {
++		return 0;
++	}
++	/* Cygwin/msys's pty is a pipe. */
++	if (GetFileType(h) != FILE_TYPE_PIPE) {
++		return 0;
++	}
++	nameinfo = malloc(size);
++	if (nameinfo == NULL) {
++		return 0;
++	}
++	/* Check the name of the pipe:
++	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
++	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
++		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
++		p = nameinfo->FileName;
++		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
++			p += 8;
++		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
++			p += 6;
++		} else {
++			p = NULL;
++		}
++		if (p != NULL) {
++			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
++				++p;
++			if (is_wprefix(p, L"-pty")) {
++				p += 4;
++			} else {
++				p = NULL;
++			}
++		}
++		if (p != NULL) {
++			while (*p && isdigit(*p))	/* Skip pty number. */
++				++p;
++			if (is_wprefix(p, L"-from-master")) {
++				//p += 12;
++			} else if (is_wprefix(p, L"-to-master")) {
++				//p += 10;
++			} else {
++				p = NULL;
++			}
++		}
++	}
++	free(nameinfo);
++	return (p != NULL);
++#endif /* STUB_IMPL */
++}
++
++/* Check if at least one cygwin/msys pty is used. */
++int is_cygpty_used(void)
++{
++	int fd, ret = 0;
++
++	for (fd = 0; fd < 3; fd++) {
++		ret |= is_cygpty(fd);
++	}
++	return ret;
++}
++
++#endif /* _WIN32 */
++
++/* vim: set ts=4 sw=4: */
+diff -Nur Python-3.6.2rc1/Python/pylifecycle.c Python-3.6.2rc1_pty/Python/pylifecycle.c
+--- Python-3.6.2rc1/Python/pylifecycle.c	2017-07-07 15:33:17.815538400 +0200
++++ Python-3.6.2rc1_pty/Python/pylifecycle.c	2017-07-07 14:20:38.085176100 +0200
+@@ -14,6 +14,7 @@
+ #include "ast.h"
+ #include "marshal.h"
+ #include "osdefs.h"
++#include "iscygpty.h"
+ #include <locale.h>
+ 
+ #ifdef HAVE_SIGNAL_H
+@@ -1705,7 +1706,7 @@
+ int
+ Py_FdIsInteractive(FILE *fp, const char *filename)
+ {
+-    if (isatty((int)fileno(fp)))
++    if (isatty((int)fileno(fp)) || is_cygpty((int)fileno(fp)))
+         return 1;
+     if (!Py_InteractiveFlag)
+         return 0;
+diff -Nur Python-3.6.2rc1/setup.py Python-3.6.2rc1_pty/setup.py
+--- Python-3.6.2rc1/setup.py	2017-07-07 15:32:54.857225300 +0200
++++ Python-3.6.2rc1_pty/setup.py	2017-07-07 14:55:12.937850900 +0200
+@@ -818,10 +818,11 @@
+                                                      ['/usr/lib/termcap'],
+                                                      'termcap'):
+                 readline_libs.append('termcap')
+-            exts.append( Extension('readline', ['readline.c'],
++            exts.append( Extension('readline', ['readline.c', '../Python/iscygpty.c'],
+                                    library_dirs=['/usr/lib/termcap'],
+                                    extra_link_args=readline_extra_link_args,
+-                                   libraries=readline_libs) )
++                                   libraries=readline_libs,
++                                   extra_compile_args=["-D_WIN32_WINNT=0x0600"]) )
+         else:
+             missing.append('readline')
+ 

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
 pkgver=${_pybasever}.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -131,6 +131,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1630-build-winconsoleio.patch
         1640-dont-include-consoleapi-h.patch
         1650-expose-sem_unlink.patch
+        1700-cygpty-isatty-disable-readline.patch
         smoketests.py)
 
 prepare() {
@@ -247,6 +248,13 @@ prepare() {
   patch -Np1 -i "${srcdir}"/1630-build-winconsoleio.patch
   patch -Np1 -i "${srcdir}"/1640-dont-include-consoleapi-h.patch
   patch -Np1 -i "${srcdir}"/1650-expose-sem_unlink.patch
+
+  # Extend some isatty calls to check for mintty when checking for
+  # a terminal output. Disable the readline module under non-mintty as it
+  # breaks things with a real console (like conemu or winpty)
+  # https://github.com/Alexpux/MINGW-packages/issues/2645
+  # https://github.com/Alexpux/MINGW-packages/issues/2656
+  patch -Np1 -i "${srcdir}"/1700-cygpty-isatty-disable-readline.patch
 
   autoreconf -vfi
 
@@ -390,18 +398,6 @@ package() {
   # Create python executable with windows subsystem
   cp -f "${pkgdir}${MINGW_PREFIX}"/bin/python3.exe "${pkgdir}${MINGW_PREFIX}"/bin/python3w.exe
   ${MINGW_PREFIX}/bin/objcopy --subsystem windows "${pkgdir}${MINGW_PREFIX}"/bin/python3w.exe
-
-  # Add a wrapper script to force -i when invoking python. Please don't move this into a patch as
-  # hopefully one day we won't need this hack (when we replace mintty with a real console).
-  _exename="python3"
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe
-  echo "#!/usr/bin/env bash"                                           > "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "if [ \$# -eq 0 ]; then"                                       >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo '  "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" -i "$@"' >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "else"                                                         >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo '  "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"'    >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "fi"                                                           >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe
 }
 
 sha256sums=('9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9'
@@ -496,4 +492,5 @@ sha256sums=('9229773be41ed144370f47f0f626a1579931f5a390f1e8e3853174d52edd64a9'
             '8896f4e11c17498c666251cef1c89ee0d78886814c8f227ee46807bedb4b1ad3'
             '597c1c13c7f4debea71de4de3325eeb66cb9c1dc064c4961a6f27de8f07c1992'
             '14347ddde0fb78ae9d7ae1674e24fbf8c26c5c75547de33633318d785468f49e'
+            'cbd10a2b215cc698a187951f7647922d490da0f520f476f2d2c69e10a143bdaf'
             'f4f5359b35741b703cbd22dc73438c181b8541e30b3f7614bd272f7cd2c59049')


### PR DESCRIPTION
…a real Windows console

CPython uses isatty() to detect a terminal and change some settings
like line buffering and interactive mode. Use is_cygpty() to make
this also work under mintty.
See https://github.com/Alexpux/MINGW-packages/issues/2645

This also removes the bash script which forced the interactive mode
when python3 was started without arguments. This is no longer needed as
Python now detects the terminal output and does this automatically.

Also use is_cygpty() to detect when not under mintty and disable the readline
module there, as using it breaks input of certain characters and
leads to errors on shutdown when it tries to save the readline history.
(The readline module is not available in the official Python build)
See https://github.com/Alexpux/MINGW-packages/issues/2656