### PR TITLE
intel-tbb: Update to 2017_20170604

### DIFF
--- a/mingw-w64-intel-tbb/PKGBUILD
+++ b/mingw-w64-intel-tbb/PKGBUILD
@@ -3,7 +3,8 @@
 _realname=intel-tbb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2017_20170118
+pkgver=2017_20170604
+_pkgver=2017_U7
 pkgrel=1
 epoch=1
 pkgdesc='High level abstract threading library (mingw-w64)'
@@ -12,14 +13,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-make")
 options=('!strip' 'staticlibs')
 arch=('any')
 url='https://www.threadingbuildingblocks.org/'
-license=('GPL')
-source=(https://www.threadingbuildingblocks.org/sites/default/files/software_releases/source/tbb${pkgver}oss_src.tgz
+license=('Apache')
+source=(https://github.com/01org/tbb/archive/${_pkgver}.tar.gz
         'tbb-disable_windows_api.patch')
-sha256sums=('48bb526287fa8b4e7d1e1b2ba9e5fb9c3e372b497772c06ef9ccd7f93f344e74'
+sha256sums=('755b7dfaf018f5d8ae3bf2e8cfa0fa4672372548e8cc043ed1eb5b22a9bf5b72'
             '413e75118518074da634258ccdb57ff134f4ec234ca1ae17dd5a2decf8c677f6')
 
+
+
 prepare () {
-  cd tbb${pkgver}oss
+  cd ${srcdir}/tbb-${_pkgver}
 
   # do not build debug libraries
   #sed -i "/debug/d" Makefile
@@ -46,7 +49,7 @@ prepare () {
 }
 
 build() {
-  cd tbb${pkgver}oss
+  cd ${srcdir}/tbb-${_pkgver}
 
   sed -i "s|OUTPUT_KEY = -o #|OUTPUT_KEY = -Wl,--out-implib,lib\$(BUILDING_LIBRARY).a -o #|g" build/windows.gcc.inc
   #sed -i "s|\$(call detect_js,/minversion gcc 4.4)|ok|g" build/windows.gcc.inc
@@ -63,11 +66,11 @@ build() {
     parch=ia32
   fi
   unset LDFLAGS
-  mingw32-make arch=$parch tbb_os=windows runtime=mingw compiler=gcc cpp0x=1
+  mingw32-make arch=$parch tbb_os=windows runtime=mingw compiler=gcc stdver=c++11
 }
 
 package() {
-  cd tbb${pkgver}oss
+  cd ${srcdir}/tbb-${_pkgver}
 
   if test "${MINGW_CHOST}" = "x86_64-w64-mingw32"
   then


### PR DESCRIPTION
Change cpp0x=1 to stdver=c++11 as suggested by the deprecation warning
printed by the build script.

Change license to Apache:
    "TBB Version 4.4 and any older version will be under GPL license TBB
     Version 2017 and all future versions will be under Apache v2.0
     license."