### PR TITLE
meson: Various improvements

### DIFF
--- a/mingw-w64-jsonrpc-glib/PKGBUILD
+++ b/mingw-w64-jsonrpc-glib/PKGBUILD
@@ -30,7 +30,7 @@ build() {
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
 
-  meson.py \
+  meson \
     --buildtype plain \
     -Denable-tests=false \
     -Dwith_introspection=false \

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.41.1
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 url="http://mesonbuild.com/"
@@ -12,12 +12,19 @@ license=("Apache 2")
 options=('strip' 'staticlibs')
 depends=("${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-ninja")
-source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('3d160b0514ff3d25f0a47975c6f70fd82b76c589876d10413efc5e01df43e0c2')
+source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
+        'force-func-detect.patch'
+        'no-script-suffix.patch')
+sha256sums=('3d160b0514ff3d25f0a47975c6f70fd82b76c589876d10413efc5e01df43e0c2'
+            '91ff7975c3cae17536e983b35da17c5f7581ad744c4d846693a399052192faa4'
+            'ffa0f8ed4df3ae73ab6cb42d49e4cb9148f095ad308276d4c18b65d6856467bb')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # https://github.com/mesonbuild/meson/issues/1083
+  patch -Np1 -i "${srcdir}"/force-func-detect.patch
+  patch -Np1 -i "${srcdir}"/no-script-suffix.patch
 }
 
 build() {
@@ -34,13 +41,15 @@ package() {
 
   PREFIX_WIN=$(cygpath -m ${MINGW_PREFIX})
   sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i "${pkgdir}${MINGW_PREFIX}/bin/meson.py"
+    -i "${pkgdir}${MINGW_PREFIX}/bin/meson"
   sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i "${pkgdir}${MINGW_PREFIX}/bin/mesonconf.py"
+    -i "${pkgdir}${MINGW_PREFIX}/bin/mesonconf"
   sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i "${pkgdir}${MINGW_PREFIX}/bin/mesonintrospect.py"
+    -i "${pkgdir}${MINGW_PREFIX}/bin/mesonintrospect"
   sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i "${pkgdir}${MINGW_PREFIX}/bin/wraptool.py"
+    -i "${pkgdir}${MINGW_PREFIX}/bin/mesontest"
+  sed -s "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+    -i "${pkgdir}${MINGW_PREFIX}/bin/wraptool"
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -15,11 +15,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3"
 source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
         'force-func-detect.patch'
         'no-script-suffix.patch'
-        'gtkdoc-exec-perl.patch')
+        'gtkdoc-exec-perl.patch'
+        'color-term.patch'
+        )
 sha256sums=('3d160b0514ff3d25f0a47975c6f70fd82b76c589876d10413efc5e01df43e0c2'
             '91ff7975c3cae17536e983b35da17c5f7581ad744c4d846693a399052192faa4'
             'ffa0f8ed4df3ae73ab6cb42d49e4cb9148f095ad308276d4c18b65d6856467bb'
-            '2bbea2b1e803473a56f5a0acd66a0051f76e5d836a7e7dbc33088bd352a9f450')
+            '2bbea2b1e803473a56f5a0acd66a0051f76e5d836a7e7dbc33088bd352a9f450'
+            'eee384da0f3703ef64d088e9ad79be8a25566de1b0410b5e40f574e40cc41a65'
+           )
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -28,6 +32,7 @@ prepare() {
   patch -Np1 -i "${srcdir}"/force-func-detect.patch
   patch -Np1 -i "${srcdir}"/no-script-suffix.patch
   patch -Np1 -i "${srcdir}"/gtkdoc-exec-perl.patch
+  patch -Np1 -i "${srcdir}"/color-term.patch
 }
 
 build() {

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -14,10 +14,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-ninja")
 source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.gz
         'force-func-detect.patch'
-        'no-script-suffix.patch')
+        'no-script-suffix.patch'
+        'gtkdoc-exec-perl.patch')
 sha256sums=('3d160b0514ff3d25f0a47975c6f70fd82b76c589876d10413efc5e01df43e0c2'
             '91ff7975c3cae17536e983b35da17c5f7581ad744c4d846693a399052192faa4'
-            'ffa0f8ed4df3ae73ab6cb42d49e4cb9148f095ad308276d4c18b65d6856467bb')
+            'ffa0f8ed4df3ae73ab6cb42d49e4cb9148f095ad308276d4c18b65d6856467bb'
+            '2bbea2b1e803473a56f5a0acd66a0051f76e5d836a7e7dbc33088bd352a9f450')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -25,6 +27,7 @@ prepare() {
   # https://github.com/mesonbuild/meson/issues/1083
   patch -Np1 -i "${srcdir}"/force-func-detect.patch
   patch -Np1 -i "${srcdir}"/no-script-suffix.patch
+  patch -Np1 -i "${srcdir}"/gtkdoc-exec-perl.patch
 }
 
 build() {

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.41.1
-pkgrel=2
+pkgver=0.41.2
+pkgrel=1
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 url="http://mesonbuild.com/"
@@ -18,7 +18,7 @@ source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/$
         'gtkdoc-exec-perl.patch'
         'color-term.patch'
         )
-sha256sums=('3d160b0514ff3d25f0a47975c6f70fd82b76c589876d10413efc5e01df43e0c2'
+sha256sums=('074dd24fd068be0893e2e45bcc35c919d8e12777e9d6a7efdf72d4dc300867ca'
             '91ff7975c3cae17536e983b35da17c5f7581ad744c4d846693a399052192faa4'
             'ffa0f8ed4df3ae73ab6cb42d49e4cb9148f095ad308276d4c18b65d6856467bb'
             '2bbea2b1e803473a56f5a0acd66a0051f76e5d836a7e7dbc33088bd352a9f450'

--- a/mingw-w64-meson/color-term.patch
+++ b/mingw-w64-meson/color-term.patch
@@ -1,0 +1,11 @@
+--- meson-0.41.1/mesonbuild/mlog.py.orig	2017-04-15 16:27:38.000000000 +0200
++++ meson-0.41.1/mesonbuild/mlog.py	2017-07-17 09:21:03.104941200 +0200
+@@ -18,7 +18,7 @@
+ information about Meson runs. Some output goes to screen,
+ some to logging dir and some goes to both."""
+ 
+-colorize_console = platform.system().lower() != 'windows' and os.isatty(sys.stdout.fileno()) and \
++colorize_console = (platform.system().lower() != 'windows' or os.environ.get('TERM', '').startswith('xterm')) and os.isatty(sys.stdout.fileno()) and \
+     os.environ.get('TERM') != 'dumb'
+ log_dir = None
+ log_file = None

--- a/mingw-w64-meson/force-func-detect.patch
+++ b/mingw-w64-meson/force-func-detect.patch
@@ -1,0 +1,12 @@
+--- meson-0.41.1/mesonbuild/compilers.py.orig	2017-07-15 01:13:42.288422200 +0200
++++ meson-0.41.1/mesonbuild/compilers.py	2017-07-15 01:14:56.965693500 +0200
+@@ -1337,6 +1337,9 @@
+         if self.get_id() == 'msvc':
+             return False
+ 
++        if funcname in ['stpcpy', 'posix_memalign']:
++            return False
++
+         # Detect function as a built-in
+         #
+         # Some functions like alloca() are defined as compiler built-ins which

--- a/mingw-w64-meson/gtkdoc-exec-perl.patch
+++ b/mingw-w64-meson/gtkdoc-exec-perl.patch
@@ -1,0 +1,29 @@
+--- meson-0.41.1/mesonbuild/scripts/gtkdochelper.py.orig	2017-06-08 19:28:37.000000000 +0200
++++ meson-0.41.1/mesonbuild/scripts/gtkdochelper.py	2017-07-16 14:21:37.612414900 +0200
+@@ -45,10 +45,25 @@
+ parser.add_argument('--mode', dest='mode', default='')
+ parser.add_argument('--installdir', dest='install_dir')
+ 
++
++def cyg2winpath(path):
++    assert os.name == "nt"
++    win_path = subprocess.check_output(
++        ["cygpath.exe", "-m" if os.sep == "/" else "-w", "--", path])
++    return win_path.decode("utf-8").strip()
++
++
++def cygcmd(args):
++    assert os.name == "nt"
++    return [cyg2winpath("/usr/bin/perl"),
++            cyg2winpath("/usr/bin/%s" % args[0])] + list(args[1:])
++
++
+ def gtkdoc_run_check(cmd, cwd):
+     # Put stderr into stdout since we want to print it out anyway.
+     # This preserves the order of messages.
+-    p, out = Popen_safe(cmd, cwd=cwd, stderr=subprocess.STDOUT)[0:2]
++    cmd = cygcmd(cmd)
++    p, out = Popen_safe(cmd, cwd=cwd, stderr=subprocess.STDOUT, encoding="utf-8", errors="replace")[0:2]
+     if p.returncode != 0:
+         err_msg = ["{!r} failed with status {:d}".format(cmd[0], p.returncode)]
+         if out:

--- a/mingw-w64-meson/no-script-suffix.patch
+++ b/mingw-w64-meson/no-script-suffix.patch
@@ -1,0 +1,13 @@
+--- meson-0.41.1/setup.py.orig	2017-05-12 18:38:51.000000000 +0200
++++ meson-0.41.1/setup.py	2017-07-15 01:28:23.438821100 +0200
+@@ -35,10 +35,6 @@
+ 
+ class install_scripts(orig):
+     def run(self):
+-        if sys.platform == 'win32':
+-            super().run()
+-            return
+-
+         if not self.skip_build:
+             self.run_command('build_scripts')
+         self.outfiles = []

--- a/mingw-w64-template-glib/PKGBUILD
+++ b/mingw-w64-template-glib/PKGBUILD
@@ -30,7 +30,7 @@ build() {
   mkdir -p build-${MINGW_CHOST}
   cd build-${MINGW_CHOST}
 
-  meson.py \
+  meson \
     --buildtype plain \
     -Dwith_introspection=false \
     ../${_realname}-${pkgver}


### PR DESCRIPTION
* meson detects posix_memalign and stpcpy but both fails to link in
  the end, so force disable them for now. This makes glib2 master build
  using the new meson build system.

* remove the script suffixes so the naming is more in line with the
  documentation and other tools.

* fix gtkdoc invocation by using msys2 perl

* enable colored output with mintty

* Update to 0.41.2