### PR TITLE
icu: disable use of _strtod_l

### DIFF
--- a/mingw-w64-icu/PKGBUILD
+++ b/mingw-w64-icu/PKGBUILD
@@ -10,7 +10,7 @@ _realname=icu
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-${_realname}-debug-libs")
 pkgver=58.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="International Components for Unicode library (mingw-w64)"
 arch=('any')
@@ -86,6 +86,7 @@ prepare() {
 
 build() {
   local -a extra_config
+  CXXFLAGS+=" -DU_USE_STRTOD_L=0" # breaks on Windows XP
   #CXXFLAGS+=" -D_WIN32_WINNT=0x0601"
   cd "${srcdir}/icu/"
   # For ICU we ignore the options for debug above and always


### PR DESCRIPTION
The recent icu update #2424 breaks XP support, see #2708.

With this patch we can support XP a little longer (before we probably have to drop it completely in icu 59)