### PR TITLE
librsvg: Update to 2.40.18

### DIFF
--- a/mingw-w64-librsvg/PKGBUILD
+++ b/mingw-w64-librsvg/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=librsvg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.40.17
+pkgver=2.40.18
 pkgrel=1
 pkgdesc="A SVG viewing library (mingw-w64)"
 arch=('any')
@@ -22,7 +22,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-gtk3: for rsvg-view-3")
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/librsvg/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "0005-hack-unixy-paths.patch")
-sha256sums=('e6f6c5cbecc405bb945c7cd15061276035ae3173bbb3bb25e8a916779c7f69cc'
+sha256sums=('bfc8c488c89c1e7212c478beb95c41b44701636125a3e6dab41187f1485b564c'
             'b23b094c0cb65fcbbbb952350448de6f3430b30f273e05acdbf7a56d634212dc')
 
 prepare() {
@@ -44,6 +44,10 @@ build() {
 
   CXXFLAGS+=" -D_POSIX_SOURCE"
   CFLAGS+=" -D_POSIX_SOURCE"
+
+  # an argument passed to glib-mkenums starts with a c++ comment
+  export MSYS2_ARG_CONV_EXCL="/*"
+
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Also fixes a bug uncovered by running glib master. One of
the arguments passed to glib-mkenums was converted to a path
and ended up in the generated C source.