### PR TITLE
Update to cmake 3.9 - latest version (should be used with libuv and e…

### DIFF
--- a/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
@@ -35,23 +35,22 @@ index f11825083e..e8a07361c0 100644
             !(*ti)->GetPropertyAsBool("AUTORCC")) ||
            (*ti)->IsImported()) {
          continue;
-diff --git a/Source/cmQtAutoGeneratorInitializer.cxx b/Source/cmQtAutoGeneratorInitializer.cxx
-index 825eba0e1d..61652b80b1 100644
---- a/Source/cmQtAutoGeneratorInitializer.cxx
+diff --git a/Source/cmQtAutoGeneratorInitializer.cxx.orig b/Source/cmQtAutoGeneratorInitializer.cxx
+index cecf165..4884b7f 100644
+--- a/Source/cmQtAutoGeneratorInitializer.cxx.orig
 +++ b/Source/cmQtAutoGeneratorInitializer.cxx
-@@ -26,6 +26,7 @@
- #include <cmConfigure.h>
- #include <cmsys/FStream.hxx>
- #include <cmsys/RegularExpression.hxx>
+@@ -25,6 +25,7 @@
+ 
+ #include "cmConfigure.h"
+ #include "cmsys/FStream.hxx"
 +#include <cmGeneratedFileStream.h>
+ #include <algorithm>
  #include <map>
  #include <set>
- #include <sstream>
-@@ -160,6 +161,65 @@ static void SetupSourceFiles(cmGeneratorTarget const* target,
-       }
+@@ -669,6 +670,65 @@ static void RccSetupAutoTarget(cmGeneratorTarget const* target,
      }
    }
-+
+ 
 +  /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake,
 +   * macro(_populate_Core_plugin_properties ..), we'd have:
 +   * set_property(TARGET PROPERTY AUTOSTATICPLUGINS True) // Not currently need
@@ -110,47 +109,22 @@ index 825eba0e1d..61652b80b1 100644
 +      }
 +    }
 +  }
- }
- 
- static void GetCompileDefinitionsAndDirectories(
-@@ -733,7 +793,14 @@ void cmQtAutoGeneratorInitializer::InitializeAutogenTarget(
-     if (target->GetPropertyAsBool("AUTORCC")) {
-       toolNames.push_back("RCC");
-     }
- 
-+    if (toolNames.empty()) {
-+      /* AUTOSTATICPLUGINS .cpp files are created at cmake execution time,
-+       * and not at build time, so in that case it is possible to get here
-+       * with no toolNames. */
-+      return;
-+    }
 +
-     std::string tools = toolNames[0];
-     toolNames.erase(toolNames.begin());
-     while (toolNames.size() > 1) {
-@@ -894,7 +960,9 @@ void cmQtAutoGeneratorInitializer::SetupAutoGenerateTarget(
- 
-   if (target->GetPropertyAsBool("AUTOMOC") ||
-       target->GetPropertyAsBool("AUTOUIC") ||
--      target->GetPropertyAsBool("AUTORCC")) {
-+      target->GetPropertyAsBool("AUTORCC") ||
-+      (    target->GetPropertyAsBool("AUTOSTATICPLUGINS")
-+        && target->GetType() == cmStateEnums::EXECUTABLE)) {
-     SetupSourceFiles(target, mocUicSources, mocUicHeaders, skipMoc, skipUic);
-   }
-   makefile->AddDefinition(
-diff --git a/Source/cmTarget.cxx b/Source/cmTarget.cxx
-index fe3472d5d7..dcfdfcbd32 100644
---- a/Source/cmTarget.cxx
+   AddDefinitionEscaped(makefile, "_qt_rcc_executable", rccCommand);
+   AddDefinitionEscaped(makefile, "_rcc_files", _rcc_files);
+   AddDefinitionEscaped(makefile, "_rcc_inputs", _rcc_inputs);
+diff --git a/Source/cmTarget.cxx.orig b/Source/cmTarget.cxx
+index c95a3ca..9ec1995 100644
+--- a/Source/cmTarget.cxx.orig
 +++ b/Source/cmTarget.cxx
-@@ -245,6 +245,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
+@@ -247,6 +247,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
      this->SetPropertyDefault("AUTOMOC", CM_NULLPTR);
      this->SetPropertyDefault("AUTOUIC", CM_NULLPTR);
      this->SetPropertyDefault("AUTORCC", CM_NULLPTR);
 +    this->SetPropertyDefault("AUTOSTATICPLUGINS", CM_NULLPTR);
+     this->SetPropertyDefault("AUTOMOC_DEPEND_FILTERS", CM_NULLPTR);
      this->SetPropertyDefault("AUTOMOC_MOC_OPTIONS", CM_NULLPTR);
      this->SetPropertyDefault("AUTOUIC_OPTIONS", CM_NULLPTR);
-     this->SetPropertyDefault("AUTORCC_OPTIONS", CM_NULLPTR);
 diff --git a/Source/cmTargetPropertyComputer.cxx b/Source/cmTargetPropertyComputer.cxx
 index a57bc5aea5..b12bd2dea8 100644
 --- a/Source/cmTargetPropertyComputer.cxx

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.8.2
-pkgrel=2
+pkgver=3.9.0
+pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
 url="https://www.cmake.org/"
@@ -32,10 +32,10 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch"
         "cm_codecvt.patch")
-sha256sums=('da3072794eb4c09f2d782fcee043847b99bb4cf8d4573978d9b2024214d6e92d'
+sha256sums=('167701525183dbb722b9ffe69fb525aa2b81798cf12f5ce1c020c93394dfae0f'
             '0d8557d7964a624d00c64ce390a4440d6d82119b45c1cd24ddeae3ee028dcf87'
             '6845069dc9428e09d837b0f260ec3dd477533f8b19812b6d44eb29e8f4561c29'
-            'ab9fa86d0014b076fa58effb3bf14a01bde9a8e462405edef412c19b8618e351'
+            '364279aa2e55426b714561be6d179ebf92d85907817c50b47535f4aa4b545a54'
             'f8886078cb61e2b3d2cb6d7fe9325290206e006d7a1f1423425078bd35b0023f'
             'c230783cdd1a32ddd3d0d938c63d70a24e23bc6947f90f22770d85be5af54c6a'
             'a3541d1272805fa11de0bb7cb19b37f55f2e0664410247c5cfab4ee93d2637a5'
@@ -72,8 +72,8 @@ prepare() {
     0005-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch \
     0007-Do-not-generate-import-libs-for-exes.patch \
-    0008-Output-line-numbers-in-callstacks.patch \
-    cm_codecvt.patch
+    0008-Output-line-numbers-in-callstacks.patch
+#    cm_codecvt.patch
 }
 
 build() {

--- a/mingw-w64-libarchive/0001-libarchive-3.2.2-bcrypt-fix.patch
+++ b/mingw-w64-libarchive/0001-libarchive-3.2.2-bcrypt-fix.patch
@@ -1,62 +1,59 @@
---- libarchive-3.2.2/CMakeLists.txt.orig	2016-10-31 06:44:48.210114100 -0400
-+++ libarchive-3.2.2/CMakeLists.txt	2016-10-31 07:07:35.977487200 -0400
-@@ -1006,6 +1006,22 @@
- ENDIF(ENABLE_ICONV)
+--- libarchive-3.3.2/libarchive/archive_cryptor.c.orig	2017-07-14 07:42:27.977310000 -0400
++++ libarchive-3.3.2/libarchive/archive_cryptor.c	2017-07-14 07:42:17.059675800 -0400
+@@ -57,7 +57,7 @@ pbkdf2_sha1(const char *pw, size_t pw_le
+ 	return 0;
+ }
  
- #
-+# Find Bcrypt library on Windows and MSYS
-+#
-+IF(HAVE_BCRYPT_H)
-+  IF((WIN32 AND NOT CYGWIN) OR MSYS)
-+    FIND_LIBRARY(BCRYPTLIB "Bcrypt")
-+    IF(NOT BCRYPTLIB)
-+      UNSET(HAVE_BCRYPT_H CACHE)
-+      MESSAGE(STATUS "Bcrypt Library: Not Found")
-+    ELSE(NOT BCRYPTLIB)
-+      LIST(APPEND ADDITIONAL_LIBS ${BCRYPTLIB})
-+      MESSAGE(STATUS "Found Bcrypt ${BCRYPTLIB}")
-+    ENDIF(NOT BCRYPTLIB)
-+  ENDIF((WIN32 AND NOT CYGWIN) OR MSYS)
-+ENDIF(HAVE_BCRYPT_H)
-+
-+#
- # Find Libxml2
- #
- IF(ENABLE_LIBXML2)
---- libarchive-3.2.2/configure.ac.orig	2016-11-30 09:57:23.030626900 +0300
-+++ libarchive-3.2.2/configure.ac	2016-11-30 09:57:30.220842900 +0300
-@@ -279,7 +279,6 @@
- AC_CHECK_HEADERS([sys/time.h sys/utime.h sys/utsname.h sys/vfs.h])
- AC_CHECK_HEADERS([time.h unistd.h utime.h wchar.h wctype.h])
- AC_CHECK_HEADERS([windows.h])
--AC_CHECK_HEADERS([Bcrypt.h])
- # check windows.h first; the other headers require it.
- AC_CHECK_HEADERS([wincrypt.h winioctl.h],[],[],
- [[#ifdef HAVE_WINDOWS_H
-@@ -398,6 +393,9 @@
-   AC_CHECK_LIB(lzo2,lzo1x_decompress_safe)
- fi
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
+ #ifdef _MSC_VER
+ #pragma comment(lib, "Bcrypt.lib")
+ #endif
+@@ -168,7 +168,7 @@ aes_ctr_release(archive_crypto_ctx *ctx)
+ 	return 0;
+ }
  
-+AC_ARG_WITH([cng],
-+  AS_HELP_STRING([--without-cng], [Don't build support of CNG(Crypto Next Generation)]))
-+
- AC_ARG_WITH([nettle],
-   AS_HELP_STRING([--without-nettle], [Don't build with crypto support from Nettle]))
- AC_ARG_WITH([openssl],
-@@ -821,6 +819,16 @@
- 	;;
- esac
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
  
-+if test "x$with_cng" != "xno"; then
-+    AC_CHECK_HEADERS([bcrypt.h],[
-+        LIBS="$LIBS -lbcrypt"
-+    ],[],
-+    [[#ifdef HAVE_WINDOWS_H
+ static int
+ aes_ctr_init(archive_crypto_ctx *ctx, const uint8_t *key, size_t key_len)
+--- libarchive-3.3.2/libarchive/archive_cryptor_private.h.orig	2017-07-14 07:42:28.003312000 -0400
++++ libarchive-3.3.2/libarchive/archive_cryptor_private.h	2017-07-14 07:34:30.838942500 -0400
+@@ -63,7 +63,10 @@ typedef struct {
+ 	unsigned	encr_pos;
+ } archive_crypto_ctx;
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
++#if defined(__CYGWIN__)
 +    # include <windows.h>
-+    #endif
-+    ]])
-+fi
-+
- if test "x$with_nettle" != "xno"; then
-     AC_CHECK_HEADERS([nettle/md5.h nettle/ripemd160.h nettle/sha.h])
-     AC_CHECK_HEADERS([nettle/pbkdf2.h nettle/aes.h nettle/hmac.h])
++#endif
+ #include <Bcrypt.h>
+ 
+ /* Common in other bcrypt implementations, but missing from VS2008. */
+--- libarchive-3.3.2/libarchive/archive_hmac.c.orig	2017-07-14 07:42:28.032321800 -0400
++++ libarchive-3.3.2/libarchive/archive_hmac.c	2017-07-14 07:34:30.848943200 -0400
+@@ -74,7 +74,7 @@ __hmac_sha1_cleanup(archive_hmac_sha1_ct
+ 	memset(ctx, 0, sizeof(*ctx));
+ }
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
+ 
+ #ifndef BCRYPT_HASH_REUSABLE_FLAG
+ # define BCRYPT_HASH_REUSABLE_FLAG 0x00000020
+--- libarchive-3.3.2/libarchive/archive_hmac_private.h.orig	2017-07-14 07:42:28.049323000 -0400
++++ libarchive-3.3.2/libarchive/archive_hmac_private.h	2017-07-14 07:34:30.858448100 -0400
+@@ -53,7 +53,10 @@ int __libarchive_hmac_build_hack(void);
+ 
+ typedef	CCHmacContext archive_hmac_sha1_ctx;
+ 
+-#elif defined(_WIN32) && !defined(__CYGWIN__) && defined(HAVE_BCRYPT_H)
++#elif defined(_WIN32) || defined(__CYGWIN__) && defined(HAVE_BCRYPT_H) && defined(HAVE_WINDOWS_H)
++#if defined(__CYGWIN__)
++    # include <windows.h>
++#endif
+ #include <bcrypt.h>
+ 
+ typedef struct {

--- a/mingw-w64-libarchive/PKGBUILD
+++ b/mingw-w64-libarchive/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libarchive
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.1
+pkgver=3.3.2
 pkgrel=1
 pkgdesc="library that can create and read several streaming archive formats (mingw-w64)"
 arch=('any')
@@ -24,8 +24,8 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
 options=('!libtool' 'strip')
 source=("http://libarchive.org/downloads/${_realname}-${pkgver}.tar.gz"
         0001-libarchive-3.2.2-bcrypt-fix.patch)
-sha256sums=('29ca5bd1624ca5a007aa57e16080262ab4379dbf8797f5c52f7ea74a3b0424e7'
-            '47f9374cc3bf11af5b638273eb4ce3f35ea403882063ea7096834ef50d067673')
+sha256sums=('ed2dbd6954792b2c054ccf8ec4b330a54b85904a80cef477a1c74643ddafa0ce'
+            '34cca13f787493626a571bb640b62ed2193ba9c482b127ed1879819ccf3dcf2c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-ncurses/PKGBUILD
+++ b/mingw-w64-ncurses/PKGBUILD
@@ -4,7 +4,7 @@ _realname=ncurses
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _base_ver=6.0
-_date_rev=20170624
+_date_rev=20170715
 pkgver=${_base_ver}.${_date_rev}
 pkgrel=1
 pkgdesc="System V Release 4.0 curses emulation library (mingw-w64)"
@@ -17,7 +17,7 @@ options=('staticlibs' 'strip')
 # ftp://invisible-island.net/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz
 source=("${_realname}-${pkgver}.tar.gz"::"http://invisible-mirror.net/archives/ncurses/current/${_realname}-${_base_ver}-${_date_rev}.tgz"
         001-use-libsystre.patch)
-sha256sums=('271eeb6b7f334234de9c110b13dacceb95b6313ba17d04bab996bb168575e63b'
+sha256sums=('b01753b18cba6b63a7d4a79fb452c2c173c537198b5ea477827e4ddfe50c6509'
             'eb28949297a4c1eda67da49cfbed1d60f181b83101a0b3715552a4564bd90ff3')
 
 prepare() {


### PR DESCRIPTION
…xpat from previous PR requests)

mingw-w64-ncurses -  6.0  20170715 - Update to latest version
mingw-w64-libarchive - 3.3.2 - Update to latest version and update patch for bcrypt.  The logic is a little better than what was in the source-code
mingw-w64-cmake - 3.9.0 - Update to latest version