### PR TITLE
python-certifi: Update to 2017.7.27.1

### DIFF
--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=certifi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2017.4.17
+pkgver=2017.7.27.1
 pkgrel=1
 pkgdesc="Python package for providing Mozilla's CA Bundle (mingw-w64)"
 url='http://pypi.python.org/pypi/certifi'
@@ -11,10 +11,10 @@ license=('GPL')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             'mercurial')
+            )
 _dtoken="53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826"
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('f7527ebf7461582ce95f7a9e03dd141ce810d40590834f4ec20cddd54234c10a')
+sha256sums=('40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
Remove mercurial makedep, not needed afaics