### PR TITLE
Add lua-mpack

### DIFF
--- a/mingw-w64-lua-mpack/PKGBUILD
+++ b/mingw-w64-lua-mpack/PKGBUILD
@@ -1,0 +1,56 @@
+_realname=mpack
+pkgname=("${MINGW_PACKAGE_PREFIX}-lua51-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
+pkgver=1.0.4
+pkgrel=1
+arch=('any')
+url='http://github.com/libmpack/libmpack'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-lua51"
+             "${MINGW_PACKAGE_PREFIX}-lua"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+
+source=("https://github.com/libmpack/libmpack/archive/1.0.4.tar.gz")
+sha256sums=('0a5d69f3966b31d14faddbd81db53b543fb092c711250ecb0aa5e22d060aa080')
+
+build() {
+  cd libmpack-${pkgver}
+  gcc -O2 -fPIC $(pkg-config --cflags lua) -shared -o mpack.dll binding/lua/lmpack.c $(pkg-config --libs lua)
+  gcc -O2 -fPIC $(pkg-config --cflags lua5.1) -shared -o mpack.dll.5.1 binding/lua/lmpack.c $(pkg-config --libs lua5.1)
+}
+
+package_mingw-w64-lua-mpack() {
+  pkgdesc='Msgpack serialization library for Lua (mingw-w64)'
+  depends=("${MINGW_PACKAGE_PREFIX}-lua")
+
+  cd libmpack-${pkgver}
+  local luaver=$(pkg-config lua --modversion | sed -r 's/^([0-9]+[.][0-9]+)[.][0-9]+$/\1/')
+  install -Dm755 mpack.dll "${pkgdir}${MINGW_PREFIX}/lib/lua/${luaver}/mpack.dll"
+  install -Dm644 LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/lua-lmpack/LICENSE"
+}
+
+package_mingw-w64-lua51-mpack() {
+  pkgdesc='Msgpack serialization library for Lua 5.1 (mingw-w64)'
+  depends=("${MINGW_PACKAGE_PREFIX}-lua51")
+
+  cd libmpack-${pkgver}
+  install -Dm755 mpack.dll.5.1 "${pkgdir}${MINGW_PREFIX}/lib/lua/5.1/mpack.dll"
+  install -Dm644 LICENSE-MIT "${pkgdir}${MINGW_PREFIX}/share/licenses/lua51-mpack/LICENSE"
+}
+
+package_mingw-w64-i686-lua-mpack() {
+  package_mingw-w64-lua-mpack
+}
+
+package_mingw-w64-x86_64-lua-mpack() {
+    package_mingw-w64-lua-mpack
+}
+
+package_mingw-w64-i686-lua51-mpack() {
+    package_mingw-w64-lua51-mpack
+}
+
+package_mingw-w64-x86_64-lua51-mpack() {
+    package_mingw-w64-lua51-mpack
+}

--- a/mingw-w64-lua-mpack/PKGBUILD
+++ b/mingw-w64-lua-mpack/PKGBUILD
@@ -1,4 +1,7 @@
+# Maintainer: Rui Abreu Ferreira <raf-ep@gmx.com>
+
 _realname=mpack
+pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-lua51-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lua-${_realname}")
 pkgver=1.0.4
@@ -11,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-lua51"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
 
-source=("https://github.com/libmpack/libmpack/archive/1.0.4.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libmpack/libmpack/archive/1.0.4.tar.gz")
 sha256sums=('0a5d69f3966b31d14faddbd81db53b543fb092c711250ecb0aa5e22d060aa080')
 
 build() {


### PR DESCRIPTION
Adds lua-mpack 1.0.4

There are more recent releases 1.0.5/1.0.6. But I cant build those in mingw (this should be fixed in the next release https://github.com/libmpack/libmpack-lua/pull/5)