### PR TITLE
Update mingw-w64-file package

### DIFF
--- a/mingw-w64-file/PKGBUILD
+++ b/mingw-w64-file/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=file
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.25
+pkgver=5.31
 pkgrel=1
 pkgdesc='Determine the type of a file from its contents (mingw-w64)'
 arch=('any')
@@ -12,7 +12,7 @@ license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-libsystre")
 source=(#ftp://ftp.astron.com/pub/${_realname}/${_realname}-${pkgver}.tar.gz
         https://distfiles.macports.org/file/${_realname}-${pkgver}.tar.gz)
-sha256sums=('3735381563f69fb4239470b8c51b876a80425348b8285a7cded8b61d6b890eca')
+sha256sums=('09c588dac9cff4baa054f51a36141793bcf64926edc909594111ceae60fce4ee')
 options=('strip' '!libtool' 'staticlibs')
 
 prepare() {


### PR DESCRIPTION
This updates mingw-w64-file util and library to 5.31.

The resulting package is currently missing in the repository, so my hope is, that this PR will trigger a rebuild and upload.