### PR TITLE
qtbinpatcher: Fix wrong install dir

### DIFF
--- a/mingw-w64-qtbinpatcher/PKGBUILD
+++ b/mingw-w64-qtbinpatcher/PKGBUILD
@@ -28,7 +28,7 @@ build() {
 
   ${MINGW_PREFIX}/bin/cmake \
     -G"MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${pkgdir}${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX=${pkgdir}/../${pkgname}${MINGW_PREFIX} \
     -DCMAKE_BUILD_TYPE=Release \
     ../${_realname}-${pkgver}
   make


### PR DESCRIPTION
The install dir was mingw-w64-qtbinpatcher and not mingw-w64-i686-qtbinpatcher or mingw-w64-x86_64-qtbinpatcher
This patch fixes this. The variable ${pkgdir} seems to be overwritten and set to ${pkgbase}

I have no idea why this happens with this packages whereas using ${pkgdir} works fine on other packages...