### PR TITLE
pango: Update to 1.40.10

### DIFF
--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=pango
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.40.9
+pkgver=1.40.10
 pkgrel=1
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
@@ -31,23 +31,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
         0001-no-unconditional-xft-please.all.patch)
-sha256sums=('9faea6535312fe4436b93047cf7a04af544eb52a079179bd3a33821aacce7e16'
+sha256sums=('5d41d94a1f70e92ba5808e13f2bf3ef198901ddc0dc7e74e5afde994724466f6'
             'bebab6128258d300e677df0751177f5c30235d0a49c150d97987d0f00b309f35')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0001-no-unconditional-xft-please.all.patch
 
-  autoreconf -fi
+  NOCONFIGURE=1 ./autogen.sh
   sed -i 's/have_libthai=true/have_libthai=false/' configure
 }
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
-
-  mkdir -p docs/html
-  cp -rf ../${_realname}-${pkgver}/docs/html/* docs/html
 
   ../${_realname}-${pkgver}/configure \
     --prefix=${MINGW_PREFIX} \


### PR DESCRIPTION
The new tarballs are created with meson so we have to run autogen.sh
and the tarballs no longer contain the built documentation.