### PR TITLE
openjpeg2: Update to 2.2.0

### DIFF
--- a/mingw-w64-openjpeg2/0007-fix-build-2.2.0.patch
+++ b/mingw-w64-openjpeg2/0007-fix-build-2.2.0.patch
@@ -1,0 +1,66 @@
+From 1e387de74273c4dac618df94475556541c1caf3e Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Wed, 16 Aug 2017 17:38:47 +0200
+Subject: [PATCH] Fix build issue of JPWL by adding opj_image_data_alloc() and
+ opj_image_data_free() to src/lib/openmj2 (#994)
+
+---
+ src/lib/openmj2/openjpeg.c | 15 +++++++++++++++
+ src/lib/openmj2/openjpeg.h | 21 +++++++++++++++++++++
+ 2 files changed, 36 insertions(+)
+
+diff --git a/src/lib/openmj2/openjpeg.c b/src/lib/openmj2/openjpeg.c
+index ae4bf1e42..a0cce5da5 100644
+--- a/src/lib/openmj2/openjpeg.c
++++ b/src/lib/openmj2/openjpeg.c
+@@ -372,3 +372,18 @@ void OPJ_CALLCONV opj_destroy_cstr_info(opj_codestream_info_t *cstr_info)
+         opj_free(cstr_info->numdecompos);
+     }
+ }
++
++void* OPJ_CALLCONV opj_image_data_alloc(size_t size)
++{
++    /* NOTE: this defers from libopenjp2 where we use opj_aligned_malloc */
++    void* ret = opj_malloc(size);
++    /* printf("opj_image_data_alloc %p\n", ret); */
++    return ret;
++}
++
++void OPJ_CALLCONV opj_image_data_free(void* ptr)
++{
++    /* NOTE: this defers from libopenjp2 where we use opj_aligned_free */
++    /* printf("opj_image_data_free %p\n", ptr); */
++    opj_free(ptr);
++}
+diff --git a/src/lib/openmj2/openjpeg.h b/src/lib/openmj2/openjpeg.h
+index 7861edb52..10fccf1ea 100644
+--- a/src/lib/openmj2/openjpeg.h
++++ b/src/lib/openmj2/openjpeg.h
+@@ -763,6 +763,27 @@ Deallocate any resources associated with an image
+ */
+ OPJ_API void OPJ_CALLCONV opj_image_destroy(opj_image_t *image);
+ 
++/**
++ * Allocator for opj_image_t->comps[].data
++ * To be paired with opj_image_data_free.
++ *
++ * @param   size    number of bytes to allocate
++ *
++ * @return  a new pointer if successful, NULL otherwise.
++ * @since 2.2.0
++*/
++OPJ_API void* OPJ_CALLCONV opj_image_data_alloc(size_t size);
++
++/**
++ * Destructor for opj_image_t->comps[].data
++ * To be paired with opj_image_data_alloc.
++ *
++ * @param   ptr    Pointer to free
++ *
++ * @since 2.2.0
++*/
++OPJ_API void OPJ_CALLCONV opj_image_data_free(void* ptr);
++
+ /*
+ ==========================================================
+    stream functions definitions

--- a/mingw-w64-openjpeg2/PKGBUILD
+++ b/mingw-w64-openjpeg2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=openjpeg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
-pkgver=2.1.2
-pkgrel=2
+pkgver=2.2.0
+pkgrel=1
 pkgdesc="An open source JPEG 2000 codec (mingw-w64)"
 arch=('any')
 url="http://www.openjpeg.org"
@@ -22,18 +22,21 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/uclouvain/openjpeg/arc
         0001-fix-install-for-dlls.all.patch
         0003-versioned-dlls.mingw.patch
         0005-sock-jpip.all.patch
-        0006-openjpeg-2.1.0-stdcall-for-all-win.patch)
-sha256sums=('4ce77b6ef538ef090d9bde1d5eeff8b3069ab56c4906f083475517c2c023dfa7'
+        0006-openjpeg-2.1.0-stdcall-for-all-win.patch
+        0007-fix-build-2.2.0.patch)
+sha256sums=('6fddbce5a618e910e03ad00d66e7fcd09cc6ee307ce69932666d54c73b7c6e7b'
             '3f3bde353ca3432f157258164c5e3c345af82ca3a9d5a68f815c3030b01cbc32'
             'b45bc20a761b0d8dfd039ee9443a12d95ddd89ce05683fe0510fb8061f608b78'
             'b7b22dca26d5fd98ca5bc6ce775bbbabebc0e10fcf07fd0afb54d580699b8312'
-            'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919')
+            'e8c375faa317c819174b50aa43b6be61c108872661b014738c4a0cfa95aac919'
+            'c72f1ff3b7a9d607e4fd864c674f3bb611b8b852b0830609a8cb3f632db2d820')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -p1 -i ${srcdir}/0001-fix-install-for-dlls.all.patch
   patch -p1 -i ${srcdir}/0003-versioned-dlls.mingw.patch
   patch -p1 -i ${srcdir}/0005-sock-jpip.all.patch
+  patch -p1 -i ${srcdir}/0007-fix-build-2.2.0.patch
 #  patch -p1 -i ${srcdir}/0006-openjpeg-2.1.0-stdcall-for-all-win.patch
 }
 


### PR DESCRIPTION
Include a build fix from upstream master. See https://github.com/uclouvain/openjpeg/issues/994