### PR TITLE
Firebird2-git

### DIFF
--- a/mingw-w64-firebird2-git/0030-Use-nullptr.patch
+++ b/mingw-w64-firebird2-git/0030-Use-nullptr.patch
@@ -1,0 +1,52 @@
+From 2adb6fa680b81e7f95429a6041f399d91d2c160a Mon Sep 17 00:00:00 2001
+From: Tim S <stahta01@users.sourceforge.net>
+Date: Wed, 16 Aug 2017 22:38:24 -0400
+Subject: [PATCH] Use nullptr instead of zero.
+
+---
+ src/include/fb_blk.h | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/src/include/fb_blk.h b/src/include/fb_blk.h
+index 4929c525c4..b2b8a1b6cc 100644
+--- a/src/include/fb_blk.h
++++ b/src/include/fb_blk.h
+@@ -112,8 +112,6 @@ enum BlockType
+ 	rem_type_rsr
+ };
+ 
+-static void * zero = (void *) 0;
+-
+ template<BlockType BLOCK_TYPE>
+ class TypedHandle
+ {
+@@ -171,8 +169,8 @@ public:
+ 
+ private:
+     // These operators are off-limits
+-	void* operator new(size_t s) { return zero; }
+-    void* operator new[](size_t s) { return zero; }
++	void* operator new(size_t s) { return nullptr; }
++    void* operator new[](size_t s) { return nullptr; }
+ };
+ 
+ template<typename RPT, BlockType BLOCK_TYPE = type_unknown>
+@@ -195,15 +193,15 @@ public:
+ private:
+     // These operations are not supported on static repeat-base objects
+     void* operator new[](size_t s, MemoryPool& p)
+-        { return zero; }
++        { return nullptr; }
+     void operator delete[](void* mem, MemoryPool& p)
+         { }
+     void operator delete[](void* mem)
+ 		{ }
+ 
+     // These operators are off-limits
+-	void* operator new(size_t s) { return zero; }
+-    void* operator new[](size_t s) { return zero; }
++	void* operator new(size_t s) { return nullptr; }
++    void* operator new[](size_t s) { return nullptr; }
+ };
+ 
+ #endif	// INCLUDE_FB_BLK

--- a/mingw-w64-firebird2-git/0031-Fix-compiler-flags.patch
+++ b/mingw-w64-firebird2-git/0031-Fix-compiler-flags.patch
@@ -1,0 +1,26 @@
+From e801534c5eb8cb049dc480fea48fddddd8415d05 Mon Sep 17 00:00:00 2001
+From: Tim S <stahta01@users.sourceforge.net>
+Date: Wed, 16 Aug 2017 20:35:10 -0400
+Subject: [PATCH] Added build flags to fix build errors.
+
+Added "-Wno-deprecated", "-fcheck-new", and "-std=gnu++11" options to fix compiler error/warnings.
+
+---
+ builds/posix/prefix.mingw | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/builds/posix/prefix.mingw b/builds/posix/prefix.mingw
+index 8e514d8c33..e4f38a1e6e 100644
+--- a/builds/posix/prefix.mingw
++++ b/builds/posix/prefix.mingw
+@@ -23,8 +23,8 @@
+ endif
+ 
+ # -Wno-unused-variable is used due to unused gpre generated variables
+-PROD_FLAGS=-O2  -DMINGW -Wall -Wshadow -Wundef -Wno-long-long -Wno-unused-variable -Wno-sign-compare -Wno-parentheses -Wno-switch -fmessage-length=0 -Dlint -DWIN32_LEAN_AND_MEAN -MMD -mthreads
+-DEV_FLAGS=-ggdb -DMINGW -Wall -Wshadow -Wundef -Wno-long-long -Wno-unused-variable -Wno-sign-compare -Wno-parentheses -Wno-switch -fmessage-length=0 -Dlint -DWIN32_LEAN_AND_MEAN -MMD -mthreads
++PROD_FLAGS=-O2  -DMINGW -Wall -Wshadow -Wundef -Wno-long-long -Wno-unused-variable -Wno-sign-compare -Wno-parentheses -Wno-switch -Wno-deprecated -fmessage-length=0 -Dlint -DWIN32_LEAN_AND_MEAN -MMD -mthreads -fcheck-new -std=gnu++11
++DEV_FLAGS=-ggdb -DMINGW -Wall -Wshadow -Wundef -Wno-long-long -Wno-unused-variable -Wno-sign-compare -Wno-parentheses -Wno-switch -Wno-deprecated -fmessage-length=0 -Dlint -DWIN32_LEAN_AND_MEAN -MMD -mthreads -fcheck-new -std=gnu++11
+ 
+ PLATFORM_PATH=os/win32
+ 

--- a/mingw-w64-firebird2-git/PKGBUILD
+++ b/mingw-w64-firebird2-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=firebird
 pkgbase=mingw-w64-${_realname}2-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2-git"
-pkgver=2.5.8.27063.403cbaf0f0
+pkgver=2.5.8.27070.6c9924b887
 pkgrel=1
 pkgdesc="Cross-platform relational database offering many ANSI SQL standard features - version 2.x (mingw-w64)"
 url="https://www.firebirdsql.org/"
@@ -23,7 +23,7 @@ makedepends=(#"${MINGW_PACKAGE_PREFIX}-btyacc" # Maybe add check in firebird pre
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "git"
             )
-options=('!debug' 'strip')
+options=('debug' 'strip') # '!debug' is causing error in running create_db.exe empty.fdb during build.
 source=("${_realname}"::"git+https://github.com/FirebirdSQL/firebird.git#branch=B2_5_Release"
         0001-Remove-hardcoded-march-to-allow-64-bit-builds.patch
         0002-Always-use-Win32-threads-for-mingw.patch
@@ -52,7 +52,10 @@ source=("${_realname}"::"git+https://github.com/FirebirdSQL/firebird.git#branch=
         0025-Fix-building-gstat.patch
         0026-Fix-using-function-pointer.patch
         0027-The-operator-new-declaration-has-changed-slightly-in.patch
-        0028-Fix-different-warnings.patch)
+        0028-Fix-different-warnings.patch
+        0030-Use-nullptr.patch
+        0031-Fix-compiler-flags.patch
+)
 
 pkgver() {
   cd "${_realname}"
@@ -88,9 +91,11 @@ prepare() {
   git am --committer-date-is-author-date ${srcdir}/0024-Relocate-paths-for-unix-like-files-layout.patch
   git am --committer-date-is-author-date ${srcdir}/0025-Fix-building-gstat.patch
   git am --committer-date-is-author-date ${srcdir}/0026-Fix-using-function-pointer.patch
-  git am --committer-date-is-author-date ${srcdir}/0027-The-operator-new-declaration-has-changed-slightly-in.patch
+#  git am --committer-date-is-author-date ${srcdir}/0027-The-operator-new-declaration-has-changed-slightly-in.patch
   git am --committer-date-is-author-date ${srcdir}/0028-Fix-different-warnings.patch
-  
+  git am --committer-date-is-author-date ${srcdir}/0030-Use-nullptr.patch
+  git am --committer-date-is-author-date ${srcdir}/0031-Fix-compiler-flags.patch
+
   NOCONFIGURE=1 ./autogen.sh
 }
 
@@ -190,4 +195,7 @@ sha256sums=('SKIP'
             '32a3520e588f0cc6648dfdf66f5a2579ff67d4db30ecdaac69bcf275b8b8c919'
             '2e2ee6f9c6d91a707b12666fa340c31b4f8edb8e910cd7ff08d6cfed5ed4c2d2'
             '1c3cc11e3c202974aed83059a409cba881d591c6665a9564709c3eef6b4c9a46'
-            'd04a94c9900166c095b6d5b1b51e6c3504441a62508d56497bbd74e8a981b94b')
+            '0c8ee0addf55430404d0feb1f3741ce00497b945d04b0d2f0666b34a4820cdfa'
+            '6841facc994fb60364d30da5e10d424adefe719a12ff8fea57b0dba583bb3e63'
+            '43372147adb06ccd4c86bbfc426d28b3f4a8b573623cb686a49299a81cc7500e'
+)


### PR DESCRIPTION
I am mainly an C Programmer working to better my C++ knowledge.
I have not tested the package; because I have no idea how to test it.

Used compiler option "-std=gnu++11" because I could not figure out how to fix the build error below.
Changed package to options=('debug' 'strip') because '!debug' is causing error in running create_db.exe empty.fdb during build.

See also #2747 and #2536

Error # 1 fixed by 0030-Use-nullptr.patch
    ../src/jrd/gds.cpp:278:7: error: conflicting declaration 'const UCHAR zero []'
      zero[]  = { op_line, 0 },
           ^
    In file included from ../src/jrd/../jrd/../jrd/val.h:32:0,
                     from ../src/jrd/../jrd/jrd.h:39,
                     from ../src/jrd/gds.cpp:151:
    ../src/jrd/../jrd/../jrd/../include/fb_blk.h:115:15: note: previous declaration as 'void* zero'
     static void * zero = (void *) 0;
                   ^~~~

Error # 2 work around is 0031-Fix-compiler-flags.patch "-std=gnu++11".
    ../gen/firebird/bin/gpre_current.exe -n -z -gds_cxx -raw -ids ../src/jrd/dpm.epp ../temp/boot/jrd/dpm.cpp
    gpre version NP-V2.5.8.27070 Firebird 2.5
    make[3]: *** [../gen/make.rules:80: ../temp/boot/jrd/dpm.cpp] Error 127


Error # 3 work around is doing debug option.
    rm -f empty.fdb
    ../gen/firebird/bin/create_db.exe empty.fdb
    make[2]: *** [../gen/Makefile.refDatabases:68: empty.fdb] Segmentation fault
    make[2]: *** Deleting file 'empty.fdb'
