### PR TITLE
[DO NOT MERGE] python2: Use is_cygpty() to detect a terminal; disable readline with …

### DIFF
--- a/mingw-w64-python2/2700-cygpty-isatty-disable-readline.patch
+++ b/mingw-w64-python2/2700-cygpty-isatty-disable-readline.patch
@@ -1,0 +1,429 @@
+diff -Nur Python-2.7.13.orig/Include/iscygpty.h Python-2.7.13/Include/iscygpty.h
+--- Python-2.7.13.orig/Include/iscygpty.h	1970-01-01 01:00:00.000000000 +0100
++++ Python-2.7.13/Include/iscygpty.h	2017-08-19 15:50:22.584217400 +0200
+@@ -0,0 +1,41 @@
++/*
++ * iscygpty.h -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifndef _ISCYGPTY_H
++#define _ISCYGPTY_H
++
++#ifdef _WIN32
++int is_cygpty(int fd);
++int is_cygpty_used(void);
++#else
++#define is_cygpty(fd)		0
++#define is_cygpty_used()	0
++#endif
++
++#endif /* _ISCYGPTY_H */
+Binary files Python-2.7.13.orig/Lib/encodings/cp850.pyc and Python-2.7.13/Lib/encodings/cp850.pyc differ
+Binary files Python-2.7.13.orig/Lib/io.pyc and Python-2.7.13/Lib/io.pyc differ
+diff -Nur Python-2.7.13.orig/Makefile.pre.in Python-2.7.13/Makefile.pre.in
+--- Python-2.7.13.orig/Makefile.pre.in	2017-08-19 14:39:02.676420600 +0200
++++ Python-2.7.13/Makefile.pre.in	2017-08-19 15:57:17.883971100 +0200
+@@ -87,7 +87,7 @@
+ # Extra C flags added for building the interpreter object files.
+ CFLAGSFORSHARED=@CFLAGSFORSHARED@
+ # C flags used for building the interpreter object files
+-PY_CFLAGS=	$(CFLAGS) $(CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
++PY_CFLAGS=	$(CFLAGS) $(CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE -D_WIN32_WINNT=0x0600
+ 
+ # ; on Windows otherwise :
+ DELIM=		@DELIM@
+@@ -350,6 +350,7 @@
+ 		Python/graminit.o \
+ 		Python/import.o \
+ 		Python/importdl.o \
++		Python/iscygpty.o \
+ 		Python/marshal.o \
+ 		Python/modsupport.o \
+ 		Python/mystrtoul.o \
+@@ -804,6 +805,7 @@
+ 		Include/import.h \
+ 		Include/intobject.h \
+ 		Include/intrcheck.h \
++		Include/iscygpty.h \
+ 		Include/iterobject.h \
+ 		Include/listobject.h \
+ 		Include/longintrepr.h \
+diff -Nur Python-2.7.13.orig/Modules/_io/fileio.c Python-2.7.13/Modules/_io/fileio.c
+--- Python-2.7.13.orig/Modules/_io/fileio.c	2016-12-17 21:05:07.000000000 +0100
++++ Python-2.7.13/Modules/_io/fileio.c	2017-08-19 16:07:42.329687400 +0200
+@@ -13,6 +13,7 @@
+ #endif
+ #include <stddef.h> /* For offsetof */
+ #include "_iomodule.h"
++#include "iscygpty.h"
+ 
+ /*
+  * Known likely problems:
+@@ -953,7 +954,7 @@
+     if (self->fd < 0)
+         return err_closed();
+     Py_BEGIN_ALLOW_THREADS
+-    res = isatty(self->fd);
++    res = isatty(self->fd) || is_cygpty(self->fd);
+     Py_END_ALLOW_THREADS
+     return PyBool_FromLong(res);
+ }
+diff -Nur Python-2.7.13.orig/Modules/posixmodule.c Python-2.7.13/Modules/posixmodule.c
+--- Python-2.7.13.orig/Modules/posixmodule.c	2017-08-19 14:39:02.303399300 +0200
++++ Python-2.7.13/Modules/posixmodule.c	2017-08-19 16:06:05.867170100 +0200
+@@ -369,6 +369,8 @@
+ #endif
+ #endif
+ 
++#include "iscygpty.h"
++
+ 
+ #ifndef MS_WINDOWS
+ PyObject *
+@@ -6977,7 +6979,7 @@
+         return NULL;
+     if (!_PyVerify_fd(fd))
+         return PyBool_FromLong(0);
+-    return PyBool_FromLong(isatty(fd));
++    return PyBool_FromLong(isatty(fd) || is_cygpty(fd));
+ }
+ 
+ #ifdef HAVE_PIPE
+diff -Nur Python-2.7.13.orig/Modules/readline.c Python-2.7.13/Modules/readline.c
+--- Python-2.7.13.orig/Modules/readline.c	2016-12-17 21:05:07.000000000 +0100
++++ Python-2.7.13/Modules/readline.c	2017-08-19 16:15:38.831941800 +0200
+@@ -6,6 +6,7 @@
+ 
+ /* Standard definitions */
+ #include "Python.h"
++#include "iscygpty.h"
+ #include <setjmp.h>
+ #include <signal.h>
+ #include <errno.h>
+@@ -1204,6 +1205,11 @@
+ {
+     PyObject *m;
+ 
++    if (!is_cygpty(STDOUT_FILENO)) {
++        PyErr_SetString(PyExc_ImportError, "Not a cygwin terminal");
++        return;
++    }
++
+ #ifdef __APPLE__
+     if (strncmp(rl_library_version, libedit_version_tag, strlen(libedit_version_tag)) == 0) {
+         using_libedit_emulation = 1;
+diff -Nur Python-2.7.13.orig/Objects/fileobject.c Python-2.7.13/Objects/fileobject.c
+--- Python-2.7.13.orig/Objects/fileobject.c	2016-12-17 21:05:07.000000000 +0100
++++ Python-2.7.13/Objects/fileobject.c	2017-08-19 16:13:45.925483900 +0200
+@@ -3,6 +3,7 @@
+ #define PY_SSIZE_T_CLEAN
+ #include "Python.h"
+ #include "structmember.h"
++#include "iscygpty.h"
+ 
+ #ifdef HAVE_SYS_TYPES_H
+ #include <sys/types.h>
+@@ -986,7 +987,7 @@
+     if (f->f_fp == NULL)
+         return err_closed();
+     FILE_BEGIN_ALLOW_THREADS(f)
+-    res = isatty((int)fileno(f->f_fp));
++    res = isatty((int)fileno(f->f_fp)) || is_cygpty((int)fileno(f->f_fp));
+     FILE_END_ALLOW_THREADS(f)
+     return PyBool_FromLong(res);
+ }
+diff -Nur Python-2.7.13.orig/Python/bltinmodule.c Python-2.7.13/Python/bltinmodule.c
+--- Python-2.7.13.orig/Python/bltinmodule.c	2016-12-17 21:05:07.000000000 +0100
++++ Python-2.7.13/Python/bltinmodule.c	2017-08-19 16:02:12.832841300 +0200
+@@ -2,6 +2,7 @@
+ 
+ #include "Python.h"
+ #include "Python-ast.h"
++#include "iscygpty.h"
+ 
+ #include "node.h"
+ #include "code.h"
+diff -Nur Python-2.7.13.orig/Python/frozenmain.c Python-2.7.13/Python/frozenmain.c
+--- Python-2.7.13.orig/Python/frozenmain.c	2016-12-17 21:05:07.000000000 +0100
++++ Python-2.7.13/Python/frozenmain.c	2017-08-19 16:03:06.009882800 +0200
+@@ -2,6 +2,7 @@
+ /* Python interpreter main program for frozen scripts */
+ 
+ #include "Python.h"
++#include "iscygpty.h"
+ 
+ #ifdef MS_WINDOWS
+ extern void PyWinFreeze_ExeInit(void);
+@@ -58,7 +59,7 @@
+     else
+         sts = 0;
+ 
+-    if (inspect && isatty((int)fileno(stdin)))
++    if (inspect && (isatty((int)fileno(stdin)) || is_cygpty((int)fileno(stdin))))
+         sts = PyRun_AnyFile(stdin, "<stdin>") != 0;
+ 
+ #ifdef MS_WINDOWS
+diff -Nur Python-2.7.13.orig/Python/iscygpty.c Python-2.7.13/Python/iscygpty.c
+--- Python-2.7.13.orig/Python/iscygpty.c	1970-01-01 01:00:00.000000000 +0100
++++ Python-2.7.13/Python/iscygpty.c	2017-08-19 15:50:12.959666900 +0200
+@@ -0,0 +1,185 @@
++/*
++ * iscygpty.c -- part of ptycheck
++ * https://github.com/k-takata/ptycheck
++ *
++ * Copyright (c) 2015-2017 K.Takata
++ *
++ * You can redistribute it and/or modify it under the terms of either
++ * the MIT license (as described below) or the Vim license.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files (the
++ * "Software"), to deal in the Software without restriction, including
++ * without limitation the rights to use, copy, modify, merge, publish,
++ * distribute, sublicense, and/or sell copies of the Software, and to
++ * permit persons to whom the Software is furnished to do so, subject to
++ * the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#ifdef _WIN32
++
++#include <ctype.h>
++#include <io.h>
++#include <wchar.h>
++#include <windows.h>
++
++#ifdef USE_FILEEXTD
++/* VC 7.1 or earlier doesn't support SAL. */
++# if !defined(_MSC_VER) || (_MSC_VER < 1400)
++#  define __out
++#  define __in
++#  define __in_opt
++# endif
++/* Win32 FileID API Library:
++ * http://www.microsoft.com/en-us/download/details.aspx?id=22599
++ * Needed for WinXP. */
++# include <fileextd.h>
++#else /* USE_FILEEXTD */
++/* VC 8 or earlier. */
++# if defined(_MSC_VER) && (_MSC_VER < 1500)
++#  ifdef ENABLE_STUB_IMPL
++#   define STUB_IMPL
++#  else
++#   error "Win32 FileID API Library is required for VC2005 or earlier."
++#  endif
++# endif
++#endif /* USE_FILEEXTD */
++
++
++#include "iscygpty.h"
++
++//#define USE_DYNFILEID
++#ifdef USE_DYNFILEID
++typedef BOOL (WINAPI *pfnGetFileInformationByHandleEx)(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++);
++static pfnGetFileInformationByHandleEx pGetFileInformationByHandleEx = NULL;
++
++# ifndef USE_FILEEXTD
++static BOOL WINAPI stub_GetFileInformationByHandleEx(
++		HANDLE                    hFile,
++		FILE_INFO_BY_HANDLE_CLASS FileInformationClass,
++		LPVOID                    lpFileInformation,
++		DWORD                     dwBufferSize
++		)
++{
++	return FALSE;
++}
++# endif
++
++static void setup_fileid_api(void)
++{
++	if (pGetFileInformationByHandleEx != NULL) {
++		return;
++	}
++	pGetFileInformationByHandleEx = (pfnGetFileInformationByHandleEx)
++		GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
++				"GetFileInformationByHandleEx");
++	if (pGetFileInformationByHandleEx == NULL) {
++# ifdef USE_FILEEXTD
++		pGetFileInformationByHandleEx = GetFileInformationByHandleEx;
++# else
++		pGetFileInformationByHandleEx = stub_GetFileInformationByHandleEx;
++# endif
++	}
++}
++#else
++# define pGetFileInformationByHandleEx	GetFileInformationByHandleEx
++# define setup_fileid_api()
++#endif
++
++
++#define is_wprefix(s, prefix) \
++	(wcsncmp((s), (prefix), sizeof(prefix) / sizeof(WCHAR) - 1) == 0)
++
++/* Check if the fd is a cygwin/msys's pty. */
++int is_cygpty(int fd)
++{
++#ifdef STUB_IMPL
++	return 0;
++#else
++	HANDLE h;
++	int size = sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * MAX_PATH;
++	FILE_NAME_INFO *nameinfo;
++	WCHAR *p = NULL;
++
++	setup_fileid_api();
++
++	h = (HANDLE) _get_osfhandle(fd);
++	if (h == INVALID_HANDLE_VALUE) {
++		return 0;
++	}
++	/* Cygwin/msys's pty is a pipe. */
++	if (GetFileType(h) != FILE_TYPE_PIPE) {
++		return 0;
++	}
++	nameinfo = malloc(size);
++	if (nameinfo == NULL) {
++		return 0;
++	}
++	/* Check the name of the pipe:
++	 * '\{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master' */
++	if (pGetFileInformationByHandleEx(h, FileNameInfo, nameinfo, size)) {
++		nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';
++		p = nameinfo->FileName;
++		if (is_wprefix(p, L"\\cygwin-")) {		/* Cygwin */
++			p += 8;
++		} else if (is_wprefix(p, L"\\msys-")) {	/* MSYS and MSYS2 */
++			p += 6;
++		} else {
++			p = NULL;
++		}
++		if (p != NULL) {
++			while (*p && isxdigit(*p))	/* Skip 16-digit hexadecimal. */
++				++p;
++			if (is_wprefix(p, L"-pty")) {
++				p += 4;
++			} else {
++				p = NULL;
++			}
++		}
++		if (p != NULL) {
++			while (*p && isdigit(*p))	/* Skip pty number. */
++				++p;
++			if (is_wprefix(p, L"-from-master")) {
++				//p += 12;
++			} else if (is_wprefix(p, L"-to-master")) {
++				//p += 10;
++			} else {
++				p = NULL;
++			}
++		}
++	}
++	free(nameinfo);
++	return (p != NULL);
++#endif /* STUB_IMPL */
++}
++
++/* Check if at least one cygwin/msys pty is used. */
++int is_cygpty_used(void)
++{
++	int fd, ret = 0;
++
++	for (fd = 0; fd < 3; fd++) {
++		ret |= is_cygpty(fd);
++	}
++	return ret;
++}
++
++#endif /* _WIN32 */
++
++/* vim: set ts=4 sw=4: */
+diff -Nur Python-2.7.13.orig/Python/pythonrun.c Python-2.7.13/Python/pythonrun.c
+--- Python-2.7.13.orig/Python/pythonrun.c	2017-08-19 14:39:02.294398800 +0200
++++ Python-2.7.13/Python/pythonrun.c	2017-08-19 15:54:43.491140400 +0200
+@@ -18,6 +18,7 @@
+ #include "eval.h"
+ #include "marshal.h"
+ #include "abstract.h"
++#include "iscygpty.h"
+ 
+ #ifdef HAVE_SIGNAL_H
+ #include <signal.h>
+@@ -1864,7 +1865,7 @@
+ int
+ Py_FdIsInteractive(FILE *fp, const char *filename)
+ {
+-    if (isatty((int)fileno(fp)))
++    if (isatty((int)fileno(fp)) || is_cygpty((int)fileno(fp)))
+         return 1;
+     if (!Py_InteractiveFlag)
+         return 0;
+diff -Nur Python-2.7.13.orig/setup.py Python-2.7.13/setup.py
+--- Python-2.7.13.orig/setup.py	2017-08-19 14:39:10.682878600 +0200
++++ Python-2.7.13/setup.py	2017-08-19 16:16:38.642362700 +0200
+@@ -655,8 +655,10 @@
+         # Python 3.1 _io library
+         exts.append( Extension("_io",
+             ["_io/bufferedio.c", "_io/bytesio.c", "_io/fileio.c",
+-             "_io/iobase.c", "_io/_iomodule.c", "_io/stringio.c", "_io/textio.c"],
+-             depends=["_io/_iomodule.h"], include_dirs=["Modules/_io"]))
++             "_io/iobase.c", "_io/_iomodule.c", "_io/stringio.c", "_io/textio.c",
++             "../Python/iscygpty.c"],
++             depends=["_io/_iomodule.h"], include_dirs=["Modules/_io"],
++             extra_compile_args=["-D_WIN32_WINNT=0x0600"]))
+         # _functools
+         # On win32 host(mingw build in MSYS environment) show that site.py
+         # fail to load if some modules are not build-in:
+@@ -841,10 +843,11 @@
+                                                      [sr + '/lib/termcap' for sr in with_build_sysroots],
+                                                      'termcap'):
+                 readline_libs.append('termcap')
+-            exts.append( Extension('readline', ['readline.c'],
++            exts.append( Extension('readline', ['readline.c', '../Python/iscygpty.c'],
+                                    library_dirs=[sr + '/lib/termcap' for sr in with_build_sysroots],
+                                    extra_link_args=readline_extra_link_args,
+-                                   libraries=readline_libs) )
++                                   libraries=readline_libs,
++                                   extra_compile_args=["-D_WIN32_WINNT=0x0600"]) )
+         else:
+             missing.append('readline')
+ 

--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.13
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -109,7 +109,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1030-use-gnu_printf-in-format.patch
         1040-install-msilib.patch
         1050-skip-add-db-includes-for-win.patch
-        2000-distutils-add-windmc-to-cygwinccompiler.patch)
+        2000-distutils-add-windmc-to-cygwinccompiler.patch
+        2700-cygpty-isatty-disable-readline.patch)
 
 prepare() {
   cd "${srcdir}/Python-${pkgver}"
@@ -219,6 +220,13 @@ prepare() {
 
   plain "Apply Renato Silva's patch to distutils"
   patch -p1 -i "${srcdir}"/2000-distutils-add-windmc-to-cygwinccompiler.patch
+
+  # Extend some isatty calls to check for mintty when checking for
+  # a terminal output. Disable the readline module under non-mintty as it
+  # breaks things with a real console (like conemu or winpty)
+  # https://github.com/Alexpux/MINGW-packages/issues/2645
+  # https://github.com/Alexpux/MINGW-packages/issues/2656
+  patch -p1 -i "${srcdir}"/2700-cygpty-isatty-disable-readline.patch
 
   autoreconf -vfi
 
@@ -361,18 +369,6 @@ package() {
   # Create python executable with windows subsystem
   cp -f "${pkgdir}${MINGW_PREFIX}"/bin/python2.exe "${pkgdir}${MINGW_PREFIX}"/bin/python2w.exe
   ${MINGW_PREFIX}/bin/objcopy --subsystem windows "${pkgdir}${MINGW_PREFIX}"/bin/python2w.exe
-
-  # Add a wrapper script to force -i when invoking python. Please don't move this into a patch as
-  # hopefully one day we won't need this hack (when we replace mintty with a real console).
-  _exename="python2"
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe
-  echo "#!/usr/bin/env bash"                                           > "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "if [ \$# -eq 0 ]; then"                                       >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo '  "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" -i "$@"' >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "else"                                                         >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo '  "$( dirname ${BASH_SOURCE[0]} )/'${_exename}'.exe" "$@"'    >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  echo "fi"                                                           >> "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}
-  mv "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}_exe "${pkgdir}"${MINGW_PREFIX}/bin/${_exename}.exe
 }
 
 sha256sums=('35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731'
@@ -458,4 +454,5 @@ sha256sums=('35d543986882f78261f97787fd3e06274bfa6df29fac9b4a94f73930ff98f731'
             '073a2882d383d87d37e9fc1b3e57b8d94898784df8d9b144a07767b2f3497e23'
             'f1cfeb815277166384632bd9730fe89f64dc5da7ee09c13a0b3515da08b08847'
             'be5379525508e0bc0c374f20a669c38c93986e24a07696d2a83a9552cc085b8d'
-            'aa623bd762f33f2724b40a55bd2d2c4100b47b81586ae2f5d6b430ab4646f02c')
+            'aa623bd762f33f2724b40a55bd2d2c4100b47b81586ae2f5d6b430ab4646f02c'
+            'c15b2b8140988af7ce1aa9f3f7465301f35de701b5fb7a6e51b17c950ec255d6')


### PR DESCRIPTION
…a real Windows console

This is the same patch as https://github.com/Alexpux/MINGW-packages/pull/2675
adjusted to work with Python 2.7