### PR TITLE
soundtouch: Update to 2.0.0

### DIFF
--- a/mingw-w64-soundtouch/PKGBUILD
+++ b/mingw-w64-soundtouch/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=soundtouch
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.9.2
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="An audio processing library (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ options=('strip' 'staticlibs')
 source=(http://www.surina.net/soundtouch/${_realname}-${pkgver}.tar.gz
         0001-no-undefined-on.mingw.patch
         0003-fix-docdir.mingw.patch)
-sha256sums=('caeb86511e81420eeb454cb5db53f56d96b8451d37d89af6e55b12eb4da1c513'
+sha256sums=('d224f7d1421b5f8e74a74c85741345bd9802618a40ae30ce5b427a5705c89d25'
             '68d545eedd45afa26723aa2e3d7a447d179c78566308b29fa9d1c6a71476f50d'
             '2cd136046831f3ad9a2e37c0afe3ecd9f25ce27f5dbf4ee8b23b862a96e76cd5')
 


### PR DESCRIPTION
As far as I can see no API/ABI break:
    https://www.surina.net/soundtouch/README.html