### PR TITLE
pyqt5: Update to 5.9 and related changes

### DIFF
--- a/mingw-w64-pyqt5/001-mingw-python.patch
+++ b/mingw-w64-pyqt5/001-mingw-python.patch
@@ -1,5 +1,5 @@
---- PyQt5_gpl-5.6.orig/configure.py	2016-04-24 11:55:08.000000000 +0100
-+++ PyQt5_gpl-5.6/configure.py	2016-07-19 14:09:00.230550900 +0100
+--- PyQt5_gpl-5.9/configure.py.orig	2017-08-22 15:11:51.878439200 +0200
++++ PyQt5_gpl-5.9/configure.py	2017-08-22 15:15:44.292242200 +0200
 @@ -25,6 +25,7 @@
  import shutil
  import stat
@@ -8,16 +8,16 @@
  
  
  # Initialise the constants.
-@@ -400,7 +401,7 @@
-         self.venv_inc_dir = sysconfig.get_python_inc(prefix=sys.prefix)
+@@ -408,7 +409,7 @@
          self.module_dir = sysconfig.get_python_lib(plat_specific=1)
+         self.debug = hasattr(sys, 'gettotalrefcount')
  
 -        if sys.platform == 'win32':
 +        if sys.platform == 'win32' and not _POSIX_BUILD:
              self.bin_dir = sys.exec_prefix
              self.data_dir = sys.prefix
              self.lib_dir = sys.prefix + '\\libs'
-@@ -409,6 +410,13 @@
+@@ -417,6 +418,13 @@
              self.data_dir = sys.prefix + '/share'
              self.lib_dir = sys.prefix + '/lib'
  
@@ -31,30 +31,7 @@
          # The name of the interpreter used by the pyuic5 wrapper.
          if sys.platform == 'darwin':
              # The installation of MacOS's python is a mess that changes from
-@@ -481,7 +489,9 @@
- 
-         # The qmake spec we want to use.
-         if self.py_platform == 'win32':
--            if self.py_version >= 0x030500:
-+            if _POSIX_BUILD:
-+                self.qmake_spec = "win32-g++"
-+            elif self.py_version >= 0x030500:
-                 self.qmake_spec = 'win32-msvc2015'
-             elif self.py_version >= 0x030300:
-                 self.qmake_spec = 'win32-msvc2010'
-@@ -702,7 +712,10 @@
- 
-         # Create the output file, first making sure it doesn't exist.
-         remove_file(out_file)
--        run_command(cmd, verbose)
-+        if "MSYSTEM" in os.environ:
-+            run_command("sh -c "+cmd, verbose)
-+        else:
-+            run_command(cmd, verbose)
- 
-         if not os.access(out_file, os.F_OK):
-             error("%s failed to create %s. Make sure your Qt installation is correct." % (cmd, out_file))
-@@ -731,7 +744,7 @@
+@@ -625,7 +633,7 @@
          py_major = self.py_version >> 16
          py_minor = (self.py_version >> 8) & 0x0ff
  
@@ -63,7 +40,7 @@
              debug_suffix = self.get_win32_debug_suffix()
  
              # See if we are using the limited API.
-@@ -803,6 +816,9 @@
+@@ -724,6 +732,9 @@
  
          self.designer_plugin_dir = qt_config.QT_INSTALL_PLUGINS + '/designer'
          self.qml_plugin_dir = qt_config.QT_INSTALL_PLUGINS + '/PyQt5'
@@ -73,17 +50,27 @@
  
          if self.sysroot == '':
              self.sysroot = qt_config.QT_SYSROOT
-@@ -811,7 +827,8 @@
+@@ -732,6 +743,8 @@
          # in the default location.
          self.qsci_api_dir = os.path.join(qt_config.QT_INSTALL_DATA, 'qsci')
          self.qsci_api = os.path.isdir(self.qsci_api_dir)
--
 +        if "MSYSTEM" in os.environ:
 +            self.qsci_api_dir = os.popen(' '.join(['cygpath', '--unix', self.qsci_api_dir])).readline().strip()
-         # Save the default qmake spec. and finalise the value we want to use.
-         self.default_qmake_spec = qt_config.QMAKE_SPEC
  
-@@ -959,6 +976,15 @@
+         # Save the default qmake spec. and finalise the value we want to use.
+         self.qmake_spec_default = qt_config.QMAKE_SPEC
+@@ -739,7 +752,9 @@
+         # On Windows for Qt versions prior to v5.9.0 we need to be explicit
+         # about the qmake spec.
+         if self.qt_version < 0x050900 and self.py_platform == 'win32':
+-            if self.py_version >= 0x030500:
++            if _POSIX_BUILD:
++                self.qmake_spec = "win32-g++"
++            elif self.py_version >= 0x030500:
+                 self.qmake_spec = 'win32-msvc2015'
+             elif self.py_version >= 0x030300:
+                 self.qmake_spec = 'win32-msvc2010'
+@@ -919,6 +934,15 @@
          if opts.vendlibdir is not None:
              self.vend_lib_dir = opts.vendlibdir
  
@@ -99,3 +86,15 @@
          # Handle any conflicts.
          if not self.qt_shared:
              if not self.static:
+@@ -2230,7 +2254,10 @@
+ 
+     # Create the output file, first making sure it doesn't exist.
+     remove_file(out_file)
+-    run_command(test + ' ' + out_file, verbose)
++    if "MSYSTEM" in os.environ:
++        run_command('sh -c "'+test + ' ' + out_file + '"', True)
++    else:
++        run_command(test + ' ' + out_file, True)
+ 
+     if not os.access(out_file, os.F_OK):
+         error("%s failed to create %s. Make sure your Qt installation is correct." % (test, out_file))

--- a/mingw-w64-pyqt5/PKGBUILD
+++ b/mingw-w64-pyqt5/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pyqt5
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-common" "${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.8.2
+pkgver=5.9
 #_pre_ver=5.8.dev1702091323
 pkgrel=1
 pkgdesc="Qt5 bindings for Python (mingw-w64)"
@@ -19,8 +19,8 @@ options=('strip' 'staticlibs')
 source=("https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-${pkgver}/PyQt5_gpl-${pkgver}.tar.gz"
         #https://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt5_gpl-${_pre_ver}.tar.gz
         001-mingw-python.patch)
-sha256sums=('ebd70515b30bbd6098fee29e6271a6696b1183c5530ee30e6ba9aaab195536e8'
-            '7ab51a7ef2aef12805e50316f5ffa84f6f22a5fb38f00dd5efa7f757b9a818bd')
+sha256sums=('ab0e7999cf202cc72962c78aefe461d16497b3c1a8282ab966ad90b6cb271096'
+            'bf03d0a7ab4e7378e6516450396c132086ca4c0426a04298549ced07c4b8286c')
 
 prepare() {
  cd "${srcdir}"/PyQt5_gpl-${pkgver}

--- a/mingw-w64-sip/PKGBUILD
+++ b/mingw-w64-sip/PKGBUILD
@@ -4,9 +4,9 @@
 _realname=sip
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}" "${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.19.2
+pkgver=4.19.3
 #_pre_ver=4.19.1.dev1702081834
-pkgrel=2
+pkgrel=1
 pkgdesc="Tool to create Python bindings for C and C++ libraries (mingw-w64)"
 arch=('any')
 license=('GPL')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=("https://downloads.sourceforge.net/project/pyqt/${_realname}/${_realname}-${pkgver}/${_realname}-${pkgver}.tar.gz"
         #https://www.riverbankcomputing.com/static/Downloads/sip/sip-${_pre_ver}.tar.gz
         "0001-mingw-python.patch")
-sha256sums=('432b4aad25254e6997913e33b1ca3cf5fd21d5729a50a3ce2edccbea82c80533'
+sha256sums=('740df844f80cc45dcc9b23294a92492923bc403ce88e68c35783f27c177c4b74'
             'eab49324d351582f3f7d5da772a009fdf54d2a8366ed28bba2318a7b384a980c')
 
 prepare() {


### PR DESCRIPTION
Had to update sip to 4.19.3 as required by pyqt5.

pyqt5 5.9 works with both Qt 5.9.0 and Qt 5.9.1.

Tested with a basic hello world application.