### PR TITLE
pillow: Add missing dependency (libraqm)

### DIFF
--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -4,13 +4,14 @@ _realname=Pillow
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-pillow" "${MINGW_PACKAGE_PREFIX}-python3-pillow")
 pkgver=4.2.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 license=('custom')
 url="https://github.com/python-pillow/Pillow/"
 depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-libraqm"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"


### PR DESCRIPTION
Pillow can make use of libraqm since version 4.2.0 (i.e. links against it since f46e8b3fc1e729d4fb593bff924ab4f28a70c006) and therefore is now missing a dependency.

(alternative would be to use [`--disable-raqm` build flag](https://pillow.readthedocs.io/en/latest/installation.html#build-options))