### PR TITLE
cairo: add patch to fix unbounded surface assertion

### DIFF
--- a/mingw-w64-cairo/0027-win32-print-fix-unbounded-surface-assertion.patch
+++ b/mingw-w64-cairo/0027-win32-print-fix-unbounded-surface-assertion.patch
@@ -1,23 +1,21 @@
-From 90d50cd92315d6760069ad8062aba5e297370b20 Mon Sep 17 00:00:00 2001
-From: Adrian Johnson <ajohnson@redneon.com>
-Date: Sun, 19 Jun 2016 19:52:32 +0930
-Subject: win32-print: fix unbounded surface assertion
-
-https://lists.cairographics.org/archives/cairo/2016-June/027445.html
-
-diff --git a/src/win32/cairo-win32-printing-surface.c b/src/win32/cairo-win32-printing-surface.c
-index afc0b11..983ef59 100644
---- a/src/win32/cairo-win32-printing-surface.c
-+++ b/src/win32/cairo-win32-printing-surface.c
-@@ -389,7 +389,7 @@ _cairo_win32_printing_surface_analyze_operation (cairo_win32_printing_surface_t
-     if (pattern->type == CAIRO_PATTERN_TYPE_SURFACE) {
+diff -ru cairo-1.15.6/src/win32/cairo-win32-printing-surface.c cairo-1.15.6b/src/win32/cairo-win32-printing-surface.c
+--- cairo-1.15.6/src/win32/cairo-win32-printing-surface.c	2017-06-09 08:46:49.000000000 +0200
++++ cairo-1.15.6b/src/win32/cairo-win32-printing-surface.c	2017-07-26 21:41:09.380698500 +0200
+@@ -335,7 +335,7 @@
+ static cairo_bool_t
+ surface_pattern_supported (const cairo_surface_pattern_t *pattern)
+ {
+-    if (_cairo_surface_is_recording (pattern->surface))
++    if (pattern->surface->type == CAIRO_SURFACE_TYPE_RECORDING)
+ 	return TRUE;
+ 
+     if (pattern->surface->backend->acquire_source_image == NULL)
+@@ -1119,7 +1119,7 @@
+     case CAIRO_PATTERN_TYPE_SURFACE: {
  	cairo_surface_pattern_t *surface_pattern = (cairo_surface_pattern_t *) pattern;
  
 -	if ( _cairo_surface_is_recording (surface_pattern->surface))
 +	if (surface_pattern->surface->type == CAIRO_SURFACE_TYPE_RECORDING)
- 	    return CAIRO_INT_STATUS_ANALYZE_RECORDING_SURFACE_PATTERN;
-     }
- 
--- 
-cgit v0.10.2
-
+ 	    status = _cairo_win32_printing_surface_paint_recording_pattern (surface, surface_pattern);
+ 	else
+ 	    status = _cairo_win32_printing_surface_paint_image_pattern (surface, pattern, extents);

--- a/mingw-w64-cairo/PKGBUILD
+++ b/mingw-w64-cairo/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cairo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.15.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Cairo vector graphics library (mingw-w64)"
 arch=('any')
 url="https://cairographics.org/"
@@ -31,15 +31,18 @@ options=('strip' 'staticlibs')
 source=(#"https://cairographics.org/releases/cairo-${pkgver}.tar.xz"
         https://cairographics.org/snapshots/cairo-${pkgver}.tar.xz
         0009-standalone-headers.mingw.patch
-        0026-create-argb-fonts.all.patch)
+        0026-create-argb-fonts.all.patch
+        0027-win32-print-fix-unbounded-surface-assertion.patch)
 sha256sums=('5228e0a1f8fd14317f30f08f3dd72971bca432f8cdd2281d421fdcc2279de58c'
             '234de8c5d4c28b03c19e638a353e8defb2de0367a634c002b0ea7d2877bd0756'
-            '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975')
+            '6db6c44fbdb4926d09afa978fe80430186c4b7b7d255059602b1f94c6a079975'
+            '7e244c20eec8c7b287dbee1d34de178d9b0c419dc4c2b11c90eaf626c92bf781')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0009-standalone-headers.mingw.patch
   patch -p1 -i ${srcdir}/0026-create-argb-fonts.all.patch
+  patch -p1 -i ${srcdir}/0027-win32-print-fix-unbounded-surface-assertion.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
This fixes crashes when using the cairo-win32 print backend.

Reported upstream (see https://bugs.freedesktop.org/show_bug.cgi?id=101833) but 
upstream seems to be working a bit slowly these days...