### PR TITLE
Gprbuild

### DIFF
--- a/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
+++ b/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
@@ -1,0 +1,65 @@
+# ArchLinux Maintainer: Pierre-Marie de Rodat <pmderodat on #ada at freenode.net>
+# ArchLinux Contributor: Rod Kay <charlie5 on #ada at freenode.net>
+# Contributor: Tim S <stahta01@gmail.com>
+
+
+_realname=gprbuild-bootstrap
+pkgbase=mingw-w64-${_realname}-git
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-git
+pkgver=r3202.51774659
+pkgrel=1
+pkgdesc="Static GPRbuild to bootstrap XML/Ada and GPRbuild itself"
+arch=('any')
+url='https://github.com/AdaCore/gprbuild/'
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=(
+  'git'
+  "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+)
+provides=(
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap"
+)
+conflicts=(
+  "${MINGW_PACKAGE_PREFIX}-gprbuild"
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-gpl"
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap"
+)
+source=('git+https://github.com/AdaCore/gprbuild.git'
+        'git+https://github.com/AdaCore/xmlada.git')
+sha1sums=(SKIP SKIP)
+
+
+pkgver() {
+    cd "$srcdir/gprbuild"
+    printf "r%s.%s" \
+        "$(git rev-list --count HEAD)" \
+        "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+    cd "$srcdir/gprbuild"
+
+    # GPRbuild hard-codes references to /usr/libexec, but ArchLinux packages
+    # must use /usr/lib instead.
+    sed -i 's/libexec/lib/g' doinstall gprbuild.gpr \
+        share/gprconfig/compilers.xml \
+        share/gprconfig/linker.xml \
+        share/gprconfig/gnat.xml
+}
+
+build() {
+    cd "$srcdir/gprbuild"
+
+    export GNATMAKEFLAGS="-j$(nproc)"
+    export DESTDIR="$srcdir/bootstrap"
+    ./bootstrap.sh \
+        --prefix=${MINGW_PREFIX} \
+        --libexecdir=/lib \
+        --with-xmlada="$srcdir/xmlada"
+}
+
+package() {
+    cd "$srcdir/bootstrap"
+    cp -a --no-preserve=ownership -- "$srcdir/bootstrap/${MINGW_PREFIX}" "$pkgdir"
+}

--- a/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
+++ b/mingw-w64-gprbuild-bootstrap-git/PKGBUILD
@@ -1,6 +1,6 @@
-# ArchLinux Maintainer: Pierre-Marie de Rodat <pmderodat on #ada at freenode.net>
+# Maintainer: Tim S <stahta01@gmail.com>
+# ArchLinux Contributor: Pierre-Marie de Rodat <pmderodat on #ada at freenode.net>
 # ArchLinux Contributor: Rod Kay <charlie5 on #ada at freenode.net>
-# Contributor: Tim S <stahta01@gmail.com>
 
 
 _realname=gprbuild-bootstrap
@@ -8,7 +8,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}-git
 pkgver=r3202.51774659
 pkgrel=1
-pkgdesc="Static GPRbuild to bootstrap XML/Ada and GPRbuild itself"
+pkgdesc="Static GPRbuild to bootstrap XML/Ada and GPRbuild itself (mingw-w64)"
 arch=('any')
 url='https://github.com/AdaCore/gprbuild/'
 license=('GPL3')
@@ -17,9 +17,7 @@ makedepends=(
   'git'
   "${MINGW_PACKAGE_PREFIX}-gcc-ada"
 )
-provides=(
-  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap"
-)
+provides=("${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap")
 conflicts=(
   "${MINGW_PACKAGE_PREFIX}-gprbuild"
   "${MINGW_PACKAGE_PREFIX}-gprbuild-gpl"

--- a/mingw-w64-gprbuild-gpl/PKGBUILD
+++ b/mingw-w64-gprbuild-gpl/PKGBUILD
@@ -1,38 +1,41 @@
 # Maintainer: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# Contributor: Tim S <stahta01@gmail.com>
 
 _realname=gprbuild-gpl
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
 pkgrel=1
-pkgver=2014
+pkgver=2016
 pkgdesc="Software tool designed to help automate the construction of multi-language systems"
 arch=('any')
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname%-*}")
 license=('GPL3')
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
-             #"${MINGW_PACKAGE_PREFIX}-xmlada"
-            )
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada"
-        # "${MINGW_PACKAGE_PREFIX}-xmlada"
-         )
 url="http://www.adacore.com/gnatpro/toolsuite/gprbuild/"
-source=("http://downloads.dragonlace.net/src/${_realname}-${pkgver}-src.tar.gz"
-        "0001_gnat_vmsp.patch")
-sha256sums=('3c8986ff5f83cc0d3ee69f6e71d9f69a7eb1a7e2656493c829b18fb55c4ad5ac'
-            'a05e637de1ef87d3cf64bb179594a6707fae650120adeee8ae0310622b2ced02')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+  "${MINGW_PACKAGE_PREFIX}-xmlada"
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap-git"
+)
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+  "${MINGW_PACKAGE_PREFIX}-xmlada"
+)
+conflicts=(
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap"
+)
+source=('http://mirrors.cdn.adacore.com/art/57399662c7a447658e0affa8')
+sha256sums=('d51659454bc0aaf1a9a9f1d05aab469a1f3d900065a4542123d3a59ab067275d')
 
 prepare()
 {
-  cd ${srcdir}/${_realname}-${pkgver}-src
+  cd ${srcdir}/gprbuild-gpl-$pkgver-src
 
-  patch -p1 -i "${srcdir}/0001_gnat_vmsp.patch"
+#  ./bootstrap.sh
 }
 
 build() {
-  cd ${srcdir}/${_realname}-${pkgver}-src
-  if [ -f Makefile ]; then
-    make distclean
-  fi
+  cd ${srcdir}/gprbuild-gpl-$pkgver-src
+
   ./configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -42,7 +45,7 @@ build() {
 }
 
 package() {
-  cd ${srcdir}/${_realname}-${pkgver}-src
+  cd ${srcdir}/gprbuild-gpl-$pkgver-src
   make prefix="${pkgdir}${MINGW_PREFIX}" INSTALL=cp install
 
   # Copy License Files

--- a/mingw-w64-xmlada-gpl/PKGBUILD
+++ b/mingw-w64-xmlada-gpl/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# Contributor: Tim S <stahta01@gmail.com>
 
 # Pathnames in this project can get quite long, so at least on Windows
 # I recommend to use a short BUILDDIR setting to avoid problems
@@ -14,13 +15,24 @@ arch=('any')
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname%-*}")
 url="https://libre.adacore.com/libre/tools/xmlada/"
 license=('GPL3')
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-ada")
-source=(http://downloads.dragonlace.net/src/${_realname}-${pkgver}-src.tar.gz)
-sha256sums=('f686bc49318583c0a3bd12315e0ac8fcb3721bb8d528cdbf3bccbd753d227e69')
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+  "${MINGW_PACKAGE_PREFIX}-gprbuild-bootstrap-git"
+  "git"
+)
+depends=()
+source=("${_realname}"::"git+https://github.com/AdaCore/xmlada.git#branch=gpl-${pkgver}")
+sha256sums=('SKIP')
 options=('strip')
 
+prepare()
+{
+  cd ${srcdir}/${_realname}
+
+}
+
 build() {
-  cd ${srcdir}/${_realname:0:6}-${pkgver}-src
+  cd ${srcdir}/${_realname}
   ./configure \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
@@ -35,7 +47,7 @@ package() {
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/xmlada/relocatable
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/gnat/xmlada
 
-  cd ${srcdir}/${_realname:0:6}-${pkgver}-src
+  cd ${srcdir}/${_realname}
   make prefix=${pkgdir}${MINGW_PREFIX} INSTALL=cp install
 
   rm -rf ${pkgdir}${MINGW_PREFIX}/share/examples
@@ -43,6 +55,6 @@ package() {
 
   # Copy License Files
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
-  cp -pf ${srcdir}/${_realname:0:6}-${pkgver}-src/COPYING* \
+  cp -pf ${srcdir}/${_realname}/COPYING* \
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
 }


### PR DESCRIPTION
I noticed that the mingw-w64-xmlada-gpl and mingw-w64-gprbuild-gpl packages were not building.
I have gotten them to build; but, I have no idea if they work.
The newest mingw-w64-xmlada-gpl version that built (They all have unicode related errors) was 2014.
Tim S.



