### PR TITLE
exiv2: Turn on unicode paths.

### DIFF
--- a/mingw-w64-exiv2/0001-fix-tests.patch
+++ b/mingw-w64-exiv2/0001-fix-tests.patch
@@ -18,3 +18,39 @@ diff -Naur exiv2-0.26.orig/test/functions.source exiv2-0.26/test/functions.sourc
  	else
  		export PLATFORM=$os
  	fi
+$ diff -Naur exiv2-0.26.orig/include/exiv2/config.h.orig  exiv2-0.26/include/exiv2/config.h
+--- exiv2-0.26.orig/include/exiv2/config.h.orig        2017-08-31 10:06:58.847065500 +0200
++++ exiv2-0.26/include/exiv2/config.h     2017-06-21 19:54:35.768220600 +0200
+@@ -158,9 +158,9 @@
+ # ifdef  EXV_HAVE_REGEX
+ #  undef EXV_HAVE_REGEX
+ # endif
+-#ifdef EXV_UNICODE_PATH
+-#error EXV_UNICODE_PATH is not supported for MinGW builds
+-#endif
++//#ifdef EXV_UNICODE_PATH
++//#error EXV_UNICODE_PATH is not supported for MinGW builds
++//#endif
+ #endif
+
+ #ifndef __CYGWIN__
+diff -Naur exiv2-0.26/src/actions.cpp.orig exiv2-0.26/src/actions.cpp
+--- exiv2-0.26/src/actions.cpp.orig     2017-04-26 21:16:21.000000000 +0200
++++ exiv2-0.26/src/actions.cpp  2017-08-31 10:58:49.555946500 +0200
+@@ -2117,11 +2117,11 @@
+         Action::Modify::applyCommands(sourceImage.get());
+
+         // Open or create the target file
+-#ifdef EXV_UNICODE_PATH
+-        std::string target = bStdout ? Exiv2::ws2s(temporaryPath()) : tgt;
+-#else
++//#ifdef EXV_UNICODE_PATH
++//        std::string target = bStdout ? Exiv2::ws2s(temporaryPath()) : tgt;
++//#else
+         std::string target = bStdout ?             temporaryPath()  : tgt;
+-#endif
++//#endif
+
+         Exiv2::Image::AutoPtr targetImage;
+         if (Exiv2::fileExists(target)) {
+

--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.26
-pkgrel=1
+pkgrel=2
 pkgdesc="Exif and Iptc metadata manipulation library and tools (mingw-w64)"
 arch=('any')
 url="http://exiv2.org"
@@ -16,12 +16,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-gettext"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-libssh2"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('strip' 'staticlibs')
 source=("https://github.com/Exiv2/${_realname}/archive/v${pkgver}.tar.gz"
         0001-fix-tests.patch)
 sha256sums=('51cffa8d19d67e1da6c1d0f570a75b8f6c814113367318c2c0407691888c5f01'
-            'b8f06f3f89980766e2e7b986cad2f3d9592081326f0997ad0d9f674d664b9ba7')
+            'a87f79c66b4440a4822f5b0c68b0dbd091f1b1cb2a95e4371de708fb5bc57aa8')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -41,6 +43,10 @@ build() {
     -DBUILD_SHARED_LIBS=ON \
     -DEXIV2_ENABLE_VIDEO=ON \
     -DEXIV2_ENABLE_NLS=OFF \
+    -DEXIV2_ENABLE_WIN_UNICODE=ON \
+    -DEXIV2_ENABLE_BUILD_SAMPLES=OFF \
+    -DEXIV2_ENABLE_CURL=ON \
+    -DEXIV2_ENABLE_SSH=ON \
     ../${_realname}-${pkgver}
 
   make


### PR DESCRIPTION
That requires rebuild for programs which are using this library due to changing ABI. I'm aware of only on such package (gexiv2)