### PR TITLE
mingw-w64-gdb-git: Fix patch 0006 according to upstream changes.

### DIFF
--- a/mingw-w64-gdb-git/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
+++ b/mingw-w64-gdb-git/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
@@ -1,46 +1,33 @@
-From 8f19bff31adb8b5f7da8a0c96667cc564b3c62e6 Mon Sep 17 00:00:00 2001
+From f70628a40e8b0f308da6f9773c171aa4bc32af08 Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Sun, 2 Jul 2017 13:44:19 +0800
 Subject: [PATCH] Disable checks using setenv() or unsetenv() as they do not
  exist on Windows.
 
 ---
- gdb/unittests/environ-selftests.c | 4 ++++
- 1 file changed, 4 insertions(+)
+ gdb/unittests/environ-selftests.c | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/gdb/unittests/environ-selftests.c b/gdb/unittests/environ-selftests.c
-index 28b16f828f..f916fe3b5d 100644
+index 81a71ee01e..11fdfb4a10 100644
 --- a/gdb/unittests/environ-selftests.c
 +++ b/gdb/unittests/environ-selftests.c
-@@ -28,10 +28,12 @@ namespace gdb_environ_tests {
+@@ -268,6 +268,7 @@ test_set_unset_reset ()
  static void
  run_tests ()
  {
 +#ifndef _WIN32
-   /* Set a test environment variable.  This will be unset at the end
-      of this function.  */
+   /* Set a test environment variable.  */
    if (setenv ("GDB_SELFTEST_ENVIRON", "1", 1) != 0)
      error (_("Could not set environment variable for testing."));
-+#endif
+@@ -286,6 +287,7 @@ run_tests ()
  
-   gdb_environ env;
- 
-@@ -53,6 +55,7 @@ run_tests ()
-   /* Initialize the environment vector using the host's environ.  */
-   env = gdb_environ::from_host_environ ();
- 
-+#ifndef _WIN32
-   /* Our test environment variable should be present at the
-      vector.  */
-   SELF_CHECK (strcmp (env.get ("GDB_SELFTEST_ENVIRON"), "1") == 0);
-@@ -91,6 +94,7 @@ run_tests ()
- 
-   /* Get rid of our test variable.  */
+   /* Get rid of our test variable.  We won't need it anymore.  */
    unsetenv ("GDB_SELFTEST_ENVIRON");
 +#endif
  
-   /* Test the case when we set a variable A, then set a variable B,
-      then unset A, and make sure that we cannot find A in the environ
+   test_set_A_unset_B_unset_A_cannot_find_A_can_find_B ();
+ 
 -- 
-2.13.0
+2.13.3
 

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}
-pkgver=r90917.2a9f9e83e5
+pkgver=r91505.63345acf64
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -40,7 +40,7 @@ sha256sums=('SKIP'
             'c8aab67618e05c31e3b60b59319d8fa3eeb7ca9dbf8de937a07c99533557dd5f'
             '4ddb55be45625efd1b2c82d2e344f4ebc9f17e362642489f21eb19fa9ec8d94b'
             '9d2aa8b97952e92973b4c306aafbf338c1cd6c1bb1f75f81bdf85751464a9750'
-            'b165d602dfbeab226ca1bee1d9b85f98c6d86d9cc5bdd8e2258f705206b63c62')
+            '4b21429e3583866b25ca4feb6ae57daab81d8735d1eb52ab61338184f58bc2fb')
 
 pkgver() {
   cd "$srcdir/$_realname"


### PR DESCRIPTION
This makes `mingw-w64-gdb-git` build again.