### PR TITLE
gcc-git: Update diagnostic color patch.

### DIFF
--- a/mingw-w64-gcc-git/0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch
+++ b/mingw-w64-gcc-git/0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch
@@ -1,13 +1,13 @@
-From 597cbbbf789ecef0af62686d02a8e342cda8371e Mon Sep 17 00:00:00 2001
+From 2e35677294089d4af7016fcaa4d82e91b726c845 Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
-Date: Wed, 6 Sep 2017 17:28:12 +0800
-Subject: [PATCH] This patch enables a native GCC to color diagnostic messages
- sent over Windows consoles.
+Date: Thu, 7 Sep 2017 12:50:07 +0800
+Subject: [PATCH] Enable a native GCC to color diagnostic messages sent over
+ Windows consoles.
 
 ---
  gcc/diagnostic-color.c |  28 ++-
- gcc/pretty-print.c     | 606 +++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 624 insertions(+), 10 deletions(-)
+ gcc/pretty-print.c     | 664 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 682 insertions(+), 10 deletions(-)
 
 diff --git a/gcc/diagnostic-color.c b/gcc/diagnostic-color.c
 index 8353fe016b7..c002331a31f 100644
@@ -68,10 +68,10 @@ index 8353fe016b7..c002331a31f 100644
  }
 -#endif
 diff --git a/gcc/pretty-print.c b/gcc/pretty-print.c
-index bcb1a70ac03..91685484a39 100644
+index bcb1a70ac03..fba4ba87499 100644
 --- a/gcc/pretty-print.c
 +++ b/gcc/pretty-print.c
-@@ -30,6 +30,608 @@ along with GCC; see the file COPYING3.  If not see
+@@ -30,6 +30,666 @@ along with GCC; see the file COPYING3.  If not see
  #include <iconv.h>
  #endif
  
@@ -113,8 +113,7 @@ index bcb1a70ac03..91685484a39 100644
 +      character X in [0x40,0x5F], returns X and stores a pointer to
 +      the third character into *head.
 +   2. If the sequence begins with a character X in [0x80,0x9F], returns
-+      return (X-0x40) and stores a pointer to the second character
-+      into *head.
++      (X-0x40) and stores a pointer to the second character into *head.
 +   Stores the number of ESC character(s) in *prefix_len.
 +   Returns 0 if no such sequence can be found. */
 +static int
@@ -194,6 +193,7 @@ index bcb1a70ac03..91685484a39 100644
 +  COORD cr;
 +  /* ED and EL parameters. */
 +  DWORD cnt, step;
++  long rows;
 +  /* SGR parameters. */
 +  WORD attrib_add, attrib_rm;
 +  const char *param;
@@ -347,7 +347,7 @@ index bcb1a70ac03..91685484a39 100644
 +      break;
 +
 +    /* ESC [ n1 'G'
-+	 Move the cursor to the the (1-based) n1-th column. */
++	 Move the cursor to the (1-based) n1-th column. */
 +    case MAKEWORD ('[', 'G'):
 +      if (esc_head == esc_term)
 +	n1 = 1;
@@ -375,7 +375,7 @@ index bcb1a70ac03..91685484a39 100644
 +
 +    /* ESC [ n1 ';' n2 'H'
 +       ESC [ n1 ';' n2 'f'
-+	 Move the cursor to the the (1-based) n1-th row and
++	 Move the cursor to the (1-based) n1-th row and
 +	 (also 1-based) n2-th column. */
 +    case MAKEWORD ('[', 'H'):
 +    case MAKEWORD ('[', 'f'):
@@ -434,6 +434,64 @@ index bcb1a70ac03..91685484a39 100644
 +	  else
 +	    cr.X = n2;
 +	  SetConsoleCursorPosition (h, cr);
++	}
++      break;
++
++    /* ESC [ n1 'J'
++	 Erase display. */
++    case MAKEWORD ('[', 'J'):
++      if (esc_head == esc_term)
++	/* This is one of the very few codes whose parameters have
++	   a default value of zero. */
++	n1 = 0;
++      else
++	{
++	  n1 = strtol (esc_head, &eptr, 10);
++	  if (eptr != esc_term)
++	    break;
++	}
++
++      if (GetConsoleScreenBufferInfo (h, &sb))
++	{
++	  /* The cursor is not necessarily in the console window, which
++	     makes the behavior of this code harder to define. */
++	  switch (n1)
++	    {
++	    case 0:
++	      /* If the cursor is in or above the window, erase from
++		 it to the bottom of the window; otherwise, do nothing. */
++	      cr = sb.dwCursorPosition;
++	      cnt = sb.dwSize.X - sb.dwCursorPosition.X;
++	      rows = sb.srWindow.Bottom - sb.dwCursorPosition.Y;
++	      break;
++	    case 1:
++	      /* If the cursor is in or under the window, erase from
++		 it to the top of the window; otherwise, do nothing. */
++	      cr.X = 0;
++	      cr.Y = sb.srWindow.Top;
++	      cnt = sb.dwCursorPosition.X + 1;
++	      rows = sb.dwCursorPosition.Y - sb.srWindow.Top;
++	      break;
++	    case 2:
++	      /* Erase the entire window. */
++	      cr.X = sb.srWindow.Left;
++	      cr.Y = sb.srWindow.Top;
++	      cnt = 0;
++	      rows = sb.srWindow.Bottom - sb.srWindow.Top + 1;
++	      break;
++	    default:
++	      /* Erase the entire buffer. */
++	      cr.X = 0;
++	      cr.Y = 0;
++	      cnt = 0;
++	      rows = sb.dwSize.Y;
++	      break;
++	    }
++	  if (rows < 0)
++	    break;
++	  cnt += rows * sb.dwSize.X;
++	  FillConsoleOutputCharacterW (h, L' ', cnt, cr, &step);
++	  FillConsoleOutputAttribute (h, sb.wAttributes, cnt, cr, &step);
 +	}
 +      break;
 +
@@ -680,7 +738,7 @@ index bcb1a70ac03..91685484a39 100644
  static void pp_quoted_string (pretty_printer *, const char *, size_t = -1);
  
  /* Overwrite the given location/range within this text_info's rich_location.
-@@ -140,7 +742,11 @@ void
+@@ -140,7 +800,11 @@ void
  pp_write_text_to_stream (pretty_printer *pp)
  {
    const char *text = pp_formatted_text (pp);

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -63,7 +63,7 @@ source=("git://gcc.gnu.org/git/gcc.git#branch=${_branch}"
         "0014-gcc-7-branch-clone_function_name_1-Retain-any-stdcall-suffix.patch"
         "0016-disable-weak-refs-in-libstdc++.patch"
         "0017-gcc-7-branch-Enable-std-experimental-filesystem.patch"
-        "0018-gcc-7-branch-diagnostic-color.c.patch"
+        "0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch"
         "9999-gcc-6-branch-Add-defines-to-disable-optimize-for-size-changes.patch")
 sha256sums=('SKIP'
             '49a5e264e611de7f2388f01ba649ec22cf3ae1cde3ba45082a7d72294c2f4fd7'
@@ -87,7 +87,7 @@ sha256sums=('SKIP'
             '60a58ed41389691a68ef4b7d47a0328df4d28d26e6c680a6b06b31191481ca65'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
             '4c190efddb73a3e0a7163653e60f299e66dfb172f4d0f2f775fdd80713c1b845'
-            '4e233f97fb5090e9c3971c57bd2acea528b1afae1c706069f177ad7e3e51f797'
+            '33392651e17b81609718873ff32606deee5f3fc5176c197bb96eedc3dada8912'
             'a82eadfbb6a182b1ffeb860e89c89f46373a8b891594280b2268ecac8d7bac88')
 
 _threads="posix"
@@ -117,7 +117,7 @@ prepare() {
   ${GIT_AM} ${srcdir}/0016-disable-weak-refs-in-libstdc++.patch
   if [ "${_branch}" == "gcc-7-branch" ]; then
     ${GIT_AM} ${srcdir}/0017-gcc-7-branch-Enable-std-experimental-filesystem.patch
-    ${GIT_AM} ${srcdir}/0018-gcc-7-branch-diagnostic-color.c.patch
+    ${GIT_AM} ${srcdir}/0018-gcc-7-branch-Enable-a-native-GCC-to-color-diagnostic-messages-sen.patch
   fi
   # ${GIT_AM} ${srcdir}/9999-gcc-6-branch-Add-defines-to-disable-optimize-for-size-changes.patch
 


### PR DESCRIPTION
This fixes a few typos in comments in the original patch and adds a handler for the `ESC [ n J` (Erase Display, ED) sequence.