### PR TITLE
Aspell: update to 0.60.7-rc1 and fix segmentation fault

### DIFF
--- a/mingw-w64-aspell/0008-cache-Attempt-to-prevent-premature-destruction-of-gl.patch
+++ b/mingw-w64-aspell/0008-cache-Attempt-to-prevent-premature-destruction-of-gl.patch
@@ -1,0 +1,67 @@
+From 208e7e93466d02b583012029a60ad958b1eb234b Mon Sep 17 00:00:00 2001
+From: Jeremy Tan <jtanx@outlook.com>
+Date: Sun, 10 Sep 2017 13:55:41 +1000
+Subject: [PATCH] cache: Attempt to prevent premature destruction of global
+ cache lock
+
+https://stackoverflow.com/questions/335369/finding-c-static-initialization-order-problems#335746
+---
+ common/cache-t.hpp | 1 +
+ common/cache.cpp   | 8 ++++----
+ 2 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/common/cache-t.hpp b/common/cache-t.hpp
+index c326fd2..b39b847 100644
+--- a/common/cache-t.hpp
++++ b/common/cache-t.hpp
+@@ -16,6 +16,7 @@ public: // but don't use
+   const char * name;
+   GlobalCacheBase * next;
+   GlobalCacheBase * * prev;
++  static Mutex global_cache_lock;
+ protected:
+   Cacheable * first;
+   void del(Cacheable * d);
+diff --git a/common/cache.cpp b/common/cache.cpp
+index c4884e5..3cc48ab 100644
+--- a/common/cache.cpp
++++ b/common/cache.cpp
+@@ -5,8 +5,8 @@
+ 
+ namespace acommon {
+ 
+-static StackPtr<Mutex> global_cache_lock(new Mutex);
+ static GlobalCacheBase * first_cache = 0;
++Mutex GlobalCacheBase::global_cache_lock;
+ 
+ void Cacheable::copy() const
+ {
+@@ -70,7 +70,7 @@ void release_cache_data(GlobalCacheBase * cache, const Cacheable * d)
+ GlobalCacheBase::GlobalCacheBase(const char * n)
+   : name (n)
+ {
+-  LOCK(global_cache_lock);
++  LOCK(&global_cache_lock);
+   next = first_cache;
+   prev = &first_cache;
+   if (first_cache) first_cache->prev = &next;
+@@ -80,14 +80,14 @@ GlobalCacheBase::GlobalCacheBase(const char * n)
+ GlobalCacheBase::~GlobalCacheBase()
+ {
+   detach_all();
+-  LOCK(global_cache_lock);
++  LOCK(&global_cache_lock);
+   *prev = next;
+   if (next) next->prev = prev;
+ }
+ 
+ bool reset_cache(const char * which)
+ {
+-  LOCK(global_cache_lock);
++  LOCK(&GlobalCacheBase::global_cache_lock);
+   bool any = false;
+   for (GlobalCacheBase * i = first_cache; i; i = i->next)
+   {
+-- 
+2.13.3
+

--- a/mingw-w64-aspell/PKGBUILD
+++ b/mingw-w64-aspell/PKGBUILD
@@ -24,7 +24,8 @@ source=("http://alpha.gnu.org/gnu/${_realname}/${_realname}-${_ver_base}-${_date
         0004-reloc.mingw.patch
         0005-w32-home.all.patch
         0006-abort.mingw.patch
-        0007-fix-including-langinfo.patch)
+        0007-fix-including-langinfo.patch
+        0008-cache-Attempt-to-prevent-premature-destruction-of-gl.patch)
 sha256sums=('86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
             '903c798d1afa40b4e36ec0d4c1b82a967d217507f03742c3c480568cc527e429'
             'ec5c71c96f9e8e299a818aae930a766832f52c431f44a7d42b0c69ad3cb18ffe'
@@ -32,7 +33,8 @@ sha256sums=('86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
             '458bc2d9b2193fb6c40023d4656bee603ea5996ea55ba4b86ae337ca3fed2f2d'
             'c0cd30738e30de948b4cfc33f2b8672c7b57410f6c5bd04358fa9cfba29ab9c9'
             '34155f49b3cddd1e02e0d244cba286d97dab229088148261c2b5c499664ba299'
-            '8ff2cfc11963d0738c435a27c42e2f28dabf473270310f98ef6252a9707d4501')
+            '8ff2cfc11963d0738c435a27c42e2f28dabf473270310f98ef6252a9707d4501'
+            '6325f1d8e95e94c4977d484501e1ca88a11b467c0208b9f447e855189621b126')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${_ver_base}-${_date_ver}
@@ -43,6 +45,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0005-w32-home.all.patch
   patch -p1 -i ${srcdir}/0006-abort.mingw.patch
   patch -p1 -i ${srcdir}/0007-fix-including-langinfo.patch
+  patch -p1 -i ${srcdir}/0008-cache-Attempt-to-prevent-premature-destruction-of-gl.patch
 
   autoreconf -fi
 }

--- a/mingw-w64-aspell/PKGBUILD
+++ b/mingw-w64-aspell/PKGBUILD
@@ -3,10 +3,10 @@
 _realname=aspell
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_date_ver=20131207
+_date_ver=rc1
 _ver_base=0.60.7
 pkgver=${_ver_base}.${_date_ver}
-pkgrel=3
+pkgrel=1
 pkgdesc="A spell checker designed to eventually replace Ispell (mingw-w64)"
 arch=('any')
 url="http://aspell.net/"
@@ -25,7 +25,7 @@ source=("http://alpha.gnu.org/gnu/${_realname}/${_realname}-${_ver_base}-${_date
         0005-w32-home.all.patch
         0006-abort.mingw.patch
         0007-fix-including-langinfo.patch)
-sha256sums=('319787085a34840cfef5d9a258d10d8ba7a7d47899faf5f107ac66a0b53f4e83'
+sha256sums=('86b5662f24316142f70c5890787bdc5596625ca3604dfe85926ee61f27f2365e'
             '903c798d1afa40b4e36ec0d4c1b82a967d217507f03742c3c480568cc527e429'
             'ec5c71c96f9e8e299a818aae930a766832f52c431f44a7d42b0c69ad3cb18ffe'
             'b2c36f72abae7b31bf988fb9466543f0836aecbf84abcce09ca7c04c5e7fd4ff'


### PR DESCRIPTION
This allows to build with gcc 7 and fixes a segmentation fault.

(see previous description and patch by @jtanx for details)

<s>Unfortunately Aspell is still incompatible with recent versions of winpthreads making it SEGFAULT frequently, see #904 (and links in that bug).

Downgrading winpthreads temporarily is a workaround in some cases but is not really possible in others (e.g. I just realized that Inkscape, which is linked against the shared Aspell library, crashes *every* time on exit due to this issue).

Any help with this would be highly appreciated!

(P.S. In principle this could be merged, but as long as no fix is found there's probably not much reason to package a release candidate at this point; just wanted to make it available in case somebody want to try to build it)</s>