### PR TITLE
plplot: Updated to version 5.13.0 and fixed building of package.

### DIFF
--- a/mingw-w64-plplot/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
+++ b/mingw-w64-plplot/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
@@ -1,0 +1,25 @@
+From 5b683ad7f12bb302667ce82950458f3f93c05e48 Mon Sep 17 00:00:00 2001
+From: Tim S <stahta01@users.sourceforge.net>
+Date: Wed, 5 Apr 2017 14:11:11 -0400
+Subject: [PATCH] plplot: Include "wx/msw/wrapwin.h" instead of "Windows.h".
+
+---
+ drivers/wxwidgets_comms.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/wxwidgets_comms.h b/drivers/wxwidgets_comms.h
+index dafbe9797..1da64918d 100644
+--- a/drivers/wxwidgets_comms.h
++++ b/drivers/wxwidgets_comms.h
+@@ -24,7 +24,7 @@
+ 
+ #include "plplotP.h"
+ #ifdef WIN32
+-#include <Windows.h>
++#include <wx/msw/wrapwin.h>
+ #else
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+-- 
+2.12.2.windows.1
+

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 # Contributor: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# Contributor: Tim S. <stahta01@gmail.com>
 
 _realname=plplot
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.11.0
-pkgrel=2
+pkgver=5.13.0
+pkgrel=1
 arch=('any')
 pkgdesc="Scientific plotting software (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
@@ -15,32 +16,33 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-python2"
          "${MINGW_PACKAGE_PREFIX}-python2-numpy"
          "${MINGW_PACKAGE_PREFIX}-qhull"
-         "${MINGW_PACKAGE_PREFIX}-swig"
          "${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-wxWidgets"
         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2"
+             "${MINGW_PACKAGE_PREFIX}-libgd"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
-             "${MINGW_PACKAGE_PREFIX}-gcc-ada")
+             "${MINGW_PACKAGE_PREFIX}-gcc-ada"
+             "${MINGW_PACKAGE_PREFIX}-swig")
+optdepends=("${MINGW_PACKAGE_PREFIX}-swig: connects Plplot C library to Python and Lua"
+            "${MINGW_PACKAGE_PREFIX}-libgd: ability to output png, jpeg and gif files")
 options=('strip' 'staticlibs')
 license=('LGPL')
 url="https://plplot.sourceforge.io/"
 source=(https://downloads.sourceforge.net/sourceforge/plplot/${_realname}-${pkgver}.tar.gz
-        find-gd.patch)
-sha256sums=('bfa8434e6e1e7139a5651203ec1256c8581e2fac3122f907f7d8d25ed3bd5f7e'
-            'd5fbcb9369824c0f3da24bc63fcf4d764bbf70a2c727f7fec6ad3bf42edaa92f')
+        find-gd.patch
+        "Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch")
+sha256sums=('ec36bbee8b03d9d1c98f8fd88f7dc3415560e559b53eb1aa991c2dcf61b25d2b'
+            'd5fbcb9369824c0f3da24bc63fcf4d764bbf70a2c727f7fec6ad3bf42edaa92f'
+            '9c81879ade97eb15bdefc04c476e986e5996ac52fff2428f90c136e16d54f275')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/find-gd.patch
+  patch -p1 -i ${srcdir}/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
 }
 
 build() {
-  # cmake's FindSWIG doesn't work properly on MSYS,
-  # so we provide SWIG here
-  SWIG_DIR_U=`${MINGW_PREFIX}/bin/swig -swiglib`
-  SWIG_DIR=`cygpath -m ${SWIG_DIR_U}`
-
   # cmake may be confused if there is a Windows installation
   # of the official Python MSI. Please do the Python-enabled
   # build only, if no official Python is installed.
@@ -55,12 +57,18 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_TESTING=OFF \
-    -DSWIG_EXECUTABLE="${SWIG_EXECUTABLE}" \
-    -DSWIG_DIR="${SWIG_DIR}" \
     -DQHULL_INCLUDE_DIR=${MINGW_PREFIX}/include \
     -DGD_INCLUDE_DIR=${MINGW_PREFIX}/include \
+    -DDEFAULT_NO_BINDINGS=ON \
+    -DENABLE_ada=ON \
+    -DENABLE_cxx=ON \
+    -DENABLE_f95=ON \
     -DENABLE_lua=ON \
     -DENABLE_python=ON \
+    -DENABLE_tcl=ON \
+    -DENABLE_tk=ON \
+    -DENABLE_itk=OFF \
+    -DENABLE_wxwidgets=ON \
     ../${_realname}-${pkgver}
 
   make V=1
@@ -69,6 +77,36 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
+
+  local MINGW_PREFIX_WIN=$(cygpath -am ${MINGW_PREFIX})
+  local MSYS2_USR_WIN=$(cygpath -am /usr)
+
+  # Fix paths in pkgconfig files
+  find "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig" -type f -name '*.pc' \
+    -exec sed -i -e "s|${MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+
+  # Fix paths in example files
+  find "${pkgdir}${MINGW_PREFIX}/share/plplot5.13.0/examples" -type f -name '*.sh' \
+    -exec sed -i -e "s|${MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+  find "${pkgdir}${MINGW_PREFIX}/share/plplot5.13.0/examples" -type f -name 'Makefile' \
+    -exec sed -i -e "s|${MINGW_PREFIX_WIN}|${MINGW_PREFIX}|g" {} \;
+  find "${pkgdir}${MINGW_PREFIX}/share/plplot5.13.0/examples" -type f -name '*.sh' \
+    -exec sed -i -e "s|${MSYS2_USR_WIN}|/usr|g" {} \;
+  find "${pkgdir}${MINGW_PREFIX}/share/plplot5.13.0/examples" -type f -name 'Makefile' \
+    -exec sed -i -e "s|${MSYS2_USR_WIN}|/usr|g" {} \;
+
+  # Fix paths in the remaing odd files
+  sed -s "s|${MINGW_PREFIX_WIN}|\${MINGW_PREFIX}|g" -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/wish_runAllDemos
+  sed -s "s|${MINGW_PREFIX_WIN}|\${MINGW_PREFIX}|g" -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/wish_standard_examples
+  sed -s "s|${MINGW_PREFIX_WIN}|\${MINGW_PREFIX}|g" -i "${pkgdir}"${MINGW_PREFIX}/lib/cmake/plplot/export_plplot.cmake
+  sed -s "s|${MINGW_PREFIX_WIN}|\${MINGW_PREFIX}|g" -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/cmake/modules/plplot_configure.cmake
+  sed -s "s|${MSYS2_USR_WIN}|/usr|g"                -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/cmake/modules/plplot_configure.cmake
+  sed -s "s|${MSYS2_USR_WIN}|/usr|g"                -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/plserver_runAllDemos
+  sed -s "s|${MSYS2_USR_WIN}|/usr|g"                -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/plserver_standard_examples
+  sed -s "s|${MSYS2_USR_WIN}|/usr|g"                -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/wish_runAllDemos
+  sed -s "s|${MSYS2_USR_WIN}|/usr|g"                -i "${pkgdir}"${MINGW_PREFIX}/share/plplot5.13.0/examples/tk/wish_standard_examples
+
+
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/$_realname
   cp -pf ${srcdir}/${_realname}-${pkgver}/Copyright \
     ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -19,12 +19,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-wxWidgets"
         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2"
-             "${MINGW_PACKAGE_PREFIX}-libgd"
+makedepends=("${MINGW_PACKAGE_PREFIX}-libgd"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-swig"
-             "make")
+             "make"
+             "${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-swig: connects Plplot C library to Python and Lua"
             "${MINGW_PACKAGE_PREFIX}-libgd: ability to output png, jpeg and gif files")
 options=('strip' 'staticlibs')

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -51,7 +51,7 @@ build() {
 
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
-    -G "MSYS Makefiles" \
+    -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_Fortran_COMPILER=${MINGW_PREFIX}/bin/gfortran.exe \
     -DCMAKE_BUILD_TYPE=Release \

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -23,7 +23,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2"
              "${MINGW_PACKAGE_PREFIX}-libgd"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-gcc-ada"
-             "${MINGW_PACKAGE_PREFIX}-swig")
+             "${MINGW_PACKAGE_PREFIX}-swig"
+             "make")
 optdepends=("${MINGW_PACKAGE_PREFIX}-swig: connects Plplot C library to Python and Lua"
             "${MINGW_PACKAGE_PREFIX}-libgd: ability to output png, jpeg and gif files")
 options=('strip' 'staticlibs')

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -23,7 +23,9 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-libgd"
              "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
              "${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-swig"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "make"
+             "perl"
              "${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-swig: connects Plplot C library to Python and Lua"
             "${MINGW_PACKAGE_PREFIX}-libgd: ability to output png, jpeg and gif files")


### PR DESCRIPTION
I have only been testing the build under Windows 10 32 bit. I have not had the energy to get my Windows 7 64 bit laptop up and running; I have installed the 32 bit package; but, have no idea of how to test and see if it works. Tim S.

plplot: Updated to version 5.13.0 and fixed building of package.
Added >=3.6.2 to cmake depends.
Changed include of "Windows.h" to "wx/msw/wrapwin.h" via patch file.
Removed "Fix CMake FindSWIG" code from package.
And, Removed local folder names from package.
And, added defines:
  DEFAULT_NO_BINDINGS=ON
  ENABLE_ada=ON
  ENABLE_cxx=ON
  ENABLE_f95=ON
  ENABLE_tcl=ON
  ENABLE_tk=ON
  ENABLE_wxwidgets=ON
  ENABLE_itk=OFF