### PR TITLE
Update kf5 libs to 5.38.0

### DIFF
--- a/mingw-w64-PKGBUILD-common/kde-frameworks5
+++ b/mingw-w64-PKGBUILD-common/kde-frameworks5
@@ -17,9 +17,9 @@ _kde_f5_add_depends() {
   _VARIANT=$1; shift
   while (( "$#" )); do
     if [ "${_VARIANT}" = "-static" ]; then
-      depends+=("$1")
-    else
       makedepends+=("$1")
+    else
+      depends+=("$1")
     fi
     shift
   done

--- a/mingw-w64-attica-qt5/PKGBUILD
+++ b/mingw-w64-attica-qt5/PKGBUILD
@@ -5,17 +5,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "attica"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="A Qt5 library that implements the Open Collaboration Services API (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('873d406c50a5abfed196a087281bdc7a6683e713ef255306fedce97f720e6114')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('26f124e686d4a1ff005798958d63ddccd0bc23a763ea0578c4d2337a1a6b558b')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.32.0
+pkgver=5.38.0
 pkgrel=1
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cmake"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-sphinx") # qt5-tools for QtHelp pages
 source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "set-AUTOSTATICPLUGINS.patch")
-sha256sums=('b1d87be86f36c20ec1f4ad7946f702fd1a7cab0e2ea2e81f4f9a2d937f9f0ac7'
+sha256sums=('6188a8ac8d799439204f69a1eb229431fc9f196790b88d6fb72bb3d57edb2332'
             'a246d25065ac7472b3a4e5995b3c6cb32081ffa21c7de7455006398431e6c886')
 
 prepare() {

--- a/mingw-w64-karchive-qt5/PKGBUILD
+++ b/mingw-w64-karchive-qt5/PKGBUILD
@@ -5,17 +5,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "karchive"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Qt 5 addon providing access to numerous types of archives (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('88fa48f5af0574c65d6fc99d8ec6a128ce2453836b1165dc902cdec0a7be0636')
+source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('9354d45219342b888ac0eccbc3ce3a054858fcce9d4c93817352d2b447ebb658')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kcodecs-qt5/PKGBUILD
+++ b/mingw-w64-kcodecs-qt5/PKGBUILD
@@ -5,17 +5,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcodecs"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins allowing Qt applications to access further types of images (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('fed6361d8d43880c0bf9ef2a67d75664971870c08885542f835f8de26e0c9ff7')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('31a22d37da33d86d492b4bf5e439566d8f6a0783f74382931cee4c59a482dd32')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kconfig-qt5/PKGBUILD
+++ b/mingw-w64-kconfig-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kconfig"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="KConfig provides an advanced configuration system (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('4c15c64125a2f22bce1a2b3e14613a24e6585e973f35d5d8d92f723d0370adb7')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('79744af26c90b78f01e065049daea0a6470f0d8b8e71334652179bac1b12243a')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kcoreaddons-qt5/PKGBUILD
+++ b/mingw-w64-kcoreaddons-qt5/PKGBUILD
@@ -5,17 +5,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcoreaddons"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Classes built on top of QtCore to perform various tasks (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('87426e981bf84ae6899d07c78f45be50f44d0dbbdf45de9ac99a8b6b4c1a21f0')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('9be3dd86402e173da025c0d326fd9a38ffeecb34828a287f8b8c530a5db275d4')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kcrash-qt5/PKGBUILD
+++ b/mingw-w64-kcrash-qt5/PKGBUILD
@@ -6,17 +6,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcrash"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Support for application crash analysis and bug report from apps (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_namesuff}>=${pkgver}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwindowsystem-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('ef16a2c37ac2582df8961ee546610199c099a7e7d769e5236c79facc814ba602')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('215c90bf6501cb90db01f2a04155bcd8a8e66fcfb4a94649e72204c5a1df10a9')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kdbusaddons-qt5/PKGBUILD
+++ b/mingw-w64-kdbusaddons-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kdbusaddons"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="KConfig provides an advanced configuration system (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('6d40ddd2efeba7a0f43ebab0e5249063c127fd1f8e22f775a5c7447d9db2cad9')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('1c1f8955570cd7e0480ec619084c5ea56cbffaca5307d9053d52092f10d589d7')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kdoctools-qt5/PKGBUILD
+++ b/mingw-w64-kdoctools-qt5/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer (MSYS2): Michael Hansen (zrax0111@gmail.com)
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "kdoctools"
+pkgver=5.38.0
+pkgrel=1
+arch=('any')
+pkgdesc="KF5 documentation framework using docbook (mingw-w64-qt5${_namesuff})"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}" "perl")
+depends=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-libxslt${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-docbook-xsl${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}>=${pkgver}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesuff}>=${pkgver}"
+groups=('kf5')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
+        'catalog_path.patch')
+sha256sums=('c95f7e604bd16c3ef97b3fc0320a5656ef1ea3b3c75b7d4d22348391423c7b39'
+            '7dafde4dd5a202c82b3e88480c0c80a045845f9bf35576e061a54a7fc2d31303')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+
+  # Passing CMAKE_INSTALL_PREFIX=/mingw64 causes meinproc to look in
+  # C:/mingw64 for its catalog files, which is almost never correct
+  ( cd ${_basename}-${pkgver} && patch -p1 -i "${srcdir}/catalog_path.patch" )
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DMSYS_REAL_INSTALL_DIR=${QT5_PREFIX} \
+      -DCMAKE_INSTALL_DATAROOTDIR=share \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DBUILD_TESTING=OFF \
+      -DECM_DIR=${MINGW_PREFIX}/share/ECM \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-kdoctools-qt5/catalog_path.patch
+++ b/mingw-w64-kdoctools-qt5/catalog_path.patch
@@ -1,0 +1,9 @@
+diff -rupN a/config-kdoctools.h.cmake b/config-kdoctools.h.cmake
+--- a/config-kdoctools.h.cmake	2017-09-13 15:09:36.293815700 -0700
++++ b/config-kdoctools.h.cmake	2017-09-13 15:11:00.881032300 -0700
+@@ -2,4 +2,4 @@
+ 
+ #define DOCBOOK_XML_CURRDTD "@DocBookXML4_DTD_DIR@"
+ 
+-#define KDOCTOOLS_INSTALL_DATADIR_KF5 "${CMAKE_INSTALL_PREFIX}/${KDE_INSTALL_DATADIR_KF5}"
++#define KDOCTOOLS_INSTALL_DATADIR_KF5 "${MSYS_REAL_INSTALL_DIR}/${KDE_INSTALL_DATADIR_KF5}"

--- a/mingw-w64-kglobalaccel-qt5/PKGBUILD
+++ b/mingw-w64-kglobalaccel-qt5/PKGBUILD
@@ -3,17 +3,21 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kglobalaccel"
-_kde_f5_add_depends "${_variant}" "kconfig" "ki18n"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Global desktop keyboard shortcuts (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
+depeneds=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcrash-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdbusaddons-qt5${_namesuff}"
 groups=('kf5')
 # install=${pkgname}.install
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('28d725dc0f6d322a63f413f5c16b17c2bc85a4d9038d827233de5352c39013dd')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('ba0a9084bd456fe4b9b9e308a0105ea744cf980bf4b5fcb0b1cd0a302a7cb5e7')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kguiaddons-qt5/PKGBUILD
+++ b/mingw-w64-kguiaddons-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kguiaddons"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Utilities for graphical user interfaces (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('e3726591d6ba2daf97415d7466632f693556f9cd3bfa7cb36d4ded138cdd8968')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('01a6350be86f86fb11625393fdc2cb1fe70b7289d06140afa7b0186339047aca')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-ki18n-qt5/PKGBUILD
+++ b/mingw-w64-ki18n-qt5/PKGBUILD
@@ -3,18 +3,18 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "ki18n"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="KDE Gettext-based UI text internationalization (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
         "build-ktranscript-plugin-statically-if-not-shared.patch")
-sha256sums=('3f3722e5cd4570ecad944cff5c776c53c471e5b2f02124bea5194d1c15dc7185'
+sha256sums=('240ccf22a65cf85da900c88afceac8bedc40b71a4d19bad526c03aa285cc2a7d'
             'fb05bcdf56feec1cae600a10b9706c6573bc9b39becea0e1061b10a65dc68a40')
 
 prepare() {

--- a/mingw-w64-kidletime-qt5/PKGBUILD
+++ b/mingw-w64-kidletime-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kidletime"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Reporting of idle time of user and system (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('0c0bd1ca3e028b5e78a5c3d2313aa24d62ddbe66971c41ac3a81e9033091fbe6')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('5bd30a316ea72a44ed4e4f7f11533e5aa74fc817f360f471b2658ac560e221c5')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kimageformats-qt5/PKGBUILD
+++ b/mingw-w64-kimageformats-qt5/PKGBUILD
@@ -3,17 +3,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kimageformats"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-openexr${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('4703cd44a57497f194e273386876e7ac0ccdf03f2d5a9854f968cb4e24ef21c1')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('97ca8eaa52f296e7fddde25abfe6c7707070b075e92e487da9edb3c719d4e860')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kitemmodels-qt5/PKGBUILD
+++ b/mingw-w64-kitemmodels-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kitemmodels"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('bab2321ffcb6a86358a7766f17f76501de8e5f5b72599fbc8a60fead5359ba72')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('4cfa7661b6d3c1e242b92c9200383400398af1db341dbbd2de573429898d4068')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kitemviews-qt5/PKGBUILD
+++ b/mingw-w64-kitemviews-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kitemviews"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('c220e481834cb231de23ea293e2bee98b39cb2808bac542b02876beb67ba946b')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('46df0b2a0fe436cac2e1984d9038ac894ac86d9650db5328fa7069a13f46b151')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kjs-qt5/PKGBUILD
+++ b/mingw-w64-kjs-qt5/PKGBUILD
@@ -3,17 +3,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kjs"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}" "perl")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-pcre${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdoctools-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/portingAids/${_basename}-${pkgver}.tar.xz")
-sha256sums=('faa68493b57f7f3a3e1b05775da0a0477320f712e62cde499f6d0f0befb54caa')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/${_basename}-${pkgver}.tar.xz")
+sha256sums=('c173775230d93ef9da043e2664c71d0bd84c6dc4b05b881730dbcf32012a3c36')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kplotting-qt5/PKGBUILD
+++ b/mingw-w64-kplotting-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kplotting"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('5445f5b8de641242ce29454e43c1758816d46acac21c2fe41b5f7777e2a200f6')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('e2d8ef624735a56f3998c88af6f06209221af5f27ef05096d65ebb124dc56ec3')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
+++ b/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kwidgetsaddons"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('46e3374aa2b8b0526d054f943a7b5b5be615f01166e29ad883992b6be460c38a')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('45ee4f81cd91e61e82306f757a06849644fde73e09650e0498797cdc3a4604fa')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kwindowsystem-qt5/PKGBUILD
+++ b/mingw-w64-kwindowsystem-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kwindowsystem"
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('74b2af8fb9cda160818798f9ede907e993d779b671cb0a6e6506857c80835d3a')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('2c16eb635714ff122b9348c0cc880be60d08c817c98026029f78434d918db90b')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-solid-qt5/PKGBUILD
+++ b/mingw-w64-solid-qt5/PKGBUILD
@@ -1,22 +1,21 @@
 # Maintainer (MSYS2): Ray Donnelly <mingw.android@gmail.com>
 
-_variant=-static
-#_variant=-shared
+_variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "solid"
 pkgbase=mingw-w64-solid-qt5
-pkgver=5.12.0
+pkgver=5.38.0
 pkgrel=1
 arch=('any')
 url='https://projects.kde.org/projects/frameworks/${_basename}'
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
-source=("http://download.kde.org/Attic/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('b2fa6f7ac911673bb9c667378ae132dd02780459ff4a2338d0a08c5d58967d68')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('1052830aaed16391563dc35fe0e01bba2813acf2e0c70fa2223d54d2732b6cac')
 
 prepare() {
   cd "${srcdir}"/${_basename}-${pkgver}

--- a/mingw-w64-syntax-highlighting-qt5/PKGBUILD
+++ b/mingw-w64-syntax-highlighting-qt5/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer (MSYS2): Michael Hansen <zrax0111@gmail.com>
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "syntax-highlighting"
+pkgver=5.38.0
+pkgrel=1
+arch=('any')
+pkgdesc="Syntax highlighting library using Kate's syntax rules (mingw-w64-qt5${_namesuff})"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
+depends=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+groups=('kf5')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('d4b887e2b4c0bb0d0c723325b11897d1ab38a644e3276d57eae8393928783680')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DBUILD_TESTING=OFF \
+      -DECM_DIR=${MINGW_PREFIX}/share/ECM \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-threadweaver-qt5/PKGBUILD
+++ b/mingw-w64-threadweaver-qt5/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer (MSYS2): Michael Hansen <zrax0111@gmail.com>
+
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "threadweaver"
+pkgver=5.38.0
+pkgrel=1
+arch=('any')
+pkgdesc="High-level multithreading framework for Qt (mingw-w64-qt5${_namesuff})"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
+depends=()
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+groups=('kf5')
+source=("http://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('db6dca72315a376fa8852f0059113a5880a002e311e5f4591138303b69a209b5')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DBUILD_TESTING=OFF \
+      -DECM_DIR=${MINGW_PREFIX}/share/ECM \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
Update existing kf5 framework libraries to 5.38.0, including extra-cmake-modules (ECM).
Also adds some additional kf5 libs:
* KDocTools (Needed for building KJS)
* KSyntaxHighlighting
* ThreadWeaver

I may add more in the future if these end up working.