### PR TITLE
libcello-git: fix pkgname

### DIFF
--- a/mingw-w64-libcello-git/PKGBUILD
+++ b/mingw-w64-libcello-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _realname=libcello
 pkgbase="mingw-w64-${_realname}-git"
-pkgname="${pkgbase}-git"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 pkgver=2.0.3.293.a6a7354
 pkgrel=1
 pkgdesc="A library brings higher level programming to C"


### PR DESCRIPTION
This fixes an unintended rename in 4d8828efed588cf6c8
I missed that pkgbase was included in pkgname when renaming it.

Thanks to @filnet for catching this.