### PR TITLE
gdal: add crypto++ and netcdf dependencies

### DIFF
--- a/mingw-w64-gdal/PKGBUILD
+++ b/mingw-w64-gdal/PKGBUILD
@@ -8,7 +8,7 @@ _realname=gdal
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A translator library for raster geospatial data formats (mingw-w64)"
 arch=('any')
 url="http://www.gdal.org/"
@@ -18,6 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-postgresql"
              "${MINGW_PACKAGE_PREFIX}-qhull")
 depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
+         "${MINGW_PACKAGE_PREFIX}-crypto++"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-geos"
@@ -35,6 +36,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cfitsio"
          "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libwebp"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
+         "${MINGW_PACKAGE_PREFIX}-netcdf"
          "${MINGW_PACKAGE_PREFIX}-openjpeg2"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-poppler"


### PR DESCRIPTION
When testnig https://github.com/osmcode/libosmium with MSYS2, noticed that current gdal binaries were broken (asking missing dlls like libcryptopp.dll and libnetcdf.dll). Added the missing libraries to dependencies, but the package also needs rebuilding with new Poppler (currently it wants libpoppler-67 dll with libpoppler-70 present).
Postgresql client is also needed to run .exe-s , but currently postgres is a monolyt package (server+client) and I do not know if it should be a mandatory dependency.