### PR TITLE
glib2: updated to 2.54.0.

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.52.3
+pkgver=2.54.0
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -28,7 +28,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0023-print-in-binary-more-for-testing.all.patch
         0027-no_sys_if_nametoindex.patch
         0028-inode_directory.patch)
-sha256sums=('25ee7635a7c0fcd4ec91cbc3ae07c7f8f5ce621d8183511f414ded09e7e4e128'
+sha256sums=('fe22998ff0394ec31e6e5511c379b74011bee61a4421bca7fcab223dfbe0fc6a'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'


### PR DESCRIPTION
Before build you must update the gtk-doc package