### PR TITLE
gdb-git: Use system readline instead of the bundled one.

### DIFF
--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}-git
-pkgver=r91505.63345acf64
+pkgver=r91614.ea992a4681
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -18,6 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          "${MINGW_PACKAGE_PREFIX}-python2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-winpthreads")
 #checkdepends=('dejagnu' 'bc')
 makedepends=("${MINGW_PACKAGE_PREFIX}-iconv"
@@ -92,6 +93,7 @@ build() {
     --with-libiconv-prefix=${MINGW_PREFIX} \
     --with-zlib \
     --with-lzma \
+    --with-system-readline \
     --enable-tui
 
   make all-gdb


### PR DESCRIPTION
The bundled one since GDB 8.0 does not handle backspaces correctly in CMD, and it crashes x64 build recently.