### PR TITLE
clang: add patch enabling -flto-visibility-public-std

### DIFF
--- a/mingw-w64-clang/0101-Allow-build-static-clang-library-for-mingw.patch
+++ b/mingw-w64-clang/0101-Allow-build-static-clang-library-for-mingw.patch
@@ -1,7 +1,7 @@
 From ded1b370c6ccbb427406edc6ab39656144d61818 Mon Sep 17 00:00:00 2001
 From: Alexey Pavlov <alexpux@gmail.com>
 Date: Fri, 25 Dec 2015 20:14:51 +0100
-Subject: [PATCH 1/5] Allow build static clang library for mingw
+Subject: [PATCH 1/6] Allow build static clang library for mingw
 
 ---
  tools/libclang/CMakeLists.txt | 2 +-
@@ -21,5 +21,5 @@ index 2dd6703076..477e53dd15 100644
  endif()
  
 -- 
-2.13.3
+2.14.1
 

--- a/mingw-w64-clang/0102-fix-libclang-name-for-mingw.patch
+++ b/mingw-w64-clang/0102-fix-libclang-name-for-mingw.patch
@@ -1,7 +1,7 @@
 From 4fea4f3cc0f23cc4aacc727cff812303a63a83b5 Mon Sep 17 00:00:00 2001
 From: Mateusz Mikula <mati865@gmail.com>
 Date: Thu, 2 Feb 2017 12:21:45 +0100
-Subject: [PATCH 2/5] fix libclang name for mingw
+Subject: [PATCH 2/6] fix libclang name for mingw
 
 ---
  tools/libclang/CMakeLists.txt | 2 +-
@@ -21,5 +21,5 @@ index 477e53dd15..dc2e3538fa 100644
  else()
    set(output_name "clang")
 -- 
-2.13.3
+2.14.1
 

--- a/mingw-w64-clang/0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch
+++ b/mingw-w64-clang/0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch
@@ -1,7 +1,7 @@
 From 5042e15216190f11cfb12f0c81c187c7353fb1d5 Mon Sep 17 00:00:00 2001
 From: Martell Malone <martellmalone@gmail.com>
 Date: Sun, 28 Jun 2015 19:12:19 +0100
-Subject: [PATCH 3/5] Set the x86 arch name to i686 for mingw-w64
+Subject: [PATCH 3/6] Set the x86 arch name to i686 for mingw-w64
 
 ---
  lib/Driver/Driver.cpp | 5 +++++
@@ -24,5 +24,5 @@ index ba4d0e836b..9f8c850b22 100644
  
    // Handle -miamcu flag.
 -- 
-2.13.3
+2.14.1
 

--- a/mingw-w64-clang/0104-link-pthread-with-mingw.patch
+++ b/mingw-w64-clang/0104-link-pthread-with-mingw.patch
@@ -1,7 +1,7 @@
 From 9498118b65fa150f074efb52b4507b53434a90ad Mon Sep 17 00:00:00 2001
 From: Mateusz Mikula <mati865@gmail.com>
 Date: Thu, 2 Feb 2017 12:33:51 +0100
-Subject: [PATCH 4/5] link pthread with mingw
+Subject: [PATCH 4/6] link pthread with mingw
 
 ---
  lib/Driver/ToolChains/MinGW.cpp | 2 +-
@@ -21,5 +21,5 @@ index 632b76d92b..23da2d6376 100644
  
        // add system libraries
 -- 
-2.13.3
+2.14.1
 

--- a/mingw-w64-clang/0105-use-emulated-tls-with-mingw.patch
+++ b/mingw-w64-clang/0105-use-emulated-tls-with-mingw.patch
@@ -1,7 +1,7 @@
 From 89e43bd7141cc12f6b4eca71b549d6b2eb6030c0 Mon Sep 17 00:00:00 2001
 From: Mateusz Mikula <mati865@gmail.com>
 Date: Wed, 1 Mar 2017 19:56:37 +0100
-Subject: [PATCH 5/5] use emulated tls with mingw
+Subject: [PATCH 5/6] use emulated tls with mingw
 
 ---
  lib/Driver/ToolChains/Clang.cpp | 3 ++-
@@ -22,5 +22,5 @@ index 6a6b90f868..f7967fe79b 100644
                     EmulatedTLSDefault))
      CmdArgs.push_back("-femulated-tls");
 -- 
-2.13.3
+2.14.1
 

--- a/mingw-w64-clang/0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch
+++ b/mingw-w64-clang/0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch
@@ -1,0 +1,29 @@
+From a719447157a7cb8746f0779dc1fa5e3de56b86ee Mon Sep 17 00:00:00 2001
+From: Mateusz Mikula <mati865@gmail.com>
+Date: Mon, 18 Sep 2017 12:25:11 +0200
+Subject: [PATCH 6/6] MinGW: use -flto-visibility-public-std CC1 arg to get rid
+ of undefined reference to _imp___cxa* errors
+
+---
+ lib/Driver/ToolChains/Clang.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/Driver/ToolChains/Clang.cpp b/lib/Driver/ToolChains/Clang.cpp
+index f7967fe79b..46e7998a72 100644
+--- a/lib/Driver/ToolChains/Clang.cpp
++++ b/lib/Driver/ToolChains/Clang.cpp
+@@ -3200,6 +3200,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
+     IsHosted = false;
+   }
+ 
++  if (Triple.isWindowsGNUEnvironment() &&
++      Args.hasArg(options::OPT_static) &&
++      getToolChain().GetCXXStdlibType(Args) == ToolChain::CST_Libstdcxx)
++    CmdArgs.push_back("-flto-visibility-public-std");
++
+   // Forward -f (flag) options which we can pass directly.
+   Args.AddLastArg(CmdArgs, options::OPT_femit_all_decls);
+   Args.AddLastArg(CmdArgs, options::OPT_fheinous_gnu_extensions);
+-- 
+2.14.1
+

--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=5.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -59,6 +59,7 @@ source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         "0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
         "0104-link-pthread-with-mingw.patch"
         "0105-use-emulated-tls-with-mingw.patch"
+        "0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch"
         "0201-mingw-w64-__udivdi3-mangle-hack.patch"
         "0202-compiler-rt-fix-mingw-build.patch"
         "0401-mingw-w64-hack-and-slash-fixes-for-libc.patch"
@@ -104,11 +105,12 @@ sha256sums=('e35dcbae6084adcf4abb32514127c5eabd7d63b733852ccdb31e06f1373136da'
             'ef273f4b3abb2e0ee5c452362fe82195c3f1787bd6788ed24234aaf8180a015e'
             '5303e8a2d64a4c08a2088a3610d74cfda3adbf5fdf172c4ca1f0ddc8701e3cf2'
             'f6e04b5e2a65e1eaa4ab6d14427cf17b1e79625a428430dd16a441578b31df55'
-            '8599e0ca38c96cff811a17f0cffd9ff970632a0357ae8e6076b4dff03a18182c'
-            '1e602bc8d51e77942e0ea7bb6174f8c2256817887dca8d941bba063c06d6845d'
-            '1bbc52f951eb1a1162b8c01a3a951b1da8612572d346d603272229bd84c4d2e3'
-            '47621da0a866702525429fbe4b584eb5d719a93b249a90c0e7dbdfc2cf33ab44'
-            '4260da29db788e478503bcf3e3b1522991be3545828776cf7bc94df48f484328'
+            'f2b0403e6b6cafddf364a90a6bb1e57793fd98d6f80f8976a87574cd93eb1d1a'
+            'b1ed2ccdb87bb4f024a5cd750e71de3706fd24ccfeb87835403dab84ef7a9019'
+            'ab49b90d69a609f441fa58e835873f2b1a8a060c9ca6358fee7d99c1973da692'
+            '53646dd01af2862473e9719c5223366486268891ccbff86413943a432a8342e9'
+            '7b85221a5d8506abc622dc8f252866c93183ccd7e44d5e1bc082d6fcb244e7d3'
+            '3d6045cf35d5523c68baf87bd490007d4ac8fe3eabcbc23d8c66e80ff1c234e7'
             'bafaf7d06bec3ed7fba58e8a926e7b472b5e16442b6ee9dd8c7ee6c0cce9792a'
             'a9e1c001701508c6ffd808cf530e0f6a756253a5cdb72d166e7987fa5ab64960'
             'da44cca549bc7fb9e04f0f038a1ed68ba99cdfec834fc241ab13880bd0aa3b0f'
@@ -150,6 +152,7 @@ prepare() {
   patch -p1 -i "${srcdir}/0103-Set-the-x86-arch-name-to-i686-for-mingw-w64.patch"
   patch -p1 -i "${srcdir}/0104-link-pthread-with-mingw.patch"
   patch -p1 -i "${srcdir}/0105-use-emulated-tls-with-mingw.patch"
+  patch -p1 -i "${srcdir}/0106-MinGW-use-flto-visibility-public-std-CC1-arg-to-get-.patch"
 
   cd "${srcdir}/compiler-rt-${pkgver}.src"
   patch -p1 -i "${srcdir}/0201-mingw-w64-__udivdi3-mangle-hack.patch"


### PR DESCRIPTION
It fixes `undefined reference to _imp___cxa*` errors.

@martell Saleem told me to try with `-flto-visibility-public-std` and my very limited testing shows it resolves issue on both MSYS2 and Ubuntu (clang 5.0) when using static libstdc++ (MSVC use it in some cases already). Any thoughts?

Minimal testcase (example command `clang++ -std=gnu++14 -static test.cc`):
```
#include <string>
int main() { std::u16string b; }
```

@Alexpux sorry for another release in short time but you don't have to hurry. This fix alone isn't very important because of multiple definition errors that happen often when using static libstdc++ with clang (I can even revert `pkgrel` to 1).