### PR TITLE
plplot: Added to makedepends and changed defines passed to cmake.

### DIFF
--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -2,6 +2,10 @@
 # Contributor: Jürgen Pfeifer <juergen@familiepfeifer.de>
 # Contributor: Tim S. <stahta01@gmail.com>
 
+# Note: Added "ENABLE_itk=OFF" because of random build errors;
+# It appeared to think it found the itk library; but, it then errored out.
+# Set "ENABLE_qt=OFF" and "DEFAULT_NO_CAIRO_DEVICES=ON" to reduce warnings.
+
 _realname=plplot
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -15,7 +19,6 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-lua"
          "${MINGW_PACKAGE_PREFIX}-python2"
          "${MINGW_PACKAGE_PREFIX}-python2-numpy"
-         "${MINGW_PACKAGE_PREFIX}-qhull"
          "${MINGW_PACKAGE_PREFIX}-tk"
          "${MINGW_PACKAGE_PREFIX}-wxWidgets"
         )
@@ -24,8 +27,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-libgd"
              "${MINGW_PACKAGE_PREFIX}-gcc-ada"
              "${MINGW_PACKAGE_PREFIX}-swig"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-qhull"
              "make"
+             "patch"
              "perl"
+             "bsdtar>=3.3"
              "${MINGW_PACKAGE_PREFIX}-cmake>=3.6.2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-swig: connects Plplot C library to Python and Lua"
             "${MINGW_PACKAGE_PREFIX}-libgd: ability to output png, jpeg and gif files")
@@ -52,6 +58,15 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
+  local pyexe="${MINGW_PREFIX}/bin/python2.exe"
+
+  local pyver=$(${pyexe} -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
+
+  local pylib="${MINGW_PREFIX}/lib/libpython${pyver}.dll.a"
+  if [[ ${pyver:0:1} != "2" ]] ; then
+     pylib="${MINGW_PREFIX}/lib/libpython${pyver}m.dll.a"
+  fi
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G"MSYS Makefiles" \
@@ -59,19 +74,27 @@ build() {
     -DCMAKE_Fortran_COMPILER=${MINGW_PREFIX}/bin/gfortran.exe \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -DBUILD_TESTING=OFF \
-    -DQHULL_INCLUDE_DIR=${MINGW_PREFIX}/include \
+    -DBUILD_TEST=OFF \
+    -DPYTHON_VERSION=${pyver} \
+    -DPYTHON_EXECUTABLE=${pyexe} \
+    -DPYTHON_LIBRARY=${pylib} \
+    -DPYTHON_INCLUDE_DIRS=${MINGW_PREFIX}/include/python${pyver} \
+    -DQHULL_INCLUDE_DIRS=${MINGW_PREFIX}/include \
+    -DQHULL_LIBRARY_DIRS=${MINGW_PREFIX}/lib \
+    -DQHULL_LIBRARIES=qhullstatic \
     -DGD_INCLUDE_DIR=${MINGW_PREFIX}/include \
     -DDEFAULT_NO_BINDINGS=ON \
     -DENABLE_ada=ON \
     -DENABLE_cxx=ON \
-    -DENABLE_f95=ON \
+    -DENABLE_fortran=ON \
     -DENABLE_lua=ON \
     -DENABLE_python=ON \
     -DENABLE_tcl=ON \
     -DENABLE_tk=ON \
-    -DENABLE_itk=OFF \
     -DENABLE_wxwidgets=ON \
+    -DDEFAULT_NO_CAIRO_DEVICES=ON \
+    -DENABLE_itk=OFF \
+    -DENABLE_qt=OFF \
     ../${_realname}-${pkgver}
 
   make V=1


### PR DESCRIPTION
Added "patch" and "bsdtar>=3.3" to make depends.
Added this define "ENABLE_qt=OFF" and
changed the "ENABLE_f95=ON" define to "ENABLE_fortran=ON".
Also, added paths and libname to help find the qhull lib.
In addition, added code to find the correct Python library.

The gdlib/libgd is still not being found. I hope this second try fixes the 64 bit build problem.
This time using python2 like the package did before I started editing it.
Tim S.