### PR TITLE
Add exe launchers for Python scripts in glib2 and gobject-introspecti…

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.54.0
-pkgrel=1
+pkgrel=2
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -19,22 +19,30 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-pcre"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-python2" "gtk-doc")
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-python2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "gtk-doc"
+             "python2-six"  # Fixed by https://github.com/Alexpux/MSYS2-packages/pull/1003
+             )
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
         0001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
         0004-glib-prefer-constructors-over-DllMain.patch
         0017-glib-use-gnu-print-scanf.patch
         0023-print-in-binary-more-for-testing.all.patch
         0027-no_sys_if_nametoindex.patch
-        0028-inode_directory.patch)
+        0028-inode_directory.patch
+        pyscript2exe.py)
 sha256sums=('fe22998ff0394ec31e6e5511c379b74011bee61a4421bca7fcab223dfbe0fc6a'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'
             'd1d35bb7865527422e28635ed373731e800c30ff5732c7bf8c66be37158509fb'
             '5cb481295ff86c2802030984d8b2bf6a3b1dcd5e5fe7b0be68b22d9116305837'
-            'f7f06a90156fe0a308412512c359072922f7f0d19dd4bed30d863db18e48940b')
+            'f7f06a90156fe0a308412512c359072922f7f0d19dd4bed30d863db18e48940b'
+            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
 
 
 prepare() {
@@ -115,4 +123,9 @@ package() {
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i gio-2.0.pc
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i glib-2.0.pc
   popd > /dev/null
+
+  for name in glib-mkenums glib-gettextize glib-genmarshal gdbus-codegen; do
+    ${MINGW_PREFIX}/bin/python2 \
+      "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
+  done
 }

--- a/mingw-w64-glib2/pyscript2exe.py
+++ b/mingw-w64-glib2/pyscript2exe.py
@@ -1,0 +1,20 @@
+"""
+Creates an exe launcher for Python scripts for the executing interpreter.
+foobar.py -> foobar.exe + foobar-script.py
+"""
+
+import sys
+import re
+import os
+from setuptools.command.easy_install import get_win_launcher
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = f.read()
+with open(path, "wb") as f:
+    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
+root, ext = os.path.splitext(path)
+with open(root + ".exe", "wb") as f:
+    f.write(get_win_launcher("cli"))
+os.rename(path, root + "-script.py")

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.54.0
-pkgrel=0
+pkgrel=1
 arch=('any')
 url="https://live.gnome.org/GObjectIntrospection"
 license=("LGPL")
@@ -26,7 +26,8 @@ source=(https://download.gnome.org/sources/gobject-introspection/${pkgver%.*}/${
         0025-more-tolerant-rmtreeing.patch
         0026-giscanner-assertions-and-waits.patch
         0027-wait-for-xml-parse-too.patch
-        0055-fix-python-detection.patch)
+        0055-fix-python-detection.patch
+        pyscript2exe.py)
 
 sha256sums=('67e76742ce78821bce8a613183368222919b24e2dcf5fe26f17726c11c422ed7'
             'f84df99e1ce5a3a0b640ef172de068958eb0b3d0be43a454dd86e6ccb8cfc386'
@@ -36,7 +37,8 @@ sha256sums=('67e76742ce78821bce8a613183368222919b24e2dcf5fe26f17726c11c422ed7'
             'f7fa69b6af7571371b1e162cacac05fc2a2877d057dd61649948d973b74a9e8d'
             '19ca830262339c4ac9f21bfb8d669ee8e126a949a4237d55656e00c5ae81c451'
             '3f38bdd0dd43d9cf626cbca7c2abd22a7ed0213e6756252c6d467d470d9c5948'
-            'f61d099aa7cd37c437f01d98bb95c57c66f07c78028675ae19fac87f943d189d')
+            'f61d099aa7cd37c437f01d98bb95c57c66f07c78028675ae19fac87f943d189d'
+            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -97,6 +99,11 @@ package_gobject-introspection() {
     pushd $(dirname "${PYD}")
       cp $(basename "${PYD}") $(basename "${PYD}" .pyd)_d.pyd
     popd
+  done
+
+  for name in g-ir-scanner g-ir-doc-tool g-ir-annotation-tool; do
+    ${MINGW_PREFIX}/bin/python2 \
+      "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
   done
 }
 

--- a/mingw-w64-gobject-introspection/pyscript2exe.py
+++ b/mingw-w64-gobject-introspection/pyscript2exe.py
@@ -1,0 +1,20 @@
+"""
+Creates an exe launcher for Python scripts for the executing interpreter.
+foobar.py -> foobar.exe + foobar-script.py
+"""
+
+import sys
+import re
+import os
+from setuptools.command.easy_install import get_win_launcher
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = f.read()
+with open(path, "wb") as f:
+    shebang = "#!/usr/bin/env " + os.path.basename(sys.executable)
+    f.write(re.sub(b"^#![^\n\r]*", shebang.encode(), data))
+root, ext = os.path.splitext(path)
+with open(root + ".exe", "wb") as f:
+    f.write(get_win_launcher("cli"))
+os.rename(path, root + "-script.py")

--- a/mingw-w64-json-glib/PKGBUILD
+++ b/mingw-w64-json-glib/PKGBUILD
@@ -4,14 +4,15 @@ _realname=json-glib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.4.2
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="JSON-GLib implements a full suite of JSON-related tools using GLib and GObject (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-glib2")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc")
 options=('strip' 'staticlibs')
 license=('LGPL2.1+')
 url="https://wiki.gnome.org/Projects/JsonGlib"
@@ -29,7 +30,7 @@ build() {
 
   meson \
     --buildtype plain \
-    -Dintrospection=false \
+    -Ddocs=true \
     ../${_realname}-${pkgver}
 
   ninja


### PR DESCRIPTION
…on; Reenable G-I for json-glib

* Add exe launchers to glib2 to fix the upgrade naming conflict as pacman
  can't see the difference between the new Python script without extension
  and the old .exe file.
* Also add exe launchers for gobject-introspection so that meson can execute them.
  The scripts currently have a broken shebang including an absolute path
  (also the case on Linux), and fixing that would at least work for meson as it has
  a shebang parser. But the exe launcher seems less error prone and also works
  with other tools.
* The last update to json-glib disabled introspection due to the above mentioned
  bug. This reenables it and also enables gtk-doc building while at it.
  (first package fully build using only mingw tools \o/)