### PR TITLE
libgd: Update to 2.2.5

### DIFF
--- a/mingw-w64-libgd/PKGBUILD
+++ b/mingw-w64-libgd/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libgd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.2.4
-pkgrel=4
+pkgver=2.2.5
+pkgrel=1
 pkgdesc="GD is an open source code library for the dynamic creation of images by programmers. (mingw-w64)"
 arch=('any')
 url="https://libgd.github.io/"
@@ -24,8 +24,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libgd/libgd/releases/download/gd-${pkgver}/${_realname}-${pkgver}.tar.gz"
         "libgd-export-pkg-config-build-in-subdirs.patch")
-sha256sums=('487a650aa614217ed08ab1bd1aa5d282f9d379cfd95c756aed0b43406381be65'
-            'f3f8e232d642a55d469bd2233402dce86275a8dbabe9d99cc6a50277a654f922')
+sha256sums=('a66111c9b4a04e818e9e2a37d7ae8d4aae0939a100a36b0ffb52c706a09074b5'
+            'a9ffea602bed53253fdec65695be00f047649446d212d83e3e8eb5774116ee16')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-libgd/PKGBUILD
+++ b/mingw-w64-libgd/PKGBUILD
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/libgd/libgd/releases/download/gd-${pkgver}/${_realname}-${pkgver}.tar.gz"
         "libgd-export-pkg-config-build-in-subdirs.patch")
 sha256sums=('a66111c9b4a04e818e9e2a37d7ae8d4aae0939a100a36b0ffb52c706a09074b5'
-            'a9ffea602bed53253fdec65695be00f047649446d212d83e3e8eb5774116ee16')
+            'bc435caee30e508813b6949f8ff2716f2d1bf22ad7fd520568f27973f404eb21')
 
 prepare() {
     cd "${srcdir}/${_realname}-${pkgver}"

--- a/mingw-w64-libgd/libgd-export-pkg-config-build-in-subdirs.patch
+++ b/mingw-w64-libgd/libgd-export-pkg-config-build-in-subdirs.patch
@@ -352,3 +352,18 @@ diff -aur libgd-2.2.4/config/gdlib-config.in.orig libgd-2.2.4/config/gdlib-confi
  	echo "libdir:     $libdir"
  	echo "features:   @FEATURES@"
  	;;
+--- libgd-2.2.4/src/gd.h.orig	2017-08-30 04:05:54.000000000 -0700
++++ libgd-2.2.4/src/gd.h	2017-09-23 11:49:10.071934900 -0700
+@@ -63,7 +63,11 @@
+ #   define BGD_EXPORT_DATA_PROT __declspec(dllimport)
+ #  endif
+ # endif
+-# define BGD_STDCALL __stdcall
++# if !defined(__MINGW32__)
++#  define BGD_STDCALL __stdcall
++# else
++#  define BGD_STDCALL
++# endif
+ # define BGD_EXPORT_DATA_IMPL
+ #else
+ # if defined(__GNUC__) || defined(__clang__)

--- a/mingw-w64-libgd/libgd-export-pkg-config-build-in-subdirs.patch
+++ b/mingw-w64-libgd/libgd-export-pkg-config-build-in-subdirs.patch
@@ -99,7 +99,7 @@ diff -ur libgd-2.2.3/config/gdlib.pc.in libgd-2.2.3-new/config/gdlib.pc.in
 +prefix=@CMAKE_INSTALL_PREFIX@
 +exec_prefix=${prefix}
 +libdir=${prefix}/lib
-+includedir=${prefix}/include/libgd-@GD_VERSION_STRING@
++includedir=${prefix}/include/
  
  Name: gd
  Description: GD graphics library
@@ -291,7 +291,7 @@ diff -aur libgd-2.2.4/config/gdlib-config.in.orig libgd-2.2.4/config/gdlib-confi
 +prefix=@CMAKE_INSTALL_PREFIX@
 +exec_prefix=${prefix}
 +libdir=${prefix}/lib
-+includedir=${prefix}/include/libgd-@GD_VERSION_STRING@
++includedir=${prefix}/include
 +bindir=${prefix}/bin
  
  usage()
@@ -334,7 +334,7 @@ diff -aur libgd-2.2.4/config/gdlib-config.in.orig libgd-2.2.4/config/gdlib-confi
  	;;
      --cflags|--includes)
 -	echo -I@includedir@
-+	echo -I${prefix}/include/libgd-@GD_VERSION_STRING@
++	echo -I${prefix}/include
  	;;
      --features)
  	echo @FEATURES@
@@ -346,7 +346,7 @@ diff -aur libgd-2.2.4/config/gdlib-config.in.orig libgd-2.2.4/config/gdlib-confi
 -	echo "cflags:     -I@includedir@"
 -	echo "ldflags:    @LDFLAGS@"
 -	echo "libs:       @LIBS@ @LIBICONV@"
-+	echo "cflags:     -I${prefix}/include/libgd-@GD_VERSION_STRING@"
++	echo "cflags:     -I${prefix}/include"
 +	echo "ldflags:    @CMAKE_MODULE_LINKER_FLAGS@"
 +	echo "libs:       @PRIVLIBLIST@"
  	echo "libdir:     $libdir"


### PR DESCRIPTION
Also fixing the pkg-config and gdlib-config, after the lib and headers were moved back from their subfolder to the /lib and /include folder, the .PC and the gdlib-config scripts were still pointing to the subfolders - this is now also fixed.