### PR TITLE
protobuf: update to 3.4.1

### DIFF
--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -3,19 +3,19 @@
 _realname=protobuf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.4.0
+pkgver=3.4.1
 pkgrel=1
 pkgdesc="Protocol Buffers - Google's data interchange format (mingw-w64)"
 arch=('any')
 url='https://developers.google.com/protocol-buffers/'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "automake" "autoconf" "libtool")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "automake" "autoconf" "libtool" "unzip")
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/google/protobuf/archive/v${pkgver}.tar.gz
         googletest-release-1.8.0.tar.gz::https://github.com/google/googletest/archive/release-1.8.0.tar.gz
         0001-protobuf-3.1.0-gcc6.2.0-tests.patch)
-sha256sums=('cd55ee08e64a86cf12aaadd4672961813f592c194ed0c9ad94da0ec75acf219f'
+sha256sums=('8e0236242106e680b4f9f576cc44b8cd711e948b20a9fc07769b0a20ceab9cc4'
             '58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8'
             '15c2248597356040be0111d5bfc7317d59a49552d5cd05b0fa70c76980b7ca66')
 
@@ -55,7 +55,7 @@ build() {
       -DCMAKE_SKIP_RPATH="ON" \
       -Dprotobuf_MSVC_STATIC_RUNTIME="ON" \
       -DBUILD_SHARED_LIBS="ON" \
-      -Dprotobuf_BUILD_TESTS="ON" \
+      -Dprotobuf_BUILD_TESTS="OFF" \
       -Dprotobuf_WITH_ZLIB="ON"
 
   make -j1


### PR DESCRIPTION
add missing dep
disable tests as building does not work