### PR TITLE
docbook-xsl: Update to 1.79.2

### DIFF
--- a/mingw-w64-docbook-xsl/PKGBUILD
+++ b/mingw-w64-docbook-xsl/PKGBUILD
@@ -3,18 +3,18 @@
 _realname=docbook-xsl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.79.1
+pkgver=1.79.2
 pkgrel=1
 pkgdesc='XML stylesheets for Docbook-xml transformations (mingw-w64)'
 arch=('any')
 license=('custom')
-url='https://docbook.sourceforge.io/'
+url='http://docbook.org/'
 depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libxslt"
          "${MINGW_PACKAGE_PREFIX}-docbook-xml")
 install=${_realname}-${CARCH}.install
-source=("https://downloads.sourceforge.net/docbook/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968')
+source=("https://github.com/docbook/xslt10-stylesheets/releases/download/release/${pkgver}/docbook-xsl-${pkgver}.tar.bz2")
+sha256sums=('316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371')
 
 package() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
Upstream has moved to github: https://github.com/docbook/xslt10-stylesheets