### PR TITLE
Add transmission package

### DIFF
--- a/mingw-w64-libevent/PKGBUILD
+++ b/mingw-w64-libevent/PKGBUILD
@@ -4,9 +4,9 @@
 _realname=libevent
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.22
-pkgrel=2
-pkgdesc="An event notification library"
+pkgver=2.1.8
+pkgrel=1
+pkgdesc="An event notification library (mingw-w64)"
 arch=('any')
 url="http://libevent.org"
 license=('BSD')
@@ -14,11 +14,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-openssl"
              "${MINGW_PACKAGE_PREFIX}-python2")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python2")
-source=(https://github.com/${_realname}/${_realname}/releases/download/release-${pkgver}-stable/${_realname}-${pkgver}-stable.tar.gz)
-sha256sums=('71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3')
+source=(https://github.com/${_realname}/${_realname}/releases/download/release-${pkgver}-stable/${_realname}-${pkgver}-stable.tar.gz
+        'event2-02-win32.patch')
+sha256sums=('965cc5a8bb46ce4199a47e9b2c9e1cae3b137e8356ffdad6d94d3b9069b71dc2'
+            'e572ed628daba12915aaa5867b35ef1b0ca3ed3eb6e9759f97136dd8eab32c08')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}-stable"
+
+  # to make transmission work, taken from:
+  # https://github.com/transmission/libevent/commit/72e50166aaa2c3b3c35e336039df7101bd418264
+  patch -p1 -i ${srcdir}/event2-02-win32.patch
 }
 
 build() {

--- a/mingw-w64-libevent/event2-02-win32.patch
+++ b/mingw-w64-libevent/event2-02-win32.patch
@@ -1,0 +1,11 @@
+--- libevent-2.1.8-stable/evutil.c.orig	2017-09-25 23:12:58.960674400 +0200
++++ libevent-2.1.8-stable/evutil.c	2017-09-25 23:13:49.827963900 +0200
+@@ -1838,7 +1838,7 @@
+ 	int r;
+ 	if (!buflen)
+ 		return 0;
+-#if defined(_MSC_VER) || defined(_WIN32)
++#if (defined(_MSC_VER) && _MSC_VER < 1900) || (defined(_WIN32) && (!defined(__USE_MINGW_ANSI_STDIO) || (__USE_MINGW_ANSI_STDIO + 0) == 0))
+ 	r = _vsnprintf(buf, buflen, format, ap);
+ 	if (r < 0)
+ 		r = _vscprintf(format, ap);

--- a/mingw-w64-transmission/PKGBUILD
+++ b/mingw-w64-transmission/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=transmission
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.92
+pkgrel=1
+pkgdesc="Fast, easy, and free BitTorrent client (mingw-w64)"
+arch=('any')
+url='http://www.transmissionbt.com/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-libevent"
+         "${MINGW_PACKAGE_PREFIX}-gtk3"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-miniupnpc")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+options=('strip' 'staticlibs')
+source=("https://github.com/transmission/transmission-releases/raw/master/transmission-${pkgver}.tar.xz"
+        "skip-broken-cmake-rc.patch")
+sha256sums=('3a8d045c306ad9acb7bf81126939b9594553a388482efa0ec1bfb67b22acd35f'
+            '2aa843e0d5cd342e8008280bc9d97a8e503c1c3c5fe9e418cdbd203f959733d5')
+
+prepare() {
+  cd "$srcdir"/${_realname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/skip-broken-cmake-rc.patch
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  # TODO: package more needed libraries instead of including them.
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DENABLE_TESTS=OFF \
+      -DENABLE_QT=OFF \
+      -DENABLE_GTK=ON \
+      -DUSE_SYSTEM_EVENT2=ON \
+      -DUSE_SYSTEM_DHT=OFF \
+      -DUSE_SYSTEM_MINIUPNPC=ON \
+      -DUSE_SYSTEM_NATPMP=OFF \
+      -DUSE_SYSTEM_UTP=OFF \
+      -DUSE_SYSTEM_B64=OFF \
+      -DWITH_CRYPTO=openssl \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+
+  make install DESTDIR="${pkgdir}"
+}

--- a/mingw-w64-transmission/skip-broken-cmake-rc.patch
+++ b/mingw-w64-transmission/skip-broken-cmake-rc.patch
@@ -1,0 +1,10 @@
+--- transmission-2.92/gtk/CMakeLists.txt.orig	2017-09-25 21:22:58.414905400 +0200
++++ transmission-2.92/gtk/CMakeLists.txt	2017-09-25 21:23:16.236137000 +0200
+@@ -148,7 +148,6 @@
+     ${${PROJECT_NAME}_SOURCES}
+     ${${PROJECT_NAME}_HEADERS}
+     ${${PROJECT_NAME}_DESKTOP_FILE}
+-    ${${PROJECT_NAME}_WIN32_RC_FILE}
+ )
+ 
+ target_link_libraries(${TR_NAME}-gtk


### PR DESCRIPTION
* Adds transmission bittorrent client using gtk3
* Updates libevent (dll version bump, but nothing depends on it)
  and add patch from upstream transmission. Otherwise tracker
  connections fail.
* More of the included libraries could be packaged separately,
  but this is a start..