### PR TITLE
gtk3: Don't force enable client side decoration

### DIFF
--- a/mingw-w64-gtk3/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+++ b/mingw-w64-gtk3/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
@@ -1,0 +1,35 @@
+From 07bbd9b206f9a8712e1d77a6f86e260023738247 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Thu, 28 Sep 2017 12:02:03 +0200
+Subject: [PATCH] gtkwindow: Don't force enable CSD under Windows
+
+CSD look a bit out of place under Windows, especially
+when the application doesn't use the headerbar and the CSD
+doesn't add any value.
+
+Instead let the application decide, like under X11.
+It can still be force enabled through GTK_CSD=1
+---
+ gtk/gtkwindow.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/gtk/gtkwindow.c b/gtk/gtkwindow.c
+index 9f1e52ab04..7c6d874afb 100644
+--- a/gtk/gtkwindow.c
++++ b/gtk/gtkwindow.c
+@@ -6107,12 +6107,6 @@ gtk_window_should_use_csd (GtkWindow *window)
+     return TRUE;
+ #endif
+ 
+-#ifdef GDK_WINDOWING_WIN32
+-  if (g_strcmp0 (csd_env, "0") != 0 &&
+-      GDK_IS_WIN32_DISPLAY (gtk_widget_get_display (GTK_WIDGET (window))))
+-    return TRUE;
+-#endif
+-
+   return (g_strcmp0 (csd_env, "1") == 0);
+ }
+ 
+-- 
+2.14.1
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.22.21
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -28,11 +28,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-pango"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
-source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz")
-sha256sums=('1bd3c1a85cfb4db112cabb5379abb05a1a94fe43052d309d573493fca00e6b87')
+source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
+        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
+sha256sums=('1bd3c1a85cfb4db112cabb5379abb05a1a94fe43052d309d573493fca00e6b87'
+            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
+
+  # https://bugzilla.gnome.org/show_bug.cgi?id=778791
+  patch -p1 -i "${srcdir}"/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
 
   autoreconf -i
 }


### PR DESCRIPTION
So that for example gtk3-demo-application.exe uses the default
Windows window decorations.