### PR TITLE
docbook-xsl: fix uri rewrites

### DIFF
--- a/mingw-w64-docbook-xsl/0001-add-back-old-uri-rewrite.patch
+++ b/mingw-w64-docbook-xsl/0001-add-back-old-uri-rewrite.patch
@@ -1,0 +1,11 @@
+--- docbook-xsl-1.79.2/catalog.xml.orig	2016-12-09 23:46:49.000000000 +0100
++++ docbook-xsl-1.79.2/catalog.xml	2017-09-29 18:35:12.544642100 +0200
+@@ -5,4 +5,8 @@
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/current/" rewritePrefix="./"/>
+   <rewriteURI uriStartString="http://cdn.docbook.org/release/xsl/1.79.2/" rewritePrefix="./"/>
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/1.79.2/" rewritePrefix="./"/>
++  <rewriteURI uriStartString=" http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
++  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
++  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/1.79.2/" rewritePrefix="./"/>
++  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/1.79.2/" rewritePrefix="./"/>
+ </catalog>

--- a/mingw-w64-docbook-xsl/PKGBUILD
+++ b/mingw-w64-docbook-xsl/PKGBUILD
@@ -4,7 +4,7 @@ _realname=docbook-xsl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.79.2
-pkgrel=1
+pkgrel=2
 pkgdesc='XML stylesheets for Docbook-xml transformations (mingw-w64)'
 arch=('any')
 license=('custom')
@@ -13,8 +13,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libxslt"
          "${MINGW_PACKAGE_PREFIX}-docbook-xml")
 install=${_realname}-${CARCH}.install
-source=("https://github.com/docbook/xslt10-stylesheets/releases/download/release/${pkgver}/docbook-xsl-${pkgver}.tar.bz2")
-sha256sums=('316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371')
+source=("https://github.com/docbook/xslt10-stylesheets/releases/download/release/${pkgver}/docbook-xsl-${pkgver}.tar.bz2"
+        "0001-add-back-old-uri-rewrite.patch")
+sha256sums=('316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371'
+            'd327885bab0027e9c2c646cdd0d0d1bd264b9f4a5e908d6244ed0cfa1e5b37ff')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/0001-add-back-old-uri-rewrite.patch
+}
 
 package() {
   cd ${srcdir}/${_realname}-${pkgver}


### PR DESCRIPTION
The last release changed the URI rewrites from sourceforge to
docbook.org. Things like gtk-doc docs reference the sourceforge ones,
so add them back.