### PR TITLE
harfbuzz: Make cairo an optional depends.

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -5,7 +5,7 @@ _realname=harfbuzz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -13,14 +13,17 @@ license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-icu"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config")
-depends=("${MINGW_PACKAGE_PREFIX}-cairo"
-         "${MINGW_PACKAGE_PREFIX}-freetype"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-cairo")
+depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphite2")
 options=('strip' 'staticlibs')
-optdepends=("${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support")
+optdepends=(
+  "${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support"
+  "${MINGW_PACKAGE_PREFIX}-cairo: hb-view program"
+)
 source=("https://www.freedesktop.org/software/harfbuzz/release/${_realname}-${pkgver}.tar.bz2")
 sha256sums=('56838dfdad2729b8866763c82d623354d138a4d99d9ffb710c7d377b5cfc7c51')
 


### PR DESCRIPTION
While trying to fix fontconfig; I was getting these messages that I thought was wrong.

Tim S.

updating font cache... C:/Apps64/MSys2/mingw64/bin/fc-cache.exe: error while loading shared libraries: ?: cannot open shared object file: No such file or directory
done.

warning: dependency cycle detected:
warning: mingw-w64-i686-harfbuzz will be installed before its mingw-w64-i686-freetype dependency
warning: dependency cycle detected:
warning: mingw-w64-i686-cairo will be installed before its mingw-w64-i686-freetype dependency
warning: dependency cycle detected:
warning: mingw-w64-i686-fontconfig will be installed before its mingw-w64-i686-freetype dependency


