### PR TITLE
atk: Drop gnome-common dependency

### DIFF
--- a/mingw-w64-atk/PKGBUILD
+++ b/mingw-w64-atk/PKGBUILD
@@ -5,16 +5,16 @@ _realname=atk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.26.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library providing a set of interfaces for accessibility (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
 license=(LGPL2)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-            "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+            "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+            "autoconf-archive")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-gnome-common"
          "${MINGW_PACKAGE_PREFIX}-glib2>=2.46.0")
 options=('strip' 'staticlibs')
 source=("https://download.gnome.org/sources/atk/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")


### PR DESCRIPTION
no longer needed, upstream uses autoconf-archive now