### PR TITLE
glib: Update to 2.54.1 v2

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,8 +6,8 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.54.0
-pkgrel=2
+pkgver=2.54.1
+pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -24,8 +24,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-             "gtk-doc"
-             "python2-six"  # Fixed by https://github.com/Alexpux/MSYS2-packages/pull/1003
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              )
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
         0001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
@@ -35,7 +34,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0027-no_sys_if_nametoindex.patch
         0028-inode_directory.patch
         pyscript2exe.py)
-sha256sums=('fe22998ff0394ec31e6e5511c379b74011bee61a4421bca7fcab223dfbe0fc6a'
+sha256sums=('50c01b1419324f10fbf9b9709ec2164b18586968bdce7540583bf32302cf47a3'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'
@@ -110,11 +109,7 @@ package() {
   rm -rf "${pkgdir}/static"
 
   rm -f "${pkgdir}${MINGW_PREFIX}"/lib/charset.alias
-  #rm -rf "${pkgdir}${MINGW_PREFIX}"/{share/{gtk-doc,man,bash-completion,gdb},lib/charset.alias,etc}
   rm "${pkgdir}${MINGW_PREFIX}/lib/"*.def
-
-  #rm -f "${pkgdir}${MINGW_PREFIX}/bin/gdbus-codegen"
-  #rm -rf "${pkgdir}${MINGW_PREFIX}/lib/gdbus-2.0"
 
   install -Dm644 "${srcdir}/glib-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 
@@ -124,7 +119,7 @@ package() {
   sed -s "s|${PREFIX_DEPS}|${MINGW_PREFIX}|g" -i glib-2.0.pc
   popd > /dev/null
 
-  for name in glib-mkenums glib-gettextize glib-genmarshal gdbus-codegen; do
+  for name in glib-mkenums glib-genmarshal gdbus-codegen; do
     ${MINGW_PREFIX}/bin/python2 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
   done

--- a/mingw-w64-gtk-doc/0002-fixxref-rebase-Don-t-depend-on-glib-being-installed.patch
+++ b/mingw-w64-gtk-doc/0002-fixxref-rebase-Don-t-depend-on-glib-being-installed.patch
@@ -1,0 +1,82 @@
+From 9fbeb8fddae98ee80d9195a78cef3ca3d510c927 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Tue, 3 Oct 2017 13:22:56 +0200
+Subject: [PATCH] fixxref/rebase: Don't depend on glib being installed
+
+As is the case when you build docs for glib itself.
+---
+ gtkdoc/fixxref.py | 28 ++++++++++++++++------------
+ gtkdoc/rebase.py  | 11 ++++++++---
+ 2 files changed, 24 insertions(+), 15 deletions(-)
+
+diff --git a/gtkdoc/fixxref.py b/gtkdoc/fixxref.py
+index a7029cb..7b1901f 100755
+--- a/gtkdoc/fixxref.py
++++ b/gtkdoc/fixxref.py
+@@ -71,18 +71,22 @@ def Run(options):
+ 
+     # We scan the directory containing GLib and any directories in GNOME2_PATH
+     # first, but these will be overriden by any later scans.
+-    dir = common.GetModuleDocDir('glib-2.0')
+-    if os.path.exists(dir):
+-        # Some predefined link targets to get links into type hierarchies as these
+-        # have no targets. These are always absolute for now.
+-        Links['GBoxed'] = dir + '/gobject/gobject-Boxed-Types.html'
+-        Links['GEnum'] = dir + '/gobject/gobject-Enumeration-and-Flag-Types.html'
+-        Links['GFlags'] = dir + '/gobject/gobject-Enumeration-and-Flag-Types.html'
+-        Links['GInterface'] = dir + '/gobject/GTypeModule.html'
+-
+-        if dir != options.html_dir:
+-            logging.info('Scanning GLib directory: %s', dir)
+-            ScanIndices(dir, (re.search(prefix_match, dir) is None))
++    try:
++        dir = common.GetModuleDocDir('glib-2.0')
++    except subprocess.CalledProcessError:
++        pass
++    else:
++        if os.path.exists(dir):
++            # Some predefined link targets to get links into type hierarchies as these
++            # have no targets. These are always absolute for now.
++            Links['GBoxed'] = dir + '/gobject/gobject-Boxed-Types.html'
++            Links['GEnum'] = dir + '/gobject/gobject-Enumeration-and-Flag-Types.html'
++            Links['GFlags'] = dir + '/gobject/gobject-Enumeration-and-Flag-Types.html'
++            Links['GInterface'] = dir + '/gobject/GTypeModule.html'
++
++            if dir != options.html_dir:
++                logging.info('Scanning GLib directory: %s', dir)
++                ScanIndices(dir, (re.search(prefix_match, dir) is None))
+ 
+     path = os.environ.get('GNOME2_PATH')
+     if path:
+diff --git a/gtkdoc/rebase.py b/gtkdoc/rebase.py
+index d6affe3..44ca5a9 100755
+--- a/gtkdoc/rebase.py
++++ b/gtkdoc/rebase.py
+@@ -30,6 +30,7 @@ from six import iteritems, iterkeys
+ import logging
+ import os
+ import re
++import subprocess
+ 
+ from . import common
+ 
+@@ -63,9 +64,13 @@ def run(options):
+                 log(options, "Prepending GNOME2_PATH directory:", dir)
+                 other_dirs = [dir] + other_dirs
+ 
+-    dir = common.GetModuleDocDir('glib-2.0')
+-    log(options, "Prepending GLib directory", dir)
+-    other_dirs = [dir] + other_dirs
++    try:
++        dir = common.GetModuleDocDir('glib-2.0')
++    except subprocess.CalledProcessError:
++        pass
++    else:
++        log(options, "Prepending GLib directory", dir)
++        other_dirs = [dir] + other_dirs
+ 
+     # Check all other dirs, but skip already scanned dirs ord subdirs of those
+ 
+-- 
+2.14.2
+

--- a/mingw-w64-gtk-doc/PKGBUILD
+++ b/mingw-w64-gtk-doc/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk-doc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.26
-pkgrel=2
+pkgrel=3
 pkgdesc="Documentation tool for public library API (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/gtk-doc/"
@@ -26,16 +26,21 @@ url="https://www.gtk.org/gtk-doc/"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver}/${_realname}-${pkgver}.tar.xz
         pyscript2exe.py
         0001-Always-open-files-in-text-mode-and-always-use-utf-8.patch
+        0002-fixxref-rebase-Don-t-depend-on-glib-being-installed.patch
         win-fixes.patch)
 sha256sums=('bff3f44467b1d39775e94fad545f050faa7e8d68dc6a31aef5024ba3c2d7f2b7'
             'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3'
             '02c7544fb2d84cd4fb7884a2521239008f75c35c085b3d1da06aa73d2a456296'
+            '32e6c1f17ff6182c0f480e930beeb3bdc5ad8fb6bf4339b0838b9abc58680584'
             'bab8527690d529300b85154bd51b8118e0dfe3db1afec51d52d815066000b2e5')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
+  # https://bugzilla.gnome.org/show_bug.cgi?id=787862
   patch -Np1 -i "${srcdir}"/0001-Always-open-files-in-text-mode-and-always-use-utf-8.patch
+  # https://bugzilla.gnome.org/show_bug.cgi?id=787768
+  patch -Np1 -i "${srcdir}"/0002-fixxref-rebase-Don-t-depend-on-glib-being-installed.patch
   patch -Np1 -i "${srcdir}"/win-fixes.patch
 }
 


### PR DESCRIPTION
* Fix wrong python exe wrapper for glib-gettextize
* Move to mingw gtk-doc
* Add gtk-doc patch for https://bugzilla.gnome.org/show_bug.cgi?id=787768