### PR TITLE
opencv and suitesparse compile error fix.

### DIFF
--- a/mingw-w64-opencv/0013-dnn_modern-NO_STRICT-fix.patch
+++ b/mingw-w64-opencv/0013-dnn_modern-NO_STRICT-fix.patch
@@ -1,0 +1,11 @@
+--- opencv_contrib-3.3.0/modules/dnn_modern/src/caffe_converter.cpp.org	2017-07-31 22:58:38.000000000 +0800
++++ opencv_contrib-3.3.0/modules/dnn_modern/src/caffe_converter.cpp	2017-10-05 14:52:19.512831000 +0800
+@@ -41,7 +41,7 @@
+   or tort (including negligence or otherwise) arising in any way out of
+   the use of this software, even if advised of the possibility of such damage.
+  */
+-
++#define NO_STRICT 
+ #include "precomp.hpp"
+ #include <opencv2/imgproc.hpp>
+ 

--- a/mingw-w64-opencv/PKGBUILD
+++ b/mingw-w64-opencv/PKGBUILD
@@ -54,7 +54,8 @@ source=("${_realname}-${pkgver}.tar.gz"::https://github.com/opencv/opencv/archiv
         '0009-openblas-find.patch'
         '0010-find-libpng-header.patch'
         '0011-dshow-build-fix.patch'
-        '0012-dnn_modern-test-fix.patch')
+        '0012-dnn_modern-test-fix.patch'
+        '0013-dnn_modern-NO_STRICT-fix.patch')
 sha256sums=('8bb312b9d9fd17336dc1f8b3ac82f021ca50e2034afc866098866176d985adc6'
             'e94acf39cd4854c3ef905e06516e5f74f26dddfa6477af89558fb40a57aeb444'
             '9ce9cd5cbf76aea9f007f388dd71ccd7c9a656a274a84ef9a4e45af77b211fc0'
@@ -68,7 +69,8 @@ sha256sums=('8bb312b9d9fd17336dc1f8b3ac82f021ca50e2034afc866098866176d985adc6'
             'af2ff48a93e8a789b581163e62f67ff8bddfe741372d1c98fc21c77057f2743e'
             '15d4cf15196c7557af6e14d1d7b99aa9b462bd13435b3878dc28f85d00aa3e72'
             '7958ac5d80c643060e482fd6bac3bddd1199c1629ea6bea674179e7279b07d5d'
-            '44dc368dcf0c882a81fe4a38b4269e7139686cb108890d890c14db3b0ec4c002')
+            '44dc368dcf0c882a81fe4a38b4269e7139686cb108890d890c14db3b0ec4c002'
+            '01e305d36eaafbde8de20efd6eef13c34feb1bc8e6f9b54102bc20b84dfc9aa8')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -88,6 +90,7 @@ prepare() {
   patch -Np1 -i "${srcdir}/0006-somehow-uint-not-detected.patch"
   patch -Np1 -i "${srcdir}/0007-mingw-w64-have-sincos.patch"
   patch -Np1 -i "${srcdir}/0012-dnn_modern-test-fix.patch"
+  patch -Np1 -i "${srcdir}/0013-dnn_modern-NO_STRICT-fix.patch"
 }
 
 build() {

--- a/mingw-w64-suitesparse/0003-mingw-w64-no-CUDA.patch
+++ b/mingw-w64-suitesparse/0003-mingw-w64-no-CUDA.patch
@@ -1,0 +1,12 @@
+diff -urN SuiteSparse.orig/SuiteSparse_config/SuiteSparse_config.mk SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk
+--- SuiteSparse.orig/SuiteSparse_config/SuiteSparse_config.mk	2017-10-03 20:02:09.070092300 +0800
++++ SuiteSparse/SuiteSparse_config/SuiteSparse_config.mk	2017-10-03 20:23:32.245485700 +0800
+@@ -194,6 +195,8 @@
+ 
+     # CUDA is detected automatically, and used if found.  To disable CUDA,
+     # use CUDA=no
++    
++    CUDA=no
+ 
+     ifneq ($(CUDA),no)
+         CUDA_PATH = $(shell which nvcc 2>/dev/null | sed "s/\/bin\/nvcc//")

--- a/mingw-w64-suitesparse/PKGBUILD
+++ b/mingw-w64-suitesparse/PKGBUILD
@@ -11,19 +11,22 @@ license=('GPL')
 arch=('any')
 source=("http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-${pkgver}.tar.gz"
         "0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch"
-        "0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch")
+        "0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch"
+        "0003-mingw-w64-no-CUDA.patch")
 depends=("${MINGW_PACKAGE_PREFIX}-openblas"
          "${MINGW_PACKAGE_PREFIX}-metis")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
 options=('staticlibs')
 sha256sums=('b9a98de0ddafe7659adffad8a58ca3911c1afa8b509355e7aa58b02feb35d9b6'
             '81478c001fb9ec12ecdae0e1af482707ee83544cdf5954c68abc032f93c14d74'
-            '71036a7d03118e2019eed7d9fadf28aa544d1de6d84592d2bab61b604227b3c5')
+            '71036a7d03118e2019eed7d9fadf28aa544d1de6d84592d2bab61b604227b3c5'
+            'ba683605113eac73eaa63cb1b24fde8110f395c888f5331870222f59ecdc354a')
 
 prepare() {
   cd "${srcdir}"/SuiteSparse
   patch -p1 -i "${srcdir}"/0001-mingw-w64-Use-a-not-lib-as-AR_TARGET-extension.patch
   patch -p1 -i "${srcdir}"/0002-mingw-w64-Set-SO_OPTS--shared-move-dlls-create-import-libs.patch
+  patch -p1 -i "${srcdir}"/0003-mingw-w64-no-CUDA.patch
 }
 
 build() {


### PR DESCRIPTION
opencv 3.3.0 and suitesparse 4.5.5 compiling error fixed.