### PR TITLE
Limit curl rtmp support to the GnuTLS variant

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -25,12 +25,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libmetalink"
          "${MINGW_PACKAGE_PREFIX}-libssh2"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-rtmpdump"
          $([[ "$_variant" == "-openssl" ]] && echo \
             "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
             "${MINGW_PACKAGE_PREFIX}-openssl" \
             "${MINGW_PACKAGE_PREFIX}-nghttp2")
          $([[ "$_variant" == "-gnutls" ]] && echo \
+            "${MINGW_PACKAGE_PREFIX}-rtmpdump"
             "${MINGW_PACKAGE_PREFIX}-ca-certificates" \
             "${MINGW_PACKAGE_PREFIX}-gnutls")
          )
@@ -73,17 +73,20 @@ build() {
     _variant_config+=("--with-winssl")
     _variant_config+=('--without-nghttp2')
     _variant_config+=("--without-ca-bundle")
-    _variant_config+=("--without-ca-path")  
+    _variant_config+=("--without-ca-path")
+    _variant_config+=("--without-librtmp")
   elif [ "${_variant}" = "-gnutls" ]; then
     _variant_config+=("--without-ssl")
     _variant_config+=("--with-gnutls")
     _variant_config+=('--without-nghttp2')
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
+    _variant_config+=("--with-librtmp")
   elif [ "${_variant}" = "-openssl" ]; then
     _variant_config+=("--without-gnutls")
     _variant_config+=("--with-ssl")
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
     _variant_config+=('--with-nghttp2=${MINGW_PREFIX}/')
+    _variant_config+=("--without-librtmp")
   fi
   cd "${srcdir}/build-${CARCH}"
   ../${_realname}-${pkgver}/configure \


### PR DESCRIPTION
`curl` will have `rtmp` support if it's built against GnuTLS, a
non-default variant currently. `librtmp` is built against GnuTLS,
so at the moment the curl executable and `libcurl.dll` will link
against both OpenSSL and GnuTLS, with the latter pulling in
a long list of additional library dependencies (gmp nettle hogweed
tasn1 p11-kit). After this change curl would only depend on OpenSSL
by default. `rtmp` is a rarely used protocol with `curl` and there
are alternative tools to achieve the same functionality, e.g.
`rtmpdump` and `ffmpeg`. For these reasons, I believe it'd
be more optimal not to include its functionality in curl by default,
allowing to use the libcurl library with less overhead for most
use-cases.

If `rtmp` support in `curl` is deemed critical in MSYS2, another
approach is to build `librtmp` against OpenSSL (instead of GnuTLS).
This way the overhead imposed on curl could be minimized.