### PR TITLE
curl: enable MultiSSL mode by enabling WinSSL

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -13,7 +13,7 @@ _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
 pkgver=7.56.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
 url="https://curl.haxx.se/"
@@ -76,16 +76,20 @@ build() {
     _variant_config+=("--without-ca-path")
     _variant_config+=("--without-librtmp")
   elif [ "${_variant}" = "-gnutls" ]; then
+    _variant_config+=("--with-default-ssl-backend=gnutls")
     _variant_config+=("--without-ssl")
     _variant_config+=("--with-gnutls")
+    _variant_config+=("--with-winssl")
     _variant_config+=('--without-nghttp2')
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
     _variant_config+=("--with-librtmp")
   elif [ "${_variant}" = "-openssl" ]; then
+    _variant_config+=("--with-default-ssl-backend=openssl")
     _variant_config+=("--without-gnutls")
     _variant_config+=("--with-ssl")
+    _variant_config+=("--with-winssl")
     _variant_config+=("--with-ca-bundle=${MINGW_PREFIX}/ssl/certs/ca-bundle.crt")
-    _variant_config+=('--with-nghttp2=${MINGW_PREFIX}/')
+    _variant_config+=("--with-nghttp2=${MINGW_PREFIX}/")
     _variant_config+=("--without-librtmp")
   fi
   cd "${srcdir}/build-${CARCH}"


### PR DESCRIPTION
In both the openssl and gnutls variants. MultiSSL has
been introduced in curl 7.56.0 and allows multiple
SSL backends to be linked at the same time. It's then
possible to select between them at runtime.

Ref: https://curl.haxx.se/libcurl/c/curl_global_sslset.html
Ref: https://github.com/curl/curl/commit/1328f69d53f2f2e937696ea954c480412b018451

Also fix quote in `--with-nghttp2=` option.