### PR TITLE
python3: Disable broken gdbm module

### DIFF
--- a/mingw-w64-python3/1701-disable-broken-gdbm-module.patch
+++ b/mingw-w64-python3/1701-disable-broken-gdbm-module.patch
@@ -1,0 +1,11 @@
+--- Python-3.6.3/setup.py.orig	2017-10-17 18:21:50.539998900 +0200
++++ Python-3.6.3/setup.py	2017-10-17 18:44:29.430072300 +0200
+@@ -1315,7 +1315,7 @@
+             if dbm_args:
+                 dbm_order = [arg.split('=')[-1] for arg in dbm_args][-1].split(":")
+             else:
+-                dbm_order = "ndbm:gdbm:bdb".split(":")
++                dbm_order = []
+             dbmext = None
+             for cand in dbm_order:
+                 if cand == "ndbm":

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
 pkgver=${_pybasever}.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -26,7 +26,6 @@ url="https://www.python.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-gdbm"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-openssl"
@@ -133,6 +132,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1650-expose-sem_unlink.patch
         1690-need-win7-headers.patch
         1700-cygpty-isatty-disable-readline.patch
+        1701-disable-broken-gdbm-module.patch
         smoketests.py)
 
 prepare() {
@@ -260,6 +260,11 @@ prepare() {
   # https://github.com/Alexpux/MINGW-packages/issues/2656
   patch -Np1 -i "${srcdir}"/1700-cygpty-isatty-disable-readline.patch
 
+  # gdbm is broken and as a result breaks dbm/shelve.
+  # Don't include it so the dbm.dumb backend is used instead,
+  # like with the official CPython build.
+  patch -Np1 -i "${srcdir}"/1701-disable-broken-gdbm-module.patch
+
   autoreconf -vfi
 
   # Temporary workaround for FS#22322
@@ -333,7 +338,6 @@ build() {
     --without-ensurepip \
     "${_extra_config[@]}" \
     OPT=""
-    #--with-dbmliborder='gdbm:ndbm'
 
   make
 }
@@ -498,4 +502,5 @@ sha256sums=('cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da'
             '14347ddde0fb78ae9d7ae1674e24fbf8c26c5c75547de33633318d785468f49e'
             'ef192ac5bba7bd39c1a4c701b437099fe87e20759016a1e0e3d6709bc6f0a741'
             '7b0ba12b62e64ad4fa6914e66a1c38c584c93160314693bed1bb39a1d3af77d4'
+            '90cf511bec827adbdfda3969718248343e0eb728b747cc1557e0e8d36ae50c7b'
             'f4f5359b35741b703cbd22dc73438c181b8541e30b3f7614bd272f7cd2c59049')


### PR DESCRIPTION
gdbm is broken and as a result breaks dbm/shelve (dbm.open fails)
Don't include it so the dbm.dumb backend is used instead,
like with the official CPython build.