### PR TITLE
python2: Disable broken gdbm module

### DIFF
--- a/mingw-w64-python2/2701-disable-broken-gdbm-module.patch
+++ b/mingw-w64-python2/2701-disable-broken-gdbm-module.patch
@@ -1,0 +1,11 @@
+--- Python-2.7.14/setup.py.orig	2017-10-17 19:40:39.480898400 +0200
++++ Python-2.7.14/setup.py	2017-10-17 19:46:31.369088600 +0200
+@@ -1348,7 +1352,7 @@
+             if dbm_args:
+                 dbm_order = [arg.split('=')[-1] for arg in dbm_args][-1].split(":")
+             else:
+-                dbm_order = "ndbm:gdbm:bdb".split(":")
++                dbm_order = []
+             dbmext = None
+             for cand in dbm_order:
+                 if cand == "ndbm":

--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.14
-pkgrel=1
+pkgrel=2
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -15,7 +15,6 @@ url="https://www.python.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-gdbm"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-openssl"
@@ -110,7 +109,8 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1040-install-msilib.patch
         1050-skip-add-db-includes-for-win.patch
         2000-distutils-add-windmc-to-cygwinccompiler.patch
-        2700-cygpty-isatty-disable-readline.patch)
+        2700-cygpty-isatty-disable-readline.patch
+        2701-disable-broken-gdbm-module.patch)
 
 prepare() {
   cd "${srcdir}/Python-${pkgver}"
@@ -227,6 +227,11 @@ prepare() {
   # https://github.com/Alexpux/MINGW-packages/issues/2645
   # https://github.com/Alexpux/MINGW-packages/issues/2656
   patch -p1 -i "${srcdir}"/2700-cygpty-isatty-disable-readline.patch
+
+  # gdbm is broken and as a result breaks anydbm/shelve.
+  # Don't include it so the dumbdbm backend is used instead,
+  # like with the official CPython build.
+  patch -p1 -i "${srcdir}"/2701-disable-broken-gdbm-module.patch
 
   autoreconf -vfi
 
@@ -455,4 +460,5 @@ sha256sums=('71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66'
             'f1cfeb815277166384632bd9730fe89f64dc5da7ee09c13a0b3515da08b08847'
             'be5379525508e0bc0c374f20a669c38c93986e24a07696d2a83a9552cc085b8d'
             'aa623bd762f33f2724b40a55bd2d2c4100b47b81586ae2f5d6b430ab4646f02c'
-            '2f5044f0a61b5de400479d19cbc4e622f32a046f5eb360229793a4be76fe08fd')
+            '2f5044f0a61b5de400479d19cbc4e622f32a046f5eb360229793a4be76fe08fd'
+            'da2353b0d62d3511e44f27696cea0d4b7540b77cedffa5840fe202ae57e09890')


### PR DESCRIPTION
gdbm is broken and as a result breaks anydbm/shelve (anydbm.open fails).
Don't include it so the dumbdbm backend is used instead,
like with the official CPython build.