### PR TITLE
gst-libav: Build with system ffmpeg instead of internal one

### DIFF
--- a/mingw-w64-gst-libav/PKGBUILD
+++ b/mingw-w64-gst-libav/PKGBUILD
@@ -4,17 +4,16 @@ _realname=gst-libav
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.12.3
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer libav (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python2"
-             "yasm")
-depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
-         "${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
+             "${MINGW_PACKAGE_PREFIX}-python2")
+depends=("${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
+         "${MINGW_PACKAGE_PREFIX}-ffmpeg")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('015ef8cab6f7fb87c8fb42642486423eff3b6e6a6bccdcd6a189f436a3619650')
@@ -38,7 +37,8 @@ build() {
     --disable-static \
     --enable-shared \
     --enable-silent-rules \
-    --disable-gtk-doc
+    --disable-gtk-doc \
+    --with-system-libav
   make
 }
 


### PR DESCRIPTION
No need to include ffmpeg since it's likely getting pulled in by something
else anyway. This is also what Arch Linux does.