### PR TITLE
SDL2: update to 2.0.7

### DIFF
--- a/mingw-w64-SDL2/PKGBUILD
+++ b/mingw-w64-SDL2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=SDL2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.6
+pkgver=2.0.7
 pkgrel=1
 pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Version 2) (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libiconv")
 options=('staticlibs' 'strip')
 source=("https://libsdl.org/release/SDL2-${pkgver}.tar.gz")
-sha256sums=('03658b5660d16d7b31263a691e058ed37acdab155d68dabbad79998fb552c5df')
+sha256sums=('ee35c74c4313e2eda104b14b1b86f7db84a04eeab9430d56e001cea268bf4d5e')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
TODO: find out why this doesn't build with libsamplerate support