### PR TITLE
gtk2: restore patch

### DIFF
--- a/mingw-w64-gtk2/0017-fix-dead-keys-part-4.patch
+++ b/mingw-w64-gtk2/0017-fix-dead-keys-part-4.patch
@@ -1,0 +1,35 @@
+From dc442d167a83d83c54181c08682fe0b7f80112d6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=A0=D1=83=D1=81=D0=BB=D0=B0=D0=BD=20=D0=98=D0=B6=D0=B1?=
+ =?UTF-8?q?=D1=83=D0=BB=D0=B0=D1=82=D0=BE=D0=B2?= <lrn1986@gmail.com>
+Date: Sun, 15 Jan 2017 14:03:50 +0000
+Subject: [PATCH] GDK W32: Replace wcscpy_s with wcsncpy for XP compatibility
+
+https://bugzilla.gnome.org/show_bug.cgi?id=768722
+---
+ gdk/win32/gdkkeys-win32.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gdk/win32/gdkkeys-win32.c b/gdk/win32/gdkkeys-win32.c
+index 12c6c07..36113e3 100644
+--- a/gdk/win32/gdkkeys-win32.c
++++ b/gdk/win32/gdkkeys-win32.c
+@@ -559,7 +559,7 @@ check_that_active_layout_is_in_sync (GdkWin32Keymap *keymap)
+   if (hkl != cached_hkl)
+     {
+       if (!GetKeyboardLayoutNameW (hkl_name))
+-        wcscpy_s (hkl_name, KL_NAMELENGTH, L"(NULL)");
++        wcsncpy (hkl_name, L"(NULL)", KL_NAMELENGTH);
+ 
+       g_warning ("Cached active layout #%d (0x%p) does not match actual layout %S, 0x%p",
+                  keymap->active_layout, cached_hkl, hkl_name, hkl);
+@@ -656,7 +656,7 @@ update_keymap (GdkKeymap *gdk_keymap)
+           wchar_t hkl_name[KL_NAMELENGTH];
+ 
+           if (!GetKeyboardLayoutNameW (hkl_name))
+-            wcscpy_s (hkl_name, KL_NAMELENGTH, L"(NULL)");
++            wcsncpy (hkl_name, L"(NULL)", KL_NAMELENGTH);
+ 
+           GDK_NOTE (EVENTS, g_print ("(active, %S)", hkl_name));
+         }
+-- 
+2.4.0

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.31
-pkgrel=5
+pkgrel=6
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -43,6 +43,7 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0014-fix-dead-keys-part-2.patch
         0015-fix-dead-keys-part-3.patch
         0016-handle-pause-key-correctly.patch
+        0017-fix-dead-keys-part-4.patch
         0018-fix-gdkwin32keys-header.patch
         0019_use_g_stat_and_gstatbuf.patch)
 
@@ -60,6 +61,7 @@ sha256sums=('68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658'
             '2787b4e9431570c3c5ab88e0ea9faf38d198900e1f2a4462bd10e6b352f019aa'
             'fe24b559c08cb4b2f4ff5c8f8fe06e45dc00dc36e4de032205bf15fd18febfda'
             '85b084d0638ad47714f8d9af26d6799c4a02d84c4f52b65e49a64b6985ecbe70'
+            '608134a833c81221c3663cf238dd969899ba4225f253ff00b577120abbd2fdfd'
             '3f449b452274b816d7bd2155aeaa6cb4f0f8071653b03316efc48d9a6e63ac05'
             '2903708fda7b9f306a6a7b7b41518ce7a9ac7b9e622d4a1eed9ce30b945d5971')
 
@@ -80,6 +82,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0014-fix-dead-keys-part-2.patch
   patch -p1 -i ${srcdir}/0015-fix-dead-keys-part-3.patch
   patch -p1 -i ${srcdir}/0016-handle-pause-key-correctly.patch
+  patch -p1 -i ${srcdir}/0017-fix-dead-keys-part-4.patch
   patch -p1 -i ${srcdir}/0018-fix-gdkwin32keys-header.patch
   patch -p1 -i ${srcdir}/0019_use_g_stat_and_gstatbuf.patch
 


### PR DESCRIPTION
It was accidentally removed in e652682263f0ed6df32d5cb49d0b5882dcb9e4b1.

While it is true it landed upstream it is not yet available in a packaged release, see upstream commit https://github.com/GNOME/gtk/commit/79b2a92fe59e03cdd12cb8108a1e7b117c94f4c3