### PR TITLE
release package for GnuCOBOL (currently at version 2.2)

### DIFF
--- a/mingw-w64-gnucobol/001-mingw-gnucobol-2.2-fixformatwarnings.patch
+++ b/mingw-w64-gnucobol/001-mingw-gnucobol-2.2-fixformatwarnings.patch
@@ -1,0 +1,30 @@
+diff -Naur ./libcob/common.h.orig ./libcob/common.h
+--- ./libcob/common.h.orig	2017-09-06 20:37:28.000000000 +0200
++++ ./libcob/common.h	2017-10-25 23:26:58.208945700 +0200
+@@ -50,7 +50,7 @@
+ 
+ #endif
+ 
+-#if	defined(_WIN32)
++#if	defined(_WIN32) && !defined(__MINGW32__) /* hack for msys2 patch */
+ 
+ #define	CB_FMT_LLD		"%I64d"
+ #define	CB_FMT_LLU		"%I64u"
+@@ -389,12 +389,12 @@
+ 
+ /* Also OK for icc which defines __GNUC__ */
+ 
+-#if	defined(__GNUC__) || (defined(__xlc__) && __IBMC__ >= 700)
++#if	defined(__GNUC__) && defined(__MINGW32__) /* hack for msys2 patch */
+ #define	COB_A_NORETURN	__attribute__((noreturn))
+-#define	COB_A_FORMAT12	__attribute__((format(printf, 1, 2)))
+-#define	COB_A_FORMAT23	__attribute__((format(printf, 2, 3)))
+-#define	COB_A_FORMAT34	__attribute__((format(printf, 3, 4)))
+-#define	COB_A_FORMAT45	__attribute__((format(printf, 4, 5)))
++#define	COB_A_FORMAT12	__attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
++#define	COB_A_FORMAT23	__attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
++#define	COB_A_FORMAT34	__attribute__((format(__MINGW_PRINTF_FORMAT, 3, 4)))
++#define	COB_A_FORMAT45	__attribute__((format(__MINGW_PRINTF_FORMAT, 4, 5)))
+ #define	DECLNORET
+ #else
+ #define	COB_A_NORETURN

--- a/mingw-w64-gnucobol/002-mingw-gnucobol-2.2-skipcursestests.patch
+++ b/mingw-w64-gnucobol/002-mingw-gnucobol-2.2-skipcursestests.patch
@@ -1,0 +1,15 @@
+diff -Naur ./tests/atlocal.in.orig ./tests/atlocal.in
+--- ./tests/atlocal.in.orig	2017-10-25 23:49:02.197839900 +0200
++++ ./tests/atlocal.in	2017-10-25 23:49:24.637513300 +0200
+@@ -68,9 +68,9 @@
+ export COB_LIBRARY_PATH="${abs_top_builddir}/extras:$COB_LIBRARY_PATH"
+ export COB_UNIX_LF=YES
+ export COB_HAS_ISAM
+-if test "$MSYSTEM" = "MINGW32"; then
++if test "x$MSYSTEM" != "x"; then
+ 	# running MSYS builds as not-visible child processes result in
+-	# "Redirection is not supported"
++	# "Redirection is not supported" (old PDcurses) and exit 127 (NCurses)
+ 	COB_HAS_CURSES="no"
+ 	# Fix for testcases were cobc translates path to win32 equivalents
+ 	PATHSEP=";"

--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -5,18 +5,15 @@
 _realname=gnucobol
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-_base_ver=2.2
 pkgver=2.2
 pkgrel=1
 pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
 _dirname=${_realname}-${pkgver}
 arch=('any')
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 url="https://www.gnu.org/software/gnucobol/"
 options=('strip')
 license=('GPL3' 'LGPL3')
-# --> maybe place autoconf/make here, at least for the svn version makedepends=("")
+# note: the final binaries will call GCC, therefore it is a dependency
 depends=("${MINGW_PACKAGE_PREFIX}-gcc"
          "${MINGW_PACKAGE_PREFIX}-gmp"
          "${MINGW_PACKAGE_PREFIX}-db")

--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -16,16 +16,22 @@ license=('GPL3' 'LGPL3')
 # note: the final binaries will call GCC, therefore it is a dependency
 depends=("${MINGW_PACKAGE_PREFIX}-gcc"
          "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-gettext"
+         "${MINGW_PACKAGE_PREFIX}-ncurses"
          "${MINGW_PACKAGE_PREFIX}-db")
-optdepends=("${MINGW_PACKAGE_PREFIX}-gettext: support for internationalization"
-            "${MINGW_PACKAGE_PREFIX}-ncurses: support for extended screenio"
-            "${MINGW_PACKAGE_PREFIX}-pdcurses: support for screenio")
+# the optional depencies cannot be used for creating the binary packages, moved to depends
+#optdepends=("${MINGW_PACKAGE_PREFIX}-gettext: support for internationalization"
+#            "${MINGW_PACKAGE_PREFIX}-ncurses: support for extended screenio"
+#            "${MINGW_PACKAGE_PREFIX}-pdcurses: support for screenio")
 source=("${_realname}::https://ftp.gnu.org/gnu/${_realname}/${_dirname}.tar.xz"
         "001-mingw-gnucobol-2.2-fixformatwarnings.patch"
-        "002-mingw-gnucobol-2.2-skipcursestests.patch")
+        "002-mingw-gnucobol-2.2-skipcursestests.patch"
+        "cobenv.sh" "cobenv.cmd")
 sha256sums=('DC18FC45C269DEBFE86A4BBE20A7250983CBA6238EA1917E135DF5926CD024A0'
             '3FBFDAF61EB6EC125258DE62B404C97BF6DCCF39BD3B9152510F794B5383CA33'
-            '92F4D25AA33E4058BC48E071334697091F1DD763A7FD39D93468D52081103549')
+            '92F4D25AA33E4058BC48E071334697091F1DD763A7FD39D93468D52081103549'
+            '7B26508D34F82514CB3940C78CE181DE5B187F5ECEE6EF7DD496017A779AD273'
+            'D7619C83EF967644A96C9F6FBECB3F4585FFCB8340AF3B69F32D065673B32AE2')
 
 prepare() {
   cd "${_dirname}"
@@ -46,9 +52,11 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --infodir=${MINGW_PREFIX}/share/info \
     --mandir=${MINGW_PREFIX}/share/man \
+    --disable-rpath \
     --enable-shared \
-    --enable-static \
-    --disable-rpath
+    --disable-static
+    #  --> as using the static libcob would be the builtin default,
+    #      all generated COBOL modules would be GPLed (and big)...
 
   make -j1
 }
@@ -62,7 +70,15 @@ package() {
   cd ${srcdir}/build-${CARCH}
   make DESTDIR="${pkgdir}" install
 
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
-  cp -pf ${srcdir}/${_dirname}/COPYING* \
-    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  cd ${srcdir}
+  install -p -m777 cobenv.* "${pkgdir}${MINGW_PREFIX}/bin"
+
+  cd ${_dirname}
+  install -d "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+  install -p -m644 COPYING* "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}"
+
+  install -d "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  install -p -m644 README NEWS "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
+  cd doc
+  install -p -m644 gnucobol*.pdf "${pkgdir}${MINGW_PREFIX}/share/doc/${_realname}"
 }

--- a/mingw-w64-gnucobol/PKGBUILD
+++ b/mingw-w64-gnucobol/PKGBUILD
@@ -1,0 +1,71 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Jürgen Pfeifer <juergen@familiepfeifer.de>
+# Contributor: Simon Sobisch <simonsobisch@gnu.org>
+
+_realname=gnucobol
+pkgbase=mingw-w64-${_realname}
+pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
+_base_ver=2.2
+pkgver=2.2
+pkgrel=1
+pkgdesc="GnuCOBOL, a free and modern COBOL compiler (mingw-w64)"
+_dirname=${_realname}-${pkgver}
+arch=('any')
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+url="https://www.gnu.org/software/gnucobol/"
+options=('strip')
+license=('GPL3' 'LGPL3')
+# --> maybe place autoconf/make here, at least for the svn version makedepends=("")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc"
+         "${MINGW_PACKAGE_PREFIX}-gmp"
+         "${MINGW_PACKAGE_PREFIX}-db")
+optdepends=("${MINGW_PACKAGE_PREFIX}-gettext: support for internationalization"
+            "${MINGW_PACKAGE_PREFIX}-ncurses: support for extended screenio"
+            "${MINGW_PACKAGE_PREFIX}-pdcurses: support for screenio")
+source=("${_realname}::https://ftp.gnu.org/gnu/${_realname}/${_dirname}.tar.xz"
+        "001-mingw-gnucobol-2.2-fixformatwarnings.patch"
+        "002-mingw-gnucobol-2.2-skipcursestests.patch")
+sha256sums=('DC18FC45C269DEBFE86A4BBE20A7250983CBA6238EA1917E135DF5926CD024A0'
+            '3FBFDAF61EB6EC125258DE62B404C97BF6DCCF39BD3B9152510F794B5383CA33'
+            '92F4D25AA33E4058BC48E071334697091F1DD763A7FD39D93468D52081103549')
+
+prepare() {
+  cd "${_dirname}"
+  patch -Np1 -i ${srcdir}/001-mingw-gnucobol-2.2-fixformatwarnings.patch
+  patch -Np1 -i ${srcdir}/002-mingw-gnucobol-2.2-skipcursestests.patch
+}
+
+build() {
+  export lt_cv_deplibs_check_method='pass_all'   # libncurses with unconforming name
+  [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
+  cp -rf ${_dirname} build-${CARCH}
+  cd ${srcdir}/build-${CARCH}
+  ./configure \
+    CPPLAGS="-D__USE_MINGW_ANSI_STDIO=1" \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --prefix=${MINGW_PREFIX} \
+    --infodir=${MINGW_PREFIX}/share/info \
+    --mandir=${MINGW_PREFIX}/share/man \
+    --enable-shared \
+    --enable-static \
+    --disable-rpath
+
+  make -j1
+}
+
+check() {
+  cd ${srcdir}/build-${CARCH}
+  make check
+}
+
+package() {
+  cd ${srcdir}/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  cp -pf ${srcdir}/${_dirname}/COPYING* \
+    ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+}

--- a/mingw-w64-gnucobol/cobenv.cmd
+++ b/mingw-w64-gnucobol/cobenv.cmd
@@ -1,0 +1,185 @@
+@echo off
+
+:: cobenv.cmd
+:: Batch for setting GnuCOBOL Environment in Windows
+:: from MSYS2 MINGW32/MINGW64
+::
+:: Copyright (C) 2017 Free Software Foundation, Inc.
+:: Written by Simon Sobisch
+::
+:: This file is part of GnuCOBOL.
+::
+:: The GnuCOBOL compiler is free software: you can redistribute it
+:: and/or modify it under the terms of the GNU General Public License
+:: as published by the Free Software Foundation, either version 3 of the
+:: License, or (at your option) any later version.
+::
+:: GnuCOBOL is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+:: GNU General Public License for more details.
+::
+:: You should have received a copy of the GNU General Public License
+:: along with GnuCOBOL.  If not, see <http://www.gnu.org/licenses/>.
+goto :evaluate_opts
+
+
+:help
+  echo.
+  echo %_ce_myname% - set, show, store or restore GnuCOBOL environment
+  echo.
+  echo usage: %_ce_myextname% [options]
+  echo  note: if no option is given %_ce_myname% defaults to --setenv
+  echo.
+  echo options:
+  echo   --help,    -h  display this information
+  echo   --verbose, -v  print the environment variables set / restored
+  echo   --quiet,   -q  don't print anything
+  echo   --setenv       store current environment and set environment
+  echo                  according to MSYS2 package structure
+  echo   --save         store current environment
+  echo   --restore      restore environment to previous saved point
+  echo   --showenv      show current environment
+goto :eof
+
+
+:output
+  if %_ce_verbose% lss 0 goto :eof
+  if %_ce_verbose% equ 0 (
+    echo %*
+    goto :eof
+  )
+  echo %*:
+  echo   PATH=%PATH%
+  echo   COB_LIBRARY_PATH=%COB_LIBRARY_PATH%
+  echo   COB_CONFIG_DIR=%COB_CONFIG_DIR%
+  echo   COB_COPY_DIR=%COB_COPY_DIR%
+goto :eof
+
+
+:save
+  set "_ce_restore_path=%PATH%"
+  set "_ce_restore_library_path=%COB_LIBRARY_PATH%"
+  set "_ce_restore_copy=%COB_COPY_DIR%"
+  set "_ce_restore_config=%COB_CONFIG_DIR%"
+  call :output environment saved
+goto :eof
+
+
+:setenv
+  if %_ce_verbose% geq 0 (
+     echo Setup GnuCOBOL environment - MinGW
+  )
+  if "%_ce_restore_path%"=="" (
+    call :save
+  ) else (
+    call :restore silent
+  )
+  set "PATH=%MINGW_ROOT_PATH%\bin;%PATH%"
+  if not "%COB_LIBRARY_PATH%"=="" set "COB_LIBRARY_PATH=;%COB_LIBRARY_PATH%"
+  set "COB_LIBRARY_PATH=%MINGW_ROOT_PATH%\lib\gnucobol%COB_LIBRARY_PATH%"
+  set "COB_COPY_DIR=%MINGW_ROOT_PATH%\share\gnucobol\copy"
+  set "COB_CONFIG_DIR=%MINGW_ROOT_PATH%\share\gnucobol\config"
+  if %_ce_verbose% lss 0 goto :eof
+  call :output environment set
+goto :eof
+
+
+:unset_restore
+  set "_ce_restore_path="
+  set "_ce_restore_library_path="
+  set "_ce_restore_copy="
+  set "_ce_restore_config="
+goto :eof
+
+
+:restore
+  if "%_ce_restore_path%"=="" (
+    if %_ce_verbose% geq 0 (
+      echo nothing to restore
+    )
+    set "COB_LIBRARY_PATH="
+    set "COB_COPY_DIR="
+    set "COB_CONFIG_DIR="
+  )
+  set "PATH=%_ce_restore_path%"
+  set "COB_LIBRARY_PATH=%_ce_restore_library_path%"
+  set "COB_COPY_DIR=%_ce_restore_copy%"
+  set "COB_CONFIG_DIR=%_ce_restore_config%"
+  if [%1]==[] (
+    call :output environment restored
+  )
+goto :eof
+
+
+:showenv
+  set _ce_verbose=1
+  call :output current environment
+goto :eof
+
+
+:evaluate_opts
+set "_ce_myname=cobenv.bat"
+set "_ce_myextname=%0"
+set "MINGW_ROOT_PATH=%~dp0.."
+set _ce_verbose=0
+
+if /i [%2]==[--verbose] (
+  set _ce_verbose=1
+) else if /i [%2]==[-v] (
+  set _ce_verbose=1
+) else if /i [%2]==[--quiet] (
+  set _ce_verbose=-1
+) else if /i [%2]==[-q] (
+  set _ce_verbose=-1
+) else if not [%2]==[] (
+  shift
+) else (
+  if /i [%1]==[--verbose] (
+    set _ce_verbose=1  && shift
+  ) else if /i [%1]==[-v] (
+    set _ce_verbose=1  && shift
+  ) else if /i [%1]==[--quiet] (
+    set _ce_verbose=-1 && shift
+  ) else if /i [%1]==[-q] (
+    set _ce_verbose=-1 && shift
+  )
+)
+
+if [%1]==[--restore] (
+  call :restore
+  call :unset_restore
+) else if /i [%1]==[/restore] (
+  call :restore
+  call :unset_restore
+) else if /i [%1]==[--save] (
+  call :save
+) else if /i [%1]==[/save] (
+  call :save
+) else if /i [%1]==[--setenv] (
+  call :setenv
+) else if /i [%1]==[/setenv] (
+  call :setenv
+) else if [%1]==[] (
+  call :setenv
+) else if /i [%1]==[--showenv] (
+  call :showenv
+) else if /i [%1]==[/showenv] (
+  call :showenv
+) else if /i [%1]==[--help] (
+  call :help
+) else if /i [%1]==[/help] (
+  call :help
+) else if /i [%1]==[-h] (
+  call :help
+) else if /i [%1]==[/?] (
+  call :help
+) else (
+  echo unrecognized or misplaced option "%1"
+  call :help
+)
+
+set "_ce_verbose="
+set "_ce_myname="
+set "_ce_myextname="
+

--- a/mingw-w64-gnucobol/cobenv.sh
+++ b/mingw-w64-gnucobol/cobenv.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+#
+# cobenv.sh
+# Shell script for setting GnuCOBOL Environment
+# in MSYS2 MINGW32/MINGW64
+#
+# Copyright (C) 2017 Free Software Foundation, Inc.
+# Written by Simon Sobisch
+#
+# This file is part of GnuCOBOL.
+#
+# The GnuCOBOL compiler is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# GnuCOBOL is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GnuCOBOL.  If not, see <http://www.gnu.org/licenses/>.
+
+
+_ce_help () {
+  echo
+  echo "$_ce_myname - set, show, store or restore GnuCOBOL environment"
+  echo
+  echo "usage: source $_ce_myextname [options]"
+  echo "   or: .      $_ce_myextname [options]"
+  echo " note: if no option is given $_ce_myname defaults to --setenv"
+  echo
+  echo "options:"
+  echo "  --help,    -h  display this information"
+  echo "  --verbose, -v  print the environment variables set / restored"
+  echo "  --quiet,   -q  don't print anything"
+  echo "  --setenv       store current environment and set environment"
+  echo "                 according to MSYS2 package structure"
+  echo "  --save         store current environment"
+  echo "  --restore      restore environment to previous saved point"
+  echo "  --showenv      show current environment"
+}
+
+
+_ce_output () {
+  if test $_ce_verbose -lt 0; then return; fi
+  if test $_ce_verbose -eq 0; then
+    echo "$1"
+  else
+    echo "$1:"
+    echo "  COB_LIBRARY_PATH=$COB_LIBRARY_PATH"
+    echo "  COB_CONFIG_DIR=$COB_CONFIG_DIR"
+    echo "  COB_COPY_DIR=$COB_COPY_DIR"
+  fi
+}
+
+
+_ce_save () {
+  export "_ce_restore_library_path=$COB_LIBRARY_PATH"
+  export "_ce_restore_config=$COB_CONFIG_DIR"
+  export "_ce_restore_copy=$COB_COPY_DIR"
+  if test $_ce_verbose -lt 0; then return; fi
+  _ce_output "environment saved"
+}
+
+
+_ce_setenv () {
+  if test $_ce_verbose -ge 0; then
+    echo "Setup GnuCOBOL environment (MinGW within MSYS2)..."
+  fi
+  if test "-z ${_ce_restore_config+x}"; then
+    _ce_save
+  else
+    _ce_restore silent
+  fi
+  export "COB_CONFIG_DIR=`cygpath.exe -pw $MINGW_PREFIX/share/gnucobol/config`"
+  export "COB_COPY_DIR=`cygpath.exe -pw $MINGW_PREFIX/share/gnucobol/copy`"
+  if test "x$COB_LIBRARY_PATH" != "x"; then
+    "COB_LIBRARY_PATH=:$COB_LIBRARY_PATH"
+  fi
+  export "COB_LIBRARY_PATH=`cygpath.exe -pw $MINGW_PREFIX/lib/gnucobol`$COB_LIBRARY_PATH"
+  if test $_ce_verbose -lt 0; then return; fi
+  _ce_output "environment set"
+}
+
+
+_ce_unset_restore () {
+  unset "_ce_restore_library_path"
+  unset "_ce_restore_config"
+  unset "_ce_restore_copy"
+}
+
+
+_ce_restore () {
+  if test "-z ${_ce_restore_config+x}"; then
+    if test $_ce_verbose -ge 0; then
+      echo nothing to restore, environment is cleaned
+    fi
+    unset "COB_LIBRARY_PATH"
+    unset "COB_CONFIG_DIR"
+    unset "COB_COPY_DIR"
+  else
+    export "COB_LIBRARY_PATH=$_ce_restore_library_path"
+    export "COB_CONFIG_DIR=$_ce_restore_config"
+    export "COB_COPY_DIR=$_ce_restore_copy"
+    if test "-z ${1+x}"; then
+      _ce_output "environment restored"
+    fi
+  fi
+}
+
+
+_ce_showenv () {
+  _ce_verbose=1
+  _ce_output "current environment"
+}
+
+
+# evaluate options
+_ce_myname=cobenv.sh
+_ce_myextname=$_ce_myname
+if test ${BASH_VERSINFO[0]} -gt 2; then
+  if test "${BASH_SOURCE[0]}" = "${0}"; then
+    # if we know that we aren't sourced we can use the external name
+    _ce_myextname=$0
+    if test "$1" != "--help" -a "$1" != "-h" -a "$1" != "--showenv"; then
+      echo "This shell sets the local environment and therefore needs"
+      echo "to be sourced, consider calling $_ce_myname --help !"
+      exit 1
+    fi
+  fi
+fi
+
+_ce_verbose=0
+case "$2" in
+  "--verbose" | "-v") _ce_verbose=1;;
+  "--quiet"   | "-q") _ce_verbose=-1;;
+  *)
+  case "$1" in
+    "--verbose" | "-v") _ce_verbose=1  && shift;;
+    "--quiet"   | "-q") _ce_verbose=-1 && shift;;
+  esac
+  ;;
+esac
+
+case "$1" in
+  "--restore")      _ce_restore && _ce_unset_restore;;
+  "--save")         _ce_save;;
+  "--help" | "-h")  _ce_help;;
+  "--showenv")      _ce_showenv;;
+  "" | "--setenv")  _ce_setenv;;
+  *)
+    echo unrecognized or misplaced option "$1"
+    _ce_help
+  ;;
+esac
+
+unset _ce_help _ce_restore _ce_save _ce_setenv _ce_showenv _ce_output


### PR DESCRIPTION
Instead of the svn one (which I still would like to update to allow people to use "latest") this is the package for the most current release version.

A note concerning the patches:

* 001 will *only* work with MSYS2 (building), not with old mingw and not with any other environment - if I remember correctly this will just remove the format warnings during compilation (with the additional `-D__USE_MINGW_ANSI_STDIO=1`
* 002 is (slightly changed) in svn version already and will therefore be removed with the next release and not integrated in the svn package

A question: Is it possible to install the package with adjusting the user's environment? The generated binaries get the install-prefix' path hard-wired into them (always did) and won't work anywhere as the binaries need to use Windows paths (I could add a translation to Windows paths but this won't work for a user that has a different MSYS2 installation path than the machine creating the binaries).
The solution is to override the builtin default paths by environment variables, if we can't add a setting of these into the PKGBUILD the user would have to do so on his own before calling the binaries. Any idea to solve this problem?