### PR TITLE
Add NVPTX target to LLVM.

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -21,7 +21,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          "${MINGW_PACKAGE_PREFIX}-polly")
 pkgver=5.0.0
-pkgrel=3
+pkgrel=4
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -235,7 +235,7 @@ build() {
     -DCMAKE_C_FLAGS="${CFLAGS}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -D_GNU_SOURCE" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DLLVM_TARGETS_TO_BUILD="ARM;X86" \
+    -DLLVM_TARGETS_TO_BUILD="ARM;NVPTX;X86" \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ENABLE_THREADS=ON \
     -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python2.exe \


### PR DESCRIPTION
This simply adds NVPTX support to the LLVM built by the `mingw-w64-*-clang` package. It's very handy to have this in the MinGW-w64 package, since it's quite a hassle to build a usable LLVM from source on Windows (principally due to `llvm-config.exe` bugs, which I'd like to send PR's for upstream once I have the time). This will marginally increase the package build time and the size of `LLVM.dll`.

This is especially handy for [accelerate-llvm-ptx](https://hackage.haskell.org/package/accelerate-llvm-ptx) users on Windows, since the Stack Haskell build tool provides a sandboxed MinGW anyway.

I managed to build this on my machine without issue and the resulting package seems to work. Apologies if I've forgotten something or I'm doing something wrong; this is the first MinGW development I've done of any sort.