### PR TITLE
Add libmfx package (version 1.23)

### DIFF
--- a/mingw-w64-libmfx/PKGBUILD
+++ b/mingw-w64-libmfx/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=libmfx
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.23
+pkgrel=1
+pkgdesc="Intel Media SDK dispatcher library (mingw-w64)"
+arch=('any')
+url="https://github.com/lu-zero/mfx_dispatch/"
+license=("BSD")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+source=("https://github.com/lu-zero/mfx_dispatch/archive/${pkgver}.tar.gz")
+sha256sums=('d84db51a9d3ec6b5282fc681fba6b2c721814a6154cfc35feb422903a8d4384b')
+prepare() {
+  cd "${srcdir}/mfx_dispatch-${pkgver}"
+  autoreconf -fiv
+}
+build() {
+  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+
+  ../mfx_dispatch-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
This adds the libmfx package, the Intel Media Dispatcher toolkit.