### PR TITLE
SDL2_Mixer: link in MP3, Ogg Vorbis and FLAC support libraries

### DIFF
--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -4,7 +4,7 @@ _realname=SDL2_mixer
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A simple multi-channel audio mixer (Version 2) (mingw-w64)"
 arch=('any')
 url="https://libsdl.org/projects/SDL_mixer"
@@ -47,10 +47,13 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --enable-static \
+    --disable-music-ogg-shared \
+    --disable-music-flac-shared \
     --enable-music-mp3 \
     --disable-music-mp3-smpeg \
     --disable-music-mp3-mad-gpl \
-    --enable-music-mp3-mpg123
+    --enable-music-mp3-mpg123 \
+    --disable-music-mp3-mpg123-shared
 
   make
 }

--- a/mingw-w64-SDL2_mixer/PKGBUILD
+++ b/mingw-w64-SDL2_mixer/PKGBUILD
@@ -24,7 +24,7 @@ source=("$url/release/${_realname}-${pkgver}.zip"
         SDL2_mixer-2.0.1-find_lib.mingw.patch
         SDL2_mixer-2.0.1-libtool_windres.mingw.patch)
 sha256sums=('ecd687e74b0aa33800812dffa2fac2714260bc91d17866d307c5379181c0a9c5'
-            'e209704cd3e32932250a6191673dfc20e21a5bfe9683e3ac483212e517fe0a30'
+            'bc213c14a7a9d9e67c4c5075ee3267e43f7c095510aee6314f7cf68fa58c634d'
             '86fa38c76b834ea28d40c95d4639cf7896f449fe92a4348d21da641106a53132')
 
 prepare() {

--- a/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-find_lib.mingw.patch
+++ b/mingw-w64-SDL2_mixer/SDL2_mixer-2.0.1-find_lib.mingw.patch
@@ -99,3 +99,12 @@ Index: SDL2_mixer-2.0.2/configure.in
                  smpeg_lib=[`find_lib "smpeg2*.dll"`]
                  ;;
              *)
+@@ -648,7 +655,7 @@ if test x$enable_music_mp3_mpg123 = xyes
+             *-*-darwin*)
+                 mpg123_lib=[`find_lib libmpg123.dylib`]
+                 ;;
+-            *-*-cygwin* | *-*-mingw32*)
++            *-*-cygwin* | *-*-mingw*)
+                 mpg123_lib=[`find_lib "libmpg123*.dll"`]
+                 ;;
+             *)


### PR DESCRIPTION
Link in the libraries instead of relying on dlopen().

Support for these formats is pretty much expected nowadays and we
depend on the corresponding packages anyway. I am not applying this
to modplug and fluidsynth as well, because they support more exotic
formats and pull in some rather heavy-weight dependencies
(e.g. libglib in the case of fluidsynth).