### PR TITLE
mingw-w64-hdf5: enable ptrdiff_t in cmake on MinGW/MSYS2

### DIFF
--- a/mingw-w64-hdf5/PKGBUILD
+++ b/mingw-w64-hdf5/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _ver=1.8.19
 patch=
 pkgver=${_ver}${patch//-/.}
-pkgrel=1
+pkgrel=2
 pkgdesc="General purpose library and file format for storing scientific data (mingw-w64)"
 arch=('any')
 license=("custom")
@@ -19,6 +19,7 @@ source=("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${_ver%.*}/hdf5-${_
         "hdf5-fix-install-docs.patch"
         "hdf5-proper-library-names-mingw.patch"
         "hdf5-fix-find-szip.patch"
+        "hdf5-cmake-size-type-checks.patch"
         )
 sha256sums=('59c03816105d57990329537ad1049ba22c2b8afe1890085f0c022b75f1727238'
             '35f8d9a313e8675e79f3920b4f2f6d349887f1b1e162dc06b1ffab9872473c3e'
@@ -26,7 +27,8 @@ sha256sums=('59c03816105d57990329537ad1049ba22c2b8afe1890085f0c022b75f1727238'
             'da0e3c30982946eddd58026359352f3cbb565e4b5ba399c8921778655c4d6505'
             '72a4c3ff11b0811e2462252ddc7f14428c0241c71b3403408dbc0f93a21271c9'
             'a21a6be1fa7e606ed16d903ea8ba670a1e387cdb9aac69e2c6468a5a9fc5c990'
-            'c384db7d39123578ea7b9ead449c347ed0833bc77163c4165340a71b34baaaa0')
+            'c384db7d39123578ea7b9ead449c347ed0833bc77163c4165340a71b34baaaa0'
+            '7370973e66370bb39bf2466be3ef58f464a10478b996e8c040c5a994d143d111')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-gcc-libgfortran"
          "${MINGW_PACKAGE_PREFIX}-szip"
@@ -38,13 +40,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('staticlibs' 'strip')
 
 prepare() {
-  cd ${srcdir}/${_realname}-${_ver}${patch}
-  patch -p1 -i ${srcdir}/hdf5-link-ws2_32-mingw.patch
-  patch -p1 -i ${srcdir}/hdf5-install.patch
-  patch -p1 -i ${srcdir}/hdf5-default-import-suffix.patch
-  patch -p1 -i ${srcdir}/hdf5-fix-install-docs.patch
-  patch -p1 -i ${srcdir}/hdf5-proper-library-names-mingw.patch
-  patch -p1 -i ${srcdir}/hdf5-fix-find-szip.patch
+  cd "${srcdir}/${_realname}-${_ver}${patch}"
+  patch -p1 -i "${srcdir}/hdf5-link-ws2_32-mingw.patch"
+  patch -p1 -i "${srcdir}/hdf5-install.patch"
+  patch -p1 -i "${srcdir}/hdf5-default-import-suffix.patch"
+  patch -p1 -i "${srcdir}/hdf5-fix-install-docs.patch"
+  patch -p1 -i "${srcdir}/hdf5-proper-library-names-mingw.patch"
+  patch -p1 -i "${srcdir}/hdf5-fix-find-szip.patch"
+  patch -p1 -i "${srcdir}/hdf5-cmake-size-type-checks.patch"
 }
 
 build() {

--- a/mingw-w64-hdf5/hdf5-cmake-size-type-checks.patch
+++ b/mingw-w64-hdf5/hdf5-cmake-size-type-checks.patch
@@ -1,0 +1,12 @@
+diff -Naur hdf5-1.8.19.org/config/cmake_ext_mod/ConfigureChecks.cmake hdf5-1.8.19/config/cmake_ext_mod/ConfigureChecks.cmake
+--- hdf5-1.8.19.org/config/cmake_ext_mod/ConfigureChecks.cmake	2017-06-15 17:47:13.000000000 +0200
++++ hdf5-1.8.19/config/cmake_ext_mod/ConfigureChecks.cmake	2017-11-06 23:06:21.235526700 +0100
+@@ -420,7 +420,7 @@
+   if (NOT ${HDF_PREFIX}_SIZEOF_SSIZE_T)
+     set (${HDF_PREFIX}_SIZEOF_SSIZE_T 0)
+   endif ()
+-  if (NOT WINDOWS)
++  if (NOT MSVC)
+     HDF_CHECK_TYPE_SIZE (ptrdiff_t    ${HDF_PREFIX}_SIZEOF_PTRDIFF_T)
+   endif ()
+ endif ()


### PR DESCRIPTION
This patch is not extensively tested. I found in hdf5 build log many warnings that `H5_SIZEOF_PTRDIFF_T` is not defined, so I added this fix for cmake to define `H5_SIZEOF_PTRDIFF_T` on MinGW/MSYS2. The build and library works for me, but I did not perform heavy testing.