### PR TITLE
Add QHttpEngine.

### DIFF
--- a/mingw-w64-qhttpengine/PKGBUILD
+++ b/mingw-w64-qhttpengine/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Nathan Osman <nathan@quickmediasolutions.com>
+
+_realname=qhttpengine
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="HTTP server for Qt applications (mingw-w64)"
+arch=('any')
+license=('MIT')
+url='https://github.com/nitroshare/qhttpengine'
+depends=("${MINGW_PACKAGE_PREFIX}-qt5>=5.4")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.2"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+source=("https://github.com/nitroshare/qhttpengine/archive/${pkgver}.tar.gz")
+sha256sums=('b6330c4df9a67d82d4008ad5efea996806b2945d155892a38b6d1d1b50172098')
+
+build() {
+  mkdir ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ${srcdir}/${_realname}-${pkgver}
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
This pull request adds a `PKGBUILD` for [QHttpEngine](https://github.com/nitroshare/qhttpengine), a library that provides a simple HTTP server for Qt applications. It requires CMake to build and its only runtime dependencies are the base Qt5 libraries.