### PR TITLE
Add libblocksruntime (version 0.4.1)

### DIFF
--- a/mingw-w64-libblocksruntime/0001-libblocksruntime-0.4.1-fix-shared-installation.patch
+++ b/mingw-w64-libblocksruntime/0001-libblocksruntime-0.4.1-fix-shared-installation.patch
@@ -1,0 +1,25 @@
+unchanged:
+--- libblocksruntime-0.4.1/configure-orig.ac	2017-11-08 18:52:55.961703800 -0500
++++ libblocksruntime-0.4.1/configure.ac	2017-11-08 18:53:12.298880700 -0500
+@@ -3,7 +3,7 @@
+ 
+ AC_INIT([libBlocksRuntime], [0.4.1])
+ AC_PROG_CC([clang])
+-LT_INIT
++LT_INIT[(win32-dll)]
+ AM_INIT_AUTOMAKE([foreign subdir-objects])
+ AC_CONFIG_SRCDIR([configure.ac])
+ AC_CONFIG_HEADERS([config.h])
+only in patch2:
+unchanged:
+--- libblocksruntime-0.4.1/Makefile-orig.am	2017-11-08 18:58:16.324977000 -0500
++++ libblocksruntime-0.4.1/Makefile.am	2017-11-08 18:58:19.477580300 -0500
+@@ -6,6 +6,8 @@
+ 
+ libBlocksRuntime_la_CFLAGS = -std=c99 -Wall -Wextra -W -pedantic
+ 
++libBlocksRuntime_la_LDFLAGS = -no-undefined
++
+ libBlocksRuntime_la_SOURCES = runtime.c data.c config2.h
+ 
+ check_PROGRAMS = blockrt-test

--- a/mingw-w64-libblocksruntime/PKGBUILD
+++ b/mingw-w64-libblocksruntime/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=libblocksruntime
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.4.1
+pkgrel=1
+pkgdesc='compiler-rt Blocks runtime library for Clang (mingw-w64)'
+arch=('any')
+url="https://compiler-rt.llvm.org"
+license=("custom:University of Illinois" "MIT")
+depends=("${MINGW_PACKAGE_PREFIX}-clang")
+source=("http://http.debian.net/debian/pool/main/libb/${_realname}/${_realname}_${pkgver}.orig.tar.gz"
+        "0001-libblocksruntime-0.4.1-fix-shared-installation.patch")
+sha256sums=('7807e18d7d6cabd90f77c8b8a8ebd472516fa4ed6a02df82e0c33b1c5e112abc'
+            '73cd40b3d8da2adf03ba85ba9a615d19512289bfc71dafb1f6240bb61540b24d')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/0001-libblocksruntime-0.4.1-fix-shared-installation.patch"
+  autoreconf -fiv
+}
+
+build() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
This adds libblocksruntime, needed by some packages on Unix platforms, such as the Swift programming language.