### PR TITLE
Add QMdnsEngine.

### DIFF
--- a/mingw-w64-qmdnsengine/PKGBUILD
+++ b/mingw-w64-qmdnsengine/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Nathan Osman <nathan@quickmediasolutions.com>
+
+_realname=qmdnsengine
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Multicast DNS library for Qt applications"
+arch=('any')
+license=('MIT')
+url='https://github.com/nitroshare/qmdnsengine'
+depends=("${MINGW_PACKAGE_PREFIX}-qt5>=5.4")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.2"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+source=("https://github.com/nitroshare/qmdnsengine/archive/${pkgver}.tar.gz")
+sha256sums=('27416ca7b8b8a8588df4318de57127ef97e1205269fa506f00f21b09d30d3ac2')
+
+build() {
+  mkdir ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    ${srcdir}/${_realname}-${pkgver}
+  make
+}
+
+package() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
This pull request adds a PKGBUILD for [QMdnsEngine](https://github.com/nitroshare/qmdnsengine), a library that provides support both for discovering and providing services using mDNS (multicast DNS). It requires CMake to build and its only runtime dependencies are the base Qt5 libraries.