### PR TITLE
SDL2_image: link in PNG support library

### DIFF
--- a/mingw-w64-SDL2_image/PKGBUILD
+++ b/mingw-w64-SDL2_image/PKGBUILD
@@ -27,7 +27,8 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-static \
-    --enable-shared
+    --enable-shared \
+    --disable-png-shared
 
   make
 }


### PR DESCRIPTION
Link in the PNG library instead of relying on dlopen().

For proper read/write support for the most popular image format
the library should be linked in, we depend on the corresponding
package anyway.