### PR TITLE
goocanvas: Update to 2.0.4. Fixes #3131

### DIFF
--- a/mingw-w64-goocanvas/001-convert-python-path-to-unix.patch
+++ b/mingw-w64-goocanvas/001-convert-python-path-to-unix.patch
@@ -1,5 +1,5 @@
---- ./configure.in.orig	2013-11-03 17:56:29.000000000 +0100
-+++ ./configure.in	2015-02-22 19:47:45.372532600 +0100
+--- ./configure.ac.orig	2013-11-03 17:56:29.000000000 +0100
++++ ./configure.ac	2015-02-22 19:47:45.372532600 +0100
 @@ -94,8 +94,13 @@
  if test "x$enable_python" = "xauto"; then
  	PKG_CHECK_MODULES(PYTHON, [pygobject-3.0 >= $PYGOBJECT_REQUIRED])

--- a/mingw-w64-goocanvas/PKGBUILD
+++ b/mingw-w64-goocanvas/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=goocanvas
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.3
+pkgver=2.0.4
 pkgrel=1
 arch=('any')
 pkgdesc="Canvas widget for GTK+ that uses the Cairo 2D library (mingw-w64)"
@@ -14,7 +14,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "make"
              "libtool"
              "automake-wrapper"
@@ -26,8 +26,8 @@ options=('strip' '!debug' 'staticlibs')
 source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:3}/${_realname}-${pkgver}.tar.xz
              001-convert-python-path-to-unix.patch
              002-fix-introspection.patch)
-sha256sums=('6b5b9c25d32c05b9bafc42f5fcc28d55f1426e733e78e9fe4d191cfcd666c800'
-            '102476f04708a7009837428af5584d31ff252a16d8c78a0b92d66bb24ee83682'
+sha256sums=('c728e2b7d4425ae81b54e1e07a3d3c8a4bd6377a63cffa43006045bceaa92e90'
+            '9740420cd1e2cf2362e5170ead007685686656e3764c905f7b0313b62ed41298'
             '2dd3aa690c179b74c3c443732d43672a23271589086c248325e4a762560584f2')
 
 prepare() {
@@ -47,6 +47,8 @@ build() {
     mkdir -p docs/html
     cp -rf ../${_realname}-${pkgver}/docs/html/* docs/html
 
+    # an argument passed to glib-mkenums starts with a c++ comment
+    export MSYS2_ARG_CONV_EXCL="/*"
     export CC=gcc
     ./configure \
       --host=${MINGW_CHOST} \


### PR DESCRIPTION
And while at it move to mingw gtk-doc and fix some
path conversation problems with newer glib-mkenums.