### PR TITLE
libvisio: update to version 0.1.6

### DIFF
--- a/mingw-w64-libvisio/0001-libvisio-compare_dates_in_utc.patch
+++ b/mingw-w64-libvisio/0001-libvisio-compare_dates_in_utc.patch
@@ -1,0 +1,27 @@
+diff -ru libvisio-0.1.6.orig/src/test/importtest.cpp libvisio-0.1.6/src/test/importtest.cpp
+--- libvisio-0.1.6.orig/src/test/importtest.cpp	2017-10-21 16:38:56.000000000 +0200
++++ libvisio-0.1.6/src/test/importtest.cpp	2017-11-18 14:56:56.747233800 +0100
+@@ -10,6 +10,8 @@
+ #include <libvisio/libvisio.h>
+ #include <libxml/xpath.h>
+ #include <iostream>
++#include <stdlib.h>
++#include <time.h>
+ #include <cppunit/extensions/HelperMacros.h>
+ #include "xmldrawinggenerator.h"
+ 
+@@ -259,6 +261,14 @@
+ 
+ void ImportTest::testVsdMetadataTitleUtf8()
+ {
++  // dates need to be compared in UTC
++#ifdef _WIN32
++  _putenv_s("TZ", "UTC");
++#else
++  setenv("TZ", "UTC", 1);
++#endif
++  tzset();
++
+   m_doc = parse("fdo86729-utf8.vsd", m_buffer);
+   // Test the case when the string is UTF-8 encoded already in the file.
+   assertXPath(m_doc, "/document/setDocumentMetaData", "title", "mytitle\xC3\xA9\xC3\xA1\xC5\x91\xC5\xB1");

--- a/mingw-w64-libvisio/PKGBUILD
+++ b/mingw-w64-libvisio/PKGBUILD
@@ -19,11 +19,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "perl")
 depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
-source=(https://dev-www.libreoffice.org/src/${_realname}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('430a067903660bb1b97daf4b045e408a1bb75ca45e615cf05fb1a4da65fc5a8c')
+         "${MINGW_PACKAGE_PREFIX}-librevenge")
+source=(https://dev-www.libreoffice.org/src/${_realname}/${_realname}-${pkgver}.tar.xz
+        0001-libvisio-compare_dates_in_utc.patch)
+sha256sums=('fe1002d3671d53c09bc65e47ec948ec7b67e6fb112ed1cd10966e211a8bb50f9'
+            'c2c2d9e5e6f73f10b8ae2f30252bc6d36dce7a7de98c601270a9a976a8cc4bb5')
 
 prepare() {
   cd ${_realname}-${pkgver}
+
+  patch -p1 -i ${srcdir}/0001-libvisio-compare_dates_in_utc.patch
 }
 
 build() {

--- a/mingw-w64-libvisio/PKGBUILD
+++ b/mingw-w64-libvisio/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libvisio
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.1.5
-pkgrel=2
+pkgver=0.1.6
+pkgrel=1
 pkgdesc="libvisio is a library and a set of tools for reading and converting MS Visio diagram (mingw-w64)"
 arch=('any')
 license=('MPL2')
@@ -19,8 +19,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "perl")
 depends=("${MINGW_PACKAGE_PREFIX}-icu"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
-         "${MINGW_PACKAGE_PREFIX}-librevenge"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
 source=(https://dev-www.libreoffice.org/src/${_realname}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('430a067903660bb1b97daf4b045e408a1bb75ca45e615cf05fb1a4da65fc5a8c')
 


### PR DESCRIPTION
The solution to fix the test (see second commit) is not overly beautiful but it was the best I could come up with short of disabling the test or actually changing the OSs timezone.

If anybody knows a better solution I'm open for feedback.