### PR TITLE
add mono package (version 5.4.1.7)

### DIFF
--- a/mingw-w64-mono/0001-mono-5.4.1.7-fix-build.patch
+++ b/mingw-w64-mono/0001-mono-5.4.1.7-fix-build.patch
@@ -1,0 +1,22 @@
+unchanged:
+--- mono/mcs/build/rules-orig.make	2017-11-25 17:57:58.011752400 -0500
++++ mono/mcs/build/rules.make	2017-11-25 17:58:11.252185300 -0500
+@@ -85,7 +85,7 @@
+ include $(topdir)/build/platforms/$(BUILD_PLATFORM).make
+ 
+ PROFILE_PLATFORM = $(if $(PLATFORMS),$(if $(filter $(PLATFORMS),$(HOST_PLATFORM)),$(HOST_PLATFORM),$(error Unknown platform "$(HOST_PLATFORM)" for profile "$(PROFILE)")))
+-PROFILE_DIRECTORY = $(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))
++PROFILE_DIRECTORY = $(PROFILE)
+ 
+ ifdef PLATFORM_CORLIB
+ corlib = $(PLATFORM_CORLIB)
+only in patch2:
+unchanged:
+--- mono/mcs/Makefile-orig	2017-11-25 17:59:28.416265000 -0500
++++ mono/mcs/Makefile	2017-11-25 17:59:47.960113800 -0500
+@@ -1,3 +1,5 @@
++export MSYS2_ARG_CONV_EXCL=*
++
+ thisdir := .
+ 
+ SUBDIRS := build jay mcs class nunit24 ilasm tools tests errors docs packages

--- a/mingw-w64-mono/0002-mono-5.4.1.7-avoid-appending-prefix.patch
+++ b/mingw-w64-mono/0002-mono-5.4.1.7-avoid-appending-prefix.patch
@@ -1,0 +1,11 @@
+--- mono/configure-orig.ac	2017-11-25 21:15:11.709888600 -0500
++++ mono/configure.ac	2017-11-25 21:15:42.376656100 -0500
+@@ -6,8 +6,6 @@
+ 
+ AC_CONFIG_SRCDIR([README.md])
+ AC_CONFIG_MACRO_DIR([m4])
+-AC_CANONICAL_SYSTEM
+-AC_CANONICAL_HOST
+ 
+ # Gross hack to enable 'make dist' on automake 1.9+tar 1.14.
+ # The extra brackets are to foil regex-based scans.

--- a/mingw-w64-mono/0003-mono-5.4.1.7-fix-runtime.patch
+++ b/mingw-w64-mono/0003-mono-5.4.1.7-fix-runtime.patch
@@ -1,0 +1,38 @@
+--- mono/mcs/build/platforms/win32-orig.make	2017-12-14 16:48:32.033576800 -0500
++++ mono/mcs/build/platforms/win32.make	2017-12-14 18:04:29.841036900 -0500
+@@ -4,20 +4,16 @@
+ #
+ 
+ PLATFORM_MCS_FLAGS =
+-PLATFORM_RUNTIME = 
++PLATFORM_RUNTIME = $(RUNTIME)
+ PLATFORM_CORLIB = mscorlib.dll
+ PLATFORM_TEST_HARNESS_EXCLUDES = NotOnWindows,
+ 
+ EXTERNAL_MCS = mcs
+-EXTERNAL_MBAS = vbc.exe
++EXTERNAL_MBAS = mbas
+ EXTERNAL_RUNTIME = mono
+ 
+-# Disabled since it needs the SDK
+-#ILDISASM = ildasm.exe /test
+-
+-#ILDISASM = monodis.bat
+-## Gross hack
+-ILDISASM = $(topdir)/../mono/mono/dis/monodis
++#ILDISASM = monodis
++ILDISASM = false
+ 
+ PLATFORM_MAKE_CORLIB_CMP = yes
+ PLATFORM_CHANGE_SEPARATOR_CMD=tr '/' '\\\\'
+@@ -25,8 +21,8 @@
+ 
+ override CURDIR:=$(shell cygpath -m $(CURDIR))
+ 
+-hidden_prefix = 
+-hidden_suffix = .tmp
++hidden_prefix = .
++hidden_suffix = 
+ 
+ platform-check:
+ 	@:

--- a/mingw-w64-mono/PKGBUILD
+++ b/mingw-w64-mono/PKGBUILD
@@ -19,7 +19,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-ca-certificates")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
-			 "${MINGW_PACKAGE_PREFIX}-mono"
+             "${MINGW_PACKAGE_PREFIX}-mono"
              "git")
 provides=("${MINGW_PACKAGE_PREFIX}-monodoc")
 conflicts=("${MINGW_PACKAGE_PREFIX}-monodoc")
@@ -42,7 +42,7 @@ source=(${_realname}::"git+https://github.com/mono/mono#commit=${_gitcommit}"
         git+https://github.com/mono/xunit-binaries
         git+https://github.com/mono/api-doc-tools
         git+https://github.com/mono/api-snapshot
-		0001-mono-5.4.1.7-fix-build.patch
+        0001-mono-5.4.1.7-fix-build.patch
         0002-mono-5.4.1.7-avoid-appending-prefix.patch)
 sha256sums=('SKIP'
             'SKIP'

--- a/mingw-w64-mono/PKGBUILD
+++ b/mingw-w64-mono/PKGBUILD
@@ -1,0 +1,125 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=mono
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+
+_gitcommit=e66d9abbb271c3d08589c09afce4afc80de2d3b6
+pkgver=5.4.1.7
+pkgrel=1
+pkgdesc='Free implementation of the .NET platform including runtime and compiler (mingw-w64)'
+url='http://www.mono-project.com/'
+arch=('any')
+license=('GPL' 'LGPL2.1' 'MPL')
+depends=("${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-winpthreads"
+         "${MINGW_PACKAGE_PREFIX}-libgdiplus"
+         "${MINGW_PACKAGE_PREFIX}-python3"
+         "${MINGW_PACKAGE_PREFIX}-ca-certificates")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+			 "${MINGW_PACKAGE_PREFIX}-mono"
+             "git")
+provides=("${MINGW_PACKAGE_PREFIX}-monodoc")
+conflicts=("${MINGW_PACKAGE_PREFIX}-monodoc")
+source=(${_realname}::"git+https://github.com/mono/mono#commit=${_gitcommit}"
+        git+https://github.com/mono/aspnetwebstack
+        git+https://github.com/mono/Newtonsoft.Json
+        git+https://github.com/mono/cecil
+        git+https://github.com/mono/rx
+        git+https://github.com/mono/ikvm-fork
+        git+https://github.com/mono/ikdasm
+        git+https://github.com/mono/reference-assemblies
+        git+https://github.com/mono/NUnitLite
+        git+https://github.com/mono/NuGet.BuildTasks
+        git+https://github.com/mono/boringssl
+        git+https://github.com/mono/corefx
+        git+https://github.com/mono/bockbuild
+        git+https://github.com/mono/linker
+        git+https://github.com/mono/roslyn-binaries
+        git+https://github.com/mono/corert
+        git+https://github.com/mono/xunit-binaries
+        git+https://github.com/mono/api-doc-tools
+        git+https://github.com/mono/api-snapshot
+		0001-mono-5.4.1.7-fix-build.patch
+        0002-mono-5.4.1.7-avoid-appending-prefix.patch)
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            '04ab8ba5c7ad451b9e9d4bd76a4850afb790212ba73ac65e1e20f05c11de9924'
+            '772472f89f6884bf90159312a699a6d9768908c217edecd8bace08ab7ca7dceb')
+
+pkgver() {
+  cd ${srcdir}/${_realname}
+  git describe --always --tags | sed 's/^v//;s/^mono-//;s/-/./g'
+}
+
+prepare() {
+  cd ${srcdir}/${_realname}
+  git submodule init
+  git config submodule."external/aspnetwebstack".url "${srcdir}/aspnetwebstack"
+  git config submodule."external/Newtonsoft.Json".url "${srcdir}/Newtonsoft.Json"
+  git config submodule."external/cecil".url "${srcdir}/cecil"
+  git config submodule."external/rx".url "${srcdir}/rx"
+  git config submodule."external/ikvm".url "${srcdir}/ikvm-fork"
+  git config submodule."external/ikdasm".url "${srcdir}/ikdasm"
+  git config submodule."external/reference-assemblies".url "${srcdir}/reference-assemblies"
+  git config submodule."external/nunit-lite".url "${srcdir}/NUnitLite"
+  git config submodule."external/nuget-buildtasks".url "${srcdir}/NuGet.BuildTasks"
+  git config submodule."external/cecil-legacy".url "${srcdir}/cecil"
+  git config submodule."external/boringssl".url "${srcdir}/boringssl"
+  git config submodule."external/corefx".url "${srcdir}/corefx"
+  git config submodule."external/bockbuild".url "${srcdir}/bockbuild"
+  git config submodule."external/linker".url "${srcdir}/linker"
+  git config submodule."external/roslyn-binaries".url "${srcdir}/roslyn-binaries"
+  git config submodule."external/corert".url "${srcdir}/corert"
+  git config submodule."external/xunit-binaries".url "${srcdir}/xunit-binaries"
+  git config submodule."external/api-doc-tools".url "${srcdir}/api-doc-tools"
+  git config submodule."external/api-snapshot".url "${srcdir}/api-snapshot"
+  git submodule update --recursive
+  patch -Np1 -i "${srcdir}/0001-mono-5.4.1.7-fix-build.patch"
+  patch -Np1 -i "${srcdir}/0002-mono-5.4.1.7-avoid-appending-prefix.patch"
+
+  NOCONFIGURE=1 ./autogen.sh
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  cp -R ${srcdir}/${_realname}/. "${srcdir}"/build-${CARCH}
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-boehm \
+    --enable-static \
+    --enable-shared \
+    --with-mcs-docs=no \
+    --with-libgdiplus=${MINGW_PREFIX}
+  make
+  make -C mcs/jay
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+  make -C mcs/jay DESTDIR="${pkgdir}" prefix=${MINGW_PREFIX} install
+}

--- a/mingw-w64-mono/bootstrap/0001-mono-5.4.1.7-fix-build.patch
+++ b/mingw-w64-mono/bootstrap/0001-mono-5.4.1.7-fix-build.patch
@@ -1,0 +1,22 @@
+unchanged:
+--- mono/mcs/build/rules-orig.make	2017-11-25 17:57:58.011752400 -0500
++++ mono/mcs/build/rules.make	2017-11-25 17:58:11.252185300 -0500
+@@ -85,7 +85,7 @@
+ include $(topdir)/build/platforms/$(BUILD_PLATFORM).make
+ 
+ PROFILE_PLATFORM = $(if $(PLATFORMS),$(if $(filter $(PLATFORMS),$(HOST_PLATFORM)),$(HOST_PLATFORM),$(error Unknown platform "$(HOST_PLATFORM)" for profile "$(PROFILE)")))
+-PROFILE_DIRECTORY = $(PROFILE)$(if $(PROFILE_PLATFORM),-$(PROFILE_PLATFORM))
++PROFILE_DIRECTORY = $(PROFILE)
+ 
+ ifdef PLATFORM_CORLIB
+ corlib = $(PLATFORM_CORLIB)
+only in patch2:
+unchanged:
+--- mono/mcs/Makefile-orig	2017-11-25 17:59:28.416265000 -0500
++++ mono/mcs/Makefile	2017-11-25 17:59:47.960113800 -0500
+@@ -1,3 +1,5 @@
++export MSYS2_ARG_CONV_EXCL=*
++
+ thisdir := .
+ 
+ SUBDIRS := build jay mcs class nunit24 ilasm tools tests errors docs packages

--- a/mingw-w64-mono/bootstrap/0002-mono-5.4.1.7-avoid-appending-prefix.patch
+++ b/mingw-w64-mono/bootstrap/0002-mono-5.4.1.7-avoid-appending-prefix.patch
@@ -1,0 +1,11 @@
+--- mono/configure-orig.ac	2017-11-25 21:15:11.709888600 -0500
++++ mono/configure.ac	2017-11-25 21:15:42.376656100 -0500
+@@ -6,8 +6,6 @@
+ 
+ AC_CONFIG_SRCDIR([README.md])
+ AC_CONFIG_MACRO_DIR([m4])
+-AC_CANONICAL_SYSTEM
+-AC_CANONICAL_HOST
+ 
+ # Gross hack to enable 'make dist' on automake 1.9+tar 1.14.
+ # The extra brackets are to foil regex-based scans.

--- a/mingw-w64-mono/bootstrap/0003-mono-5.4.1.7-fix-runtime.patch
+++ b/mingw-w64-mono/bootstrap/0003-mono-5.4.1.7-fix-runtime.patch
@@ -1,0 +1,38 @@
+--- mono/mcs/build/platforms/win32-orig.make	2017-12-14 16:48:32.033576800 -0500
++++ mono/mcs/build/platforms/win32.make	2017-12-14 18:04:29.841036900 -0500
+@@ -4,20 +4,16 @@
+ #
+ 
+ PLATFORM_MCS_FLAGS =
+-PLATFORM_RUNTIME = 
++PLATFORM_RUNTIME = $(RUNTIME)
+ PLATFORM_CORLIB = mscorlib.dll
+ PLATFORM_TEST_HARNESS_EXCLUDES = NotOnWindows,
+ 
+ EXTERNAL_MCS = mcs
+-EXTERNAL_MBAS = vbc.exe
++EXTERNAL_MBAS = mbas
+ EXTERNAL_RUNTIME = mono
+ 
+-# Disabled since it needs the SDK
+-#ILDISASM = ildasm.exe /test
+-
+-#ILDISASM = monodis.bat
+-## Gross hack
+-ILDISASM = $(topdir)/../mono/mono/dis/monodis
++#ILDISASM = monodis
++ILDISASM = false
+ 
+ PLATFORM_MAKE_CORLIB_CMP = yes
+ PLATFORM_CHANGE_SEPARATOR_CMD=tr '/' '\\\\'
+@@ -25,8 +21,8 @@
+ 
+ override CURDIR:=$(shell cygpath -m $(CURDIR))
+ 
+-hidden_prefix = 
+-hidden_suffix = .tmp
++hidden_prefix = .
++hidden_suffix = 
+ 
+ platform-check:
+ 	@:

--- a/mingw-w64-mono/bootstrap/PKGBUILD
+++ b/mingw-w64-mono/bootstrap/PKGBUILD
@@ -19,8 +19,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-ca-certificates")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-mono"
-             "git")
+             "git"
+             "wget"
+             "curl")
 provides=("${MINGW_PACKAGE_PREFIX}-monodoc")
 conflicts=("${MINGW_PACKAGE_PREFIX}-monodoc")
 source=(${_realname}::"git+https://github.com/mono/mono#commit=${_gitcommit}"
@@ -117,6 +118,11 @@ build() {
     --enable-shared \
     --with-mcs-docs=no \
     --with-libgdiplus=${MINGW_PREFIX}
+  
+  make get-monolite-latest
+  mkdir -p ./mono/mini/lib/mono/4.5/
+  cp -R ./mcs/class/lib/monolite-win32/1050400003/* ./mono/mini/lib/mono/4.5/
+
   make
   make -C mcs/jay
 }


### PR DESCRIPTION
This adds the mono package (version 5.4.1.7), a C# and .NET Framework implementation.

Unfortunately it requires an already existing installation of mingw-w64-mono for bootstrapping; however, I've uploaded existing mingw-w64-mono packages here for installation and bootstrapping:
https://github.com/Adsun701/msys2-mingw-binary-packages

Thanks.