### PR TITLE
Upgrade potrace from 1.13 to 1.15.

### DIFF
--- a/mingw-w64-potrace/PKGBUILD
+++ b/mingw-w64-potrace/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=potrace
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.13
+pkgver=1.15
 pkgrel=1
 pkgdesc="Tool for tracing a bitmap, which means, transforming a bitmap into a smooth, scalable image (mingw-w64)"
 arch=('any')
 url='https://potrace.sourceforge.io/'
 license=('GPL2')
 source=("https://potrace.sourceforge.io/download/${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('6252438b6b6644b9b6298056b4c5de3690a1d4e862b66889abe21eecdf16b784')
+sha256sums=('a9b33904ace328340c850a01458199e0064e03ccaaa731bc869a842b1b8d529d')
 
 build() {
   cd "$srcdir/${_realname}-${pkgver}"


### PR DESCRIPTION
This pull request changes the potrace package from version 1.13 to 1.15 which contains important bug and security fixes.  Both i686 and x86_64 packages build and I could not find any issues with inkscape which is the only package dependent upon potrace.