### PR TITLE
libmicrohttpd: updated to version 0.9.57, improved

### DIFF
--- a/mingw-w64-libmicrohttpd/PKGBUILD
+++ b/mingw-w64-libmicrohttpd/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=libmicrohttpd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.55
+pkgver=0.9.57
 pkgrel=1
 pkgdesc="GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application (mingw-w64)"
 arch=('any')
@@ -16,12 +16,11 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libtool"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-curl")
-depends=("${MINGW_PACKAGE_PREFIX}-gnutls"
-         "${MINGW_PACKAGE_PREFIX}-libgcrypt")
+depends=("${MINGW_PACKAGE_PREFIX}-gnutls")
 source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz"{,.sig})
 validpgpkeys=('D8423BCB326C7907033929C7939E6BE1E29FC3CC'  # Christian Grothoff <christian@grothoff.org>
               '289FE99E138CF6D473A3F0CFBF7AC4A5EAC2BAF4') # Karlson2k (Evgeny Grin) <k2k@narod.ru>
-sha256sums=('0c1cab8dc9f2588bd3076a28f77a7f8de9560cbf2d80e53f9a8696ada80ed0f8'
+sha256sums=('dec1a76487d7e48ad74b468a888bfda1c05731f185ff950f1e363ca9d39caf4e'
             'SKIP')
 
 build() {
@@ -32,6 +31,7 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --disable-examples \
+    --enable-https \
     --enable-shared \
     --enable-static
 


### PR DESCRIPTION
* updated to version 0.9.57
* removed dependency on libgcrypt,
* enforced configure https flag to ensure that HTTPS support will be built.