### PR TITLE
tcl: minor relocation fix

### DIFF
--- a/mingw-w64-tcl/001-fix-relocation.patch
+++ b/mingw-w64-tcl/001-fix-relocation.patch
@@ -1,0 +1,20 @@
+--- tcl8.6.7/win/tclWinInit.orig.c	2017-05-08 18:06:31.000000000 +0200
++++ tcl8.6.7/win/tclWinInit.c	2017-11-29 00:00:42.764038800 +0100
+@@ -366,7 +366,7 @@
+     end = strrchr(name, '\\');
+     *end = '\0';
+     p = strrchr(name, '\\');
+-    if (p != NULL) {
++    if (p != NULL && !strcmp(p+1, "bin")) {
+ 	end = p;
+     }
+     *end = '\\';
+@@ -417,7 +417,7 @@
+     end = strrchr(name, '\\');
+     *end = '\0';
+     p = strrchr(name, '\\');
+-    if (p != NULL) {
++    if (p != NULL && !strcmp(p+1, "bin")) {
+ 	end = p;
+     }
+     *end = '\\';

--- a/mingw-w64-tcl/PKGBUILD
+++ b/mingw-w64-tcl/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tcl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=8.6.7
-pkgrel=1
+pkgrel=2
 pkgdesc="The Tcl scripting language (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -15,6 +15,7 @@ options=('staticlibs') # '!strip' 'debug')
 license=("custom")
 url="https://tcl.sourceforge.io/"
 source=("https://downloads.sourceforge.net/sourceforge/tcl/tcl${pkgver}-src.tar.gz"
+        001-fix-relocation.patch
         002-fix-forbidden-colon-in-paths.mingw.patch
         004-use-system-zlib.mingw.patch
         005-no-xc.mingw.patch
@@ -25,6 +26,7 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/tcl${pkgver}-src.tar.
         010-dont-link-shared-with--static-libgcc.patch)
 
 sha256sums=('7c6b8f84e37332423cfe5bae503440d88450da8cc1243496249faa5268026ba5'
+            'cfcf9b3816f8bb063b514ac7f63a5ba73108f27e16fdf8e8312dc5f0683083f6'
             '70bf0d8e84985f4e8ee63447ad37d5e50376eaf35ace51112761cacbbd596c4c'
             '931485d71969096c1d03c8bed24fae3922d143fe50820d913e2567492ad6ac41'
             '2b0f41f6704aa964dbfafa0a65dd5ce0ab97e82ff5cbbe2a95a2e8d644cc5550'
@@ -36,6 +38,7 @@ sha256sums=('7c6b8f84e37332423cfe5bae503440d88450da8cc1243496249faa5268026ba5'
 
 prepare() {
   cd "${srcdir}/tcl${pkgver}"
+  patch -Np1 -i "${srcdir}/001-fix-relocation.patch"
   patch -Np1 -i "${srcdir}/002-fix-forbidden-colon-in-paths.mingw.patch"
   patch -Np1 -i "${srcdir}/004-use-system-zlib.mingw.patch"
   patch -Np1 -i "${srcdir}/005-no-xc.mingw.patch"


### PR DESCRIPTION
Fixes an issues with tcl not finding the '/lib' folder if the library is not it a `/bin` subfolder