### PR TITLE
add python2-enum (version 0.4.6)

### DIFF
--- a/mingw-w64-python2-enum/PKGBUILD
+++ b/mingw-w64-python2-enum/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+ 
+_realname=enum
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
+pkgver=0.4.6
+pkgrel=1
+pkgdesc="Robust enumerated type support in Python. (mingw-w64)"
+arch=('any')
+url='http://pypi.python.org/pypi/enum/'
+license=('GPL3')
+depends=("${MINGW_PACKAGE_PREFIX}-python2")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=("https://pypi.python.org/packages/source/e/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('54e78526b166982b36884613f35a76d9a6711c49810d3ec1a05b10c9b31f938e')
+
+prepare() {  
+  cd "${srcdir}"
+  for builddir in python2-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+}
+
+build() {
+  for pver in 2; do
+    msg "Python ${pver} build for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+package() {
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE.GPL-3 "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+}


### PR DESCRIPTION
This adds the python2-enum package (version 0.4.6).

Good thing this does not conflict with python2-enum34.