### PR TITLE
wxPython classic version 3.0.3.0 git package added

### DIFF
--- a/mingw-w64-wxpython3-git/003-wxpython-3.0.2-fix-config.patch
+++ b/mingw-w64-wxpython3-git/003-wxpython-3.0.2-fix-config.patch
@@ -1,0 +1,116 @@
+--- wxPython-src-3.0.2.0/wxPython/config.py.orig	2016-09-24 11:14:37.082854400 +0300
++++ wxPython-src-3.0.2.0/wxPython/config.py	2016-09-24 11:44:18.791290600 +0300
+@@ -23,6 +23,7 @@
+ import sys, os, glob, fnmatch, tempfile
+ import subprocess
+ import re
++from sysconfig import _POSIX_BUILD
+ 
+ EGGing = 'bdist_egg' in sys.argv or 'egg_info' in sys.argv
+ if not EGGing:
+@@ -311,10 +312,15 @@
+         flags += ' --version=%s.%s' % (VER_MAJOR, VER_MINOR)
+ 
+         searchpath = os.environ["PATH"]
+-        for p in searchpath.split(':'):
++        if sys.platform == 'win32':
++          psplit = ';'
++        else:
++          psplit = ':'
++        for p in searchpath.split(psplit):
+             fp = os.path.join(p, 'wx-config')
+             if os.path.exists(fp) and os.access(fp, os.X_OK):
+                 # success
++                fp = fp.replace("\\", "/")
+                 msg("Found wx-config: " + fp)
+                 msg("    Using flags: " + flags)
+                 WX_CONFIG = fp + flags
+@@ -330,7 +336,7 @@
+ 
+ 
+ def getWxConfigValue(flag):
+-    cmd = "%s --version=%s.%s  %s" % (WX_CONFIG, VER_MAJOR, VER_MINOR, flag)
++    cmd = "%s \"%s --version=%s.%s  %s\"" % ("sh -c", WX_CONFIG, VER_MAJOR, VER_MINOR, flag)
+     value = os.popen(cmd, 'r').read()[:-1]
+     return value
+ 
+@@ -506,21 +512,24 @@
+         distutils.command.install_headers.install_headers.finalize_options(self)
+ 
+     def run(self):
+-        if os.name == 'nt':
++        if os.name == 'nt' and not "MSYSTEM" in os.environ:
+             return
+         headers = self.distribution.headers
+         if not headers:
+             return
+ 
+         root = self.root
++        inst_prefix = WXPREFIX
++        if _POSIX_BUILD and "MSYSTEM" in os.environ:
++            inst_prefix = os.popen(' '.join(['cygpath', '--unix', inst_prefix])).readline().strip()
+         #print "WXPREFIX is %s, root is %s" % (WXPREFIX, root)
+         # hack for universal builds, which append i386/ppc
+         # to the root
+-        if root is None or WXPREFIX.startswith(os.path.dirname(root)):
++        if root is None or inst_prefix.startswith(os.path.dirname(root)):
+             root = ''
+         for header, location in headers:
+             install_dir = os.path.normpath(root +
+-                                           WXPREFIX +
++                                           inst_prefix +
+                                            '/include/wx-%d.%d/wx' % (VER_MAJOR, VER_MINOR) +
+                                            location)
+             self.mkpath(install_dir)
+@@ -597,7 +606,7 @@
+ def findLib(name, libdirs):
+     name = makeLibName(name)[0]
+     if os.name == 'posix' or COMPILER == 'mingw32':
+-        lflags = getWxConfigValue('--libs')
++        lflags = getWxConfigValue('--libs all')
+         lflags = lflags.split()
+         
+         # if wx-config --libs output does not start with -L, wx is
+@@ -658,9 +667,11 @@
+     newLFLAGS = []
+     for flag in lflags:
+         if flag[:2] == '-L':
+-            libdirs.append(flag[2:])
++            libdirs.append(os.popen(' '.join(['cygpath', '-am', flag[2:]])).readline().strip())
+         elif flag[:2] == '-l':
+             libs.append(flag[2:])
++        elif flag[:1] == '/':
++            libs.append(os.popen(' '.join(['cygpath', '-am', flag])).readline().strip())
+         else:
+             newLFLAGS.append(flag)
+     return removeDuplicates(newLFLAGS) 
+@@ -856,14 +867,16 @@
+         # gcc needs '.res' and '.rc' compiled to object files !!!
+         try:
+             #self.spawn(["windres", "-i", src, "-o", obj])
+-            self.spawn(["windres", "-i", src, "-o", obj] +
+-                       [arg for arg in cc_args if arg.startswith("-I")] )
++            windresflags = getWxConfigValue('--rescomp')
++            windresflags = windresflags.split()
++            self.spawn(['sh', '-c', ' '.join(windresflags + ["-i", src, "-o", obj] +
++                       [arg for arg in cc_args if arg.startswith("-I")]).replace("\\", "/")])
+         except DistutilsExecError, msg:
+             raise CompileError, msg
+     else: # for other files use the C-compiler
+         try:
+-            self.spawn(self.compiler_so + cc_args + [src, '-o', obj] +
+-                       extra_postargs)
++            self.spawn(['sh', '-c', ' '.join(self.compiler_so + cc_args + [src, '-o', obj] +
++                       extra_postargs).replace("\\", "/")])
+         except DistutilsExecError, msg:
+             raise CompileError, msg
+ 
+@@ -1039,7 +1052,7 @@
+     else:
+         cflags.append('-O3')
+ 
+-    lflags = getWxConfigValue('--libs')
++    lflags = getWxConfigValue('--libs all')
+     MONOLITHIC = (lflags.find("_xrc") == -1)
+     lflags = lflags.split()
+ 

--- a/mingw-w64-wxpython3-git/004-wxpython-3.0.2-fix-cast-error.patch
+++ b/mingw-w64-wxpython3-git/004-wxpython-3.0.2-fix-cast-error.patch
@@ -1,0 +1,11 @@
+--- wxPython-src-3.0.1.1/wxPython/src/helpers.cpp.orig	2014-09-30 15:35:54.001641700 +0400
++++ wxPython-src-3.0.1.1/wxPython/src/helpers.cpp	2014-09-30 15:40:54.393928800 +0400
+@@ -2152,7 +2152,7 @@
+ long wxPyGetWinHandle(wxWindow* win) {
+ 
+ #ifdef __WXMSW__
+-    return (long)win->GetHandle();
++    return (intptr_t)win->GetHandle();
+ #endif
+ 
+ #if defined(__WXGTK__) || defined(__WXX11__)

--- a/mingw-w64-wxpython3-git/PKGBUILD
+++ b/mingw-w64-wxpython3-git/PKGBUILD
@@ -1,0 +1,97 @@
+####
+#
+# Based on packages found at these URLs
+#     https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-wxPython
+#     https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-wxWidgets
+#
+# Maintainer: Tim S <stahta01@gmail.com>
+#
+####
+
+# Packages that are assumed to be installed when building this package.
+#   pacman -S --needed --asdeps base-devel mingw-w64-i686-toolchain mingw-w64-x86_64-toolchain
+
+
+_realname=wxpython3
+_namesuffix="-git"
+_py_foldername=wxPython
+_wx_foldername=wxWidgets
+_wxver=3.0.3
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuffix}"
+pkgbase=mingw-w64-${_realname}${_namesuffix}
+pkgver=3.0.3.0.r5369.g8960e7ee0b
+pkgrel=1
+pkgdesc="A wxWidgets GUI toolkit for Python (mingw-w64)"
+arch=('any')
+license=("custom:wxWindows")
+url="https://www.wxwidgets.org/"
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+  "git"
+)
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-python2"
+  "${MINGW_PACKAGE_PREFIX}-wxWidgets"
+)
+conflicts=("${MINGW_PACKAGE_PREFIX}-wxPython" "${MINGW_PACKAGE_PREFIX}-${_realname}")
+options=('strip' 'staticlibs' 'buildflags')
+source=("git+https://github.com/wxWidgets/wxPython.git"
+  https://github.com/wxWidgets/wxWidgets/releases/download/v${_wxver}/wxWidgets-${_wxver}.tar.bz2
+  "003-wxpython-3.0.2-fix-config.patch"
+  "004-wxpython-3.0.2-fix-cast-error.patch"
+)
+sha256sums=('SKIP'
+            '08c8033f48ec1b23520f036cde37b5ae925a6a65f137ded665633ca159b9307b'
+            '61ca97f814b85b1274e751c694f9e3adc31ce1e22c56c9ca9c59e0337a36fef5'
+            'd7c4de5594149d2bba4a0ceb95d6a6a0c3c0e43ab9e876dce22440ccaad3b5f0')
+
+prepare() {
+  cd "${srcdir}"/${_py_foldername}
+  # revert changes done by wxpython patch files
+  git checkout -- config.py
+  git checkout -- src/helpers.cpp
+  patch -p2 -i "${srcdir}"/003-wxpython-3.0.2-fix-config.patch
+  patch -p2 -i "${srcdir}"/004-wxpython-3.0.2-fix-cast-error.patch
+
+  # Make sure scripts use python2
+  sed -e "s|#![ ]*/usr/bin/python$|#!/usr/bin/python2|" \
+      -e "s|#![ ]*/usr/bin/env python$|#!/usr/bin/env python2|" \
+      -e "s|#![ ]*/bin/env python$|#!/usr/bin/env python2|" \
+      -i $(find . -name '*.py')
+  # search and replace in files without file extensions
+  sed -e "s|#![ ]*/usr/bin/python$|#!/usr/bin/python2|" \
+      -e "s|#![ ]*/usr/bin/env python$|#!/usr/bin/env python2|" \
+      -e "s|#![ ]*/bin/env python$|#!/usr/bin/env python2|" \
+      -i $(find . -type f ! -name '*.*')
+}
+
+pkgver() {
+  if [[ ! -f "${srcdir}"/${_py_foldername}/cfg_version.py ]]; then
+    printf "0"
+  else
+    cd "${srcdir}"/${_py_foldername}
+    local   major=$(head -n 40 cfg_version.py | sed -e 's:#.*$::g' | grep 'VER_MAJOR'   | sed -e 's/"//g' | sed -e 's:^.*=::g' | tr -d '[:space:]')
+    local   minor=$(head -n 40 cfg_version.py | sed -e 's:#.*$::g' | grep 'VER_MINOR'   | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
+    local release=$(head -n 40 cfg_version.py | sed -e 's:#.*$::g' | grep 'VER_RELEASE' | sed -e 's/.* //' | tr '\n' '.' | sed 's/.$/\n/')
+    local  subrel=$(head -n 40 cfg_version.py | sed -e 's:#.*$::g' | grep 'VER_SUBREL'  | sed -e 's/"//g' | sed -e 's:^.*=::g' | tr -d '[:space:]')
+    local    flag=$(head -n 40 cfg_version.py | sed -e 's:#.*$::g' | grep 'VER_FLAGS'   | sed -e 's/"//g' | sed -e 's:^.*=::g' | tr -d '[:space:]')
+    printf "%s.%s.%s.%s%s.r%s.g%s" "$major" "$minor" "$release" "$subrel" "$flag" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  fi
+}
+
+build() {
+  cd "${srcdir}"/${_py_foldername}
+  export PYTHON=${MINGW_PREFIX}/bin/python2
+  export WXWIN="${srcdir}"/${_wx_foldername}-${_wxver}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-headers=;-install-data=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py WXPORT=msw BUILD_ACTIVEX=0 UNICODE=1 COMPILER=mingw32 build
+}
+
+package() {
+  cd "${srcdir}"/${_py_foldername}
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-headers=;-install-data=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py NO_HEADERS=0 WXPORT=msw BUILD_ACTIVEX=0 UNICODE=1 COMPILER=mingw32 \
+    install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+
+  install -D -m644 "${srcdir}"/${_wx_foldername}-${_wxver}/docs/licence.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/${_py_foldername}/LICENSE"
+}


### PR DESCRIPTION
wxPython is doing a complete build change for version 4 also called Phoenix.

I thought leaving wxPython for the version 4 would be in keeping with MSys2 package naming.
The current wxPython is broken, I did *not* find out till I tried to use it in learning python.
Sorry about that, since I pull requested wxWidgets 3.0.3 that broke it.

I am going back to trying to fix plplot once more. Then, after that trying to update wxPython to version 4.

Tim S.
