### PR TITLE
python2: Restore WinXP support

### DIFF
--- a/mingw-w64-python2/2700-cygpty-isatty-disable-readline.patch
+++ b/mingw-w64-python2/2700-cygpty-isatty-disable-readline.patch
@@ -53,7 +53,7 @@ diff -Nur Python-2.7.13.orig/Makefile.pre.in Python-2.7.13/Makefile.pre.in
  CFLAGSFORSHARED=@CFLAGSFORSHARED@
  # C flags used for building the interpreter object files
 -PY_CFLAGS=	$(CFLAGS) $(CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
-+PY_CFLAGS=	$(CFLAGS) $(CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE -D_WIN32_WINNT=0x0600
++PY_CFLAGS=	$(CFLAGS) $(CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE -D_WIN32_WINNT=0x0600 -DUSE_DYNFILEID
  
  # ; on Windows otherwise :
  DELIM=		@DELIM@
@@ -409,7 +409,7 @@ diff -Nur Python-2.7.13.orig/setup.py Python-2.7.13/setup.py
 +             "_io/iobase.c", "_io/_iomodule.c", "_io/stringio.c", "_io/textio.c",
 +             "../Python/iscygpty.c"],
 +             depends=["_io/_iomodule.h"], include_dirs=["Modules/_io"],
-+             extra_compile_args=["-D_WIN32_WINNT=0x0600"]))
++             extra_compile_args=["-D_WIN32_WINNT=0x0600", "-DUSE_DYNFILEID"]))
          # _functools
          # On win32 host(mingw build in MSYS environment) show that site.py
          # fail to load if some modules are not build-in:
@@ -423,7 +423,7 @@ diff -Nur Python-2.7.13.orig/setup.py Python-2.7.13/setup.py
                                     extra_link_args=readline_extra_link_args,
 -                                   libraries=readline_libs) )
 +                                   libraries=readline_libs,
-+                                   extra_compile_args=["-D_WIN32_WINNT=0x0600"]) )
++                                   extra_compile_args=["-D_WIN32_WINNT=0x0600", "-DUSE_DYNFILEID"]) )
          else:
              missing.append('readline')
  

--- a/mingw-w64-python2/PKGBUILD
+++ b/mingw-w64-python2/PKGBUILD
@@ -6,7 +6,7 @@ _realname=python2
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.7.14
-pkgrel=2
+pkgrel=3
 _pybasever=${pkgver%.*}
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
@@ -460,5 +460,5 @@ sha256sums=('71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66'
             'f1cfeb815277166384632bd9730fe89f64dc5da7ee09c13a0b3515da08b08847'
             'be5379525508e0bc0c374f20a669c38c93986e24a07696d2a83a9552cc085b8d'
             'aa623bd762f33f2724b40a55bd2d2c4100b47b81586ae2f5d6b430ab4646f02c'
-            '2f5044f0a61b5de400479d19cbc4e622f32a046f5eb360229793a4be76fe08fd'
+            '2874642706ef2360960c254a318da6be72a83e3f4c9e0cd8d411a66c0864d911'
             'da2353b0d62d3511e44f27696cea0d4b7540b77cedffa5840fe202ae57e09890')


### PR DESCRIPTION
Set USE_DYNFILEID for ptycheck so it dynamically enables pty checking only if the API is available.

Building still requires Vista+

Context: https://github.com/Alexpux/MINGW-packages/pull/2806#issuecomment-348658740