### PR TITLE
add python-pyamg (version 3.3.2)

### DIFF
--- a/mingw-w64-python-pyamg/PKGBUILD
+++ b/mingw-w64-python-pyamg/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=pyamg
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=3.3.2
+pkgrel=1
+pkgdesc="PyAMG: Algebraic Multigrid Solvers in Python (mingw-w64)"
+arch=('any')
+license=('MIT')
+url="https://github.com/pyamg/pyamg"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/p/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('ccebb1b0379cab87b493e8e5fc5388c89b9738445ae10e5adfebe6f48078ca27')
+
+prepare() {
+  cd ${srcdir}
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}
+
+build() {
+  cd "${srcdir}"
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+package_python3-pyamg() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+}
+
+package_python2-pyamg() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+}
+
+package_mingw-w64-i686-python2-pyamg() {
+  package_python2-pyamg
+}
+
+package_mingw-w64-i686-python3-pyamg() {
+  package_python3-pyamg
+}
+
+package_mingw-w64-x86_64-python2-pyamg() {
+  package_python2-pyamg
+}
+
+package_mingw-w64-x86_64-python3-pyamg() {
+  package_python3-pyamg
+}

--- a/mingw-w64-python-pyamg/PKGBUILD
+++ b/mingw-w64-python-pyamg/PKGBUILD
@@ -34,7 +34,9 @@ build() {
 }
 
 package_python3-pyamg() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-scipy"
+           "${MINGW_PACKAGE_PREFIX}-python3-numpy")
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
@@ -44,7 +46,9 @@ package_python3-pyamg() {
 }
 
 package_python2-pyamg() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-scipy"
+           "${MINGW_PACKAGE_PREFIX}-python2-numpy")
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 


### PR DESCRIPTION
This adds python-pyamg, Algebraic Multigrid Solvers in Python (version 3.3.2).