### PR TITLE
libmicrohttpd: updated to v0.9.58

### DIFF
--- a/mingw-w64-libmicrohttpd/PKGBUILD
+++ b/mingw-w64-libmicrohttpd/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=libmicrohttpd
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.9.57
+pkgver=0.9.58
 pkgrel=1
 pkgdesc="GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application (mingw-w64)"
 arch=('any')
@@ -14,13 +14,13 @@ url="https://www.gnu.org/software/libmicrohttpd"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libtool"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-curl")
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-curl")
 depends=("${MINGW_PACKAGE_PREFIX}-gnutls")
 source=("https://ftp.gnu.org/gnu/libmicrohttpd/${_realname}-${pkgver}.tar.gz"{,.sig})
 validpgpkeys=('D8423BCB326C7907033929C7939E6BE1E29FC3CC'  # Christian Grothoff <christian@grothoff.org>
               '289FE99E138CF6D473A3F0CFBF7AC4A5EAC2BAF4') # Karlson2k (Evgeny Grin) <k2k@narod.ru>
-sha256sums=('dec1a76487d7e48ad74b468a888bfda1c05731f185ff950f1e363ca9d39caf4e'
+sha256sums=('7a11e1376c62ff95bd6d2dfe6799d57ac7cdbcb32f70bfbd5e47c71f373e01f3'
             'SKIP')
 
 build() {


### PR DESCRIPTION
GNU libmicrohttpd updated to latest upstream version 0.9.58

Like in Arch repo, curl was moved to checkdepends, because it is required only for tests.