### PR TITLE
zimg: update to 2.6.3 and remove git prefix from winpthreads dependency

### DIFF
--- a/mingw-w64-zimg/PKGBUILD
+++ b/mingw-w64-zimg/PKGBUILD
@@ -3,17 +3,17 @@
 _realname=zimg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.6.1
+pkgver=2.6.3
 pkgrel=1
 pkgdesc="Scaling, colorspace conversion, and dithering library (mingw-w64)"
 arch=('any')
 url="https://github.com/sekrit-twc/zimg"
 license=("WTFPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config" "tar")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-winpthreads-git")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-winpthreads")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/sekrit-twc/${_realname}/archive/release-${pkgver}.tar.gz")
 noextract=("${_realname}-${pkgver}.tar.gz")
-sha256sums=('3f380898b4bf71c20cfedf9b2f87ba30612520c28b57c344c538dd56b1a5ea62')
+sha256sums=('a701e9ffbe3ad379e84d8720cf6220afb9c6946d761048fb77544325870cc2cb')
 
 prepare(){
   tar -xzvf "${srcdir}/${_realname}-${pkgver}.tar.gz"


### PR DESCRIPTION
This updates zimg to 2.6.3 and removes the git specificity from winpthreads dependency.