### PR TITLE
make: gettext is a runtime dependency

### DIFF
--- a/mingw-w64-make/PKGBUILD
+++ b/mingw-w64-make/PKGBUILD
@@ -5,13 +5,13 @@ _autotools=yes
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=4.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU make utility to maintain groups of programs (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/make"
 license=('GPL3')
 groups=("${MINGW_PACKAGE_PREFIX}-toolchain")
-depends=()
+depends=("${MINGW_PACKAGE_PREFIX}-gettext")
 makedepends=('wget')
 source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.bz2"
         'make-getopt.patch'


### PR DESCRIPTION
Closes Alexpux/MINGW-packages#2233, Alexpux/MSYS2-packages#828,
Alexpux/MSYS2-packages#842.