### PR TITLE
geoip: update to 1.6.11

### DIFF
--- a/mingw-w64-geoip/PKGBUILD
+++ b/mingw-w64-geoip/PKGBUILD
@@ -1,12 +1,13 @@
 # Maintainer: Mateusz Mikuła <mati865@gmail.com>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=geoip
 _pkgname=geoip-api-c
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.6.9
+pkgver=1.6.11
 pkgrel=1
-pkgdesc="GeoIP Legacy C API (mingw-w64)"
+pkgdesc="Non-DNS IP-to-country resolver C library & utils (mingw-w64)"
 arch=('any')
 url="https://www.maxmind.com/app/c"
 license=('LGPL')
@@ -16,11 +17,11 @@ makedepends=('autoconf'
              'libtool')
 options=('!emptydirs')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/maxmind/${_pkgname}/archive/v${pkgver}.tar.gz)
-sha256sums=('05468adbb6bdbddc588ee6f0df990f47b1b24d278519c35d59f7a8058a2a9825')
+sha256sums=('8859cb7c9cb63e77f4aedb40a4622024359b956b251aba46b255acbe190c34e0')
 
 prepare(){
   cd ${_pkgname}-${pkgver}
-  autoreconf -vfi
+  ./bootstrap
 }
 
 build() {


### PR DESCRIPTION
This updates geoip to 1.6.11. Previously the version of geoip was 1.6.9.