### PR TITLE
Add suitesparse dependency to gegl

### DIFF
--- a/mingw-w64-gegl/PKGBUILD
+++ b/mingw-w64-gegl/PKGBUILD
@@ -43,7 +43,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-babl"
          "${MINGW_PACKAGE_PREFIX}-lensfun"
          "${MINGW_PACKAGE_PREFIX}-openexr"
          "${MINGW_PACKAGE_PREFIX}-pango"
-         "${MINGW_PACKAGE_PREFIX}-SDL")
+         "${MINGW_PACKAGE_PREFIX}-SDL"
+         "${MINGW_PACKAGE_PREFIX}-suitesparse")
 #optdepends=("${MINGW_PACKAGE_PREFIX}-openexr: for using the openexr plugin"
 #            "${MINGW_PACKAGE_PREFIX}-ffmpeg: for using the ffmpeg plugin"
 #            "${MINGW_PACKAGE_PREFIX}-librsvg: for using the svg plugin"


### PR DESCRIPTION
$ pacman -S mingw-w64-i686-gimp
...
$ gimp-2.9.exe
GEGL-Message: Module 'M:\mingw32\lib\gegl-0.3\matting-levin.dll' load error: 'M:\mingw32\lib\gegl-0.3\matting-levin.dll': The specified module could not be found.
...

Suitesparse is present on the main build system, so GEGL gets built with --with-umfpack. Thus if suitesparse is not manually installed by the user, matting-levin.dll has missing imports from libumfpack.dll, rendering the 'gegl:matting-levin' operation present but unusable.