### PR TITLE
add a minor patch to gtkglext to fix building natively with makepkg-mingw

### DIFF
--- a/mingw-w64-gtkglext/PKGBUILD
+++ b/mingw-w64-gtkglext/PKGBUILD
@@ -30,6 +30,10 @@ build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   cp -r "${srcdir}/gtkglext-${pkgver}" "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
+
+  # an argument passed to glib-mkenums starts with a c++ comment
+  export MSYS2_ARG_CONV_EXCL="/*"
+
   ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \


### PR DESCRIPTION
Someone on IRC ran into this one while building packages on msys2 in Windows.
Basically `glib-mkenums --fprod "/* foo */"` was emitting `C:/mingw64/* foo */`, which of course confused the compiler. A newline before the comment, borrowed from the next Makefile rule, gets makepkg-mingw to pass for me.

This problem already has a fix in gtkglext git master, see [GNOME bug 608034](https://bugzilla.gnome.org/show_bug.cgi?id=608034), but this particular package looks unmaintained for a while.

I leave it to the maintainers to decide if this stop-gap solution is the right thing.