### PR TITLE
rebuild yaml-cpp due to boost update

### DIFF
--- a/mingw-w64-yaml-cpp/PKGBUILD
+++ b/mingw-w64-yaml-cpp/PKGBUILD
@@ -4,7 +4,7 @@ _realname=yaml-cpp
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="A YAML parser and emitter in C++ matching the YAML 1.2 spec (mingw-w64)"
 arch=('any')
 url="https://github.com/jbeder/yaml-cpp"
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/jbeder/yaml-cpp/archive/release-${pkgver}.tar.gz
         mingw-install-pkgconfig.patch)
-sha256sums=('ac50a27a201d16dc69a881b80ad39a7be66c4d755eda1f76c3a68781b922af8f'
+sha256sums=('3492d9c1f4319dfd5588f60caed7cec3f030f7984386c11ed4b39f8e3316d763'
             '858915b03a300145a466bd68d3f95ff80738f0821f9bba5563b4fadb2dc4fffb')
 
 prepare() {


### PR DESCRIPTION
Not rebuilding yaml-cpp since the latest boost update caused warnings during linking in an application of mine: https://github.com/carrotIndustries/horizon/issues/46

We also need to update the checksum, since it github recompressed the tarball. A tarball with the original checksum is available at http://pkgs.fedoraproject.org/repo/pkgs/yaml-cpp/yaml-cpp-0.5.3.tar.gz/64200ca0bf5e0af065804d8d3e8f6d42/yaml-cpp-0.5.3.tar.gz  The contents haven't changed.