### PR TITLE
yaml-cpp release-0.5.3.tar.gz sha256 changed

### DIFF
--- a/mingw-w64-yaml-cpp/PKGBUILD
+++ b/mingw-w64-yaml-cpp/PKGBUILD
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/jbeder/yaml-cpp/archive/release-${pkgver}.tar.gz
         mingw-install-pkgconfig.patch)
-sha256sums=('ac50a27a201d16dc69a881b80ad39a7be66c4d755eda1f76c3a68781b922af8f'
+sha256sums=('3492d9c1f4319dfd5588f60caed7cec3f030f7984386c11ed4b39f8e3316d763'
             '858915b03a300145a466bd68d3f95ff80738f0821f9bba5563b4fadb2dc4fffb')
 
 prepare() {


### PR DESCRIPTION
Possibly due to github recompressing the source code within the last two years.