### PR TITLE
libgdiplus: update to 5.6

### DIFF
--- a/mingw-w64-libgdiplus/PKGBUILD
+++ b/mingw-w64-libgdiplus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgdiplus
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=5.4
+pkgver=5.6
 pkgrel=1
 pkgdesc="An Open Source Implementation of the GDI+ API (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/mono/${_realname}/a
         "0002-libgdiplus-5.4-fix-conflicting-types-error.patch"
         "0003-libgdiplus-5.4-fix-font-windows-error.patch"
         "0004-libgdiplus-5.4-disable-tests.patch")
-sha256sums=('ce31da0c6952c8fd160813dfa9bf4a9a871bfe7284e9e3abff9a8ee689acfe58'
+sha256sums=('6a75e4a476695cd6a1475fd6b989423ecf73978fd757673669771d8a6e13f756'
             '07ab03de3c86f18a9871794f6dd41de8852b42994e7845c220ba9ad8713f0e12'
             '0fc780dd34c01623a6910d6920d17549347b80351ed1baae05ad64f65c475dd4'
             '2835964746038b10f08f3530c450d7380c0b545b1a5c4884b8f513d7e6c0f809'


### PR DESCRIPTION
This updates libgdiplus to latest version 5.6.