### PR TITLE
add mono-basic package (version 4.6)

### DIFF
--- a/mingw-w64-mono-basic/0001-mono-basic-4.6-fix-slash-vs-hyphen.patch
+++ b/mingw-w64-mono-basic/0001-mono-basic-4.6-fix-slash-vs-hyphen.patch
@@ -1,0 +1,136 @@
+--- mono-basic-4.6/build/config-default-orig.make	2018-01-01 19:18:16.865936300 -0500
++++ mono-basic-4.6/build/config-default.make	2018-01-01 19:18:38.583791500 -0500
+@@ -11,7 +11,7 @@
+ MCS_FLAGS = $(PLATFORM_DEBUG_FLAGS)
+ VBNC_FLAGS = $(PLATFORM_DEBUG_FLAGS)
+ MBAS_FLAGS = $(PLATFORM_DEBUG_FLAGS)
+-LIBRARY_FLAGS = /noconfig
++LIBRARY_FLAGS = -noconfig
+ CFLAGS = -g -O2
+ prefix = /usr/local
+ exec_prefix = $(prefix)
+--- mono-basic-4.6/build/library-orig.make	2018-01-01 19:19:48.208772300 -0500
++++ mono-basic-4.6/build/library.make	2018-01-01 19:22:47.661378600 -0500
+@@ -146,14 +146,14 @@
+ # install the DLLs.
+ 
+ ifndef RUNTIME_HAS_CONSISTENT_GACDIR
+-gacdir_flag = /gacdir $(GACDIR)
++gacdir_flag = -gacdir $(GACDIR)
+ endif
+ 
+ install-local:
+-	$(GACUTIL) /i $(the_lib) /f $(gacdir_flag) /root $(GACROOT) /package $(FRAMEWORK_VERSION)
++	$(GACUTIL) -i $(the_lib) -f $(gacdir_flag) -root $(GACROOT) -package $(FRAMEWORK_VERSION)
+ 
+ uninstall-local:
+-	-$(GACUTIL) /u $(LIBRARY_NAME:.dll=) $(gacdir_flag) /root $(GACROOT) /package $(FRAMEWORK_VERSION)
++	-$(GACUTIL) -u $(LIBRARY_NAME:.dll=) $(gacdir_flag) -root $(GACROOT) -package $(FRAMEWORK_VERSION)
+ 
+ endif
+ endif
+@@ -191,13 +191,13 @@
+ ## FIXME: i18n problem in the 'sed' command below
+ run-test-lib: test-local
+ 	ok=:; \
+-	$(TEST_RUNTIME) $(TEST_HARNESS) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) /output:TestResult-$(PROFILE).log /exclude:NotWorking,ValueAdd,CAS,InetAccess /xml:TestResult-$(PROFILE).xml $(test_assemblies) || ok=false; \
++	$(TEST_RUNTIME) $(TEST_HARNESS) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_FLAGS) -output:TestResult-$(PROFILE).log -exclude:NotWorking,ValueAdd,CAS,InetAccess -xml:TestResult-$(PROFILE).xml $(test_assemblies) || ok=false; \
+ 	sed '1,/^Tests run: /d' TestResult-$(PROFILE).log; \
+ 	$$ok
+ 
+ run-test-ondotnet-lib: test-local
+ 	ok=:; \
+-	$(TEST_HARNESS) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_ONDOTNET_FLAGS) /exclude=NotDotNet,CAS /output:TestResult-ondotnet-$(PROFILE).log /xml:TestResult-ondotnet-$(PROFILE).xml $(test_assemblies) || ok=false; \
++	$(TEST_HARNESS) $(TEST_HARNESS_FLAGS) $(LOCAL_TEST_HARNESS_ONDOTNET_FLAGS) -exclude=NotDotNet,CAS -output:TestResult-ondotnet-$(PROFILE).log -xml:TestResult-ondotnet-$(PROFILE).xml $(test_assemblies) || ok=false; \
+ 	sed '1,/^Tests run: /d' TestResult-ondotnet-$(PROFILE).log; \
+ 	$$ok
+ endif
+@@ -285,7 +285,7 @@
+ 
+ -include $(makefrag)
+ 
+-# for now, don't give any /lib flags or set MONO_PATH, since we
++# for now, don't give any -lib flags or set MONO_PATH, since we
+ # give a full path to the assembly.
+ 
+ ifdef HAVE_CS_TESTS
+--- mono-basic-4.6/build/platforms/win32-orig.make	2018-01-01 19:24:11.786180200 -0500
++++ mono-basic-4.6/build/platforms/win32.make	2018-01-01 19:25:36.761628100 -0500
+@@ -3,25 +3,19 @@
+ # Win32 platform-specific makefile rules.
+ #
+ 
+-PLATFORM_DEBUG_FLAGS = /debug+ /debug:full
+-PLATFORM_MCS_FLAGS = /nologo /optimize
+-PLATFORM_RUNTIME = 
++PLATFORM_DEBUG_FLAGS = -debug+ -debug:full
++PLATFORM_MCS_FLAGS = -nologo -optimize
++PLATFORM_RUNTIME = $(RUNTIME)
+ PLATFORM_CORLIB = mscorlib.dll
+ 
+ EXTERNAL_MCS = mcs
+-EXTERNAL_MBAS = vbc.exe
+-EXTERNAL_RUNTIME =
++EXTERNAL_MBAS = mbas
++EXTERNAL_RUNTIME = mono
+ 
+-# Disabled since it needs the SDK
+-#RESGEN = resgen.exe
+-#ILDISASM = ildasm.exe /test
+ RESGEN = MONO_PATH="$(topdir)/class/lib/$(PROFILE)$(PLATFORM_PATH_SEPARATOR)$$MONO_PATH" $(INTERNAL_RESGEN)
++#ILDISASM = monodis
++ILDISASM = false
+ 
+-#ILDISASM = monodis.bat
+-## Gross hack
+-ILDISASM = $(topdir)/../mono/mono/dis/monodis
+-
+-PLATFORM_MAKE_CORLIB_CMP = yes
+ PLATFORM_CHANGE_SEPARATOR_CMD=tr '/' '\\\\'
+ PLATFORM_PATH_SEPARATOR = ;
+ 
+--- mono-basic-4.6/build/profiles/net_4_5-orig.make	2018-01-01 19:51:30.273558000 -0500
++++ mono-basic-4.6/build/profiles/net_4_5.make	2018-01-01 19:51:33.557954500 -0500
+@@ -3,5 +3,5 @@
+ profile-check:
+ 	@:
+ 
+-PROFILE_VBNC_FLAGS = /sdkpath:$(prefix)/lib/mono/4.5/
++PROFILE_VBNC_FLAGS = -sdkpath:$(prefix)/lib/mono/4.5/
+ FRAMEWORK_VERSION = 4.5
+--- mono-basic-4.6/tools/extract-source/Makefile-orig	2018-01-01 19:55:48.503068800 -0500
++++ mono-basic-4.6/tools/extract-source/Makefile	2018-01-01 19:55:57.409883800 -0500
+@@ -5,6 +5,6 @@
+ NO_INSTALL = yes
+ 
+ PROGRAM = extract-source.exe
+-PROGRAM_COMPILE = $(BOOT_COMPILE) -r:System.Xml.dll -noconfig -define:_MYTYPE=\"Empty\" /novbruntimeref /r:../../class/lib/bootstrap/Microsoft.VisualBasic.dll
++PROGRAM_COMPILE = $(BOOT_COMPILE) -r:System.Xml.dll -noconfig -define:_MYTYPE=\"Empty\" -novbruntimeref -r:../../class/lib/bootstrap/Microsoft.VisualBasic.dll
+ 
+ include ../../build/executable.make
+--- mono-basic-4.6/vbruntime/Test/Makefile-orig	2018-01-01 19:15:45.270402800 -0500
++++ mono-basic-4.6/vbruntime/Test/Makefile	2018-01-01 19:16:09.708131000 -0500
+@@ -66,7 +66,7 @@
+ 	$(CSCOMPILER) "-out:bin/2010VB_test_CS.dll" @2010VB_test_CS.dll.rsp @2010VB_test_CS.dll.sources -lib:bin $(CSDEFINES)
+ 	
+ test-vb: test-first 2010VB_test_VB.dll.sources
+-	$(VBNC) -out:bin/2010VB_test_VB.dll @2010VB_test_VB.dll.rsp /d:NET_VER=2.0 @2010VB_test_VB.dll.sources /libpath:bin
++	$(VBNC) -out:bin/2010VB_test_VB.dll @2010VB_test_VB.dll.rsp -d:NET_VER=2.0 @2010VB_test_VB.dll.sources -libpath:bin
+ 
+ test-local: init run-test-cs run-test-vb
+ 
+--- mono-basic-4.6/vbnc/vbnc/Makefile-orig	2018-01-01 20:03:56.360843100 -0500
++++ mono-basic-4.6/vbnc/vbnc/Makefile	2018-01-01 20:04:19.762415300 -0500
+@@ -2,10 +2,10 @@
+ SUBDIRS = tests
+ include ../../build/rules.make
+ 
+-LOCAL_VBNC_FLAGS = @vbnc.exe.rsp $(EXTERNAL_VBNC_FLAGS) /r:../../class/lib/$(PROFILE)/Mono.Cecil.VB.dll
++LOCAL_VBNC_FLAGS = @vbnc.exe.rsp $(EXTERNAL_VBNC_FLAGS) -r:../../class/lib/$(PROFILE)/Mono.Cecil.VB.dll
+ 
+ PROGRAM = $(topdir)/class/lib/$(PROFILE)/vbnc.exe
+-PROGRAM_COMPILE = $(BOOT_COMPILE) /novbruntimeref /r:../../class/lib/bootstrap/Microsoft.VisualBasic.dll
++PROGRAM_COMPILE = $(BOOT_COMPILE) -novbruntimeref -r:../../class/lib/bootstrap/Microsoft.VisualBasic.dll
+ 
+ include ../../build/executable.make
+ 

--- a/mingw-w64-mono-basic/PKGBUILD
+++ b/mingw-w64-mono-basic/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=mono-basic
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.6
+pkgrel=1
+pkgdesc="Mono Visual Basic.NET compiler (mingw-w64)"
+arch=('any')
+url="http://www.mono-project.com/"
+license=('LGPL')
+depends=("${MINGW_PACKAGE_PREFIX}-mono")
+source=("${_realname}-${pkgver}.tar.xz"::"http://download.mono-project.com/sources/${_realname}/${_realname}-${pkgver}.tar.bz2"
+        "0001-mono-basic-4.6-fix-slash-vs-hyphen.patch")
+sha256sums=('303d79f73ae9d6120ef12ebeaf2ec67fda96256801e3bf305c46f8787a751e8f'
+            '5fa7bde4d52d262215b3bcf36ea4d23b879564b58c8fb48bab7f7186dd58e360')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/0001-mono-basic-4.6-fix-slash-vs-hyphen.patch"
+}
+
+build() {
+  # get rid of that .wapi errors
+  export MONO_SHARED_DIR="${srcdir}/weird-${CARCH}"
+  mkdir -p "${MONO_SHARED_DIR}"
+  
+  cd "${srcdir}"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  cp -R "${srcdir}"/${_realname}-${pkgver}/. "${srcdir}"/build-${CARCH}
+  CC=${MINGW_PREFIX}/bin/gcc.exe \
+  CSC=${MINGW_PREFIX}/bin/mcs \
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make DESTDIR="${pkgdir}" install
+  
+  sed -e "s|/sdkpath|-sdkpath|g" -i "${pkgdir}${MINGW_PREFIX}/bin/vbnc2"
+}


### PR DESCRIPTION
This adds mono-basic (version 4.6), mono's implementation of the VB.NET compiler.

This currently will fail the tests because my updated version of mono (which fixes the bin scripts) has not been uploaded to the repository yet.