### PR TITLE
fmt: update to 4.1.0 and remove failing tests

### DIFF
--- a/mingw-w64-fmt/0001-fmt-4.1.0-fix-runtime-installation.patch
+++ b/mingw-w64-fmt/0001-fmt-4.1.0-fix-runtime-installation.patch
@@ -1,0 +1,25 @@
+--- fmt-4.1.0/fmt/CMakeLists.txt.orig	2018-01-07 09:39:25.325245000 -0500
++++ fmt-4.1.0/fmt/CMakeLists.txt	2018-01-07 09:42:09.452396800 -0500
+@@ -62,6 +62,9 @@
+     set(INSTALL_TARGETS ${INSTALL_TARGETS} fmt-header-only)
+   endif ()
+ 
++  set(FMT_BIN_DIR ${CMAKE_INSTALL_BINDIR} CACHE STRING
++    "Installation directory for runtime or executables, relative to ${CMAKE_INSTALL_PREFIX}.")
++
+   set(FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
+     "Installation directory for libraries, relative to ${CMAKE_INSTALL_PREFIX}.")
+ 
+@@ -87,8 +90,10 @@
+   install(EXPORT ${targets_export_name} DESTINATION ${FMT_CMAKE_DIR}
+     NAMESPACE fmt::)
+ 
+-  # Install the library and headers.
++  # Install the library, runtime, and headers.
+   install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
+-          DESTINATION ${FMT_LIB_DIR})
++          RUNTIME DESTINATION ${FMT_BIN_DIR}
++          LIBRARY DESTINATION ${FMT_LIB_DIR}
++          ARCHIVE DESTINATION ${FMT_LIB_DIR})
+   install(FILES ${FMT_HEADERS} DESTINATION ${FMT_INC_DIR})
+ endif ()

--- a/mingw-w64-fmt/PKGBUILD
+++ b/mingw-w64-fmt/PKGBUILD
@@ -1,11 +1,12 @@
 # Maintainer: melak47 <melak47@gmail.com>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=fmt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.0.1
+pkgver=4.1.0
 pkgrel=1
-pkgdesc="Small, safe and fast formatting library (mingw-w64)"
+pkgdesc="Open-source formatting library for C++. (mingw-w64)"
 arch=('any')
 url="http://fmtlib.net"
 license=('BSD')
@@ -13,31 +14,57 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-cmake")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/fmtlib/${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('dce62ab75a161dd4353a98364feb166d35e7eea382169d59d9ce842c49c55bad')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/fmtlib/${_realname}/archive/${pkgver}.tar.gz"
+        "0001-fmt-4.1.0-fix-runtime-installation.patch")
+sha256sums=('46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d'
+            'b05c627fbde119357d7e594090e46efbe3c6ecc9333f53b2001a953abebb5a11')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/0001-fmt-4.1.0-fix-runtime-installation.patch"
+}
 
 build() {
-  [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"
-  mkdir -p ${srcdir}/build-${MINGW_CHOST}
-  cd ${srcdir}/build-${MINGW_CHOST}
-
+  # Shared Build
+  [[ -d "build-${MINGW_CHOST}-shared" ]] && rm -rf "build-${MINGW_CHOST}-shared"
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-shared
+  cd ${srcdir}/build-${MINGW_CHOST}-shared
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DFMT_TEST=OFF \
+    ../${_realname}-${pkgver}
+
+  make -j1 # parallel jobs break build
+  
+  # Static Build
+  [[ -d "build-${MINGW_CHOST}-static" ]] && rm -rf "build-${MINGW_CHOST}-static"
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-static
+  cd ${srcdir}/build-${MINGW_CHOST}-static
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
+    -DFMT_TEST=OFF \
     ../${_realname}-${pkgver}
 
   make -j1 # parallel jobs break build
 }
 
-check() {
-  cd ${srcdir}/build-${MINGW_CHOST}
-  ctest
-}
-
 package() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  # Shared Install
+  cd "${srcdir}/build-${MINGW_CHOST}-shared"
   make DESTDIR=${pkgdir} install
+  
+  # Static Install
+  cd "${srcdir}/build-${MINGW_CHOST}-static"
+  make DESTDIR=${pkgdir} install
+  
+  # License
   install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.rst ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.rst
 }


### PR DESCRIPTION
This updates fmt to 4.1.0 and removes failing tests.