### PR TITLE
Exiv2: backport a memory allocation patch

### DIFF
--- a/mingw-w64-exiv2/0002-memoryallocation.patch
+++ b/mingw-w64-exiv2/0002-memoryallocation.patch
@@ -1,24 +1,30 @@
 --- exiv2-0.26.orig/src/basicio.cpp.orig	2017-04-26 21:16:21.000000000 +0200
-+++ exiv2-0.26.orig/src/basicio.cpp	2018-01-10 22:50:16.497801700 +0100
-@@ -1093,10 +1093,11 @@
++++ exiv2-0.26.orig/src/basicio.cpp	2018-01-12 17:11:54.815825700 +0100
+@@ -1093,10 +1093,12 @@
      void MemIo::Impl::reserve(long wcount)
      {
          long need = wcount + idx_;
-+        long blockSize = 2*1024*1024;   // 32768
++        long    blockSize =     32*1024;   // 32768           `
++        long maxBlockSize = 4*1024*1024;
  
          if (!isMalloced_) {
-             // Minimum size for 1st block is 32kB
+-            // Minimum size for 1st block is 32kB
 -            long size  = EXV_MAX(32768 * (1 + need / 32768), size_);
++            // Minimum size for 1st block
 +            long size  = EXV_MAX(blockSize * (1 + need / blockSize), size_);
              byte* data = (byte*)std::malloc(size);
              std::memcpy(data, data_, size_);
              data_ = data;
-@@ -1107,7 +1108,7 @@
+@@ -1106,8 +1108,10 @@
+ 
          if (need > size_) {
              if (need > sizeAlloced_) {
-                 // Allocate in blocks of 32kB
+-                // Allocate in blocks of 32kB
 -                long want = 32768 * (1 + need / 32768);
-+                long want = blockSize * (1 + need / blockSize);
++                blockSize = 2*sizeAlloced_ ;
++                if ( blockSize > maxBlockSize ) blockSize = maxBlockSize ;
++                // Allocate in blocks
++                long want      = blockSize * (1 + need / blockSize );
                  data_ = (byte*)std::realloc(data_, want);
                  sizeAlloced_ = want;
                  isMalloced_ = true;

--- a/mingw-w64-exiv2/0002-memoryallocation.patch
+++ b/mingw-w64-exiv2/0002-memoryallocation.patch
@@ -1,0 +1,24 @@
+--- exiv2-0.26.orig/src/basicio.cpp.orig	2017-04-26 21:16:21.000000000 +0200
++++ exiv2-0.26.orig/src/basicio.cpp	2018-01-10 22:50:16.497801700 +0100
+@@ -1093,10 +1093,11 @@
+     void MemIo::Impl::reserve(long wcount)
+     {
+         long need = wcount + idx_;
++        long blockSize = 2*1024*1024;   // 32768
+ 
+         if (!isMalloced_) {
+             // Minimum size for 1st block is 32kB
+-            long size  = EXV_MAX(32768 * (1 + need / 32768), size_);
++            long size  = EXV_MAX(blockSize * (1 + need / blockSize), size_);
+             byte* data = (byte*)std::malloc(size);
+             std::memcpy(data, data_, size_);
+             data_ = data;
+@@ -1107,7 +1108,7 @@
+         if (need > size_) {
+             if (need > sizeAlloced_) {
+                 // Allocate in blocks of 32kB
+-                long want = 32768 * (1 + need / 32768);
++                long want = blockSize * (1 + need / blockSize);
+                 data_ = (byte*)std::realloc(data_, want);
+                 sizeAlloced_ = want;
+                 isMalloced_ = true;

--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -25,7 +25,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Exiv2/${_realname}/ar
         0002-memoryallocation.patch)
 sha256sums=('51cffa8d19d67e1da6c1d0f570a75b8f6c814113367318c2c0407691888c5f01'
             'a87f79c66b4440a4822f5b0c68b0dbd091f1b1cb2a95e4371de708fb5bc57aa8'
-            'effda540a336c19607a7ce0101febe144155ded97bd1a1e4bee0f9912a656c6a')
+            '74d3e4860785b8a15c875276743150f7fcbc6a6d65263f7047a759c0105896fc')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-exiv2/PKGBUILD
+++ b/mingw-w64-exiv2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=exiv2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.26
-pkgrel=2
+pkgrel=3
 pkgdesc="Exif and Iptc metadata manipulation library and tools (mingw-w64)"
 arch=('any')
 url="http://exiv2.org"
@@ -21,13 +21,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('strip' 'staticlibs')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/Exiv2/${_realname}/archive/v${pkgver}.tar.gz"
-        0001-fix-tests.patch)
+        0001-fix-tests.patch
+        0002-memoryallocation.patch)
 sha256sums=('51cffa8d19d67e1da6c1d0f570a75b8f6c814113367318c2c0407691888c5f01'
-            'a87f79c66b4440a4822f5b0c68b0dbd091f1b1cb2a95e4371de708fb5bc57aa8')
+            'a87f79c66b4440a4822f5b0c68b0dbd091f1b1cb2a95e4371de708fb5bc57aa8'
+            'effda540a336c19607a7ce0101febe144155ded97bd1a1e4bee0f9912a656c6a')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-fix-tests.patch
+  patch -p1 -i ${srcdir}/0002-memoryallocation.patch
 }
 
 build() {


### PR DESCRIPTION
We have discovered a serious [performance problem](https://github.com/Exiv2/exiv2/issues/200), this simple patch is addressing the current release until the new release will fix this on a permanent basis.