### PR TITLE
Add Argon2 package from P-H-C/phc-winner-argon2

### DIFF
--- a/mingw-w64-argon2/PKGBUILD
+++ b/mingw-w64-argon2/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Jonathan White <support@dmapps.us>
+
+_realname=argon2
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=20171227
+pkgrel=1
+pkgdesc="This is the reference implementation of Argon2, the password-hashing function that won the Password Hashing Competition (PHC)."
+arch=('any')
+license=('CC0 and Apache 2.0')
+url='https://github.com/P-H-C/phc-winner-argon2'
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/${pkgver}.tar.gz")
+sha256sums=('EAEA0172C1F4EE4550D1B6C9CE01AAB8D1AB66B4207776AA67991EB5872FDCD8')
+
+build() {
+  cd ${srcdir}/phc-winner-argon2-${pkgver}
+  make
+}
+
+package() {
+  cd ${srcdir}/phc-winner-argon2-${pkgver}
+  make install PREFIX="${pkgdir}/${MINGW_PREFIX}"
+}


### PR DESCRIPTION
Requesting to add the Argon2 library/binary to msys2 repository. This is being used in the [KeePassXC](https://github.com/keepassxreboot/keepassxc) project to provide a modern key derivation function. I tested this on a fresh MSYS2 install using the wiki instructions.