### PR TITLE
mingw-w64-c-ares - 1.13.0 - fix *.pc files so that nghttp2 configure …

### DIFF
--- a/mingw-w64-c-ares/PKGBUILD
+++ b/mingw-w64-c-ares/PKGBUILD
@@ -9,7 +9,8 @@ pkgdesc="C library that performs DNS requests and name resolves asynchronously (
 arch=('any')
 url="https://c-ares.haxx.se/"
 license=("MIT, BSD")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" 
+"${MINGW_PACKAGE_PREFIX}-pkg-config" "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip' 'staticlibs')
 source=(#"https://c-ares.haxx.se/download/${_realname}-${pkgver}.tar.gz"{,.asc}
         https://github.com/c-ares/c-ares/archive/cares-${pkgver//./_}.tar.gz

--- a/mingw-w64-c-ares/PKGBUILD
+++ b/mingw-w64-c-ares/PKGBUILD
@@ -4,7 +4,7 @@ _realname=c-ares
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.13.0
-pkgrel=3
+pkgrel=4
 pkgdesc="C library that performs DNS requests and name resolves asynchronously (mingw-w64)"
 arch=('any')
 url="https://c-ares.haxx.se/"
@@ -23,11 +23,31 @@ sha256sums=('7c48c57706a38691041920e705d2a04426ad9c68d40edd600685323f214b2d57'
             '70be0786506122dee5c105e6c00b5a430e564ac18d4e8a3778679039f84d74da'
             '5810001abdd4acb8ae725dedb4d67874c3e2935775ecba30469a2a79c76fd6a0')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 prepare() {
   cd "${srcdir}"/${_realname}-cares-${pkgver//./_}
-  patch -p1 -i ${srcdir}/0001-Use-RPM-compiler-options.patch
-  patch -p1 -i ${srcdir}/0002-Add-static-pkg-config.patch
-  patch -p1 -i ${srcdir}/0003-fix-cmake-targets.patch
+  del_file_exists libcares-static.pc.in
+  apply_patch_with_msg 0001-Use-RPM-compiler-options.patch \
+    0002-Add-static-pkg-config.patch \
+    0003-fix-cmake-targets.patch
 
   autoreconf -fi
 }
@@ -62,6 +82,7 @@ package() {
   cp ${srcdir}/${_realname}-cares-${pkgver//./_}/nameser.h ${pkgdir}${MINGW_PREFIX}/include
   
   # provide pkgconfig files
+  sed -i -e "s|Version: -|Version: ${pkgver}|g" libcares.pc libcares-static.pc
   install -Dm644 libcares.pc ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libcares.pc
   install -Dm644 libcares-static.pc ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libcares-static.pc
 }

--- a/mingw-w64-jemalloc/001-fix-library-extension.patch
+++ b/mingw-w64-jemalloc/001-fix-library-extension.patch
@@ -1,26 +1,22 @@
---- jemalloc-3.6.0/configure.ac.orig	2014-12-01 06:22:10.508800000 +0300
-+++ jemalloc-3.6.0/configure.ac	2014-12-01 06:23:07.687000000 +0300
-@@ -341,8 +341,8 @@
- 	  importlib="${so}"
- 	  DSO_LDFLAGS="-shared"
+--- jemalloc-5.0.1/configure.ac.orig	2018-01-13 03:45:41.340437700 -0500
++++ jemalloc-5.0.1/configure.ac	2018-01-13 04:06:27.193388900 -0500
+@@ -631,7 +631,7 @@ case "${host}" in
+ 	  link_whole_archive="1"
  	fi
+ 	DUMP_SYMS="dumpbin /SYMBOLS"
 -	a="lib"
--	libprefix=""
 +	a="a"
-+	libprefix="lib"
+ 	libprefix=""
  	SOREV="${so}"
  	PIC_CFLAGS=""
- 	;;
---- jemalloc-3.6.0/configure.orig	2014-12-01 06:29:33.067600000 +0300
-+++ jemalloc-3.6.0/configure	2014-12-01 06:29:07.811200000 +0300
-@@ -4924,8 +4924,8 @@
- 	  importlib="${so}"
- 	  DSO_LDFLAGS="-shared"
+--- jemalloc-5.0.1/configure.orig	2018-01-13 03:45:41.349461900 -0500
++++ jemalloc-5.0.1/configure	2018-01-13 04:09:33.169636600 -0500
+@@ -7311,7 +7299,7 @@ fi
+ 	  link_whole_archive="1"
  	fi
+ 	DUMP_SYMS="dumpbin /SYMBOLS"
 -	a="lib"
--	libprefix=""
 +	a="a"
-+	libprefix="lib"
+ 	libprefix=""
  	SOREV="${so}"
  	PIC_CFLAGS=""
- 	;;

--- a/mingw-w64-jemalloc/PKGBUILD
+++ b/mingw-w64-jemalloc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=jemalloc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=4.5.0
+pkgver=5.0.1
 pkgrel=1
 pkgdesc="General-purpose scalable concurrent malloc implementation (mingw64)"
 arch=('any')
@@ -14,18 +14,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-docbook-xsl")
 source=("https://github.com/jemalloc/jemalloc/releases/download/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         001-fix-library-extension.patch
         002-makefile.patch)
-sha256sums=('9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780'
-            '074700fcdb9d0548668d5e1f8a61b3571e35c839f45036146bb2e112ad5a5d9d'
+sha256sums=('4814781d395b0ef093b21a08e8e6e0bd3dab8762f9935bbfb71679b0dea7c3e9'
+            '15372bf631e37edc7b031fc3c13ae2db25b98bb515e9d57bef526e62cbb0d37b'
             '2d92c7e273a25e4a2f12927a3418c4ff8744962eb941f838e35f94bee46ec841')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-fix-library-extension.patch
   patch -p1 -i ${srcdir}/002-makefile.patch
-
-  #./autogen.sh
-
 }
+
 build() {
   cd ${srcdir}/${_realname}-${pkgver}
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}

--- a/mingw-w64-libmariadbclient/PKGBUILD
+++ b/mingw-w64-libmariadbclient/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=libmariadbclient
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.3.3
-pkgrel=2
+pkgver=2.3.4
+pkgrel=1
 pkgdesc="MariaDB client libraries (mingw-w64)"
 arch=('any')
 url="https://mariadb.org/"
@@ -25,7 +25,7 @@ source=(#"https://downloads.mariadb.org/interstitial/connector-c-${pkgver}/sourc
         'fix-pthread.patch'
         'add-mariadb_config.patch')
 validpgpkeys=("199369E5404BD5FC7D2FE43BCBCB082A1BB943DB") #MariaDB Package Signing Key <package-signing-key@mariadb.org>
-sha256sums=('82a5710134e7654b9cad58964d6a25ed91b3dc1804ff51e8be2def0032914089'
+sha256sums=('8beb0513da8a24ed2cb47836564c8b57045c3b36f933362f74b3676567c13abc'
             'SKIP'
             'a6c8df6e11f783be8dc2df268b4e9d086e0521ee7ebcea4ba56e533b1834a976'
             '8069bc0c7f4204fe2b1ea54c610c27aebd0c54d7a21ecf6352c9bdd9cf1c4062'
@@ -60,7 +60,10 @@ build() {
     -DWITH_OPENSSL=ON \
     -DWITH_MYSQLCOMPAT=OFF \
     ../mariadb-connector-c-${pkgver}-src
-
+  #Fix config files for local system
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}/|g" -i mariadb_config/mariadb_config.c
   make
 }
 
@@ -76,4 +79,8 @@ package() {
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadb,libmysqlclient_r}.dll.a
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadbclient,libmysqlclient}.a
   cp "${pkgdir}${MINGW_PREFIX}"/lib/{libmariadbclient,libmysqlclient_r}.a
-}
+# Fix path references in include files.
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}/|g" -i "${pkgdir}${MINGW_PREFIX}"/include/mariadb/my_config.h
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}/|g" -i "${pkgdir}${MINGW_PREFIX}"/include/mysql/my_config.h
+ }

--- a/mingw-w64-libsrtp/PKGBUILD
+++ b/mingw-w64-libsrtp/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libsrtp
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.5.4
+pkgver=1.6.0
 pkgrel=1
 pkgdesc="Library for SRTP (Secure Realtime Transport Protocol) (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/cisco/${_realname}/
         "0002-symbolic-link-creation-removal-for-mingw-platform.patch"
         "0003-fix-path-for-getopt_s.patch"
         "words.txt")
-sha256sums=('56a7b521c25134f48faff26b0b1e3d4378a14986a2d3d7bc6fefb48987304ff0'
+sha256sums=('1a3e7904354d55e45b3c5c024ec0eab1b8fa76fdbf4dd2ea2625dad2b3c6edde'
             '54df6101316d8fc29f72af88f600f302becab27bc6373d32a4dd1676e8938afb'
             '6b7893f496a15d9ee02df500b0b3488f2ce6fecf034fbc0a862b91a02adec84e'
             '477a8fc9a4485c106f711423270b44dab4a233e2867f05031f827c9785cddc63'

--- a/mingw-w64-nghttp2/PKGBUILD
+++ b/mingw-w64-nghttp2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nghttp2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.26.0
+pkgver=1.29.0
 pkgrel=1
 pkgdesc="Framing layer of HTTP/2 is implemented as a reusable C library (mingw-w64)"
 arch=('any')
@@ -13,13 +13,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-jansson"
          #"${MINGW_PACKAGE_PREFIX}-libevent"
          #"${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-spdylay"
          "${MINGW_PACKAGE_PREFIX}-c-ares")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cunit")
 license=('MIT')
 source=("https://github.com/nghttp2/nghttp2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('7ac7ef5c83449303bf38d16eb45caa9e1bd0bb3abb2afc0ab1e6b3aadbded6dd')
+sha256sums=('a7a1b18be57be6a53a7739988ea27d6ec9209e7b0e8372b8483cd911d7838739')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
…will recongize the version

mingw-w64-jemalloc - 5.0.1 - Update to latest version and adjust patch
mingw-w64-libsrtp - 1.6.0 - Update to latest version
mingw-w64-nghttp2 - 1.29.0 - Update to latest version (note that spdylay support is now completely dropped).