### PR TITLE
snappy: fix build's checkdepends and url

### DIFF
--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -5,7 +5,7 @@ _realname=snappy
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.1.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
 arch=('any')
 license=('New BSD License')
@@ -14,9 +14,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "make")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-zlib"
+              "${MINGW_PACKAGE_PREFIX}-lzo2")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/google/snappy/archive/${pkgver}.tar.gz")
 sha256sums=('3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4')
-options=('staticlibs')
 
 build() {
   # Shared Build

--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -9,7 +9,7 @@ pkgrel=2
 pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
 arch=('any')
 license=('New BSD License')
-url="hhttps://github.com/google/snappy"
+url="https://github.com/google/snappy"
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"


### PR DESCRIPTION
This fixes snappy's build via checkdepends, and also removes typo in url.
Sorry for not responding very quickly.