### PR TITLE
libtasn1: update to 4.13

### DIFF
--- a/mingw-w64-libtasn1/PKGBUILD
+++ b/mingw-w64-libtasn1/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=libtasn1
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=4.12
+pkgver=4.13
 pkgrel=1
 pkgdesc="A library for Abstract Syntax Notation One (ASN.1) and Distinguish Encoding Rules (DER) manipulation (mingw-w64)"
 arch=('any')
@@ -14,7 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('staticlibs' 'strip')
 source=("https://ftp.gnu.org/gnu/libtasn1/${_realname}-${pkgver}.tar.gz"{,.sig})
 validpgpkeys=('1F42418905D8206AA754CCDC29EE58B996865171')
-sha256sums=('6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753'
+sha256sums=('7e528e8c317ddd156230c4e31d082cd13e7ddeb7a54824be82632209550c8cca'
             'SKIP')
 
 prepare() {


### PR DESCRIPTION
This updates libtasn1 to the latest version, 4.13.