### PR TITLE
glib2: Update to 2.54.3; Switch to Python 3 for the build tools

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.54.2
+pkgver=2.54.3
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -20,10 +20,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libffi"
          "${MINGW_PACKAGE_PREFIX}-pcre"
          "${MINGW_PACKAGE_PREFIX}-zlib"
-         "${MINGW_PACKAGE_PREFIX}-python2")
+         "${MINGW_PACKAGE_PREFIX}-python3")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-python2"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              )
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
@@ -34,7 +34,7 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0027-no_sys_if_nametoindex.patch
         0028-inode_directory.patch
         pyscript2exe.py)
-sha256sums=('bb89e5c5aad33169a8c7f28b45671c7899c12f74caf707737f784d7102758e6c'
+sha256sums=('963fdc6685dc3da8e5381dfb9f15ca4b5709b28be84d9d05a9bb8e446abac0a8'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'
@@ -77,7 +77,7 @@ build() {
     --target=${MINGW_CHOST} \
     --disable-static --enable-shared \
     --disable-libelf \
-    --with-python=${MINGW_PREFIX}/bin/python.exe \
+    --with-python=${MINGW_PREFIX}/bin/python3.exe \
     --with-threads=posix \
     --with-xml-catalog=${MINGW_PREFIX}/etc/xml/catalog
   make
@@ -91,7 +91,7 @@ build() {
     --target=${MINGW_CHOST} \
     --disable-shared --enable-static \
     --disable-libelf \
-    --with-python=${MINGW_PREFIX}/bin/python.exe \
+    --with-python=${MINGW_PREFIX}/bin/python3.exe \
     --with-threads=posix \
     --with-xml-catalog=${MINGW_PREFIX}/etc/xml/catalog
   make
@@ -120,7 +120,7 @@ package() {
   popd > /dev/null
 
   for name in glib-mkenums glib-genmarshal gdbus-codegen; do
-    ${MINGW_PREFIX}/bin/python2 \
+    ${MINGW_PREFIX}/bin/python3 \
       "${srcdir}/pyscript2exe.py" "${pkgdir}${MINGW_PREFIX}/bin/${name}"
   done
 }


### PR DESCRIPTION
Python 3 is the default on Linux for most distros now, so it's a good idea
to use the same tools as everyone else.
I've built a few packages depending on glib and everything seems to work with py3.