### PR TITLE
gobject-introspection: Fix .gir build when not using libtool (with me…

### DIFF
--- a/mingw-w64-gobject-introspection/0001-scanner-Fix-library-lookup-under-MinGW-without-libto.patch
+++ b/mingw-w64-gobject-introspection/0001-scanner-Fix-library-lookup-under-MinGW-without-libto.patch
@@ -1,0 +1,49 @@
+From 46047c74b98ee2a61bb876554b86f615f1f2aaae Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Mon, 22 Jan 2018 11:20:49 +0100
+Subject: [PATCH] scanner: Fix library lookup under MinGW without libtool
+
+When executing the scanner binary use the PATH/LIB env vars
+also under MinGW, since LD_LIBRARY_PATH/rpath doesn't work there.
+
+When resolving the library name from the import library look into
+the user provided library paths first before falling back to the
+default gcc search path.
+
+This fixes the gir/typelib generation for meson under MSYS2.
+Note that MSYS2 ships various patches, so this might not fix it
+for all MinGW users.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=791902
+---
+ giscanner/ccompiler.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/giscanner/ccompiler.py b/giscanner/ccompiler.py
+index 29de0ee5..da4eaac8 100644
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -116,7 +116,7 @@ class CCompiler(object):
+         runtime_path_envvar = []
+         runtime_paths = []
+ 
+-        if self.check_is_msvc():
++        if os.name == 'nt':
+             runtime_path_envvar = ['LIB', 'PATH']
+         else:
+             runtime_path_envvar = ['LD_LIBRARY_PATH']
+@@ -288,9 +288,10 @@ class CCompiler(object):
+             proc = subprocess.Popen([self.compiler_cmd, '-print-search-dirs'],
+                                     stdout=subprocess.PIPE)
+             o, e = proc.communicate()
++            libsearch = options.library_paths
+             for line in o.decode('ascii').splitlines():
+                 if line.startswith('libraries: '):
+-                    libsearch = line[len('libraries: '):].split(os.pathsep)
++                    libsearch += line[len('libraries: '):].split(os.pathsep)
+ 
+         shlibs = []
+         not_resolved = []
+-- 
+2.15.0
+

--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.54.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 url="https://live.gnome.org/GObjectIntrospection"
 license=("LGPL")
@@ -28,6 +28,7 @@ source=(https://download.gnome.org/sources/gobject-introspection/${pkgver%.*}/${
         0026-giscanner-assertions-and-waits.patch
         0027-wait-for-xml-parse-too.patch
         0055-fix-python-detection.patch
+        0001-scanner-Fix-library-lookup-under-MinGW-without-libto.patch
         pyscript2exe.py)
 
 sha256sums=('b88ded5e5f064ab58a93aadecd6d58db2ec9d970648534c63807d4f9a7bb877e'
@@ -39,6 +40,7 @@ sha256sums=('b88ded5e5f064ab58a93aadecd6d58db2ec9d970648534c63807d4f9a7bb877e'
             '19ca830262339c4ac9f21bfb8d669ee8e126a949a4237d55656e00c5ae81c451'
             '3f38bdd0dd43d9cf626cbca7c2abd22a7ed0213e6756252c6d467d470d9c5948'
             'f61d099aa7cd37c437f01d98bb95c57c66f07c78028675ae19fac87f943d189d'
+            'b82b384453feda096a183e58a9b2e79144f17a01e4d2a349aba144ec108604b9'
             'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
 
 prepare() {
@@ -54,6 +56,7 @@ prepare() {
   patch -p1 -i "${srcdir}"/0027-wait-for-xml-parse-too.patch
   #patch -p1 -i "${srcdir}"/0050-dont-load-msvcrt.patch
   patch -p1 -i "${srcdir}"/0055-fix-python-detection.patch
+  patch -p1 -i "${srcdir}"/0001-scanner-Fix-library-lookup-under-MinGW-without-libto.patch
 
   autoreconf -fi
 }


### PR DESCRIPTION
…son for example)

g-ir-scanner just happened to work without libtool in case the library to build was
already installed.

The patch was subbmitted upstream: https://bugzilla.gnome.org/show_bug.cgi?id=791902