### PR TITLE
mingw-w64-clang - Update to 5.0.1 - use z3 library, try to fix some c…

### DIFF
--- a/mingw-w64-clang/PKGBUILD
+++ b/mingw-w64-clang/PKGBUILD
@@ -20,8 +20,8 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-llvm"
          "${MINGW_PACKAGE_PREFIX}-lldb"
          "${MINGW_PACKAGE_PREFIX}-polly")
-pkgver=5.0.0
-pkgrel=4
+pkgver=5.0.1
+pkgrel=1
 pkgdesc="C language family frontend for LLVM (mingw-w64)"
 arch=('any')
 url="https://llvm.org/"
@@ -35,7 +35,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake>=3.4.3"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "tar"
              "groff")
-depends=("${MINGW_PACKAGE_PREFIX}-gcc")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-z3")
 #options=('debug' '!strip')
 source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
         https://releases.llvm.org/${pkgver}/cfe-${pkgver}.src.tar.xz{,.sig}
@@ -77,27 +77,27 @@ source=(https://releases.llvm.org/${pkgver}/llvm-${pkgver}.src.tar.xz{,.sig}
 #0601-0699 -> libunwind
 #0701-0799 -> libc++abi
 #0801-0899 -> polly
-sha256sums=('e35dcbae6084adcf4abb32514127c5eabd7d63b733852ccdb31e06f1373136da'
+sha256sums=('5fa7489fc0225b11821cab0362f5813a05f2bcf2533e8a4ea9c9c860168807b0'
             'SKIP'
-            '019f23c2192df793ac746595e94a403908749f8e0c484b403476d2611dd20970'
+            '135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff'
             'SKIP'
-            'd5ad5266462134a482b381f1f8115b6cad3473741b3bb7d1acc7f69fd0f0c0b3'
+            '4edd1417f457a9b3f0eb88082530490edf3cf6a7335cdce8ecbc5d3e16a895da'
             'SKIP'
-            'e96c8a6150b3538be43279a44f8a3e7b74e4bd324255537ba3017ce74304cdad'
+            'db650be9ce049faa8e16ec2b12cc3ec670347d3e8677dec479e8cad499fe59e5'
             'SKIP'
-            'eae5981e9a21ef0decfcac80a1af584ddb064a32805f95a57c7c83a5eb28c9b1'
+            'fa8f99dd2bde109daa3276d529851a3bce5718d46ce1c5d0806f46caa3e57c00'
             'SKIP'
-            '176918c7eb22245c3a5c56ef055e4d69f5345b4a98833e0e8cb1a19cab6b8911'
+            '5a25152cb7f21e3c223ad36a1022faeb8a5ac27c9e75936a5ae2d3ac48f6e854'
             'SKIP'
-            '87d078b959c4a6e5ff9fd137c2f477cadb1245f93812512996f73986a6d973c6'
+            '9aada1f9d673226846c3399d13fab6bba4bfd38bcfe8def5ee7b0ec24f8cd225'
             'SKIP'
-            '399a7920a5278d42c46a7bf7e4191820ec2301457a7d0d4fcc9a4ac05dd53897'
+            'd5b36c0005824f07ab093616bdff247f3da817cae2c51371e1d1473af717d895'
             'SKIP'
-            'c0a0ca32105e9881d86b7ca886220147e686edc97fdb9f3657c6659dc6568b7d'
+            'b7c1c9e67975ca219089a3a6a9c77c2d102cead2dc38264f2524aa3326da376a'
             'SKIP'
-            '9a70e2333d54f97760623d89512c4831d6af29e78b77a33d824413ce98587f6f'
+            '6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe'
             'SKIP'
-            '44694254a2b105cec13ce0560f207e8552e6116c181b8d21bda728559cf67042'
+            '9dd52b17c07054aa8998fc6667d41ae921430ef63fa20ae130037136fdacf36e'
             'SKIP'
             'd5b11097084f8a03dd3002c2adb27b4fec99cf290404049f1a4e1185274bde67'
             '5081a1a9d8074b275f3087d4d80a13ce5d1c20bc1962819953790e54275930c8'
@@ -249,9 +249,11 @@ build() {
     -DLIBUNWIND_ENABLE_SHARED=OFF \
     -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF \
     -DLLVM_POLLY_LINK_INTO_TOOLS=OFF \
+    -DCLANG_ANALYZER_BUILD_Z3=ON \
     "${extra_config[@]}" \
     ../llvm-${pkgver}.src
 
+  false
   make ${VERBOSE}
 
   # Disable automatic installation of components that go into subpackages
@@ -292,6 +294,9 @@ package_llvm() {
 
   # FileCheck is needed to build rust.
   install -Dm755 "${srcdir}"/build-${CARCH}/bin/FileCheck.exe "${pkgdir}${MINGW_PREFIX}/bin/FileCheck.exe"
+  # fox cmake files.
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${pkgdir}/${MINGW_PREFIX}/lib/cmake/llvm/LLVMExports.cmake
 }
 
 package_compiler-rt() {
@@ -403,6 +408,9 @@ package_polly() {
 
   cd "${srcdir}"/llvm-${pkgver}.src
   make -C ../build-${CARCH}/tools/polly DESTDIR="${pkgdir}" install
+  # fox cmake files.
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}/bin/|${MINGW_PREFIX}/|g" -i "${pkgdir}/${MINGW_PREFIX}/lib/cmake/polly/PollyConfig.cmake"
 }
 
 # Wrappers

--- a/mingw-w64-mesa/PKGBUILD
+++ b/mingw-w64-mesa/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mesa
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=17.0.2
+pkgver=17.3.2
 pkgrel=1
 pkgdesc="Open-source implementation of the OpenGL specification (mingw-w64)"
 arch=('any')
@@ -11,18 +11,22 @@ depends=("")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-clang"
              "scons"
-             "python2-mako")
+             "python3-mako")
 url="https://www.mesa3d.org/"
 license=('MIT')
 options=('staticlibs' 'strip')
 source=(https://mesa.freedesktop.org/archive/${_realname}-${pkgver}.tar.xz{,.sig}
         001-extra-libs.patch
+        link-ole32.patch
         osmesa.pc)
-sha256sums=('f8f191f909e01e65de38d5bdea5fb057f21649a3aed20948be02348e77a689d4'
+sha256sums=('e2844a13f2d6f8f24bee65804a51c42d8dc6ae9c36cff7ee61d0940e796d64c6'
             'SKIP'
             'bc9bb5013ac80ded47ad164ae1ef58cc9a39784eb4bf61e8c7d654bb273b05a9'
+            'a80e9f2084933ce2bf4fea7b9a24401bf5eeac6fb33dd146588f25a77be59ead'
             'fdf26548336cc7e5700560c6636a87ffa63daa3048fa94cf4a4a0b50890c9327')
 validpgpkeys=('8703B6700E7EE06D7A39B8D6EDAE37B02CEB490D')
+validpgpkeys+=('946D09B5E4C9845E63075FF1D961C596A7203456') # Andres Gomez <tanty@igalia.com>
+validpgpkeys+=('E3E8F480C52ADD73B278EE78E1ECBE07D7D70895') # Juan Antonio Suárez Romero (Igalia, S.L.) <jasuarez@igalia.com>"
 
 case ${MINGW_CHOST} in
   i686*)
@@ -33,9 +37,32 @@ case ${MINGW_CHOST} in
   ;;
 esac
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/001-extra-libs.patch
+# Disable this patch.  llvm-config does not return the proper
+# values and we probably don't need to call it anyway.
+
+#  patch -p1 -i ${srcdir}/001-extra-libs.patch
+  apply_patch_with_msg link-ole32.patch
 }
 
 build() {
@@ -63,4 +90,8 @@ package() {
   cp -f ${srcdir}/${_realname}-${pkgver}/include/GL/gl.h ${pkgdir}${MINGW_PREFIX}/include/mesa/GL/
   cp -f ${srcdir}/${_realname}-${pkgver}/include/GL/osmesa.h ${pkgdir}${MINGW_PREFIX}/include/mesa/GL/
   cp -f ${srcdir}/osmesa.pc ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/
+  # fixup our .pc file with valid info
+  sed -e "s|/mingw64|${MINGW_PREFIX}|g" \
+    -e "s|8|${pkgver}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/osmesa.pc
 }

--- a/mingw-w64-mesa/link-ole32.patch
+++ b/mingw-w64-mesa/link-ole32.patch
@@ -1,0 +1,64 @@
+--- mesa-17.3.3/src/gallium/targets/libgl-gdi/SConscript.orig	2018-01-21 17:12:22.323248900 -0500
++++ mesa-17.3.3/src/gallium/targets/libgl-gdi/SConscript	2018-01-21 17:13:45.667612200 -0500
+@@ -15,6 +15,7 @@ env.Append(LIBS = [
+     'gdi32',
+     'user32',
+     'kernel32',
++    'ole32',
+     'ws2_32',
+ ])
+ 
+--- mesa-17.3.3/src/gallium/targets/graw-gdi/SConscript.orig	2018-01-21 17:36:04.571024700 -0500
++++ mesa-17.3.3/src/gallium/targets/graw-gdi/SConscript	2018-01-21 17:41:15.236917600 -0500
+@@ -14,6 +14,7 @@ env.Prepend(LIBS = [
+     gallium,
+     'gdi32',
+     'user32',
++    'ole32',
+     'ws2_32',
+ ])
+ 
+--- mesa-17.3.3/src/glx/Makefile.am.orig	2018-01-21 18:20:29.452763400 -0500
++++ mesa-17.3.3/src/glx/Makefile.am	2018-01-21 18:21:49.227439400 -0500
+@@ -196,7 +196,7 @@ lib@GL_LIB@_la_LIBADD = $(GL_LIBS)
+ lib@GL_LIB@_la_LDFLAGS = $(GL_LDFLAGS)
+ 
+ if HAVE_WINDOWSDRI
+-lib@GL_LIB@_la_LDFLAGS += -lgdi32 -lopengl32 -Wl,--disable-stdcall-fixup
++lib@GL_LIB@_la_LDFLAGS += -lgdi32 -lole32 -lopengl32 -Wl,--disable-stdcall-fixup
+ endif
+ 
+ SUBDIRS += . tests
+--- mesa-17.3.3/src/glx/Makefile.in.orig	2018-01-21 18:22:19.530664000 -0500
++++ mesa-17.3.3/src/glx/Makefile.in	2018-01-21 18:23:57.362006800 -0500
+@@ -167,7 +167,7 @@ target_triplet = @target@
+ @USE_LIBGLVND_FALSE@am__append_14 = \
+ @USE_LIBGLVND_FALSE@	-DGL_LIB_NAME=\"lib@GL_LIB@.so.1\"
+ 
+-@HAVE_WINDOWSDRI_TRUE@am__append_15 = -lgdi32 -lopengl32 -Wl,--disable-stdcall-fixup
++@HAVE_WINDOWSDRI_TRUE@am__append_15 = -lgdi32 -lole32 -lopengl32 -Wl,--disable-stdcall-fixup
+ subdir = src/glx
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_compile_flag.m4 \
+--- mesa-17.3.3/scons/llvm.py.orig	2018-01-18 16:30:28.000000000 -0500
++++ mesa-17.3.3/scons/llvm.py	2018-01-22 07:16:54.450780000 -0500
+@@ -208,6 +208,9 @@ def generate(env):
+                 'LLVMSupport', 'LLVMRuntimeDyld', 'LLVMObject'
+             ])
+         env.Append(LIBS = [
++            'ole32',
++            'version', 
++            'uuid',
+             'imagehlp',
+             'psapi',
+             'shell32',
+--- mesa-17.3.3/scons/gallium.py.orig	2018-01-22 01:38:20.096999500 -0500
++++ mesa-17.3.3/scons/gallium.py	2018-01-22 01:42:28.231168700 -0500
+@@ -659,6 +659,7 @@ def generate(env):
+ 
+     env.Tool('yacc')
+     if host_platform.system() == 'Windows':
++        libs += ['shell32', 'version', 'uuid', 'ole32']
+         if check_prog(env, 'win_bison'):
+             env["YACC"] = 'win_bison'
+ 

--- a/mingw-w64-z3/PKGBUILD
+++ b/mingw-w64-z3/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Some One <some.one@some.email.com>
+
+_realname=z3
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.6.0
+pkgrel=1
+pkgdesc="Z3 is a high-performance theorem prover being developed at Microsoft Research (mingw-w64)"
+arch=('any')
+url="https://github.com/Z3Prover/z3"
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "python3")
+options=('strip' 'staticlibs')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/Z3Prover/z3/archive/z3-4.6.0.tar.gz"
+        mingw-fixes.patch)
+sha256sums=('511da31d1f985cf0c79b2de05bda4e057371ba519769d1546ff71e1304fe53c9'
+            '5ad322bbaff39ebae94d5092f495c89e35ff6b53da88a86a2c1c6d972ac66b5b')
+
+apply_patch_with_msg() {
+  for _fname in "$@"
+  do
+    msg2 "Applying ${_fname}"
+    patch -Nbp1 -i "${srcdir}"/${_fname}
+  done
+}
+
+prepare() {
+  cd "$srcdir"/${_realname}-${_realname}-${pkgver}
+  apply_patch_with_msg mingw-fixes.patch
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${_realname}-${pkgver}
+
+  [[ -d "${srcdir}"/build-${CARCH}-shared ]] && rm -rf "${srcdir}"/build-${CARCH}-shared
+  cp -rf "$srcdir"/${_realname}-${_realname}-${pkgver} "${srcdir}"/build-${CARCH}-shared && cd "${srcdir}"/build-${CARCH}-shared
+
+  CXX=${CARCH}-w64-mingw32-g++ CC=${CARCH}-w64-mingw32-gcc \
+    AR=${CARCH}-w64-mingw32-gcc-ar OCAMLFIND=ocamlfind \
+    /usr/bin/python3 scripts/mk_make.py \
+   --prefix=${MINGW_PREFIX} --staticlib --staticbin --ml
+  cd build
+  make
+}
+
+check() {
+   cd "${srcdir}"/build-${CARCH}-shared/build
+   make test
+}
+
+package() {
+   cd "${srcdir}"/build-${CARCH}-shared/build
+   make install DESTDIR="${pkgdir}"
+   cp "${srcdir}"/build-${CARCH}-shared/build/libz3.dll.a ${pkgdir}/${MINGW_PREFIX}/lib
+}

--- a/mingw-w64-z3/mingw-fixes.patch
+++ b/mingw-w64-z3/mingw-fixes.patch
@@ -1,0 +1,555 @@
+--- z3-z3-4.6.0/examples/tptp/tptp5.cpp.orig	2018-01-11 11:56:50.217665100 -0500
++++ z3-z3-4.6.0/examples/tptp/tptp5.cpp	2018-01-11 11:58:28.068490100 -0500
+@@ -1057,7 +1057,7 @@ class env {
+     }
+ 
+     bool mk_env_filename(const char* rel_name, std::string& inc_name) {
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         char buffer[1024];
+         size_t sz;
+         errno_t err = getenv_s( 
+--- z3-z3-4.6.0/scripts/mk_util.py.orig	2017-12-18 09:18:30.000000000 -0500
++++ z3-z3-4.6.0/scripts/mk_util.py	2018-01-12 04:29:22.463109800 -0500
+@@ -73,6 +73,7 @@ IS_OPENBSD=False
+ IS_CYGWIN=False
+ IS_CYGWIN_MINGW=False
+ IS_MSYS2=False
++IS_MSYS2_MINGW=False
+ VERBOSE=True
+ DEBUG_MODE=False
+ SHOW_CPPS = True
+@@ -156,6 +157,9 @@ def is_cygwin_mingw():
+ def is_msys2():
+     return IS_MSYS2
+ 
++def is_msys2_mingw():
++    return IS_MSYS2_MINGW
++
+ def norm_path(p):
+     return os.path.expanduser(os.path.normpath(p))
+ 
+@@ -231,7 +235,7 @@ def rmf(fname):
+ 
+ def exec_compiler_cmd(cmd):
+     r = exec_cmd(cmd)
+-    if is_windows() or is_cygwin_mingw() or is_cygwin() or is_msys2():
++    if is_windows() or is_cygwin_mingw() or is_cygwin() or is_msys2_mingw() or is_msys2():
+         rmf('a.exe')
+     else:
+         rmf('a.out')
+@@ -612,10 +616,13 @@ elif os.name == 'posix':
+             IS_CYGWIN_MINGW=True
+     elif os.uname()[0].startswith('MSYS_NT') or os.uname()[0].startswith('MINGW'):
+         IS_MSYS2=True
+-        if os.uname()[4] == 'x86_64':
+-            LINUX_X64=True
++        if (CC != None and "mingw" in CC):
++            IS_MSYS2_MINGW=True
+         else:
+-            LINUX_X64=False
++            if os.uname()[4] == 'x86_64':
++                LINUX_X64=True
++            else:
++               LINUX_X64=False
+             
+ 
+ def display_help(exit_code):
+@@ -1984,6 +1991,9 @@ class MLComponent(Component):
+                 # Some ocamlmklib's don't like -g; observed on cygwin, but may be others as well.
+                 OCAMLMKLIB += ' -g'
+ 
++            if is_msys2() and not(is_msys2_mingw()):
++                LIBZ3 = 'libz3.dll'
++
+             z3mls = os.path.join(self.sub_dir, 'z3ml')
+             out.write('%s.cma: %s %s %s\n' % (z3mls, cmos, stubso, z3dllso))
+             out.write('\t%s -o %s -I %s %s %s %s\n' % (OCAMLMKLIB, z3mls, self.sub_dir, stubso, cmos, LIBZ3))
+@@ -2046,7 +2056,7 @@ class MLComponent(Component):
+             out.write(' %s' % ((os.path.join(self.sub_dir, 'z3ml.cmxa'))))
+             out.write(' %s' % ((os.path.join(self.sub_dir, 'z3ml.cmxs'))))
+             out.write(' %s' % ((os.path.join(self.sub_dir, 'dllz3ml'))))
+-            if is_windows() or is_cygwin_mingw():
++            if is_windows() or is_cygwin_mingw() or is_msys2_mingw():
+                 out.write('.dll')
+             else:
+                 out.write('.so') # .so also on OSX!
+@@ -2515,7 +2525,7 @@ def mk_config():
+             SO_EXT         = '.dll'
+             SLIBFLAGS      = '-shared'
+             EXE_EXT        = '.exe'
+-            LIB_EXT        = '.lib'
++            LIB_EXT        = '.a'
+         else:
+             raise MKException('Unsupported platform: %s' % sysname)
+         if is64():
+@@ -2530,7 +2540,7 @@ def mk_config():
+             SLIBFLAGS    = '%s -m32' % SLIBFLAGS
+         if TRACE or DEBUG_MODE:
+             CPPFLAGS     = '%s -D_TRACE' % CPPFLAGS
+-        if is_cygwin_mingw():
++        if is_cygwin_mingw() or is_msys2_mingw():
+             # when cross-compiling with MinGW, we need to statically link its standard libraries
+             # and to make it create an import library.
+             SLIBEXTRAFLAGS = '%s -static-libgcc -static-libstdc++ -Wl,--out-implib,libz3.dll.a' % SLIBEXTRAFLAGS
+@@ -2568,6 +2578,8 @@ def mk_config():
+             print('C Compiler  :   %s' % CC)
+             if is_cygwin_mingw():
+                 print('MinGW32 cross:  %s' % (is_cygwin_mingw()))
++            if is_msys2_mingw():
++                print('MinGW32 cross:  %s' % (is_msys2_mingw()))     
+             print('Archive Tool:   %s' % AR)
+             print('Arithmetic:     %s' % ARITH)
+             print('OpenMP:         %s' % HAS_OMP)
+--- z3-z3-4.6.0/src/api/python/setup.py.orig	2018-01-12 14:32:01.758644600 -0500
++++ z3-z3-4.6.0/src/api/python/setup.py	2018-01-12 14:46:56.618766700 -0500
+@@ -29,7 +29,7 @@ BINS_DIR = os.path.join(ROOT_DIR, 'bin')
+ if sys.platform == 'darwin':
+     LIBRARY_FILE = "libz3.dylib"
+     EXECUTABLE_FILE = "z3"
+-elif sys.platform in ('win32', 'cygwin'):
++elif sys.platform in ('win32', 'cygwin', 'msys'):
+     LIBRARY_FILE = "libz3.dll"
+     EXECUTABLE_FILE = "z3.exe"
+ else:
+--- z3-z3-4.6.0/scripts/update_api.py.orig	2018-01-12 13:50:48.748045900 -0500
++++ z3-z3-4.6.0/scripts/update_api.py	2018-01-12 13:57:52.204184700 -0500
+@@ -1637,7 +1637,7 @@ import pkg_resources
+ from .z3types import *
+ from .z3consts import *
+ 
+-_ext = 'dll' if sys.platform in ('win32', 'cygwin') else 'dylib' if sys.platform == 'darwin' else 'so'
++_ext = 'dll' if sys.platform in ('win32', 'cygwin', 'msys') else 'dylib' if sys.platform == 'darwin' else 'so'
+ _lib = None
+ _default_dirs = ['.',
+                  os.path.dirname(os.path.abspath(__file__)),
+--- z3-z3-4.6.0/src/ast/format.cpp.orig	2018-01-11 11:07:35.992267800 -0500
++++ z3-z3-4.6.0/src/ast/format.cpp	2018-01-11 11:11:40.909642300 -0500
+@@ -152,7 +152,7 @@ namespace format_ns {
+     
+     format * mk_int(ast_manager & m, int i) {
+         static char buffer[128];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%d", i);
+ #else
+         sprintf(buffer, "%d", i);
+@@ -162,7 +162,7 @@ namespace format_ns {
+     
+     format * mk_unsigned(ast_manager & m, unsigned u) {
+         static char buffer[128];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%u", u);
+ #else
+         sprintf(buffer, "%u", u);
+--- z3-z3-4.6.0/src/ast/proofs/proof_checker.cpp.orig	2018-01-11 12:44:26.513552600 -0500
++++ z3-z3-4.6.0/src/ast/proofs/proof_checker.cpp	2018-01-11 12:46:00.709486900 -0500
+@@ -1270,7 +1270,7 @@ void proof_checker::dump_proof(proof * p
+ 
+ void proof_checker::dump_proof(unsigned num_antecedents, expr * const * antecedents, expr * consequent) {
+     char buffer[128];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+     sprintf_s(buffer, ARRAYSIZE(buffer), "proof_lemma_%d.smt", m_proof_lemma_id);
+ #else
+     sprintf(buffer, "proof_lemma_%d.smt", m_proof_lemma_id);
+--- z3-z3-4.6.0/src/duality/duality_profiling.cpp.orig	2018-01-11 21:44:36.205748600 -0500
++++ z3-z3-4.6.0/src/duality/duality_profiling.cpp	2018-01-11 21:45:22.595931300 -0500
+@@ -25,7 +25,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/duality/duality_rpfp.cpp.orig	2018-01-11 21:41:10.404423800 -0500
++++ z3-z3-4.6.0/src/duality/duality_rpfp.cpp	2018-01-11 21:41:55.917482200 -0500
+@@ -21,7 +21,7 @@
+ 
+ 
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/duality/duality_solver.cpp.orig	2018-01-11 21:37:07.581282900 -0500
++++ z3-z3-4.6.0/src/duality/duality_solver.cpp	2018-01-11 21:38:29.004540500 -0500
+@@ -19,7 +19,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/duality/duality_wrapper.cpp.orig	2018-01-11 22:19:03.648441700 -0500
++++ z3-z3-4.6.0/src/duality/duality_wrapper.cpp	2018-01-11 22:20:29.572342300 -0500
+@@ -18,7 +18,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3base.cpp.orig	2018-01-11 21:58:48.064859800 -0500
++++ z3-z3-4.6.0/src/interp/iz3base.cpp	2018-01-11 21:59:28.218494600 -0500
+@@ -18,7 +18,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3checker.cpp.orig	2018-01-11 22:31:22.973263200 -0500
++++ z3-z3-4.6.0/src/interp/iz3checker.cpp	2018-01-11 22:32:09.581383900 -0500
+@@ -17,7 +17,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3hash.h.orig	2018-01-11 21:48:07.030053200 -0500
++++ z3-z3-4.6.0/src/interp/iz3hash.h	2018-01-11 21:48:53.664660800 -0500
+@@ -29,7 +29,7 @@
+ #ifndef IZ3_HASH_H
+ #define IZ3_HASH_H
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4267)
+ #endif
+ 
+--- z3-z3-4.6.0/src/interp/iz3interp.cpp.orig	2018-01-11 22:29:03.232674400 -0500
++++ z3-z3-4.6.0/src/interp/iz3interp.cpp	2018-01-11 22:29:48.796535800 -0500
+@@ -19,7 +19,7 @@
+ 
+ /* Copyright 2011 Microsoft Research. */
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3mgr.cpp.orig	2018-01-11 22:26:14.497507700 -0500
++++ z3-z3-4.6.0/src/interp/iz3mgr.cpp	2018-01-11 22:26:57.778862700 -0500
+@@ -18,7 +18,7 @@
+   --*/
+ 
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3profiling.cpp.orig	2018-01-11 22:22:45.036280500 -0500
++++ z3-z3-4.6.0/src/interp/iz3profiling.cpp	2018-01-11 22:23:44.796598400 -0500
+@@ -17,7 +17,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3proof.cpp.orig	2018-01-11 21:55:38.467724400 -0500
++++ z3-z3-4.6.0/src/interp/iz3proof.cpp	2018-01-11 21:56:30.710385200 -0500
+@@ -18,7 +18,7 @@
+   --*/
+ 
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3proof_itp.cpp.orig	2018-01-11 23:11:18.946101600 -0500
++++ z3-z3-4.6.0/src/interp/iz3proof_itp.cpp	2018-01-11 23:11:53.868063400 -0500
+@@ -17,7 +17,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3translate.cpp.orig	2018-01-11 23:05:42.806313300 -0500
++++ z3-z3-4.6.0/src/interp/iz3translate.cpp	2018-01-11 23:07:47.923551700 -0500
+@@ -17,7 +17,7 @@
+ 
+   --*/
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/interp/iz3translate_direct.cpp.orig	2018-01-11 21:51:38.814510700 -0500
++++ z3-z3-4.6.0/src/interp/iz3translate_direct.cpp	2018-01-11 21:52:28.164224300 -0500
+@@ -20,7 +20,7 @@
+   --*/
+ 
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma warning(disable:4996)
+ #pragma warning(disable:4800)
+ #pragma warning(disable:4267)
+--- z3-z3-4.6.0/src/muz/base/dl_util.cpp.orig	2018-01-11 20:33:19.778214500 -0500
++++ z3-z3-4.6.0/src/muz/base/dl_util.cpp	2018-01-11 20:35:12.917643800 -0500
+@@ -622,7 +622,7 @@ namespace datalog {
+     }
+ 
+     bool string_to_uint64(const char * s, uint64 & res) {
+-#if _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         int converted = sscanf_s(s, "%I64u", &res);
+ #else
+         int converted = sscanf(s, "%llu", &res);
+--- z3-z3-4.6.0/src/muz/fp/datalog_parser.cpp.orig	2018-01-11 20:37:19.496874600 -0500
++++ z3-z3-4.6.0/src/muz/fp/datalog_parser.cpp	2018-01-11 20:38:35.756086700 -0500
+@@ -99,7 +99,7 @@ public:
+          m_data_size(0) {
+         m_data.resize(2*s_expansion_step);
+         resize_data(0);
+-#if _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         errno_t err = fopen_s(&m_file, fname, "rb");
+         m_ok = (m_file != NULL) && (err == 0);
+ #else
+--- z3-z3-4.6.0/src/shell/main.cpp.orig	2018-01-11 12:29:22.878769800 -0500
++++ z3-z3-4.6.0/src/shell/main.cpp	2018-01-11 12:30:46.062042900 -0500
+@@ -358,7 +358,7 @@ int STD_CALL main(int argc, char ** argv
+             UNREACHABLE();
+         }
+         memory::finalize();
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         _CrtDumpMemoryLeaks();
+ #endif
+         return return_value;
+--- z3-z3-4.6.0/src/smt/smt_context_pp.cpp.orig	2018-01-11 15:56:40.665750500 -0500
++++ z3-z3-4.6.0/src/smt/smt_context_pp.cpp	2018-01-11 15:58:55.557473500 -0500
+@@ -434,7 +434,7 @@ namespace smt {
+ 
+     void context::display_lemma_as_smt_problem(unsigned num_antecedents, literal const * antecedents, literal consequent, symbol const& logic) const {
+         char buffer[BUFFER_SZ];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, BUFFER_SZ, "lemma_%d.smt2", g_lemma_id);
+ #else
+         sprintf(buffer, "lemma_%d.smt2", g_lemma_id);
+@@ -473,7 +473,7 @@ namespace smt {
+                                                unsigned num_eq_antecedents, enode_pair const * eq_antecedents,
+                                                literal consequent, symbol const& logic) const {
+         char buffer[BUFFER_SZ];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, BUFFER_SZ, "lemma_%d.smt2", g_lemma_id);
+ #else
+         sprintf(buffer, "lemma_%d.smt2", g_lemma_id);
+--- z3-z3-4.6.0/src/smt/theory_arith_pp.h.orig	2018-01-11 13:12:04.600332400 -0500
++++ z3-z3-4.6.0/src/smt/theory_arith_pp.h	2018-01-11 13:13:06.680445900 -0500
+@@ -533,7 +533,7 @@ namespace smt {
+     void theory_arith<Ext>::display_bounds_in_smtlib() const {
+         char buffer[128];
+         static int id = 0;
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "arith_%d.smt", id);
+ #else
+         sprintf(buffer, "arith_%d.smt", id);
+--- z3-z3-4.6.0/src/test/bit_blaster.cpp.orig	2018-01-11 16:13:22.995389300 -0500
++++ z3-z3-4.6.0/src/test/bit_blaster.cpp	2018-01-11 16:14:05.453200900 -0500
+@@ -26,7 +26,7 @@ void mk_bits(ast_manager & m, char const
+     b = m.mk_bool_sort();
+     for (unsigned i = 0; i < sz; ++i) {
+         char buffer[128];
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%s%d.smt", prefix, i);
+ #else
+         sprintf(buffer, "%s%d.smt", prefix, i);
+--- z3-z3-4.6.0/src/test/for_each_file.cpp.orig	2018-01-11 19:34:52.772207800 -0500
++++ z3-z3-4.6.0/src/test/for_each_file.cpp	2018-01-11 19:35:49.427071600 -0500
+@@ -17,7 +17,7 @@ Author:
+ Revision History:
+ 
+ --*/
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #include <string>
+ #include <windows.h>
+ #include <strsafe.h>
+--- z3-z3-4.6.0/src/test/interval.cpp.orig	2018-01-11 16:17:01.709647400 -0500
++++ z3-z3-4.6.0/src/test/interval.cpp	2018-01-11 16:18:12.815362100 -0500
+@@ -201,7 +201,7 @@ static int g_problem_id = 0;
+ static char g_buffer[BUFFER_SZ];
+ 
+ char const * get_next_file_name() {
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+     sprintf_s(g_buffer, BUFFER_SZ, "interval_lemma_%d.smt2", g_problem_id);
+ #else
+     sprintf(g_buffer, "interval_lemma_%d.smt2", g_problem_id);
+--- z3-z3-4.6.0/src/test/quant_elim.cpp.orig	2018-01-11 19:40:35.307417700 -0500
++++ z3-z3-4.6.0/src/test/quant_elim.cpp	2018-01-11 19:41:56.730478100 -0500
+@@ -495,7 +495,7 @@ void tst_quant_elim() {
+    
+ 
+     memory::finalize();
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+     _CrtDumpMemoryLeaks();
+ #endif
+     exit(0);
+--- z3-z3-4.6.0/src/test/quant_solve.cpp.orig	2018-01-11 19:44:53.591443300 -0500
++++ z3-z3-4.6.0/src/test/quant_solve.cpp	2018-01-11 19:46:14.201061000 -0500
+@@ -256,7 +256,7 @@ void tst_quant_solve() {
+ 
+ #if 0
+     memory::finalize();
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+     _CrtDumpMemoryLeaks();
+ #endif
+     exit(0);
+--- z3-z3-4.6.0/src/util/hwf.cpp.orig	2017-12-18 09:18:30.000000000 -0500
++++ z3-z3-4.6.0/src/util/hwf.cpp	2018-01-11 18:04:43.334885900 -0500
+@@ -20,7 +20,7 @@ Revision History:
+ #include<float.h>
+ #include<sstream>
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #pragma float_control( except, on )   // exception semantics; this does _not_ mean that exceptions are enabled (we want them off!)
+ #pragma float_control( precise, on )  // precise semantics (no guessing!)
+ #pragma fp_contract(off)              // contractions off (`contraction' means x*y+z is turned into a fused-mul-add).
+@@ -267,7 +267,7 @@ void hwf_manager::fma(mpf_rounding_mode
+     // IA64 (Itanium) will do it, if contractions are on.
+     o.value = x.value * y.value + z.value;
+ #else
+-#if defined(_WINDOWS)
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #if _MSC_VER >= 1800
+     o.value = ::fma(x.value, y.value, z.value);
+ #else // Windows, older than VS 2013
+@@ -305,7 +305,7 @@ void hwf_manager::round_to_integral(mpf_
+ 
+     // According to the Intel Architecture manual, the x87-instrunction FRNDINT is the
+     // same in 32-bit and 64-bit mode. The _mm_round_* intrinsics are SSE4 extensions.
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #if defined(USE_INTRINSICS) && \
+     (defined(_WINDOWS) && (defined(__AVX__) || defined(_M_X64))) || \
+     (!defined(_WINDOWS) && defined(__SSE4_1__))
+@@ -585,7 +585,7 @@ unsigned hwf_manager::prev_power_of_two(
+ 
+ void hwf_manager::set_rounding_mode(mpf_rounding_mode rm)
+ {
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #ifdef USE_INTRINSICS
+     switch (rm) {
+     case MPF_ROUND_NEAREST_TEVEN:
+
+--- z3-z3-4.6.0/src/util/mpn.cpp.orig	2018-01-11 15:43:20.495829500 -0500
++++ z3-z3-4.6.0/src/util/mpn.cpp	2018-01-11 15:50:21.053192200 -0500
+@@ -362,7 +362,7 @@ char * mpn_manager::to_string(mpn_digit
+     TRACE("mpn_to_string", tout << "[mpn] to_string "; display_raw(tout, a, lng); tout << " == "; );
+ 
+     if (lng == 1) {
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buf, lbuf, "%u", *a);
+ #else
+         snprintf(buf, lbuf, "%u", *a);
+--- z3-z3-4.6.0/src/util/rational.cpp.orig	2018-01-11 18:31:28.415011700 -0500
++++ z3-z3-4.6.0/src/util/rational.cpp	2018-01-11 18:32:25.661249700 -0500
+@@ -19,7 +19,7 @@ Revision History:
+ #include<sstream>
+ #include "util/util.h"
+ #include "util/rational.h"
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #include<strsafe.h>
+ #endif
+ 
+--- z3-z3-4.6.0/src/util/string_buffer.h.orig	2017-12-18 09:18:30.000000000 -0500
++++ z3-z3-4.6.0/src/util/string_buffer.h	2018-01-11 18:39:02.207515000 -0500
+@@ -80,8 +80,8 @@ public:
+     }
+ 
+     void append(int n) {
+-        char buffer[24]; 
+-#ifdef _WINDOWS
++        char buffer[24];
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%d", n);
+ #else
+         sprintf(buffer, "%d", n);
+@@ -91,7 +91,7 @@ public:
+ 
+     void append(unsigned n) {
+         char buffer[24]; 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%d", n);
+ #else
+         sprintf(buffer, "%d", n);
+@@ -101,7 +101,7 @@ public:
+ 
+     void append(long n) {
+         char buffer[24]; 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+         sprintf_s(buffer, ARRAYSIZE(buffer), "%ld", n);
+ #else
+         sprintf(buffer, "%ld", n);
+--- z3-z3-4.6.0/src/util/stopwatch.h.orig	2018-01-11 11:24:06.102799500 -0500
++++ z3-z3-4.6.0/src/util/stopwatch.h	2018-01-11 11:29:39.003463800 -0500
+@@ -20,7 +20,7 @@ Revision History:
+ #ifndef STOPWATCH_H_
+ #define STOPWATCH_H_
+ 
+-#if defined(_WINDOWS) || defined(_CYGWIN)
++#if (defined(_WINDOWS) && defined(_MSC_VER)) || defined(_CYGWIN)
+ 
+ // Does this redefinition work?
+ #define ARRAYSIZE_TEMP ARRAYSIZE
+--- z3-z3-4.6.0/src/util/util.h.orig	2018-01-11 12:08:58.915148900 -0500
++++ z3-z3-4.6.0/src/util/util.h	2018-01-11 12:10:25.793735100 -0500
+@@ -51,7 +51,7 @@ static_assert(sizeof(int64) == 8, "64 bi
+ #define UINT64_MAX 0xffffffffffffffffull
+ #endif
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #define SSCANF sscanf_s
+ #define SPRINTF sprintf_s
+ #define _Exit exit
+
+--- z3-z3-4.6.0/src/util/warning.cpp.orig	2018-01-11 10:27:42.641019100 -0500
++++ z3-z3-4.6.0/src/util/warning.cpp	2018-01-11 10:42:12.129970300 -0500
+@@ -24,7 +24,7 @@ Revision History:
+ #include "util/buffer.h"
+ #include "util/vector.h"
+ 
+-#ifdef _WINDOWS
++#if defined(_WINDOWS) && defined(_MSC_VER)
+ #define PRF sprintf_s
+ #define VPRF vsprintf_s
+ 


### PR DESCRIPTION
…make files.

mingw-w64-mesa - Update to 17.3.2, added new patch to fix linking.  Do not llvm-config, there are still issues with it.
mingw-w64-z3 - New package 4.6.0 -