### PR TITLE
python3: include official .rc files for the dlls/execs. See #3139

### DIFF
--- a/mingw-w64-python3/1800-link-win-resource-files-and-build-pythonw.patch
+++ b/mingw-w64-python3/1800-link-win-resource-files-and-build-pythonw.patch
@@ -1,0 +1,70 @@
+--- Python-3.6.4/Makefile.pre.in.orig	2018-01-22 20:02:36.256958400 +0100
++++ Python-3.6.4/Makefile.pre.in	2018-01-22 20:14:58.314401700 +0100
+@@ -236,6 +236,7 @@
+ 
+ PYTHON=		python$(EXE)
+ BUILDPYTHON=	python$(BUILDEXE)
++BUILDPYTHONW=	pythonw$(BUILDEXE)
+ 
+ PYTHON_FOR_REGEN=@PYTHON_FOR_REGEN@
+ UPDATE_FILE=@PYTHON_FOR_REGEN@ $(srcdir)/Tools/scripts/update_file.py
+@@ -448,7 +450,7 @@
+ 
+ # Default target
+ all:		@DEF_MAKE_ALL_RULE@
+-build_all:	check-clean-src $(BUILDPYTHON) oldsharedmods sharedmods gdbhooks \
++build_all:	check-clean-src $(BUILDPYTHON) $(BUILDPYTHONW) oldsharedmods sharedmods gdbhooks \
+ 		Programs/_testembed python-config
+ 
+ # Check that the source is clean when building out of source.
+@@ -551,9 +553,27 @@
+ clinic: check-clean-src $(BUILDPYTHON) $(srcdir)/Modules/_blake2/blake2s_impl.c
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) ./Tools/clinic/clinic.py --make
+ 
++pythonnt_rc.h:
++	# FIXME: FIELD3 not set
++	@echo '#define FIELD3 0' > $@
++	@echo '#define MS_DLL_ID "$(VERSION)"' >> $@
++	@echo '#define PYTHON_DLL_NAME "$(DLLLIBRARY)"' >> $@
++
++python_exe.o: pythonnt_rc.h $(srcdir)/PC/python_exe.rc
++	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_exe.rc $@
++
++pythonw_exe.o: pythonnt_rc.h $(srcdir)/PC/pythonw_exe.rc
++	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/pythonw_exe.rc $@
++
++python_nt.o: pythonnt_rc.h $(srcdir)/PC/python_nt.rc
++	windres -I$(srcdir)/Include -I$(srcdir)/PC -I. $(srcdir)/PC/python_nt.rc $@
++
++$(BUILDPYTHONW): Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) pythonw_exe.o
++	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -mwindows -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST) pythonw_exe.o
++
+ # Build the interpreter
+-$(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
+-	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
++$(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY) python_exe.o
++	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST) python_exe.o
+ 
+ platform: $(BUILDPYTHON) pybuilddir.txt
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
+@@ -662,10 +682,10 @@
+ 
+ # This rule builds the Python DLL and import library if configured
+ # for a shared core library; otherwise, this rule is a noop.
+-$(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
++$(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS) python_nt.o
+ 	if test -n "$(DLLLIBRARY)"; then \
+ 		$(LDSHARED) -Wl,--out-implib=$@ -o $(DLLLIBRARY) $^ \
+-			$(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST); \
++			$(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST) python_nt.o; \
+ 	else true; \
+ 	fi
+ 
+@@ -1162,6 +1183,7 @@
+ 	done
+ 	if test "$(PYTHONFRAMEWORKDIR)" = "no-framework" ; then \
+ 		$(INSTALL_PROGRAM) $(BUILDPYTHON) $(DESTDIR)$(BINDIR)/python$(LDVERSION)$(EXE); \
++		$(INSTALL_PROGRAM) $(BUILDPYTHONW) $(DESTDIR)$(BINDIR)/python3w$(EXE); \
+ 	else \
+ 		$(INSTALL_PROGRAM) $(STRIPFLAG) Mac/pythonw $(DESTDIR)$(BINDIR)/python$(LDVERSION)$(EXE); \
+ 	fi

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
 pkgver=${_pybasever}.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -133,6 +133,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1690-need-win7-headers.patch
         1700-cygpty-isatty-disable-readline.patch
         1701-disable-broken-gdbm-module.patch
+        1800-link-win-resource-files-and-build-pythonw.patch
         smoketests.py)
 
 prepare() {
@@ -264,6 +265,9 @@ prepare() {
   # Don't include it so the dbm.dumb backend is used instead,
   # like with the official CPython build.
   patch -Np1 -i "${srcdir}"/1701-disable-broken-gdbm-module.patch
+
+  # https://github.com/Alexpux/MINGW-packages/issues/3139
+  patch -Np1 -i "${srcdir}"/1800-link-win-resource-files-and-build-pythonw.patch
 
   autoreconf -vfi
 
@@ -402,10 +406,6 @@ package() {
   sed -i "s|${pkgdir}${MINGW_PREFIX}|${MINGW_PREFIX}|g" \
     "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/lib-dynload/_sysconfigdata*.py \
     "${pkgdir}${MINGW_PREFIX}"/lib/python${_pybasever}/smtpd.py
-
-  # Create python executable with windows subsystem
-  cp -f "${pkgdir}${MINGW_PREFIX}"/bin/python3.exe "${pkgdir}${MINGW_PREFIX}"/bin/python3w.exe
-  ${MINGW_PREFIX}/bin/objcopy --subsystem windows "${pkgdir}${MINGW_PREFIX}"/bin/python3w.exe
 }
 
 sha256sums=('159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba'
@@ -503,4 +503,5 @@ sha256sums=('159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba'
             'ef192ac5bba7bd39c1a4c701b437099fe87e20759016a1e0e3d6709bc6f0a741'
             '7b0ba12b62e64ad4fa6914e66a1c38c584c93160314693bed1bb39a1d3af77d4'
             '90cf511bec827adbdfda3969718248343e0eb728b747cc1557e0e8d36ae50c7b'
+            '5f0c5539e11dc57bba2ddf58304b434cbac8123b99e4f42586c92678b6b63b2f'
             'f4f5359b35741b703cbd22dc73438c181b8541e30b3f7614bd272f7cd2c59049')


### PR DESCRIPTION
Use windres to build the resource files and include them in the
dll and executables. Since we need a different resource for the
console/gui version move the creation of the python3w.exe file from
the PKGBUILD into the Makefile.

With a bit of luck this should allow one to opt into the new long paths
feature on Windows 10, like with the official builds.
(no Windows 10 here, can't test)