### PR TITLE
KF5 update to 5.42.0

### DIFF
--- a/mingw-w64-attica-qt5/PKGBUILD
+++ b/mingw-w64-attica-qt5/PKGBUILD
@@ -5,7 +5,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "attica"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="A Qt5 library that implements the Open Collaboration Services API (mingw-w64-qt5${_namesuff})"
@@ -15,7 +15,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('26f124e686d4a1ff005798958d63ddccd0bc23a763ea0578c4d2337a1a6b558b')
+sha256sums=('adfba910d6d3bbd814b8b8e7322e8181696f180f6088b53cb726e6a5cbd49245')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-extra-cmake-modules/PKGBUILD
+++ b/mingw-w64-extra-cmake-modules/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=extra-cmake-modules
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 pkgdesc='Extra CMake modules (mingw-w64)'
 arch=('any')
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-cmake"
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-sphinx") # qt5-tools for QtHelp pages
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         "set-AUTOSTATICPLUGINS.patch")
-sha256sums=('6188a8ac8d799439204f69a1eb229431fc9f196790b88d6fb72bb3d57edb2332'
+sha256sums=('430db21202c01e5a49f6fbaa6a0b2d7fb169857de5d16ff7a83f96acf5d086d6'
             'a246d25065ac7472b3a4e5995b3c6cb32081ffa21c7de7455006398431e6c886')
 
 prepare() {

--- a/mingw-w64-kactivities-qt5/PKGBUILD
+++ b/mingw-w64-kactivities-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kactivities"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Runtime and library to organize user work in separate activities (mingw-w64-qt5${_namesuff})"
@@ -17,7 +17,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuf
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwindowsystem-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('289d25367515e8d4668f460e3274b68ed6322a7f1c6228602c0f20462303353f')
+sha256sums=('39080e0351ee488fd0e017f14bfbb2643029e5c4f97bb4824e095f6b04610a7c')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -39,7 +39,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-karchive-qt5/PKGBUILD
+++ b/mingw-w64-karchive-qt5/PKGBUILD
@@ -5,17 +5,20 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "karchive"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Qt 5 addon providing access to numerous types of archives (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-zlib"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-xz"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('9354d45219342b888ac0eccbc3ce3a054858fcce9d4c93817352d2b447ebb658')
+sha256sums=('71e130280953918ddbabc1731c65d16923ab96313bb3c6e58786b6dadbb302ef')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +40,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kauth-qt5/PKGBUILD
+++ b/mingw-w64-kauth-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kauth"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Abstraction to system policy and authentication features (mingw-w64-qt5${_namesuff})"
@@ -14,7 +14,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('279af9593b3bf8b2730730877ff865944839e08d21855ea25864934fe372de8a')
+sha256sums=('91ebf3554551c3815e89e53e577e42d7cc3ac1f4966215fbbc93a60ca1587812')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -36,7 +36,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcodecs-qt5/PKGBUILD
+++ b/mingw-w64-kcodecs-qt5/PKGBUILD
@@ -5,7 +5,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcodecs"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins allowing Qt applications to access further types of images (mingw-w64-qt5${_namesuff})"
@@ -15,7 +15,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('31a22d37da33d86d492b4bf5e439566d8f6a0783f74382931cee4c59a482dd32')
+sha256sums=('8c574d9c1140089767c6c46fd93cf4c9a4972b83cef16da7f4b6a52c06f9292c')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcompletion-qt5/PKGBUILD
+++ b/mingw-w64-kcompletion-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcompletion"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Text completion helpers and widgets for Qt (mingw-w64-qt5${_namesuff})"
@@ -15,7 +15,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuf
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwidgetsaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('5c943799729e7ed8d101eb2e11a09a2616d6c13c33d3575b2e61667e0c2f2539')
+sha256sums=('0e448a1a05436988a836ec0f533c8cb71e955251ec0d4b7e0dbbcc06b6880c7b')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kconfig-qt5/PKGBUILD
+++ b/mingw-w64-kconfig-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kconfig"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="KConfig provides an advanced configuration system (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('79744af26c90b78f01e065049daea0a6470f0d8b8e71334652179bac1b12243a')
+sha256sums=('b8e5889989354fef6c52e7a9f40e6260382fe6bfcda3da3d3c3201064403ef21')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kconfigwidgets-qt5/PKGBUILD
+++ b/mingw-w64-kconfigwidgets-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kconfigwidgets"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Widgets for configuration dialogs (mingw-w64-qt5${_namesuff})"
@@ -13,6 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kauth-qt5${_namesuff}>=${pkgver}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_namesuff}>=${pkgver}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcodecs-qt5${_namesuff}>=${pkgver}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuff}>=${pkgver}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kguiaddons-qt5${_namesuff}>=${pkgver}"
@@ -20,7 +21,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwidgetsaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('1d70a761eefe60e6f7beb3517ed64edbb6266cfe85bbb65603c9764e524b6170')
+sha256sums=('9fe08e8811765c7893e0edd5c63bc491cc348c80ce3258cc0a00588189a83fa4')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -42,7 +43,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcoreaddons-qt5/PKGBUILD
+++ b/mingw-w64-kcoreaddons-qt5/PKGBUILD
@@ -5,18 +5,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcoreaddons"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Classes built on top of QtCore to perform various tasks (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+optdepends=("${MINGW_PACKAGE_PREFIX}-shared-mime-info: Provides information about file types")
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
         001-disable-fam-on-windows.patch)
-sha256sums=('9be3dd86402e173da025c0d326fd9a38ffeecb34828a287f8b8c530a5db275d4'
+sha256sums=('4967aba9f0175025a1c076cf15487d10ce08d27cad740f814ab58af34d3e1b9f'
             'cce04ffc4ddc00bbc47625ce2979c2c4011822ae3804561e822be26a8eed8175')
 
 prepare() {
@@ -41,7 +42,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kcrash-qt5/PKGBUILD
+++ b/mingw-w64-kcrash-qt5/PKGBUILD
@@ -6,7 +6,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcrash"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Support for application crash analysis and bug report from apps (mingw-w64-qt5${_namesuff})"
@@ -18,7 +18,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_nam
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwindowsystem-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('215c90bf6501cb90db01f2a04155bcd8a8e66fcfb4a94649e72204c5a1df10a9')
+sha256sums=('da46566c45d1c6381583f44894f82bdabbaf91a477b4d12206fe0cee5b073e11')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -40,7 +40,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kdbusaddons-qt5/PKGBUILD
+++ b/mingw-w64-kdbusaddons-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kdbusaddons"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="KConfig provides an advanced configuration system (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('1c1f8955570cd7e0480ec619084c5ea56cbffaca5307d9053d52092f10d589d7')
+sha256sums=('6dc19471c9dc53ae13c642b3cd2512fdb2aadb6ab287caeffe56829307bb2398')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kdnssd-qt5/PKGBUILD
+++ b/mingw-w64-kdnssd-qt5/PKGBUILD
@@ -2,21 +2,18 @@
 
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
-_kde_f5_init_package "${_variant}" "sonnet"
+_kde_f5_init_package "${_variant}" "kdnssd"
 pkgver=5.42.0
 pkgrel=1
 arch=('any')
-pkgdesc="Spell checking framework for Qt (mingw-w64-qt5${_namesuff})"
+pkgdesc="Abstraction to system DNS Service Discovery features (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
-             "${MINGW_PACKAGE_PREFIX}-hunspell" "${MINGW_PACKAGE_PREFIX}-aspell")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
-optdepends=("${MINGW_PACKAGE_PREFIX}-hunspell: spell checking via hunspell"
-            "${MINGW_PACKAGE_PREFIX}-aspell: spell checking via aspell")
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('3c523fa0195e2e2af0071235507a9e30d140175afb4bc0e944d5025f5bab6ae4')
+sha256sums=('946e1f9a609e55930c20127b6cb6d86599c21a4a13d83263a44ed50185f939cc')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kdoctools-qt5/PKGBUILD
+++ b/mingw-w64-kdoctools-qt5/PKGBUILD
@@ -3,14 +3,14 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kdoctools"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="KF5 documentation framework using docbook (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}" "perl")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-libxslt${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-docbook-xsl${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}>=${pkgver}"
@@ -18,7 +18,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesu
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
         'catalog_path.patch')
-sha256sums=('c95f7e604bd16c3ef97b3fc0320a5656ef1ea3b3c75b7d4d22348391423c7b39'
+sha256sums=('bf4e03e90b7b324e8b96979b0854c9d1178c7a64bf5710650d9051dab61a7ead'
             '7dafde4dd5a202c82b3e88480c0c80a045845f9bf35576e061a54a7fc2d31303')
 
 prepare() {
@@ -47,7 +47,7 @@ build() {
       -DMSYS_REAL_INSTALL_DIR=${QT5_PREFIX} \
       -DCMAKE_INSTALL_DATAROOTDIR=share \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kfilemetadata-qt5/PKGBUILD
+++ b/mingw-w64-kfilemetadata-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kfilemetadata"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="A file metadata extraction library (mingw-w64-qt5${_namesuff})"
@@ -19,7 +19,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-taglib"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ffmpeg"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('95ce8b047895d4b1efd34e841035147e282f03996e1d33d79f09a6d469ca25a0')
+sha256sums=('9f57998a1a781993efeed0749f49728d8e63a77f8bb7f4a72765603d301a930f')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -41,7 +41,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kglobalaccel-qt5/PKGBUILD
+++ b/mingw-w64-kglobalaccel-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kglobalaccel"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Global desktop keyboard shortcuts (mingw-w64-qt5${_namesuff})"
@@ -11,13 +11,13 @@ license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depeneds=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuff}"
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcrash-qt5${_namesuff}"
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdbusaddons-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kconfig-qt5${_namesuff}>=${pkgver}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcrash-qt5${_namesuff}>=${pkgver}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdbusaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 # install=${pkgname}.install
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('ba0a9084bd456fe4b9b9e308a0105ea744cf980bf4b5fcb0b1cd0a302a7cb5e7')
+sha256sums=('e6f5e6588bfcbbbdc62de2756143db34a92ee07adb5ec8a14fa76110c7519f5a')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -39,7 +39,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       -DKF5Config_DIR=${QT5_PREFIX}/lib/cmake/KF5Config \

--- a/mingw-w64-kguiaddons-qt5/PKGBUILD
+++ b/mingw-w64-kguiaddons-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kguiaddons"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Utilities for graphical user interfaces (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('01a6350be86f86fb11625393fdc2cb1fe70b7289d06140afa7b0186339047aca')
+sha256sums=('c77213c07ba790a162fff156ab2b3e1d36103f4ff38e8ad07db38de0c84271a4')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kholidays-qt5/PKGBUILD
+++ b/mingw-w64-kholidays-qt5/PKGBUILD
@@ -2,21 +2,17 @@
 
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
-_kde_f5_init_package "${_variant}" "sonnet"
-pkgver=5.42.0
+_kde_f5_init_package "${_variant}" "kholidays"
+pkgver=17.12.1
 pkgrel=1
 arch=('any')
-pkgdesc="Spell checking framework for Qt (mingw-w64-qt5${_namesuff})"
+pkgdesc="Library for regional holiday information (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
-             "${MINGW_PACKAGE_PREFIX}-hunspell" "${MINGW_PACKAGE_PREFIX}-aspell")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
-optdepends=("${MINGW_PACKAGE_PREFIX}-hunspell: spell checking via hunspell"
-            "${MINGW_PACKAGE_PREFIX}-aspell: spell checking via aspell")
-groups=('kf5')
-source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('3c523fa0195e2e2af0071235507a9e30d140175afb4bc0e944d5025f5bab6ae4')
+source=("https://download.kde.org/stable/applications/${pkgver}/src/${_basename}-${pkgver}.tar.xz")
+sha256sums=('8832f089c0a43e07567581d2b6a747b7710ac4cd6d47bb02f6137dbbf8692515')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-ki18n-qt5/PKGBUILD
+++ b/mingw-w64-ki18n-qt5/PKGBUILD
@@ -3,18 +3,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "ki18n"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="KDE Gettext-based UI text internationalization (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-gettext"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz"
         "build-ktranscript-plugin-statically-if-not-shared.patch")
-sha256sums=('240ccf22a65cf85da900c88afceac8bedc40b71a4d19bad526c03aa285cc2a7d'
+sha256sums=('a9cb8ced1284b7b983b609f93da9a596e09f0d1d06befe49928828b1a88bf9e6'
             'fb05bcdf56feec1cae600a10b9706c6573bc9b39becea0e1061b10a65dc68a40')
 
 prepare() {
@@ -39,7 +40,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kiconthemes-qt5/PKGBUILD
+++ b/mingw-w64-kiconthemes-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kiconthemes"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Support for icon themes (mingw-w64-qt5${_namesuff})"
@@ -16,7 +16,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kitemviews-qt5${_name
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('2a7dc525c1e9eea8c8952ca4eeccc22c28bb37ea83895fd7166174263218aa07')
+sha256sums=('87c54e3fdfb01d88f144078401170841ffa1d1cc27ac32682f03ed85dced7dd9')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -38,7 +38,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kidletime-qt5/PKGBUILD
+++ b/mingw-w64-kidletime-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kidletime"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Reporting of idle time of user and system (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('5bd30a316ea72a44ed4e4f7f11533e5aa74fc817f360f471b2658ac560e221c5')
+sha256sums=('b0b355c0948f5e2ab2366b089bd894051cf547a154773e8365995d2472203905')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kimageformats-qt5/PKGBUILD
+++ b/mingw-w64-kimageformats-qt5/PKGBUILD
@@ -3,19 +3,19 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kimageformats"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-openexr${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-karchive-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('97ca8eaa52f296e7fddde25abfe6c7707070b075e92e487da9edb3c719d4e860')
+sha256sums=('46a1d3a4b2b3992bc4abcd34d2e1a321a5bf6acce89097bffceaf4af6bf6c7cc')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kitemmodels-qt5/PKGBUILD
+++ b/mingw-w64-kitemmodels-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kitemmodels"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('4cfa7661b6d3c1e242b92c9200383400398af1db341dbbd2de573429898d4068')
+sha256sums=('0c5663904536568d898c3fd1655575165efc325cd2669d23bfc9edca71fb8d55')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kitemviews-qt5/PKGBUILD
+++ b/mingw-w64-kitemviews-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kitemviews"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('46df0b2a0fe436cac2e1984d9038ac894ac86d9650db5328fa7069a13f46b151')
+sha256sums=('1c11e10d03e76d1ba7ee6ea8821570695bb13cbdf928910773b62287c00238c8')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kjobwidgets-qt5/PKGBUILD
+++ b/mingw-w64-kjobwidgets-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kjobwidgets"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Widgets for tracking KJob instances (mingw-w64-qt5${_namesuff})"
@@ -15,7 +15,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_nam
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kwidgetsaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('a5340df37ba44f6b5b82f8c6732aaaa42ffc6d9a829c15b345e824360eb3e66e')
+sha256sums=('64a2cf38ed5d03b8e91e73fb81997cd4ed1eaf5c17835b36f728407e68d36cd4')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kjs-qt5/PKGBUILD
+++ b/mingw-w64-kjs-qt5/PKGBUILD
@@ -3,10 +3,10 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kjs"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
-pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
+pkgdesc="Support JS scripting in KDE applications (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}" "perl")
 depends=()
@@ -15,7 +15,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-pcre${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdoctools-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/portingAids/${_basename}-${pkgver}.tar.xz")
-sha256sums=('c173775230d93ef9da043e2664c71d0bd84c6dc4b05b881730dbcf32012a3c36')
+sha256sums=('8f8cc39503099f53b152866f931a85f30a5fcbf6629ac3e7ad8f658fc5d246d4')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -37,7 +37,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kpackage-qt5/PKGBUILD
+++ b/mingw-w64-kpackage-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kpackage"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Library to load and install packages of non-binary files as they were a plugin (mingw-w64-qt5${_namesuff})"
@@ -17,7 +17,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcoreaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('b6eb027aa8fbb0a45d87b026ae7117f14c08385628b5da5ba55994f7f01c926c')
+sha256sums=('0acbb8076953ac8fa1723a221f7043331c2dbf67292ceafd94a0a17e00845581')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -39,7 +39,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kplotting-qt5/PKGBUILD
+++ b/mingw-w64-kplotting-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kplotting"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('e2d8ef624735a56f3998c88af6f06209221af5f27ef05096d65ebb124dc56ec3')
+sha256sums=('898ea02fd03103d7b053dc40fcfc7b6a2a30835b9346743d559967a8f34b2b81')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kservice-qt5/PKGBUILD
+++ b/mingw-w64-kservice-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kservice"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Advanced plugin and service introspection (mingw-w64-qt5${_namesuff})"
@@ -18,7 +18,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kcrash-qt5${_namesuff
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdbusaddons-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('2d31c96d8fad235aa2bfc96258ac03d7ec064184fe6a54856f9d7407fbae4a7d')
+sha256sums=('31f337e0cbe53bf7c6abef03249e8750ebc97225145d3a439dbb5900da751f7d')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -40,7 +40,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-ktextwidgets-qt5/PKGBUILD
+++ b/mingw-w64-ktextwidgets-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "ktextwidgets"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Widgets for displaying and editing text (mingw-w64-qt5${_namesuff})"
@@ -17,7 +17,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kiconthemes-qt5${_nam
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-sonnet-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('eef0847aa98489437784361a281a16cbd52b3ac8a1a83619c370078e96ea1288')
+sha256sums=('d32becae0f7f57016523eb8e4328b2d59140451c8612de7bed9cf992f6fa0a21')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -39,7 +39,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kunitconversion-qt5/PKGBUILD
+++ b/mingw-w64-kunitconversion-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kunitconversion"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Abstraction to system DNS Service Discovery features (mingw-w64-qt5${_namesuff})"
@@ -14,7 +14,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ki18n-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('6c538b35e727f75e90178b6b5b17d299a3ce797bd82a6adb0af4e41096eb6082')
+sha256sums=('548c4d63fe3778387c54d0f36934b7ed4b44ec414c33559c877b0f4a94bd2908')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -36,7 +36,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
+++ b/mingw-w64-kwidgetsaddons-qt5/PKGBUILD
@@ -3,17 +3,18 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kwidgetsaddons"
-pkgver=5.38.0
+pkgver=5.42.1
+_kf5ver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${_kf5ver}")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('45ee4f81cd91e61e82306f757a06849644fde73e09650e0498797cdc3a4604fa')
+sha256sums=('8f56f65dc5dbe656fd74191b13c7e7cad3ffd52c02b5baaf0b20fe425d761b40')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +36,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kwindowsystem-qt5/PKGBUILD
+++ b/mingw-w64-kwindowsystem-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kwindowsystem"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('2c16eb635714ff122b9348c0cc880be60d08c817c98026029f78434d918db90b')
+sha256sums=('1b37f1f40fe40d8d689ccafc7b0e46a8b515c554dfe1f3eb50b3e3911ce86696')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-kxmlgui-qt5/PKGBUILD
+++ b/mingw-w64-kxmlgui-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kxmlgui"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="User configurable main windows (mingw-w64-qt5${_namesuff})"
@@ -16,7 +16,7 @@ _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-ktextwidgets-qt5${_na
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-attica-qt5${_namesuff}>=${pkgver}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('64f73ada0b1e08c97db00cfe2967b0d8354b338cd85e76644f79da022af49589')
+sha256sums=('c01715eb7ba54e10ef3754ac2fd2de580ad6b12568dbe657d17ec2cc5197dd4d')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -38,7 +38,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-solid-qt5/PKGBUILD
+++ b/mingw-w64-solid-qt5/PKGBUILD
@@ -4,7 +4,7 @@ _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "solid"
 pkgbase=mingw-w64-solid-qt5
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 url='https://projects.kde.org/projects/frameworks/${_basename}'
@@ -12,10 +12,10 @@ pkgdesc="Plugins to allow QImage to support extra file formats (mingw-w64-qt5${_
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('1052830aaed16391563dc35fe0e01bba2813acf2e0c70fa2223d54d2732b6cac')
+sha256sums=('9802cca5942ac57d113c1eb2e69244dbcf3958637f8e812c8e6a1bacd4459982')
 
 prepare() {
   cd "${srcdir}"/${_basename}-${pkgver}
@@ -38,7 +38,7 @@ build() {
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DQt5_DIR=${QT5_PREFIX}/lib/cmake/Qt5 \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \

--- a/mingw-w64-syntax-highlighting-qt5/PKGBUILD
+++ b/mingw-w64-syntax-highlighting-qt5/PKGBUILD
@@ -3,17 +3,17 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "syntax-highlighting"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="Syntax highlighting library using Kate's syntax rules (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('d4b887e2b4c0bb0d0c723325b11897d1ab38a644e3276d57eae8393928783680')
+sha256sums=('c034d9a43d81fb29af21af419169c15192d0566d2e07d2499c3215044af591c7')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \

--- a/mingw-w64-threadweaver-qt5/PKGBUILD
+++ b/mingw-w64-threadweaver-qt5/PKGBUILD
@@ -3,7 +3,7 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "threadweaver"
-pkgver=5.38.0
+pkgver=5.42.0
 pkgrel=1
 arch=('any')
 pkgdesc="High-level multithreading framework for Qt (mingw-w64-qt5${_namesuff})"
@@ -13,7 +13,7 @@ depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}" "${MINGW_PACKAGE_PREFIX}-bzip2"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('db6dca72315a376fa8852f0059113a5880a002e311e5f4591138303b69a209b5')
+sha256sums=('76e5bc74ac249358076fafb1d82cab0974fb9ccace9fdaeaf9beffeeeca558c7')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}
@@ -35,7 +35,7 @@ build() {
       -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
       -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
       -DKDE_INSTALL_LIBDIR=lib \
-      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
       -DBUILD_TESTING=OFF \
       -DECM_DIR=${MINGW_PREFIX}/share/ECM \
       "${extra_config[@]}" \


### PR DESCRIPTION
Also fixes the incorrect qmake module paths, causing qmake to be unable to find KF5 modules.