### PR TITLE
gtk3: Remove python2 makedep

### DIFF
--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.22.26
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -12,10 +12,8 @@ license=("LGPL")
 install=gtk3-${CARCH}.install
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
-# python2 is required to run gdbus-codegen
 makedepends+=("autoconf" "automake" "libtool")
 # autotools are required because several Makefile.am are modified
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"


### PR DESCRIPTION
gdbus-codegen uses Python 3 now, and it is part of glib2 which depends
on python3 anyway.