### PR TITLE
gobject-introspection: depend on pkg-config

### DIFF
--- a/mingw-w64-gobject-introspection/PKGBUILD
+++ b/mingw-w64-gobject-introspection/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-runtime")
 pkgver=1.54.1
-pkgrel=3
+pkgrel=4
 arch=('any')
 url="https://live.gnome.org/GObjectIntrospection"
 license=("LGPL")
@@ -81,6 +81,7 @@ build() {
 package_gobject-introspection() {
   pkgdesc="Introspection system for GObject-based libraries (mingw-w64)"
   depends=("${MINGW_PACKAGE_PREFIX}-gobject-introspection-runtime=${pkgver}"
+           "${MINGW_PACKAGE_PREFIX}-pkg-config"
            "${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-mako")
   options=('!emptydirs')


### PR DESCRIPTION
When you pass --pkg to g-ir-scanner it uses pkg-config.
And without mingw pkg-config it might use msys pkg-config which
leads to weird errors, see https://github.com/Alexpux/MINGW-packages/issues/2198
Better depend on it.