### PR TITLE
gdb: fix python relocatable support. See #3329

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -31,7 +31,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'gdb-perfomance.patch'
         'gdb-fix-using-gnu-print.patch'
         'gdb-7.12-dynamic-libs.patch'
-        'gdb-py3-fixes.patch')
+        'gdb-py3-fixes.patch'
+        'python-configure-path-fixes.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('3dbd5f93e36ba2815ad0efab030dcd0c7b211d7b353a40a53f4c02d7d56295e3'
             'SKIP'
@@ -41,7 +42,8 @@ sha256sums=('3dbd5f93e36ba2815ad0efab030dcd0c7b211d7b353a40a53f4c02d7d56295e3'
             '6be0f95483e02d5447c93ab5e2c9554d254c6888b1fa3f3a4c011cd6a0a403ad'
             '264eba33ef71c4762514a634dcf94fdb778914dbba6ce99e63804fe063225d97'
             '4398bd83a798baa15c0f91878391a0882239a682cf523ef6551766cba7b03699'
-            'bfe8985e806200e5a1007c4565bd60de0a297369d17d4a0178512f2df29b34fc')
+            'bfe8985e806200e5a1007c4565bd60de0a297369d17d4a0178512f2df29b34fc'
+            'bdf6c2b51d6c8c84b7b20abb9d1702f110c0c0e06e3d68eb6aba817664354450')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -60,6 +62,7 @@ prepare() {
   patch -p1 -i ${srcdir}/gdb-7.12-dynamic-libs.patch
 
   patch -p1 -i ${srcdir}/gdb-py3-fixes.patch
+  patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure

--- a/mingw-w64-gdb/python-configure-path-fixes.patch
+++ b/mingw-w64-gdb/python-configure-path-fixes.patch
@@ -1,0 +1,11 @@
+--- gdb-8.0.1/gdb/configure.orig	2018-02-04 15:54:00.599198000 +0100
++++ gdb-8.0.1/gdb/configure	2018-02-04 15:53:04.392983200 +0100
+@@ -9872,7 +9872,7 @@
+         as_fn_error "failure running python-config --ldflags" "$LINENO" 5
+       fi
+     fi
+-    python_prefix=`${python_prog} ${srcdir}/python/python-config.py --exec-prefix`
++    python_prefix=`cygpath -u "$(${python_prog} ${srcdir}/python/python-config.py --exec-prefix)"`
+     if test $? != 0; then
+       have_python_config=failed
+       if test "${with_python}" != auto; then


### PR DESCRIPTION
Previously python-config-u, a python-configure which returns unix paths,
was passed to configure. Passing a python executable of python-config
which returns Windows paths breaks the relocatable support somehow.

This patch converts the exec-prefix result of the python-config script
to a unix path so that things work as before.