### PR TITLE
appveyor: disable test discovery

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,8 @@ build_script:
     - C:\msys64\usr\bin\pacman --noconfirm --sync --refresh --refresh --sysupgrade --sysupgrade
     - C:\msys64\usr\bin\bash --login -c "$(cygpath ${APPVEYOR_BUILD_FOLDER})/ci-build.sh"
 
+test: off
+
 artifacts:
     - path: artifacts\*
 


### PR DESCRIPTION
With a mingw gdb build the auto test discovery takes 1.5 minutes, since
we don't have any tests disable them.