### PR TITLE
rocksdb: new package

### DIFF
--- a/mingw-w64-rocksdb/0001-fix-get-version-on-windows.patch
+++ b/mingw-w64-rocksdb/0001-fix-get-version-on-windows.patch
@@ -1,0 +1,50 @@
+From 8a68284558f2cce964b6d476f69ae6b978764926 Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Tue, 6 Feb 2018 18:35:50 +0100
+Subject: [PATCH 1/2] fix get version on windows
+
+---
+ CMakeLists.txt | 27 +++++++++++++--------------
+ 1 file changed, 13 insertions(+), 14 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5fb551a..eb502da 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -114,20 +114,19 @@ endif()
+ 
+ string(REGEX REPLACE "[^0-9a-f]+" "" GIT_SHA "${GIT_SHA}")
+ 
+-if(NOT WIN32)
+-  execute_process(COMMAND
+-      "./build_tools/version.sh" "full"
+-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-      OUTPUT_VARIABLE ROCKSDB_VERSION
+-  )
+-  string(STRIP "${ROCKSDB_VERSION}" ROCKSDB_VERSION)
+-  execute_process(COMMAND
+-      "./build_tools/version.sh" "major"
+-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+-      OUTPUT_VARIABLE ROCKSDB_VERSION_MAJOR
+-  )
+-  string(STRIP "${ROCKSDB_VERSION_MAJOR}" ROCKSDB_VERSION_MAJOR)
+-endif()
++set(SH_CMD "sh")
++execute_process(COMMAND
++  ${SH_CMD} -c "build_tools/version.sh full"
++  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
++  OUTPUT_VARIABLE ROCKSDB_VERSION
++)
++string(STRIP "${ROCKSDB_VERSION}" ROCKSDB_VERSION)
++execute_process(COMMAND
++  ${SH_CMD} -c "build_tools/version.sh major"
++  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
++  OUTPUT_VARIABLE ROCKSDB_VERSION_MAJOR
++)
++string(STRIP "${ROCKSDB_VERSION_MAJOR}" ROCKSDB_VERSION_MAJOR)
+ 
+ option(WITH_MD_LIBRARY "build with MD" ON)
+ if(WIN32 AND MSVC)
+-- 
+2.10.2
+

--- a/mingw-w64-rocksdb/0002-suppress-unused-warnings.patch
+++ b/mingw-w64-rocksdb/0002-suppress-unused-warnings.patch
@@ -1,0 +1,59 @@
+From a973589e20c0e7a5fc372d1eee358f8b22ac77c6 Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Tue, 6 Feb 2018 18:21:35 +0100
+Subject: [PATCH 2/2] suppress unused warnings
+
+---
+ port/win/env_win.cc | 2 +-
+ port/win/io_win.cc  | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/port/win/env_win.cc b/port/win/env_win.cc
+index 87b4eb1..dc83467 100644
+--- a/port/win/env_win.cc
++++ b/port/win/env_win.cc
+@@ -75,7 +75,7 @@ WinEnvIO::WinEnvIO(Env* hosted_env)
+   {
+     LARGE_INTEGER qpf;
+     // No init as the compiler complains about unused var
+-    BOOL ret;
++    BOOL ret __attribute__((__unused__));
+     ret = QueryPerformanceFrequency(&qpf);
+     assert(ret == TRUE);
+     perf_counter_frequency_ = qpf.QuadPart;
+diff --git a/port/win/io_win.cc b/port/win/io_win.cc
+index 9403c82..0819feb 100644
+--- a/port/win/io_win.cc
++++ b/port/win/io_win.cc
+@@ -192,8 +192,8 @@ WinMmapReadableFile::WinMmapReadableFile(const std::string& fileName,
+       length_(length) {}
+ 
+ WinMmapReadableFile::~WinMmapReadableFile() {
+-  BOOL ret = ::UnmapViewOfFile(mapped_region_);
+-  (void)ret;
++  BOOL ret __attribute__((__unused__));
++  ret = ::UnmapViewOfFile(mapped_region_);
+   assert(ret);
+ 
+   ret = ::CloseHandle(hMap_);
+@@ -279,7 +279,7 @@ Status WinMmapFile::MapNewRegion() {
+ 
+     if (hMap_ != NULL) {
+       // Unmap the previous one
+-      BOOL ret;
++      BOOL ret __attribute__((__unused__));
+       ret = ::CloseHandle(hMap_);
+       assert(ret);
+       hMap_ = NULL;
+@@ -1021,7 +1021,7 @@ Status WinDirectory::Fsync() { return Status::OK(); }
+ /// WinFileLock
+ 
+ WinFileLock::~WinFileLock() {
+-  BOOL ret;
++  BOOL ret __attribute__((__unused__));
+   ret = ::CloseHandle(hFile_);
+   assert(ret);
+ }
+-- 
+2.10.2
+

--- a/mingw-w64-rocksdb/0003-add-with-gflags-option.patch
+++ b/mingw-w64-rocksdb/0003-add-with-gflags-option.patch
@@ -1,0 +1,48 @@
+From 921caeeb1cc6d9649647a7c20fe7101176221f6c Mon Sep 17 00:00:00 2001
+From: Philippe Renon <philippe_renon@yahoo.fr>
+Date: Fri, 9 Feb 2018 10:54:08 +0100
+Subject: [PATCH 3/3] add with gflags option
+
+---
+ CMakeLists.txt | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eb502da..43ab9c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,6 +57,17 @@ else()
+     endif()
+   endif()
+ 
++  # No config file for this
++  option(WITH_GFLAGS "build with GFlags" ON)
++  if(WITH_GFLAGS)
++    find_package(gflags)
++    if(gflags_FOUND)
++      add_definitions(-DGFLAGS=1)
++      include_directories(${gflags_INCLUDE_DIR})
++      list(APPEND THIRDPARTY_LIBS ${gflags_LIBRARIES})
++    endif()
++  endif()
++
+   option(WITH_SNAPPY "build with SNAPPY" OFF)
+   if(WITH_SNAPPY)
+     find_package(snappy REQUIRED)
+@@ -253,13 +264,6 @@ if(WITH_UBSAN)
+   endif()
+ endif()
+ 
+-find_package(gflags)
+-if(gflags_FOUND)
+-  add_definitions(-DGFLAGS=1)
+-  include_directories(${gflags_INCLUDE_DIR})
+-  list(APPEND THIRDPARTY_LIBS ${gflags_LIBRARIES})
+-endif()
+-
+ find_package(NUMA)
+ if(NUMA_FOUND)
+   add_definitions(-DNUMA)
+-- 
+2.10.2
+

--- a/mingw-w64-rocksdb/PKGBUILD
+++ b/mingw-w64-rocksdb/PKGBUILD
@@ -1,0 +1,78 @@
+# Maintainer: Philippe Renon <philippe.renon@yahoo.fr>
+
+_realname=rocksdb
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=5.10.2
+pkgrel=1
+pkgdesc="A library that provides an embeddable, persistent key-value store for fast storage (mingw-w64)"
+arch=('any')
+url="http://rocksdb.org"
+license=("Apache")
+depends=("${MINGW_PACKAGE_PREFIX}-intel-tbb"
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-lz4"
+         "${MINGW_PACKAGE_PREFIX}-bzip2"
+         "${MINGW_PACKAGE_PREFIX}-snappy")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc")
+options=('staticlibs' 'strip')
+source=("https://github.com/facebook/${_realname}/archive/${_realname}-${pkgver}.tar.gz"
+        "0001-fix-get-version-on-windows.patch"
+        "0002-suppress-unused-warnings.patch"
+        "0003-add-with-gflags-option.patch")
+sha256sums=('11cbb016071cb79b0817866f30250bab851f5b069b13784af08de990a6f774b6'
+            '31f7046c83e0f9afed64675f80e62245c631a22feaf9297898ab03ab3c94d25a'
+            '5fcf5be787ada79ed29a8852c41f634118f00e9900838285eb0834b234f9e199'
+            '3175e7acf36a053532c8249560738fd871f346461c42a03e7fc1625463fadc46')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${_realname}-${pkgver}"
+
+  patch -p1 -i "${srcdir}/0001-fix-get-version-on-windows.patch"
+  patch -p1 -i "${srcdir}/0002-suppress-unused-warnings.patch"
+  patch -p1 -i "${srcdir}/0003-add-with-gflags-option.patch"
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir ${srcdir}/build-${MINGW_CHOST}
+  cd ${srcdir}/build-${MINGW_CHOST}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    # tests don't compile in Release mode
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release", "-DWITH_TESTS=OFF", "-DWITH_GFLAGS=OFF")
+  else
+    # not tested + needs gflags dependency
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    "${extra_config[@]}" \
+    -DWITH_ZLIB=ON \
+    -DWITH_BZ2=ON \
+    -DWITH_LZ4=ON \
+    -DWITH_SNAPPY=ON \
+    -DROCKSDB_INSTALL_ON_WINDOWS=ON \
+    ../${_realname}-${_realname}-${pkgver}
+
+  make DESTDIR=${pkgdir}
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+
+  local WINPREFIX=$(cygpath -wm ${MINGW_PREFIX})
+  # Fix paths
+  sed -i "s|${WINPREFIX}|${MINGW_PREFIX}|g" \
+    ${pkgdir}${MINGW_PREFIX}/lib/cmake/rocksdb/RocksDBTargets.cmake
+
+  install -Dm644 ${srcdir}/${_realname}-${_realname}-${pkgver}/LICENSE.Apache "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${_realname}-${pkgver}/LICENSE.leveldb "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE.leveldb
+  install -Dm644 "${srcdir}/${_realname}-${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
WIP as there are some issues:

1/ when packaging there is this warning:
`WARNING: Package contains reference to $(cygpath -m /)`

2/ when compiling rocksdb with more libraries (lz4, bz2, snappy) then osgearth fails to link.
osgearth does not pick up the additional "external" libraries needed by rocksdb.
