### PR TITLE
mbedtls: Updated to 2.7.0

### DIFF
--- a/mingw-w64-mbedtls/PKGBUILD
+++ b/mingw-w64-mbedtls/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mbedtls
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.6.0
+pkgver=2.7.0
 pkgrel=1
 arch=('any')
 url='https://tls.mbed.org/'
@@ -20,7 +20,7 @@ source=(${_realname}-${pkgver}.tar.gz::"https://tls.mbed.org/download/mbedtls-${
         'symlink-test.patch'
         'dll-location.patch'
         'enable-features.patch')
-sha256sums=('99bc9d4212d3d885eeb96273bcde8ecc649a481404b8d7ea7bb26397c9909687'
+sha256sums=('aeb66d6cd43aa1c79c145d15845c655627a7fc30d624148aaafbb6c36d7f55ef'
             '5c5382ff266e5cc293f31a46e1f10782c765c5cc1476dfc21d5c4ad405f647a0'
             '89eb82f9e9fb456d0595035925d2d512aa2ca9b9e283b9c51d5524bfc8dbf996'
             '1be88267b045a8728fe4dde663faf328ad788eeefcb43915beeb364b4d2dd2e8')


### PR DESCRIPTION
[mbed TLS Security Advisory 2018-01](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2018-01)