### PR TITLE
add hdf4 package (for use in gdal)

### DIFF
--- a/mingw-w64-hdf4/PKGBUILD
+++ b/mingw-w64-hdf4/PKGBUILD
@@ -1,0 +1,57 @@
+# Maintainer: Jeroen Ooms <jeroen@berkeley.edu>
+
+_realname=hdf
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=4.2.13
+pkgrel=1
+pkgdesc="Legacy HDF4 driver for GDAL"
+arch=('any')
+url='https://support.hdfgroup.org/products/hdf4/'
+license=('GPL2')
+source=("https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/${_realname}-${pkgver}.tar.gz")
+sha256sums=('be9813c1dc3712c2df977d4960e1f13f20f447dfa8c3ce53331d610c1f470483')
+
+depends=("${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-zlib")
+options=('strip' 'staticlibs')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  sed -i '873s/-pc-cygwin/mingw/' configure.ac
+  sed -i '760s/X$BUILD_XDR/X$NOTHING/' configure.ac
+  sed -i '50s/WIN32/MSVC/' mfhdf/fortran/mfsdf.c
+  sed -i 's/WIN32/MSVC/' mfhdf/libsrc/local_nc.h
+  sed -i 's#<rpc/#<../xdr/#' mfhdf/libsrc/local_nc.h
+  autoreconf -fiv
+}
+
+build() {
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --disable-fortran \
+    --disable-netcdf
+
+  cd hdf
+  make
+  cd ../mfhdf/xdr
+  make || true
+  sed -i 's#LIBS =#LIBS = .libs/libxdr.a -lws2_32#g' Makefile
+  make
+  cd ../libsrc
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}/hdf
+  make install DESTDIR="${pkgdir}"
+  cd "${srcdir}"/build-${CARCH}/mfhdf/libsrc
+  make install DESTDIR="${pkgdir}"
+  cd "${srcdir}"/build-${CARCH}/mfhdf/xdr
+  make install DESTDIR="${pkgdir}"
+}


### PR DESCRIPTION
The hdf4 library has been superseded by hdf5, but many scientists need both hdf4 as well as hdf5 to do their job (i.e. work with legacy systems in gdal).

This is mostly to enable the gdal driver, i.e. we could build gdal with `--enable-hdf4 --enable-hdf5`. The build script is a bit of a hack because the upstream authors only test with MSVC, so we need to disable some `_WIN32` macros. The resulting libs has been tested to support `--enable-hdf4` in `mingw-w64-gdal`.

