### PR TITLE
mingw-w64-python-sphinx -  1.7.0 - Update to latest version and fix s…

### DIFF
--- a/mingw-w64-python-docutils/PKGBUILD
+++ b/mingw-w64-python-docutils/PKGBUILD
@@ -5,7 +5,7 @@ _realname=docutils
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.14
-pkgrel=1
+pkgrel=2
 pkgdesc="Set of tools for processing plaintext docs into formats such as HTML, XML, or LaTeX (mingw-w64)"
 arch=('any')
 license=('custom')
@@ -15,29 +15,42 @@ source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.t
 sha256sums=('51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
-build() {
+prepare() {  
+  cd "$srcdir"/  
   [[ -d ${srcdir}/${_realname}-${pkgver} ]] && rm -rf ${srcdir}/${_realname}-${pkgver}
   tar -xzf ${srcdir}/${_realname}-${pkgver}.tar.gz -C $srcdir || true
-  
-  cd "${srcdir}/${_realname}-${pkgver}"
-  ${MINGW_PREFIX}/bin/python3 setup.py build --build-lib=build/python3
-  find build/python3 -type f -exec \
-    sed -i '1s,^#! \?/usr/bin/\(env \|\)python$,#!/usr/bin/python3,' {} \;
 
-  ${MINGW_PREFIX}/bin/python2 setup.py build --build-lib=build/python2
-  find build/python2 -type f -exec \
-    sed -i '1s,^#! \?/usr/bin/\(env \|\)python$,#!/usr/bin/python2,' {} \;
+  for builddir in python{2,3}-build-${CARCH}; do  
+    rm -rf $builddir | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done  
+}  
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build --build-lib=build/python${pver}
+    find build/python${pver} -type f -exec \
+      sed -i "1s,^#! \?/usr/bin/\(env \|\)python$,#!/usr/bin/python${pver}," {} \;
+  done  
+
+#  find build/python3 -type f -exec \
+#    sed -i '1s,^#! \?/usr/bin/\(env \|\)python$,#!/usr/bin/python3,' {} \;
+
+#  find build/python2 -type f -exec \
+#    sed -i '1s,^#! \?/usr/bin/\(env \|\)python$,#!/usr/bin/python2,' {} \;
 }
 
 check() {
-  cd ${_realname}-${pkgver}
-  # we need utf locale to valid utf8 tests
   export LANG=en_US.UTF-8
-  # Disable python3 check
-  #msg2 'python checks'
-  #PYTHONPATH="$PWD/build/python3/" ${MINGW_PREFIX}/bin/python3 test3/alltests.py
-  msg2 'python2 checks'
-  PYTHONPATH="$PWD/build/python2/" ${MINGW_PREFIX}/bin/python2 test/alltests.py
+  for pver in {2,3}; do  
+    msg "Python ${pver} test for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+       PYTHONPATH="$PWD/build/python${pver}/" ${MINGW_PREFIX}/bin/python${pver} test/alltests.py
+  done
 }
 
 package_python3-docutils() {
@@ -45,7 +58,7 @@ package_python3-docutils() {
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
-  cd ${_realname}-${pkgver}
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py build --build-lib=build/python3 \
       install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
@@ -59,7 +72,11 @@ package_python3-docutils() {
   # symlink without .py
   for f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     ln -s "$(basename $f)" "${pkgdir}${MINGW_PREFIX}/bin/$(basename $f .py)"
+#fix so the file is a script that can run with no issues on the command-line w/o
+#specifying an interpretter
+    sed -e "s|/usr/bin/env python3.exe|${MINGW_PREFIX}/bin/python3.exe|g" -i "${pkgdir}${MINGW_PREFIX}/bin/$(basename $f .py)"
   done
+
   # setup license
   install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING.txt"
   install -D -m644 licenses/python* "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/"
@@ -72,7 +89,7 @@ package_python2-docutils() {
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
-  cd ${_realname}-${pkgver}
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py build --build-lib=build/python2 \
          install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
@@ -84,6 +101,9 @@ package_python2-docutils() {
   # symlink without .py
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     ln -s "$(basename $_f)" "${pkgdir}${MINGW_PREFIX}/bin/$(basename $_f .py)"
+#fix so the file is a script that can run with no issues on the command-line w/o
+#specifying an interpretter
+    sed -e "s|/usr/bin/env python2.exe|${MINGW_PREFIX}/bin/python2.exe|g" -i "${pkgdir}${MINGW_PREFIX}/bin/$(basename $_f .py)"
   done
   # setup license
   install -D -m644 COPYING.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING.txt"

--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -5,7 +5,7 @@ _pyname=sphinx
 _realname=sphinx
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.6.6
+pkgver=1.7.0
 pkgrel=1
 pkgdesc="Python documentation generator (mingw-w64)"
 arch=('any')
@@ -45,9 +45,9 @@ checkdepends=(
               "${MINGW_PACKAGE_PREFIX}-python2-enum34"
               #'texlive-latexextra'
               )
-_dtoken="7a/1e/415e6071c7bbceb5ce5e92b06297a5192544bcd5c0d50fd73e1f61da55f5"
+_dtoken="ab/9b/c4e6ded46bf0a17fed97fa57100fce8a3af8f0a762f7e6521844fc54a044"
 source=("https://pypi.python.org/packages/${_dtoken}/Sphinx-${pkgver}.tar.gz")
-sha256sums=('c39a6fa41bd3ec6fc10064329a664ed3a3ca2e27640a823dc520c682e4433cdb')
+sha256sums=('278b7923f3f4ed2a1d1359f0ae94d89ac90ddd4189e8362f4b4d3baa2afe6b4a')
 
 prepare() {
   # souce duplication is required because makefile modify source code
@@ -106,7 +106,7 @@ package_python3-sphinx() {
   #rm -f ${pkgdir}${MINGW_PREFIX}/bin/sphinx{.exe,-script.py,.exe.manifest}
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
 }
 
@@ -140,22 +140,26 @@ package_python2-sphinx() {
 
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
 }
 
 package_mingw-w64-i686-python2-sphinx() {
+  install=${_realname}3-${CARCH}.install
   package_python2-sphinx
 }
 
 package_mingw-w64-i686-python3-sphinx() {
+  install=${_realname}3-${CARCH}.install 
   package_python3-sphinx
 }
 
 package_mingw-w64-x86_64-python2-sphinx() {
+  install=${_realname}3-${CARCH}.install
   package_python2-sphinx
 }
 
 package_mingw-w64-x86_64-python3-sphinx() {
+  install=${_realname}3-${CARCH}.install
   package_python3-sphinx
 }

--- a/mingw-w64-python-sphinx/sphinx2-i686.install
+++ b/mingw-w64-python-sphinx/sphinx2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in sphinx-apidoc2 sphinx-autogen2 sphinx-build2 sphinx-quickstart2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-sphinx/sphinx2-x86_64.install
+++ b/mingw-w64-python-sphinx/sphinx2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in sphinx-apidoc2 sphinx-autogen2 sphinx-build2 sphinx-quickstart2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-sphinx/sphinx3-i686.install
+++ b/mingw-w64-python-sphinx/sphinx3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in sphinx-apidoc sphinx-autogen sphinx-build sphinx-quickstart; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-sphinx/sphinx3-x86_64.install
+++ b/mingw-w64-python-sphinx/sphinx3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in sphinx-apidoc sphinx-autogen sphinx-build sphinx-quickstart; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
…o that it can work on the command line.

mingw-w64-python-docutils -  0.0.14 - Fix so that it can run from the bash prompt even with the "MSYS" command item.  This is similar to what is done with python-pip.