### PR TITLE
mingw-w64-python-babel - 2.5.3 - Update to latest version.  Fix so th…

### DIFF
--- a/mingw-w64-python-babel/PKGBUILD
+++ b/mingw-w64-python-babel/PKGBUILD
@@ -4,7 +4,7 @@ _pyname=babel
 _realname=babel
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.5.1
+pkgver=2.5.3
 pkgrel=1
 pkgdesc="A collection of tools for internationalizing Python applications"
 url="http://babel.pocoo.org/"
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-pytz"
              "${MINGW_PACKAGE_PREFIX}-python3-pytz")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/python-babel/babel/archive/v${pkgver}.tar.gz")
-sha256sums=('78f5e290909a99fc77b7a8076c154189eb2b43761f4d10a4798e521920c2db60')
+sha256sums=('4c231f28875552abe18c6c10829cec0884d7eeb27423b562357250dc32090cb9')
 
 prepare() {
   cd ${srcdir}
@@ -38,7 +38,7 @@ package_python3-babel() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 }
 
@@ -55,7 +55,7 @@ package_python2-babel() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
   for f in pybabel; do
@@ -69,17 +69,21 @@ package_python2-babel() {
 }
 
 package_mingw-w64-i686-python2-babel() {
+  install=${_realname}3-${CARCH}.install
   package_python2-babel
 }
 
 package_mingw-w64-i686-python3-babel() {
+  install=${_realname}3-${CARCH}.install
   package_python3-babel
 }
 
 package_mingw-w64-x86_64-python2-babel() {
+  install=${_realname}3-${CARCH}.install
   package_python2-babel
 }
 
 package_mingw-w64-x86_64-python3-babel() {
+  install=${_realname}3-${CARCH}.install
   package_python3-babel
 }

--- a/mingw-w64-python-babel/babel2-i686.install
+++ b/mingw-w64-python-babel/babel2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pybabel2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-babel/babel2-x86_64.install
+++ b/mingw-w64-python-babel/babel2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pybabel2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-babel/babel3-i686.install
+++ b/mingw-w64-python-babel/babel3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pybabel; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-babel/babel3-x86_64.install
+++ b/mingw-w64-python-babel/babel3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in pybabel; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
…at you can run it from the bash prompt and automated scripts.  Make sure it runs the correct interpretter.