### PR TITLE
Several other testing things that need to reference the proper interp…

### DIFF
--- a/mingw-w64-python-beaker/PKGBUILD
+++ b/mingw-w64-python-beaker/PKGBUILD
@@ -4,39 +4,41 @@
 _realname=beaker
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.8.1
-pkgrel=2
+pkgver=1.9.0
+pkgrel=1
 pkgdesc="Caching and sessions WSGI middleware for use with web applications and stand-alone Python scripts and applications (mingw-w64)"
 arch=('any')
 license=('custom')
 url="http://beaker.groovie.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/bbangert/beaker/archive/${pkgver}.tar.gz)
-sha256sums=('1b72df92918be4a72c732ed9a28f0d77fb46f4449bd8bf58eaf394ecbf0aab6f')
+sha256sums=('ac8828ea391b463b0f6b844a04648ea8172fd6e9938fe6a7bea412cc6795d5c8')
 
 prepare() {
   cd "${srcdir}/Beaker-${pkgver}"
   #patch -p1 -i ${srcdir}/mingw-python-fix.patch
 
   cd "${srcdir}"
-  cp -r Beaker-${pkgver} python2-Beaker-${pkgver}
-  cp -r Beaker-${pkgver} python3-Beaker-${pkgver}
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
 }
 
 build() {
-  cd "${srcdir}/python3-Beaker-${pkgver}"
-  sed -i "s#/usr/bin/python#/usr/bin/env python3#" beaker/crypto/pbkdf2.py
-  ${MINGW_PREFIX}/bin/python3 setup.py build
-
-  cd "${srcdir}/python2-Beaker-${pkgver}"
-  sed -i "s#/usr/bin/python#/usr/bin/env python2#" beaker/crypto/pbkdf2.py
-  ${MINGW_PREFIX}/bin/python2 setup.py build
+ cd "${srcdir}"
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    sed -i "s#/usr/bin/python#/usr/bin/env python3#" beaker/crypto/pbkdf2.py
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done 
 }
 
 package_python3-beaker() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
-  cd "${srcdir}/python3-Beaker-${pkgver}"
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-beaker/LICENSE"
@@ -45,7 +47,7 @@ package_python3-beaker() {
 package_python2-beaker() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
-  cd "${srcdir}/python2-Beaker-${pkgver}"
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=;--install-purelib=;--install-data=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-beaker/LICENSE"

--- a/mingw-w64-python-mako/PKGBUILD
+++ b/mingw-w64-python-mako/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mako
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.0.7
-pkgrel=1
+pkgrel=2
 pkgdesc="A super-fast templating language that borrows the best ideas from the existing templating languages (mingw-w64)"
 arch=('any')
 license=('custom')
@@ -24,39 +24,41 @@ sha256sums=('4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae')
 
 prepare() {
   cd ${srcdir}
-  cp -r Mako-$pkgver python2-build
-  cp -r Mako-$pkgver python3-build
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
 }
 
 build() {
   cd "${srcdir}"
-  for builddir in python{2,3}-build; do
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
-    popd
-  done
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
 }
 
 check() {
   cd "${srcdir}"
-  for builddir in python{2,3}-build; do
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py test
-    popd
-  done
+  for pver in {2,3}; do  
+    msg "Python ${pver} test for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done  
 }
 
 package_python2-mako() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2-markupsafe" "${MINGW_PACKAGE_PREFIX}-python2-beaker")
+  cd "${srcdir}/python2-build-${CARCH}"
 
-  cd "${srcdir}/python2-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
   # fix python command in files
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
   mv ${pkgdir}${MINGW_PREFIX}/bin/mako-render{,2}.exe
@@ -73,31 +75,35 @@ package_python2-mako() {
 package_python3-mako() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3-markupsafe" "${MINGW_PACKAGE_PREFIX}-python3-beaker")
 
-  cd "${srcdir}/python3-build"
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
   # fix python command in files
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
 }
 
 package_mingw-w64-i686-python2-mako() {
+  install=${_realname}2-${CARCH}.install
   package_python2-mako
 }
 
 package_mingw-w64-i686-python3-mako() {
+  install=${_realname}3-${CARCH}.install
   package_python3-mako
 }
 
 package_mingw-w64-x86_64-python2-mako() {
+  install=${_realname}2-${CARCH}.install
   package_python2-mako
 }
 
 package_mingw-w64-x86_64-python3-mako() {
+  install=${_realname}3-${CARCH}.install
   package_python3-mako
 }

--- a/mingw-w64-python-mako/mako2-i686.install
+++ b/mingw-w64-python-mako/mako2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in mako-render2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-mako/mako2-x86_64.install
+++ b/mingw-w64-python-mako/mako2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in mako-render; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-mako/mako3-i686.install
+++ b/mingw-w64-python-mako/mako3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in mako-render; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-mako/mako3-x86_64.install
+++ b/mingw-w64-python-mako/mako3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in mako-render; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-nose/PKGBUILD
+++ b/mingw-w64-python-nose/PKGBUILD
@@ -5,7 +5,7 @@ _realname=nose
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.3.7
-pkgrel=5
+pkgrel=6
 pkgdesc="A discovery-based unittest extension (mingw-w64)"
 arch=('any')
 license=('LGPL-2.1')
@@ -14,18 +14,22 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFI
 source=("https://pypi.python.org/packages/source/n/nose/nose-${pkgver}.tar.gz")
 sha256sums=('f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98')
 
-build() {
-  cd "${srcdir}/nose-${pkgver}"
-  sed -i -e "s:man/man1:share/man/man1:g" setup.py
-
-  cd "${srcdir}"
-  rm -rf python{2,3}-build
-  for builddir in python{2,3}-build; do
-    cp -r nose-${pkgver} $builddir
-    pushd ${builddir}
-    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
-    popd
+prepare() {
+  cd ${srcdir}
+  for pver in {2,3}; do 
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
+}
+
+build() {
+  cd "${srcdir}"
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    sed -i -e "s:man/man1:share/man/man1:g" setup.py
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done 
 }
 
 package_python3-nose() {
@@ -33,7 +37,7 @@ package_python3-nose() {
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
-  cd "${srcdir}/python3-build"
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
@@ -49,7 +53,7 @@ package_python3-nose() {
 #  rm -f ${pkgdir}${MINGW_PREFIX}/bin/nosetests{.exe,-script.py,.exe.manifest}
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
   rm -rf "${pkgdir}${MINGW_PREFIX}/share"
 }
@@ -59,13 +63,13 @@ package_python2-nose() {
 
   local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
 
-  cd "${srcdir}/python2-build"
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
 
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${_mingw_prefix}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_f}
   done
   #Create an alias so we could do nose tests in a loop with python major versions.
   for f in nosetests; do
@@ -79,17 +83,21 @@ package_python2-nose() {
 }
 
 package_mingw-w64-i686-python2-nose() {
+  install=${_realname}2-${CARCH}.install
   package_python2-nose
 }
 
 package_mingw-w64-i686-python3-nose() {
+  install=${_realname}3-${CARCH}.install
   package_python3-nose
 }
 
 package_mingw-w64-x86_64-python2-nose() {
+  install=${_realname}2-${CARCH}.install
   package_python2-nose
 }
 
 package_mingw-w64-x86_64-python3-nose() {
+  install=${_realname}3-${CARCH}.install
   package_python3-nose
 }

--- a/mingw-w64-python-nose/nose2-i686.install
+++ b/mingw-w64-python-nose/nose2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in nosetests nosetests2 nosetests-2.7; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-nose/nose2-x86_64.install
+++ b/mingw-w64-python-nose/nose2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in nosetests nosetests2 nosetests-2.7; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-nose/nose3-i686.install
+++ b/mingw-w64-python-nose/nose3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in nosetests3 nosetests-3.6; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-nose/nose3-x86_64.install
+++ b/mingw-w64-python-nose/nose3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in nosetests3 nosetests-3.6; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
…retter and an updated beaker.  These should go together because tof dependencies.

Note that it does seem necessary to have a path reference to the proper interpretter instead of using env because it might reference the wrong classes from the wrong python library.  That can cause problems if the MSYS version is different than the ones for mingw32 and mingw64.  Thus, we should do a fixup in the *.install scripts like python-pip.

beaker - update to version 1.9.0 and rework to conform with the pattern I use.
make - make sure the command line .exe script uses the right interpreter and classes.
nose - make sure the command line .exe script uses the right interpretter and classes