### PR TITLE
Add SOIL package

### DIFF
--- a/mingw-w64-soil/PKGBUILD
+++ b/mingw-w64-soil/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: John Murray <john@menaceinc.com>
+
+_realname=soil
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.16.0
+pkgrel=1
+pkgdesc="C library used for loading image files into OpenGL (mingw-w64)"
+arch=('any')
+url='http://lonesock.net/soil.html'
+license=('Public Domain')
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+source=("http://www.lonesock.net/files/${_realname}.zip")
+sha256sums=('a2305b8d64f6d636e36d669bbdb0ca5445d1345c754b3d61d3f037dad2e5f701')
+
+build() {
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}/obj
+  cd "${srcdir}/Simple OpenGL Image Library/projects/makefile"
+  make OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj
+}
+
+package() {
+  cd "${srcdir}/Simple OpenGL Image Library/projects/makefile"
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/include/SOIL
+  make LOCAL=${pkgdir}${MINGW_PREFIX} OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj install
+  mv ${pkgdir}${MINGW_PREFIX}/include/SOIL.h ${pkgdir}${MINGW_PREFIX}/include/SOIL/
+  
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/doc/SOIL
+  cp -r "$srcdir/Simple OpenGL Image Library/soil.html" \
+   ${pkgdir}${MINGW_PREFIX}/share/doc/SOIL
+  find ${pkgdir}${MINGW_PREFIX} -type f -exec chmod 644 {} \;
+  find ${pkgdir}${MINGW_PREFIX} -type d -exec chmod 755 {} \;
+}
+

--- a/mingw-w64-soil/PKGBUILD
+++ b/mingw-w64-soil/PKGBUILD
@@ -10,20 +10,22 @@ arch=('any')
 url='http://lonesock.net/soil.html'
 license=('Public Domain')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("http://www.lonesock.net/files/${_realname}.zip")
+source=("${_realname}-${pkgver}.zip::http://www.lonesock.net/files/${_realname}.zip")
 sha256sums=('a2305b8d64f6d636e36d669bbdb0ca5445d1345c754b3d61d3f037dad2e5f701')
 
 build() {
   mkdir -p ${srcdir}/build-${MINGW_CHOST}/obj
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}/lib
   cd "${srcdir}/Simple OpenGL Image Library/projects/makefile"
-  make OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj
+  make OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj LIBDIR=${srcdir}/build-${MINGW_CHOST}/lib
 }
 
 package() {
   cd "${srcdir}/Simple OpenGL Image Library/projects/makefile"
   mkdir -p ${pkgdir}${MINGW_PREFIX}/lib
   mkdir -p ${pkgdir}${MINGW_PREFIX}/include/SOIL
-  make LOCAL=${pkgdir}${MINGW_PREFIX} OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj install
+  make LOCAL=${pkgdir}${MINGW_PREFIX} OBJDIR=${srcdir}/build-${MINGW_CHOST}/obj \
+   LIBDIR=${srcdir}/build-${MINGW_CHOST}/lib install
   mv ${pkgdir}${MINGW_PREFIX}/include/SOIL.h ${pkgdir}${MINGW_PREFIX}/include/SOIL/
   
   mkdir -p ${pkgdir}${MINGW_PREFIX}/share/doc/SOIL


### PR DESCRIPTION
Tested using
```
MINGW_INSTALLS=mingw64 makepkg-mingw -sLf
pacman -U mingw-w64-x86_64-soil-1.16.0-1-any.pkg.tar.xz
```
as well as
```
MINGW_INSTALLS=mingw32 makepkg-mingw -sLf
pacman -U mingw-w64-i686-soil-1.16.0-1-any.pkg.tar.xz
```

Both worked just fine when building a project with a SOIL dependency.

Related to issue #3369 