### PR TITLE
gst-python: Add Python 2 variant; Drop libgstpythonplugin. Fixes #2034

### DIFF
--- a/mingw-w64-gst-python/PKGBUILD
+++ b/mingw-w64-gst-python/PKGBUILD
@@ -2,19 +2,18 @@
 
 _realname=gst-python
 pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-gst-python" "${MINGW_PACKAGE_PREFIX}-gst-python2")
 pkgver=1.12.4
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer GObject Introspection overrides for Python 3 (mingw-w64)"
 arch=('any')
 license=('LGPL')
-depends=("${MINGW_PACKAGE_PREFIX}-gstreamer"
-         "${MINGW_PACKAGE_PREFIX}-python3-gobject"
-         "${MINGW_PACKAGE_PREFIX}-gobject-introspection")
-makedepends=('git')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
+             "${MINGW_PACKAGE_PREFIX}-python2-gobject"
+             "${MINGW_PACKAGE_PREFIX}-python3-gobject")
 url='https://gstreamer.freedesktop.org/modules/gst-python.html'
-options=(!libtool strip staticlibs)
-
 source=(https://gstreamer.freedesktop.org/src/gst-python/${_realname}-${pkgver}.tar.xz
         '0001-msys2-python3-config-returns-1-so-use-which.patch'
         '0002-msys2-fix-linking-errors.patch'
@@ -37,25 +36,65 @@ prepare() {
 }
 
 build() {
-  [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p build-${MINGW_CHOST}
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  rm -rf python{2,3}-build devel || true
+  mkdir python{2,3}-build devel
 
-  PYTHON=${MINGW_PREFIX}/bin/python3 \
-  ../${_realname}-${pkgver}/configure \
-      --prefix=${MINGW_PREFIX} \
-      --bindir=${MINGW_PREFIX}/bin \
-      --build=${MINGW_CHOST} \
-      --host=${MINGW_CHOST} \
-      --target=${MINGW_CHOST} \
-      --disable-silent-rules
-  make
+  for builddir in python{2,3}-build; do
+    pushd ${builddir} > /dev/null
+      PYTHON=${MINGW_PREFIX}/bin/${builddir%-build} \
+      ../${_realname}-${pkgver}/configure \
+        --prefix=${MINGW_PREFIX} \
+        --build=${MINGW_CHOST} \
+        --host=${MINGW_CHOST} \
+        --target=${MINGW_CHOST} \
+        --disable-silent-rules
+      make
+    popd > /dev/null
+  done
 }
 
-package() {
-  cd build-${MINGW_CHOST}
+package_gst-python() {
+  pkgdesc="GStreamer GObject Introspection overrides for Python 3 (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gstreamer"
+           "${MINGW_PACKAGE_PREFIX}-python3-gobject")
+
+  cd python3-build
   make DESTDIR="${pkgdir}" install
 
-  mv ${pkgdir}${MINGW_PREFIX}/lib/bin/*.dll ${pkgdir}${MINGW_PREFIX}/lib/gstreamer-1.0/
-  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/bin
+  mv "${pkgdir}${MINGW_PREFIX}"/lib/bin/*.dll "${pkgdir}${MINGW_PREFIX}"/lib/gstreamer-1.0/
+  rm -rf "${pkgdir}${MINGW_PREFIX}/lib/bin"
+
+  # The python plugin loader makes problems because it links against libpython
+  # which might be in conflict one already used loading the plugin.
+  # The overrides don't need it so just remove it for now.
+  # https://github.com/Alexpux/MINGW-packages/issues/2034
+  rm -r "${pkgdir}${MINGW_PREFIX}/lib/gstreamer-1.0"
+}
+
+package_gst-python2() {
+  pkgdesc="GStreamer GObject Introspection overrides for Python 2 (mingw-w64)"
+  depends=("${MINGW_PACKAGE_PREFIX}-gstreamer"
+           "${MINGW_PACKAGE_PREFIX}-python2-gobject")
+
+  cd python2-build
+  make DESTDIR="${pkgdir}" install
+
+  # See other package()
+  rm -r "${pkgdir}${MINGW_PREFIX}/lib/gstreamer-1.0"
+}
+
+package_mingw-w64-i686-gst-python2() {
+  package_gst-python2
+}
+
+package_mingw-w64-i686-gst-python() {
+  package_gst-python
+}
+
+package_mingw-w64-x86_64-gst-python2() {
+  package_gst-python2
+}
+
+package_mingw-w64-x86_64-gst-python() {
+  package_gst-python
 }


### PR DESCRIPTION
Adds a Python 2 variant of the package called gst-python2 like in Arch.

Drops the gstreamer plugin (libgstpythonplugin) because it creates problems
with Python applications loading the plugins. The plugin links against py3
and when loaded from a Python 2 procedss or vice versa it loads pygobject
+ gst overrides again which leads to gtype conflicts. See #2034