### PR TITLE
global: Fix segmentation fault caused by NULL parameter

### DIFF
--- a/mingw-w64-global/001-global-6.6.2-mingw64.txt
+++ b/mingw-w64-global/001-global-6.6.2-mingw64.txt
@@ -1,6 +1,6 @@
 diff -Naur global-6.6.2/configure.ac src/global-6.6.2/configure.ac
 --- global-6.6.2/configure.ac	2018-02-10 04:31:39.000000000 +0800
-+++ src/global-6.6.2/configure.ac	2018-02-14 22:39:29.112990100 +0800
++++ src/global-6.6.2/configure.ac	2018-02-21 00:09:04.819014500 +0800
 @@ -67,16 +67,6 @@
          AC_MSG_ERROR([dirent(3) is required but not found.])
  fi
@@ -20,7 +20,7 @@ diff -Naur global-6.6.2/configure.ac src/global-6.6.2/configure.ac
  AC_HEADER_TIME
 diff -Naur global-6.6.2/libdb/bt_open.c src/global-6.6.2/libdb/bt_open.c
 --- global-6.6.2/libdb/bt_open.c	2018-02-10 04:31:39.000000000 +0800
-+++ src/global-6.6.2/libdb/bt_open.c	2018-02-14 23:06:40.172226800 +0800
++++ src/global-6.6.2/libdb/bt_open.c	2018-02-21 00:09:04.834920100 +0800
 @@ -402,7 +402,9 @@
  static int
  tmp(void)
@@ -31,9 +31,24 @@ diff -Naur global-6.6.2/libdb/bt_open.c src/global-6.6.2/libdb/bt_open.c
  	int fd;
  	char *envtmp;
  	char path[1024];
+diff -Naur global-6.6.2/libutil/path.c src/global-6.6.2/libutil/path.c
+--- global-6.6.2/libutil/path.c	2018-02-10 04:31:40.000000000 +0800
++++ src/global-6.6.2/libutil/path.c	2018-02-21 00:39:20.671989400 +0800
+@@ -185,8 +185,9 @@
+ 	} else
+ 		_fixpath(in_path, out_path);
+ #else
+-	_fullpath(out_path, in_path, MAXPATHLEN);
+-	canonpath(out_path);
++	out_path = _fullpath(out_path, in_path, MAXPATHLEN);
++	if (out_path)
++		canonpath(out_path);
+ #endif
+ 	return out_path;
+ }
 diff -Naur global-6.6.2/libutil/secure_popen.c src/global-6.6.2/libutil/secure_popen.c
 --- global-6.6.2/libutil/secure_popen.c	2018-02-10 04:31:40.000000000 +0800
-+++ src/global-6.6.2/libutil/secure_popen.c	2018-02-14 23:06:45.359375400 +0800
++++ src/global-6.6.2/libutil/secure_popen.c	2018-02-21 00:09:04.850266100 +0800
 @@ -23,7 +23,9 @@
  #endif
  #include <stdio.h>

--- a/mingw-w64-global/PKGBUILD
+++ b/mingw-w64-global/PKGBUILD
@@ -15,7 +15,7 @@ source=("https://ftp.gnu.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
 	'001-global-6.6.2-mingw64.txt'
 	)
 sha256sums=('ca1dc15e9f320983e4d53ccb947ce58729952728273fdf415ab309ea2c0cd7fa'
-            '620f533f198c52488f2c3563921b4a0554dbc3d4689830dddbc45482c96c9bac')
+            '2bb92dd9c93ebd26913b3cd768a5f2f0a7f5d6367a19f05323f9b89ec84e492e')
 
 _global_srcdir=${_realname}-${pkgver}
 


### PR DESCRIPTION
It seems the preferred build environment is different with the pull request pre-check, because the sha256 checksum of downloaded source code archive is different, see [this commit](https://github.com/Alexpux/MINGW-packages/commit/3c8999f9cb9073c7b541633cbe535431fb2815ce). 