### PR TITLE
Remove make parallel opts and add pinentry dep to gnupg

### DIFF
--- a/mingw-w64-gnupg/PKGBUILD
+++ b/mingw-w64-gnupg/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: Yuui Tanabe <yuuitanabe@163.com>
 
 _realname=gnupg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Privacy Guard - a PGP replacement tool (mingw-w64)"
 arch=('any')
 depends=("${MINGW_PACKAGE_PREFIX}-adns"
@@ -19,7 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-adns"
          "${MINGW_PACKAGE_PREFIX}-npth"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
-         "${MINGW_PACKAGE_PREFIX}-zlib")
+         "${MINGW_PACKAGE_PREFIX}-zlib"
+         "${MINGW_PACKAGE_PREFIX}-pinentry")
 makedepends=("texinfo" "${MINGW_PACKAGE_PREFIX}-gcc")
 # REMOVE openldap package before build
 license=('GPL')

--- a/mingw-w64-pinentry/PKGBUILD
+++ b/mingw-w64-pinentry/PKGBUILD
@@ -38,11 +38,11 @@ build()
     --enable-pinentry-qt \
     --enable-libsecret
 
-  make -j $(nproc)
+  make
 }
 
 package()
 {
-    cd "${srcdir}/build-${MINGW_CHOST}"
-    make -j $(nproc) DESTDIR=${pkgdir} install
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
 }


### PR DESCRIPTION
Removed make parallel opts because makepkg setted MAKEOPTS and added pinentry dependency to gnupg