### PR TITLE
argon2: build without optimizations

### DIFF
--- a/mingw-w64-argon2/PKGBUILD
+++ b/mingw-w64-argon2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=argon2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20171227
-pkgrel=1
+pkgrel=2
 pkgdesc="This is the reference implementation of Argon2, the password-hashing function that won the Password Hashing Competition (PHC) (mingw-w64)"
 arch=('any')
 license=('CC0 and Apache 2.0')
@@ -27,12 +27,12 @@ build() {
   cp -rf ${srcdir}/phc-winner-argon2-${pkgver} "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  make CC=${MINGW_PREFIX}/bin/gcc
+  make CC=${MINGW_PREFIX}/bin/gcc OPTTARGET=none
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make install DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}"
+  make install DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" OPTTARGET=none
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -Dm644 ${srcdir}/libargon2.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libargon2.pc"


### PR DESCRIPTION
From https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/argon2&id=fdf4c3b0da6a02d52ce845b511edadbf66b4711a

It's causing illegal instructions when run in Ivy Bridge CPUs without AVX2.