### PR TITLE
djvulibre - 3.5.27 add libtiff and libiconv as dependencies

### DIFF
--- a/mingw-w64-djview/PKGBUILD
+++ b/mingw-w64-djview/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=djview
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=4.10.6
+pkgrel=1
+pkgdesc='Portable DjVu viewer (mingw-w64)'
+url='http://djvu.sourceforge.net/djview4.html'
+license=('GPL')
+arch=('any')
+depends=("${MINGW_PACKAGE_PREFIX}-djvulibre"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-qt5" 
+         "${MINGW_PACKAGE_PREFIX}-libtiff")
+source=("https://downloads.sourceforge.net/djvu/${_realname}-${pkgver}.tar.gz")
+sha256sums=('8446f3cd692238421a342f12baa365528445637bffb96899f319fe762fda7c21')
+conflicts=("${MINGW_PACKAGE_PREFIX}-djview4")
+provides=(${MINGW_PACKAGE_PREFIX}-djview4")
+replaces=(${MINGW_PACKAGE_PREFIX}-djview4")
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  cp -rf ${_realname}-${pkgver} build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+  export QMAKE=${MINGW_PREFIX}/bin/qmake.exe
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+  cp src/release/djview.exe "${pkgdir}${MINGW_PREFIX}"/bin/djview4.exe
+  ln -s "${pkgdir}${MINGW_PREFIX}"/bin/djview4.exe "${pkgdir}${MINGW_PREFIX}"/bin/djview.exe
+}

--- a/mingw-w64-djvulibre/PKGBUILD
+++ b/mingw-w64-djvulibre/PKGBUILD
@@ -4,15 +4,16 @@ _realname=djvulibre
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.5.27
-pkgrel=2
+pkgrel=3
 pkgdesc="Suite to create, manipulate and view DjVu (mingw-w64)"
 arch=('any')
 url="https://djvu.sourceforge.io/"
 license=("GPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
-         "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-libiconv"
+         "${MINGW_PACKAGE_PREFIX}-libtiff"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/djvu/${_realname}-${pkgver}.tar.gz"
@@ -36,8 +37,8 @@ build() {
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --enable-static \
-    --enable-shared
-
+    --enable-shared \
+    --with-libiconv-prefix=${MINGW_PREFIX}
   make
 }
 

--- a/mingw-w64-graphicsmagick/PKGBUILD
+++ b/mingw-w64-graphicsmagick/PKGBUILD
@@ -4,7 +4,7 @@ _realname=graphicsmagick
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.28
-pkgrel=1
+pkgrel=2
 pkgdesc="An image viewing/manipulation program (mingw-w64)"
 arch=('any')
 url="http://www.graphicsmagick.org/"
@@ -16,14 +16,17 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-libtiff"
              "${MINGW_PACKAGE_PREFIX}-libxml2"
              "${MINGW_PACKAGE_PREFIX}-libwebp"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "txt2html")
 depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
          "${MINGW_PACKAGE_PREFIX}-fontconfig"
          "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-jbigkit"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
          "${MINGW_PACKAGE_PREFIX}-libtool"
+         "${MINGW_PACKAGE_PREFIX}-libwinpthread-git"
          "${MINGW_PACKAGE_PREFIX}-xz"
          "${MINGW_PACKAGE_PREFIX}-zlib")
          #"${MINGW_PACKAGE_PREFIX}-perl"
@@ -63,7 +66,7 @@ prepare() {
   del_file_exists \
     magick/pathtools.c \
     magick/pathtools.h
-  patch -p1 -i ${srcdir}/001-relocate.patch
+  apply_patch_with_msg 001-relocate.patch
   autoreconf -fiv
 }
 

--- a/mingw-w64-pdf2djvu/PKGBUILD
+++ b/mingw-w64-pdf2djvu/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pdf2djvu
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.9.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Creates DjVu files from PDF files"
 arch=('any')
 url="http://jwilk.net/software/pdf2djvu"
@@ -11,10 +11,14 @@ license=('GPL2')
 depends=("${MINGW_PACKAGE_PREFIX}-poppler"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-djvulibre"
+         "${MINGW_PACKAGE_PREFIX}-exiv2"
+         "${MINGW_PACKAGE_PREFIX}-gettext"
          "${MINGW_PACKAGE_PREFIX}-graphicsmagick"
-         "${MINGW_PACKAGE_PREFIX}-exiv2")
+          "${MINGW_PACKAGE_PREFIX}-libiconv"
+          "${MINGW_PACKAGE_PREFIX}-poppler")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose")
 source=(https://github.com/jwilk/pdf2djvu/releases/download/${pkgver}/pdf2djvu-${pkgver}.tar.xz{,.asc})
 sha256sums=('cf45731fd8e635fd39502deddc13c2810805cf30f43c6b0c1fa1b55429b1834d'
             'SKIP')
@@ -24,6 +28,9 @@ noextract=(pdf2djvu-${pkgver}.tar.xz)
 prepare() {
   [[ -d ${_realname}-${pkgver} ]] && rm -rf ${_realname}-${pkgver}
   tar -xJvf pdf2djvu-${pkgver}.tar.xz || true
+  cp ${srcdir}/${_realname}-${pkgver}/tests/test-antialias-off.tex \
+     ${srcdir}/${_realname}-${pkgver}/tests/test-antialias-on.tex
+         
 }
 
 build() {
@@ -34,7 +41,8 @@ build() {
       --prefix=${MINGW_PREFIX} \
       --build=${MINGW_CHOST} \
       --host=${MINGW_CHOST} \
-      --target=${MINGW_CHOST}
+      --target=${MINGW_CHOST} \
+      --with-libiconv-prefix=${MINGW_PREFIX}
   make
 }
 


### PR DESCRIPTION
graphicsmagic - 2.3.28 - add gcc-libs, libwinpthreads, and txt2html as dependencies.  Rebuilding using txt2html to generate HTML documentation.
pdf2djvu - 0.9.8 - add exiv2, gettext, libiconv, poppler to dependendencies.  Add nose2 to checkdepends for future-proofing
djview - 4.10.6 - New package.  Portable DjVu viewer using the QT5 library.