### PR TITLE
python-{sphinx,packaging,urllib3}: Fix dependencies

### DIFF
--- a/mingw-w64-python-packaging/PKGBUILD
+++ b/mingw-w64-python-packaging/PKGBUILD
@@ -47,7 +47,9 @@ check() {
 
 
 package_python3-packaging() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-pyparsing"
+           "${MINGW_PACKAGE_PREFIX}-python3-six")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -58,7 +60,9 @@ package_python3-packaging() {
 }
 
 package_python2-packaging() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-pyparsing"
+           "${MINGW_PACKAGE_PREFIX}-python2-six")
 
   cd "${srcdir}/python2-build-${CARCH}"
 

--- a/mingw-w64-python-sphinx/PKGBUILD
+++ b/mingw-w64-python-sphinx/PKGBUILD
@@ -79,21 +79,18 @@ build() {
 package_python3-sphinx() {
   pkgdesc='Python3 documentation generator'
   depends=("${MINGW_PACKAGE_PREFIX}-python3-babel"
-           "${MINGW_PACKAGE_PREFIX}-python3-certifi"
-           "${MINGW_PACKAGE_PREFIX}-python3-chardet"
            "${MINGW_PACKAGE_PREFIX}-python3-colorama"
            "${MINGW_PACKAGE_PREFIX}-python3-docutils"
-           "${MINGW_PACKAGE_PREFIX}-python3-idna"
            "${MINGW_PACKAGE_PREFIX}-python3-imagesize"
            "${MINGW_PACKAGE_PREFIX}-python3-jinja"
+           "${MINGW_PACKAGE_PREFIX}-python3-packaging"
            "${MINGW_PACKAGE_PREFIX}-python3-pygments"
            "${MINGW_PACKAGE_PREFIX}-python3-requests"
-           "${MINGW_PACKAGE_PREFIX}-python3-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python3-snowballstemmer"
            "${MINGW_PACKAGE_PREFIX}-python3-sphinx-alabaster-theme"
+           "${MINGW_PACKAGE_PREFIX}-python3-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python3-sphinxcontrib-websupport"
            "${MINGW_PACKAGE_PREFIX}-python3-six"
-           "${MINGW_PACKAGE_PREFIX}-python3-urllib3"
            "${MINGW_PACKAGE_PREFIX}-python3-whoosh")
   #optdepends=("${MINGW_PACKAGE_PREFIX}-texlive-latexextra": for generation of PDF documentation')
 
@@ -113,21 +110,18 @@ package_python3-sphinx() {
 package_python2-sphinx() {
   pkgdesc='Python2 documentation generator'
   depends=("${MINGW_PACKAGE_PREFIX}-python2-babel"
-           "${MINGW_PACKAGE_PREFIX}-python2-certifi"
            "${MINGW_PACKAGE_PREFIX}-python2-colorama"
-           "${MINGW_PACKAGE_PREFIX}-python2-chardet"
            "${MINGW_PACKAGE_PREFIX}-python2-docutils"
-           "${MINGW_PACKAGE_PREFIX}-python2-idna"
            "${MINGW_PACKAGE_PREFIX}-python2-imagesize"
            "${MINGW_PACKAGE_PREFIX}-python2-jinja"
+           "${MINGW_PACKAGE_PREFIX}-python2-packaging"
            "${MINGW_PACKAGE_PREFIX}-python2-pygments"
            "${MINGW_PACKAGE_PREFIX}-python2-requests"
-           "${MINGW_PACKAGE_PREFIX}-python2-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python2-snowballstemmer"
            "${MINGW_PACKAGE_PREFIX}-python2-sphinx-alabaster-theme"
+           "${MINGW_PACKAGE_PREFIX}-python2-sphinx_rtd_theme"
            "${MINGW_PACKAGE_PREFIX}-python2-sphinxcontrib-websupport"
            "${MINGW_PACKAGE_PREFIX}-python2-six"
-           "${MINGW_PACKAGE_PREFIX}-python2-urllib3"
            "${MINGW_PACKAGE_PREFIX}-python2-whoosh"
            "${MINGW_PACKAGE_PREFIX}-python2-typing")
   #optdepends=("${MINGW_PACKAGE_PREFIX}-texlive-latexextra": for generation of PDF documentation')

--- a/mingw-w64-python-urllib3/PKGBUILD
+++ b/mingw-w64-python-urllib3/PKGBUILD
@@ -49,7 +49,9 @@ build() {
 }
 
 package_python3-urllib3() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-certifi"
+           "${MINGW_PACKAGE_PREFIX}-python3-idna")
   cd ${srcdir}/python3-build-${CARCH}
   ${MINGW_PREFIX}/bin/python3 setup.py build
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -59,7 +61,9 @@ package_python3-urllib3() {
 }
 
 package_python2-urllib3() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-certifi"
+           "${MINGW_PACKAGE_PREFIX}-python2-idna")
   cd ${srcdir}/python2-build-${CARCH}
   ${MINGW_PREFIX}/bin/python2 setup.py build
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
Some dependencies are not correct.

Sphinx now requires 'packaging', and 'packaging' requires 'pyparsing'.
Also sort the lists in the alphabetical order.

Remove chardet, idna and urllib3 from the dependencies of sphinx, because they are
not directly required by it. They are required by 'requests'
and it already has them as the dependencies.

Move certifi from sphinx to urllib3.