### PR TITLE
mpv: add missing lua51 dependency

### DIFF
--- a/mingw-w64-mpv/PKGBUILD
+++ b/mingw-w64-mpv/PKGBUILD
@@ -5,7 +5,7 @@ _realname=mpv
 pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.27.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Video player based on MPlayer/mplayer2 (mingw-w64)"
 url="https://mpv.io/"
 arch=('any')
@@ -22,6 +22,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-angleproject-git"
          "${MINGW_PACKAGE_PREFIX}-libdvdnav"
          "${MINGW_PACKAGE_PREFIX}-libdvdread"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-lua51"
          "${MINGW_PACKAGE_PREFIX}-rubberband"
          "${MINGW_PACKAGE_PREFIX}-uchardet"
          "winpty")


### PR DESCRIPTION
Fixes #3450. The lua51 package has a dll that's required to execute mpv.exe.