### PR TITLE
SDL: Updates to SDL 2.0.8 and SDL2_image 2.0.3

### DIFF
--- a/mingw-w64-SDL2/PKGBUILD
+++ b/mingw-w64-SDL2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=SDL2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.0.7
+pkgver=2.0.8
 pkgrel=1
 pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Version 2) (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libiconv")
 options=('staticlibs' 'strip')
 source=("https://libsdl.org/release/SDL2-${pkgver}.tar.gz")
-sha256sums=('ee35c74c4313e2eda104b14b1b86f7db84a04eeab9430d56e001cea268bf4d5e')
+sha256sums=('edc77c57308661d576e843344d8638e025a7818bff73f8fbfab09c3c5fd092ec')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}

--- a/mingw-w64-SDL2_image/PKGBUILD
+++ b/mingw-w64-SDL2_image/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=SDL2_image
 pkgbase=mingw-w64-${_realname}
 pkgname=${MINGW_PACKAGE_PREFIX}-${_realname}
-pkgver=2.0.2
+pkgver=2.0.3
 pkgrel=1
 pkgdesc="A simple library to load images of various formats as SDL surfaces (Version 2)"
 arch=('any')
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-SDL2"
          "${MINGW_PACKAGE_PREFIX}-libwebp")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 source=("${url}/release/${_realname}-${pkgver}.zip")
-sha256sums=('7c3158ca1bf84ef041bcf55ea237306684caf6b70f4303ee7e1f0777bfba55a2')
+sha256sums=('8939a1057e15cbfc2d8527274aeceefb875ffb3a8196057736611d17130c9268')
 
 build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}


### PR DESCRIPTION
This PR updates the SDL2 libs to SDL 2.0.8 and SDL2_image to 2.0.3.