### PR TITLE
fontconfig: update to version 2.13.0

### DIFF
--- a/mingw-w64-fontconfig/0003-fix-link-libintl.patch
+++ b/mingw-w64-fontconfig/0003-fix-link-libintl.patch
@@ -1,0 +1,34 @@
+From 07bd14c5c7fed103020dc9b630d6a254861ada07 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Fri, 9 Mar 2018 11:55:43 +0900
+Subject: Fix the build issue again on MinGW with enabling nls
+
+---
+ src/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 1ff065b..2111ce0 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -82,7 +82,7 @@ AM_CPPFLAGS = 						\
+ 	-DFC_CACHEDIR='"$(FC_CACHEDIR)"'                \
+ 	-DFONTCONFIG_PATH='"$(BASECONFIGDIR)"'		\
+ 	-DFC_TEMPLATEDIR='"$(TEMPLATEDIR)"'
+-LDADD  = $(INTLLIBS)
++LDADD  = $(LIBINTL)
+ 
+ EXTRA_DIST += makealias
+ 
+@@ -168,7 +168,7 @@ lib_LTLIBRARIES = libfontconfig.la
+ libfontconfig_la_LDFLAGS =			\
+ 	-version-info @LIBT_VERSION_INFO@ -no-undefined $(export_symbols)
+ 
+-libfontconfig_la_LIBADD = $(ICONV_LIBS) $(FREETYPE_LIBS) $(LIBXML2_LIBS) $(EXPAT_LIBS) $(UUID_LIBS) $(INTLLIBS)
++libfontconfig_la_LIBADD = $(ICONV_LIBS) $(FREETYPE_LIBS) $(LIBXML2_LIBS) $(EXPAT_LIBS) $(UUID_LIBS) $(LTLIBINTL)
+ 
+ libfontconfig_la_DEPENDENCIES = $(fontconfig_def_dependency)
+ 
+-- 
+cgit v1.1
+

--- a/mingw-w64-fontconfig/PKGBUILD
+++ b/mingw-w64-fontconfig/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=fontconfig
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.12.6
+pkgver=2.13.0
 pkgrel=1
 pkgdesc="A library for configuring and customizing font access (mingw-w64)"
 arch=('any')
@@ -23,12 +23,14 @@ install=${_realname}-${CARCH}.install
 source=("https://www.freedesktop.org/software/fontconfig/release/fontconfig-${pkgver}.tar.bz2"
         0001-fix-config-linking.all.patch
         0002-fix-mkdir.mingw.patch
+        0003-fix-link-libintl.patch
         0004-fix-mkdtemp.mingw.patch
         0005-fix-setenv.mingw.patch
         0007-pkgconfig.mingw.patch)
-sha256sums=('cf0c30807d08f6a28ab46c61b8dbd55c97d2f292cf88f3a07d3384687f31f017'
+sha256sums=('91dde8492155b7f34bb95079e79be92f1df353fcc682c19be90762fd3e12eeb9'
             '1266d4bbd8270f013fee2401c890f0251babf50a175a69d681d3a6af5003c899'
             '0d950eb8a19858bff1f0b26e4a560f589e79e7eb7f22f723267748dfe55e0b63'
+            '7b88b82d1dfba8ccd5a85f103e2f36c4ecc40c5d4acfe1992836fca66d284da7'
             '57ff8420dbf62873b6fcb38b52fb7b37e0e278425a9125e15dccba54668c8ab9'
             '552b54010f9fe4097f332cf2397bbd3e78489542d3bbf07792ed1cfe9381796e'
             'af373531873da46d0356305da5444c1ec74f443cd2635ea2db6b7dadd1561f5b')
@@ -38,6 +40,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/0001-fix-config-linking.all.patch
   patch -p1 -i ${srcdir}/0002-fix-mkdir.mingw.patch
+  patch -p1 -i ${srcdir}/0003-fix-link-libintl.patch
   patch -p1 -i ${srcdir}/0004-fix-mkdtemp.mingw.patch
   patch -p1 -i ${srcdir}/0005-fix-setenv.mingw.patch
   patch -p1 -i ${srcdir}/0007-pkgconfig.mingw.patch


### PR DESCRIPTION
This release brings greatly reduced font cache creation times (https://bugs.freedesktop.org/show_bug.cgi?id=64766)

Includes a post-release build fix.