### PR TITLE
ngraph-gtk: new upstream release version 6.07.06.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,13 +3,14 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.07.05
+pkgver=6.07.06
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
+         "${MINGW_PACKAGE_PREFIX}-gtksourceview3"
          "${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-gsl"
          "${MINGW_PACKAGE_PREFIX}-ruby")
@@ -19,7 +20,7 @@ options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("071d471e0efbb469b8f917194b526bff34a0458d7fb068ec3e7f31e29b3231ad")
+sha256sums=("99d13f5b79fda26793b879534df2045dc1ed31ab91631f125a3b1d93027d4bbd")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -45,4 +46,5 @@ package() {
   make DESTDIR=${pkgdir} install
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${pkgdir}${MINGW_PREFIX}/share/${_realname}/gtksourceview/ngraph-math.lang" "${pkgdir}${MINGW_PREFIX}/share/gtksourceview-3.0/language-specs/ngraph-math.lang"
 }


### PR DESCRIPTION
New upstream version 6.07.06 is released.