### PR TITLE
glib-openssl: New package

### DIFF
--- a/mingw-w64-glib-openssl/PKGBUILD
+++ b/mingw-w64-glib-openssl/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=glib-openssl
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.50.8
+pkgrel=1
+arch=('any')
+pkgdesc="Network-related giomodule for glib using openssl (mingw-w64)"
+depends=("${MINGW_PACKAGE_PREFIX}-glib2"
+         "${MINGW_PACKAGE_PREFIX}-openssl")
+makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
+             "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+license=('custom: LGPL2+ with openssl exception')
+url="https://git.gnome.org/browse/glib-openssl"
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
+        "fix-cert-path.patch")
+sha256sums=('869f08e4e9a719c1df411c2fb5554400f6b24a9db0cb94c4359db8dad18d185f'
+            'cd771f490c74a8276c9dba0e836542a5b11ecc51c166221b091446197533faa7')
+
+prepare() {
+  cd "${srcdir}"/${_realname}-${pkgver}
+
+  patch -p1 -i "${srcdir}/fix-cert-path.patch"
+}
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  meson \
+    --buildtype plain \
+    --prefix=${MINGW_PREFIX} \
+    ../${_realname}-${pkgver}
+
+  ninja
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  DESTDIR=${pkgdir}${MINGW_PREFIX} ninja install
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}

--- a/mingw-w64-glib-openssl/fix-cert-path.patch
+++ b/mingw-w64-glib-openssl/fix-cert-path.patch
@@ -1,0 +1,11 @@
+--- glib-openssl-2.50.8/tls/openssl/gtlsbackend-openssl.c.orig	2018-02-26 11:03:32.000000000 +0100
++++ glib-openssl-2.50.8/tls/openssl/gtlsbackend-openssl.c	2018-03-13 07:58:22.822305900 +0100
+@@ -191,7 +191,7 @@
+   gchar *cert_path;
+ 
+   module_dir = g_win32_get_package_installation_directory_of_module (NULL);
+-  cert_path = g_build_filename (module_dir, "bin", "cert.pem", NULL);
++  cert_path = g_build_filename (module_dir, "ssl", "cert.pem", NULL);
+   g_free (module_dir);
+ 
+   if (g_file_test (cert_path, G_FILE_TEST_IS_REGULAR))


### PR DESCRIPTION
Allows glib to use openssl for TLS instead of gnutls