### PR TITLE
Rebuild with imprevements

### DIFF
--- a/mingw-w64-cppcheck/PKGBUILD
+++ b/mingw-w64-cppcheck/PKGBUILD
@@ -4,7 +4,7 @@ _realname=cppcheck
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.82
-pkgrel=1
+pkgrel=2
 pkgdesc="static analysis of C/C++ code (mingw-w64)"
 arch=('any')
 url="https://cppcheck.sourceforge.io/"
@@ -29,8 +29,13 @@ prepare() {
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
-
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  cp -r "${srcdir}/${_realname}-${pkgver}" "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  
   LANG='en_US.UTF-8' make \
+    PREFIX=${MINGW_PREFIX} \
+    CXX=${MINGW_PREFIX}/bin/g++ \
+    LD=${MINGW_PREFIX}/bin/ld \
     SRCDIR=build \
     CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
     HAVE_RULES=yes \
@@ -42,31 +47,41 @@ build() {
 
   cd gui
   lrelease gui.pro
-  ${MINGW_PREFIX}/bin/qmake HAVE_RULES=yes CONFIG+=release
+  ${MINGW_PREFIX}/bin/qmake HAVE_RULES=yes HAVE_QCHART=yes CONFIG+=release
   make \
+    CXX=${MINGW_PREFIX}/bin/g++ \
+    LD=${MINGW_PREFIX}/bin/ld \
+    PREFIX=${MINGW_PREFIX} \
     SRCDIR=build \
     CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
-    HAVE_RULES=yes
+    HAVE_RULES=yes \
+    HAVE_QCHART=yes
 }
 
 check() {
-  cd "${srcdir}/${_realname}-${pkgver}"
-
-  # LANG='en_US.UTF-8' make test \
-  #   SRCDIR=build \
-  #   CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
-  #   HAVE_RULES=yes \
-  #   LDFLAGS=-lshlwapi RDYNAMIC=
+  cd "${srcdir}"/build-${CARCH}
+   LANG='en_US.UTF-8' make test \
+     SRCDIR=build \
+     CXX=${MINGW_PREFIX}/bin/g++ \
+     LD=${MINGW_PREFIX}/bin/ld \
+     PREFIX="${MINGW_PREFIX}" \
+     CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+     HAVE_RULES=yes \
+     HAVE_QCHART=yes \
+     LDFLAGS=-lshlwapi RDYNAMIC=
 }
 
 package() {
-  cd "${srcdir}/${_realname}-${pkgver}"
+  cd "${srcdir}"/build-${CARCH}
 
   LANG='en_US.UTF-8' make install \
     DESTDIR="${pkgdir}" \
+    CXX=${MINGW_PREFIX}/bin/g++ \
+    LD=${MINGW_PREFIX}/bin/ld \
     PREFIX="${MINGW_PREFIX}" \
     SRCDIR=build \
     CFGDIR=${MINGW_PREFIX}/share/cppcheck/cfg \
+    HAVE_QCHART=yes \
     HAVE_RULES=yes
 
   # man and COPYING


### PR DESCRIPTION
specify path to compiler to reduce chance that it will be called with the wrong compiler.
Make copies of source-code for each platform.  Othwise, you can get an error about unrecognized formats with w Win64 binary is used with a 32-bit binary build process.
Enable QChart.
enable build tests.