### PR TITLE
Update jq, oniguruma

### DIFF
--- a/mingw-w64-jq/PKGBUILD
+++ b/mingw-w64-jq/PKGBUILD
@@ -4,7 +4,7 @@ _realname=jq
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Command-line JSON processor (mingw-w64)"
 arch=('any')
 url='https://stedolan.github.io/jq/'
@@ -38,6 +38,11 @@ build() {
     --enable-shared
 
   make
+}
+
+check() {
+    cd "${srcdir}"/build-${CARCH}
+  make check
 }
 
 package() {

--- a/mingw-w64-oniguruma/PKGBUILD
+++ b/mingw-w64-oniguruma/PKGBUILD
@@ -4,7 +4,7 @@ _realname=onig
 _fullname=oniguruma
 pkgbase=mingw-w64-${_fullname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_fullname}"
-pkgver=6.0.0
+pkgver=6.8.0
 pkgrel=1
 pkgdesc="A regular expressions library (mingw-w64)"
 arch=('any')
@@ -14,7 +14,7 @@ options=('staticlibs')
 source=("https://github.com/kkos/${_fullname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz"
         001-no-undefined.patch
         002-autoconf.patch)
-sha256sums=('0cd75738a938faff4a48c403fb171e128eb9bbd396621237716dbe98c3ecd1af'
+sha256sums=('c9cd7b50f96460a8f5823f5916f57038c24cfb0d8e3bb86b8bb8b990daa4755c'
             '3cef29d0ad118d1a83f017d81ac0c4095290131c57221b982f211240a63da3ff'
             '95ab626f9332c2f5fb6c811055baffc79e75789e9f244ac225093ba151a5a519')
 


### PR DESCRIPTION
mingw-w64-jq - 3.5 - Rebuild to prevent breakage
mingw-w64-oniguruma - 8.6.0 - Update to latest version