### PR TITLE
appveyor: Reduce PATH to the default Windows entries + git

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 clone_folder: C:\M
 
 environment:
+    PATH: C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Program Files\Git\cmd
     DEPLOY_PROVIDER: bintray
     BINTRAY_ACCOUNT: alexpux
     BINTRAY_REPOSITORY: msys2


### PR DESCRIPTION
PATH on appveyor contains 80+ directories and we don't need any of it.