### PR TITLE
Fix debug build for QScintilla

### DIFF
--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -43,7 +43,7 @@ build() {
   make
 
   cd ../designer-Qt4Qt5
-  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
+  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake CONFIG+=build_all designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
   make
 
   cd ../

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -41,10 +41,12 @@ build() {
   cd ${srcdir}/QScintilla-gpl-${pkgver}/Qt4Qt5
   ${MINGW_PREFIX}/bin/qmake CONFIG+=build_all qscintilla.pro
   make
+  make install
 
   cd ../designer-Qt4Qt5
-  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
+  ${MINGW_PREFIX}/bin/qmake designer.pro
   make
+  make install
 
   cd ../
   cp -rf Python Python2

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -41,12 +41,10 @@ build() {
   cd ${srcdir}/QScintilla-gpl-${pkgver}/Qt4Qt5
   ${MINGW_PREFIX}/bin/qmake CONFIG+=build_all qscintilla.pro
   make
-  make install
 
   cd ../designer-Qt4Qt5
-  ${MINGW_PREFIX}/bin/qmake designer.pro
+  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release
   make
-  make install
 
   cd ../
   cp -rf Python Python2

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -43,7 +43,7 @@ build() {
   make
 
   cd ../designer-Qt4Qt5
-  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release
+  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
   make
 
   cd ../

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -55,7 +55,7 @@ package_qscintilla() {
   depends=("${MINGW_PACKAGE_PREFIX}-qt5")
 
   cd QScintilla-gpl-${pkgver}/Qt4Qt5
-  make install
+  make DESTDIR="${pkgdir}" INSTALL_ROOT="${pkgdir}" install
 
   cd ../designer-Qt4Qt5
   make install

--- a/mingw-w64-qscintilla/PKGBUILD
+++ b/mingw-w64-qscintilla/PKGBUILD
@@ -39,11 +39,11 @@ prepare() {
 
 build() {
   cd ${srcdir}/QScintilla-gpl-${pkgver}/Qt4Qt5
-  ${MINGW_PREFIX}/bin/qmake qscintilla.pro
+  ${MINGW_PREFIX}/bin/qmake CONFIG+=build_all qscintilla.pro
   make
 
   cd ../designer-Qt4Qt5
-  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake CONFIG+=build_all designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
+  QMAKEFEATURES=../Qt4Qt5/features ${MINGW_PREFIX}/bin/qmake designer.pro INCLUDEPATH+=../Qt4Qt5 QMAKE_LIBDIR+=../Qt4Qt5/release ../Qt4Qt5/debug
   make
 
   cd ../


### PR DESCRIPTION
The library is already built with debug symbols, just need to make sure Qt can find it. This enables users of this package to build their apps in debug mode through Qt Creator.

http://pyqt.sourceforge.net/Docs/QScintilla2/
https://www.riverbankcomputing.com/software/qscintilla/download