### PR TITLE
openssl: Update to 1.0.2o

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openssl
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-_ver=1.0.2n
+_ver=1.0.2o
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
 pkgrel=1
@@ -21,7 +21,7 @@ source=(https://www.openssl.org/source/${_realname}-${_ver}.tar.gz{,.asc}
         'openssl-1.0.1-x32.patch'
         'openssl-0.9.6-x509.patch'
         'openssl-1.0.1i-relocation.patch')
-sha256sums=('370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe'
+sha256sums=('ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d'
             'SKIP'
             '164aa4928b022cc716fac545b4fd69899cb274682aa487100e595abb652adbae'
             '609d7ca040f7ab26f5e9844e486b3bcc04f3da656ce2db7733fbd65c6d10457a'


### PR DESCRIPTION
Out of curiosity: For [RubyInstaller](https://rubyinstaller.org) we're using OpenSSL-1.1.0 already, with an adjusted path-relocation patch. Are there plans to switch MSYS2/MINGW to OpenSSL-1.1.0 as well?

See: https://github.com/oneclick/rubyinstaller2-packages/tree/master/mingw-w64-openssl

