### PR TITLE
wxWidgets: Update to 3.0.4

### DIFF
--- a/mingw-w64-wxWidgets/PKGBUILD
+++ b/mingw-w64-wxWidgets/PKGBUILD
@@ -9,8 +9,8 @@ _wx_basever=3.0
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 provides=("${MINGW_PACKAGE_PREFIX}-wxmsw${_wx_basever}")
 pkgbase=mingw-w64-${_realname}
-pkgver=${_wx_basever}.3
-pkgrel=3
+pkgver=${_wx_basever}.4
+pkgrel=1
 pkgdesc="A C++ library that lets developers create applications for Windows, Linux and UNIX (mingw-w64)"
 arch=('any')
 license=("custom:wxWindows")
@@ -30,7 +30,7 @@ source=(https://github.com/wxWidgets/wxWidgets/releases/download/v${pkgver}/wxWi
         "001-wxWidgets-3.0.2-relocate-prefix-in-bin-wx-config.patch"
         "002-wxWidgets-3.0.2-relax-abi-compatibility-gcc.patch"
         "003-wxWidgets-3.0.2-fix-access-sample.patch")
-sha256sums=('08c8033f48ec1b23520f036cde37b5ae925a6a65f137ded665633ca159b9307b'
+sha256sums=('96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0'
             '7c3b8f6ba275a448a5e82d64c4914acd5aefb8bbb952389688f3e7167a787c56'
             '3138f7b84bf988892f62167afc6fa640ac154b629b243d86413f7c811e508713'
             'b8684dca94b288a023a8a3d55ad56bce87570576ead71670a237d909ff1c3625')
@@ -43,14 +43,13 @@ prepare() {
   patch -p1 -i "${srcdir}"/003-wxWidgets-3.0.2-fix-access-sample.patch
 }
 
-check() {
-  cd "${srcdir}"/build-${CARCH}/samples && make
-  cd "${srcdir}"/build-${CARCH}-static/samples && make
+#check() {
+  #cd "${srcdir}"/build-${CARCH}/samples && make
+  #cd "${srcdir}"/build-${CARCH}-static/samples && make
 
-#  cd "${srcdir}"/build-${CARCH}/tests && make || true
-  # static test errors out because of mingw64 CRT duplicate symbol issue
-#  cd "${srcdir}"/build-${CARCH}-static/tests && make || true
-}
+  #cd "${srcdir}"/build-${CARCH}/tests && make || true
+  #cd "${srcdir}"/build-${CARCH}-static/tests && make || true
+#}
 
 build() {
   #CXXFLAGS+=" -std=gnu++11"


### PR DESCRIPTION
And, commented out the check function I added in the recent past.
I decided it makes no sense to run the check function just to build the samples.

Note: The sample and the tests do build now. Did not run either the samples or the tests.
In version 3.0.3, the non gui test seg faulted; and, that is likely still true.

Tim S.