### PR TITLE
glib2: Build with win32 threads model

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -78,7 +78,7 @@ build() {
     --disable-static --enable-shared \
     --disable-libelf \
     --with-python=${MINGW_PREFIX}/bin/python3.exe \
-    --with-threads=posix \
+    --with-threads=win32 \
     --with-xml-catalog=${MINGW_PREFIX}/etc/xml/catalog
   make
 
@@ -92,7 +92,7 @@ build() {
     --disable-shared --enable-static \
     --disable-libelf \
     --with-python=${MINGW_PREFIX}/bin/python3.exe \
-    --with-threads=posix \
+    --with-threads=win32 \
     --with-xml-catalog=${MINGW_PREFIX}/etc/xml/catalog
   make
 }


### PR DESCRIPTION
Win32 threads are much more efficient than winpthreads. Some cases show 10x increase of performance. This patch forces glib to use win32 threads.