### PR TITLE
poppler: fix introspection build

### DIFF
--- a/mingw-w64-poppler/003-fix-introspection.patch
+++ b/mingw-w64-poppler/003-fix-introspection.patch
@@ -1,0 +1,11 @@
+--- poppler-0.63.0/glib/CMakeLists.txt.orig	2018-04-07 11:30:26.431808400 +0200
++++ poppler-0.63.0/glib/CMakeLists.txt	2018-04-07 11:28:05.331959900 +0200
+@@ -126,7 +126,7 @@
+   set(Poppler_0_18_gir_INCLUDES GObject-2.0 Gio-2.0 cairo-1.0)
+   get_directory_property(_tmp_includes INCLUDE_DIRECTORIES)
+   _list_prefix(_includes _tmp_includes "-I")
+-  set(Poppler_0_18_gir_CFLAGS ${_includes} -L${CMAKE_BINARY_DIR})
++  set(Poppler_0_18_gir_CFLAGS ${_includes} -L${CMAKE_BINARY_DIR} -L${CMAKE_CURRENT_BINARY_DIR})
+   set(Poppler_0_18_gir_LIBS poppler-glib)
+   _list_prefix(_abs_introspection_files introspection_files "${CMAKE_CURRENT_SOURCE_DIR}/")
+   list(APPEND _abs_introspection_files

--- a/mingw-w64-poppler/PKGBUILD
+++ b/mingw-w64-poppler/PKGBUILD
@@ -4,7 +4,7 @@ _realname=poppler
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.63.0
-pkgrel=1
+pkgrel=2
 pkgdesc="PDF rendering library based on xpdf 3.0 (mingw-w64)"
 arch=('any')
 url="https://poppler.freedesktop.org/"
@@ -32,15 +32,18 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-glib2: libpoppler-glib"
 options=('strip' 'staticlibs')
 source=("https://poppler.freedesktop.org/${_realname}-${pkgver}.tar.xz"
         001-enable-nss-mingw.patch
-        002-fix-win-build.patch)
+        002-fix-win-build.patch
+        003-fix-introspection.patch)
 sha256sums=('27cc8addafc791e1a26ce6acc2b490926ea73a4f89196dd8a7742cff7cf8a111'
             '1f63b502cd0f5eae61a25fc24c0ff900146da54d785ba13602638c08c9f4a890'
-            '6c58ac890b92014c81670a19ead77bcf5986dc9ef5c920b678cfdaff3794c69e')
+            '6c58ac890b92014c81670a19ead77bcf5986dc9ef5c920b678cfdaff3794c69e'
+            '686eccb2799763253da3f598e6469d91eb4e2d9f18321891f95bf8ba182353a3')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/001-enable-nss-mingw.patch
   patch -p1 -i ${srcdir}/002-fix-win-build.patch
+  patch -p1 -i ${srcdir}/003-fix-introspection.patch
 }
 
 build() {


### PR DESCRIPTION
Add the build directory to the library search path