### PR TITLE
sqlite3: Update to 3.23.1

### DIFF
--- a/mingw-w64-sqlite3/PKGBUILD
+++ b/mingw-w64-sqlite3/PKGBUILD
@@ -5,8 +5,8 @@
 _realname=sqlite3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-_amalgamationver=3210000
-pkgver=3.23.0
+_amalgamationver=3230100
+pkgver=3.23.1
 pkgrel=1
 pkgdesc="A C library that implements an SQL database engine (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=("https://www.sqlite.org/2018/sqlite-autoconf-${_amalgamationver}.tar.gz"
         LICENSE)
-sha256sums=('d7dd516775005ad87a57f428b6f86afd206cb341722927f104d3f0cf65fbbbe3'
+sha256sums=('92842b283e5e744eff5da29ed3c69391de7368fccc4d0ee6bf62490ce555ef25'
             '0b76663a90e034f3d7f2af5bfada4cedec5ebc275361899eccc5c18e6f01ff1f')
 options=('!strip' 'staticlibs' '!buildflags')
 


### PR DESCRIPTION
The current package (ver 3.23.0) downloads a wrong amalgamation version (sqlite-autoconf-3210000.tar.gz instead of sqlite-autoconf-3230000.tar.gz)
So this commit in practice updates sqlite3 from version 3.21