### PR TITLE
mingw-w64-cmake - Update to version 3.11

### DIFF
--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.10.2
+pkgver=3.11.0
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -31,7 +31,7 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('80d0faad4ab56de07aa21a7fc692c88c4ce6156d42b0579c6962004a70a3218b'
+sha256sums=('c313bee371d4d255be2b4e96fd59b11d58bc550a7c78c021444ae565709a656b'
             '5f9f13286ab701d89a0080427acc5f823e4a7fa46474df012e85da8d20c1d3f6'
             '2c7fbff6326141de993ea1d29805152990a46d7a215e827e55d05506cbdf726a'
             'e38b2a66f1a562d6347a25c7bcec469e5ff202f87f0cc02ade3d08ae78b0b662'
@@ -65,8 +65,9 @@ prepare() {
   cd ${_realname}-${pkgver}
   apply_patch_with_msg \
     0001-Windows-Add-missing-stringapiset.h-include.patch \
-    0003-Disable-response-files-for-MSYS-Generator.patch \
-    0004-Implement-Qt5-static-plugin-support.patch \
+    0003-Disable-response-files-for-MSYS-Generator.patch
+#    0004-Implement-Qt5-static-plugin-support.patch \
+apply_patch_with_msg \
     0005-Do-not-install-Qt-bundle-in-cmake-gui.patch \
     0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch \
     0007-Do-not-generate-import-libs-for-exes.patch \


### PR DESCRIPTION
Drop 0004 patch about qtstatic plugins sk since I can't figure out what to do about it - see: https://github.com/Alexpux/MINGW-packages/issues/3545 .