### PR TITLE
meld3: fix "has no attribute Win32FontMap" error on start. Fixes #3610

### DIFF
--- a/mingw-w64-meld3/PKGBUILD
+++ b/mingw-w64-meld3/PKGBUILD
@@ -5,7 +5,7 @@ _realname=meld
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.19.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Visual diff and merge tool (mingw-w64)"
 arch=('any')
 url="http://meldmerge.org/"
@@ -23,14 +23,19 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              'itstool')
 install=meld-${CARCH}.install
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
-        '0001-fixes-for-MinGW-w64-symlinks-and-use-sh-to-spawn.patch')
+        '0001-fixes-for-MinGW-w64-symlinks-and-use-sh-to-spawn.patch'
+        'dont-use-private-api.patch')
 sha256sums=('d3ff595db814fb3c4f65b80e642d04c2437bce641abae3fbcace9ee4adb7d9cf'
-            'b961732116ff7d1060d7480f46900c03259d4089264b5063161982d22ea15d9f')
+            'b961732116ff7d1060d7480f46900c03259d4089264b5063161982d22ea15d9f'
+            '500fade16ea6cf1c5572fe4bd58836d351b95dbefba180c27223f57d5c864acd')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   patch -p1 -i "${srcdir}/0001-fixes-for-MinGW-w64-symlinks-and-use-sh-to-spawn.patch"
+
+  # https://github.com/Alexpux/MINGW-packages/issues/3610
+  patch -p1 -i "${srcdir}/dont-use-private-api.patch"
 }
 
 build() {

--- a/mingw-w64-meld3/dont-use-private-api.patch
+++ b/mingw-w64-meld3/dont-use-private-api.patch
@@ -1,0 +1,26 @@
+--- meld-3.19.0/bin/meld.orig	2018-03-23 00:07:52.000000000 +0100
++++ meld-3.19.0/bin/meld	2018-04-17 10:50:43.104917400 +0200
+@@ -347,6 +347,12 @@
+ 
+ 
+ if __name__ == '__main__':
++    if sys.platform == 'win32':
++        # FontConfig on win32 at least with version <= 2.12.6 can cause several
++        # minutes 'hang' during first startup. So use native fonts backend.
++        assert "gi.repository.PangoCairo" not in sys.modules
++        os.environ['PANGOCAIRO_BACKEND'] = 'win32'
++
+     setup_logging()
+     disable_stdout_buffering()
+     check_requirements()
+@@ -360,10 +366,5 @@
+         from gi.repository import GLib
+         GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT,
+                              lambda *args: meld.meldapp.app.quit(), None)
+-    if sys.platform == 'win32':
+-        # FontConfig on win32 at least with version <= 2.12.6 can cause several
+-        # minutes 'hang' during first startup. So use native fonts backend.
+-        from gi.repository import PangoCairo
+-        PangoCairo.FontMap.set_default(PangoCairo.Win32FontMap())
+     status = meld.meldapp.app.run(sys.argv)
+     sys.exit(status)


### PR DESCRIPTION
I think this type was supposed to be private in pango and not exported in the gir.
But it was anyway with the autotools build and now no longer is with the meson one.

The code in question was trying to set the win32 pango backend which is also
possible through an env var, so just do that instead and make sure we do it
before importing pango.