### PR TITLE
fribidi: update source url to new location

### DIFF
--- a/mingw-w64-fribidi/PKGBUILD
+++ b/mingw-w64-fribidi/PKGBUILD
@@ -12,7 +12,7 @@ url="https://fribidi.org/"
 depends=("${MINGW_PACKAGE_PREFIX}-glib2")
 options=('strip' '!libtool' 'staticlibs')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-source=("https://fribidi.org/download/${_realname}-${pkgver}.tar.bz2"
+source=("https://github.com/fribidi/fribidi/releases/download/${pkgver}/${_realname}-${pkgver}.tar.bz2"
         "0001-No-need-to-specialcase-export-symbols-for-OS_WIN32.patch"
         "0003-fix-eols-in-tests-on.mingw.patch")
 sha256sums=('08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e'


### PR DESCRIPTION
The old url is 404 now.