### PR TITLE
gtkspell3: drop gtk2 build

### DIFF
--- a/mingw-w64-gtkspell3/PKGBUILD
+++ b/mingw-w64-gtkspell3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtkspell3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.0.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Provides word-processor-style highlighting and replacement of misspelled words in a GtkTextView widget (mingw-w64)"
 arch=('any')
 url="https://gtkspell.sourceforge.io/"
@@ -17,7 +17,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gtk-doc"
              "intltool")
 depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
-         "${MINGW_PACKAGE_PREFIX}-gtk2"
          "${MINGW_PACKAGE_PREFIX}-enchant")
 options=(!libtool strip staticlibs)
 source=(https://sourceforge.net/projects/gtkspell/files/${pkgver}/${_realname}-${pkgver}.tar.xz
@@ -41,7 +40,7 @@ build() {
     --host=${MINGW_CHOST} \
     --enable-shared \
     --disable-static \
-    --enable-gtk2 \
+    --disable-gtk2 \
     --enable-gtk-doc
 
   make


### PR DESCRIPTION
gtkspell3 is a dependency of geany and gitg, and both are gtk3 now.
No need to pull in gtk2.