### PR TITLE
cmake: Update to 3.11.0 (#3545)

### DIFF
--- a/mingw-w64-cmake/0001-Windows-Add-missing-stringapiset.h-include.patch
+++ b/mingw-w64-cmake/0001-Windows-Add-missing-stringapiset.h-include.patch
@@ -1,4 +1,4 @@
-From 1a42d44ec1a582a52d56eb44d4a130d285f7fa18 Mon Sep 17 00:00:00 2001
+From 7618a242db1a0a8792f0fd6b79da26a03ba883ba Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 23 Jan 2017 12:46:49 +0000
 Subject: [PATCH 1/8] Windows: Add missing stringapiset.h include
@@ -9,11 +9,11 @@ This is needed for WideCharToMultiByte()
  1 file changed, 1 insertion(+)
 
 diff --git a/Source/cmFileCommand.cxx b/Source/cmFileCommand.cxx
-index fdd5f0c81..8d8c1f5bd 100644
+index d3dcc0112..05d2c6151 100644
 --- a/Source/cmFileCommand.cxx
 +++ b/Source/cmFileCommand.cxx
-@@ -78,6 +78,7 @@ static mode_t mode_setgid = S_ISGID;
- #endif
+@@ -54,6 +54,7 @@ class cmSystemToolsFileTime;
+ using namespace cmFSPermissions;
  
  #if defined(_WIN32)
 +#include <stringapiset.h>
@@ -21,5 +21,5 @@ index fdd5f0c81..8d8c1f5bd 100644
  // Convert string from UTF-8 to ACP if this is a file:// URL.
  static std::string fix_file_url_windows(const std::string& url)
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0003-Disable-response-files-for-MSYS-Generator.patch
+++ b/mingw-w64-cmake/0003-Disable-response-files-for-MSYS-Generator.patch
@@ -1,4 +1,4 @@
-From 7faa6c278672e4fe36f7e52918f07e61b6056e8a Mon Sep 17 00:00:00 2001
+From 489ea612609f40b9db8c7c99f79727572f970b94 Mon Sep 17 00:00:00 2001
 From: Alexpux <alexey.pawlow@gmail.com>
 Date: Mon, 3 Aug 2015 22:00:16 +0100
 Subject: [PATCH 3/8] Disable response files for MSYS Generator
@@ -27,5 +27,5 @@ index cfb325b9d..f0e04cb56 100644
    # We prefer "@" for response files but it is not supported by gcc 3.
    execute_process(COMMAND ${CMAKE_${lang}_COMPILER} --version OUTPUT_VARIABLE _ver ERROR_VARIABLE _ver)
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
@@ -1,4 +1,4 @@
-From 838e486b12b15ce0b4dd8afbd8c8471ed4da3769 Mon Sep 17 00:00:00 2001
+From 34b900087c505d65b54a429abcba7f7526ce1ba4 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 3 Aug 2015 22:00:16 +0100
 Subject: [PATCH 4/8] Implement Qt5 static plugin support
@@ -17,17 +17,19 @@ from [1] are necessary [2], [3] and [4]
 .. and also some more minor ones that aren't strictly related to Qt5 static
 CMake but are necessary for this to work on MinGW-w64 (0040- for example).
 ---
- Source/cmGlobalGenerator.cxx            |  3 +-
- Source/cmQtAutoGeneratorInitializer.cxx | 60 +++++++++++++++++++++++++++++++++
- Source/cmTarget.cxx                     |  1 +
- Source/cmTargetPropertyComputer.cxx     |  1 +
- 4 files changed, 64 insertions(+), 1 deletion(-)
+ Source/cmGlobalGenerator.cxx        |  6 ++--
+ Source/cmQtAutoGen.h                |  3 +-
+ Source/cmQtAutoGenInitializer.cxx   | 65 ++++++++++++++++++++++++++++++++++++-
+ Source/cmQtAutoGenInitializer.h     |  2 ++
+ Source/cmTarget.cxx                 |  1 +
+ Source/cmTargetPropertyComputer.cxx |  1 +
+ 6 files changed, 74 insertions(+), 4 deletions(-)
 
 diff --git a/Source/cmGlobalGenerator.cxx b/Source/cmGlobalGenerator.cxx
-index 05efff317..49dbc10fe 100644
+index c805b98d7..aa50eebc8 100644
 --- a/Source/cmGlobalGenerator.cxx
 +++ b/Source/cmGlobalGenerator.cxx
-@@ -1427,7 +1427,8 @@ cmQtAutoGenDigestUPV cmGlobalGenerator::CreateQtAutoGeneratorsTargets()
+@@ -1502,7 +1502,8 @@ cmGlobalGenerator::CreateQtAutoGenInitializers()
        const bool mocEnabled = target->GetPropertyAsBool("AUTOMOC");
        const bool uicEnabled = target->GetPropertyAsBool("AUTOUIC");
        const bool rccEnabled = target->GetPropertyAsBool("AUTORCC");
@@ -37,32 +39,88 @@ index 05efff317..49dbc10fe 100644
          continue;
        }
  
-diff --git a/Source/cmQtAutoGeneratorInitializer.cxx b/Source/cmQtAutoGeneratorInitializer.cxx
-index b02d872a4..999b96913 100644
---- a/Source/cmQtAutoGeneratorInitializer.cxx
-+++ b/Source/cmQtAutoGeneratorInitializer.cxx
-@@ -24,6 +24,7 @@
- #include "cmake.h"
- #include "cmsys/FStream.hxx"
+@@ -1514,7 +1515,8 @@ cmGlobalGenerator::CreateQtAutoGenInitializers()
+       }
  
-+#include <cmGeneratedFileStream.h>
- #include <algorithm>
- #include <array>
- #include <deque>
-@@ -650,6 +651,65 @@ static void SetupAutoTargetRcc(cmQtAutoGenDigest const& digest)
+       autogenInits.emplace_back(new cmQtAutoGenInitializer(
+-        target, mocEnabled, uicEnabled, rccEnabled, qtVersionMajor));
++        target, mocEnabled, uicEnabled, rccEnabled, staticPluginsEnabled,
++        qtVersionMajor));
+     }
+   }
+ #endif
+diff --git a/Source/cmQtAutoGen.h b/Source/cmQtAutoGen.h
+index 67f61b197..3d156e056 100644
+--- a/Source/cmQtAutoGen.h
++++ b/Source/cmQtAutoGen.h
+@@ -25,7 +25,8 @@ public:
+     GEN, // General
+     MOC,
+     UIC,
+-    RCC
++    RCC,
++    STATICPLUGINS
+   };
+ 
+ public:
+diff --git a/Source/cmQtAutoGenInitializer.cxx b/Source/cmQtAutoGenInitializer.cxx
+index 93c78b5bd..9e7349baa 100644
+--- a/Source/cmQtAutoGenInitializer.cxx
++++ b/Source/cmQtAutoGenInitializer.cxx
+@@ -86,6 +86,9 @@ static bool AddToSourceGroup(cmMakefile* makefile, std::string const& fileName,
+         case cmQtAutoGen::GeneratorT::RCC:
+           props[0] = "AUTORCC_SOURCE_GROUP";
+           break;
++        case cmQtAutoGen::GeneratorT::STATICPLUGINS:
++          props[0] = "AUTOSTATICPLUGINS_SOURCE_GROUP";
++          break;
+         default:
+           props[0] = "AUTOGEN_SOURCE_GROUP";
+           break;
+@@ -192,11 +195,12 @@ static bool StaticLibraryCycle(cmGeneratorTarget const* targetOrigin,
+ 
+ cmQtAutoGenInitializer::cmQtAutoGenInitializer(
+   cmGeneratorTarget* target, bool mocEnabled, bool uicEnabled, bool rccEnabled,
+-  std::string const& qtVersionMajor)
++  bool staticPluginsEnabled, std::string const& qtVersionMajor)
+   : Target(target)
+   , MocEnabled(mocEnabled)
+   , UicEnabled(uicEnabled)
+   , RccEnabled(rccEnabled)
++  , StaticPluginsEnabled(staticPluginsEnabled)
+   , MultiConfig(false)
+   , QtVersionMajor(qtVersionMajor)
+ {
+@@ -366,6 +370,12 @@ void cmQtAutoGenInitializer::InitCustomTargets()
+     }
    }
  
-   cmMakefile* makefile = digest.Target->Target->GetMakefile();
-+  /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake,
-+   * macro(_populate_Core_plugin_properties ..), we'd have:
-+   * set_property(TARGET PROPERTY AUTOSTATICPLUGINS True) // Not currently need
-+   * as defaults to "ON"
-+   * set_property(TARGET Qt5::Core APPEND PROPERTY STATIC_PLUGINS ${Plugin})
-+   */
-+  cmGeneratorTarget* target = digest.Target;
-+  if (target->GetPropertyAsBool("AUTOSTATICPLUGINS")) {
++  // Add AutoStaticPlugins import to generated files list
++  if (this->StaticPluginsEnabled) {
++    std::string staticPluginsComp = this->DirBuild + "/plugin_import.cpp";
++    this->AddGeneratedSource(staticPluginsComp, GeneratorT::STATICPLUGINS);
++  }
++
+   // Extract relevant source files
+   std::vector<std::string> generatedSources;
+   std::vector<std::string> generatedHeaders;
+@@ -1051,6 +1061,59 @@ void cmQtAutoGenInitializer::SetupCustomTargets()
+       }
+     }
+   }
++
++  // Generate plugin static-link source files
++  if (this->StaticPluginsEnabled)
++  {
++    /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake,
++     * macro(_populate_Core_plugin_properties ..), we'd have:
++     * set_property(TARGET PROPERTY AUTOSTATICPLUGINS True) // Not currently needed
++     * as defaults to "ON"
++     * set_property(TARGET Qt5::Core APPEND PROPERTY STATIC_PLUGINS ${Plugin})
++     */
++
 +    std::vector<const cmGeneratorTarget*> libTargets =
-+      target->GetLinkImplementationClosure("");
++      this->Target->GetLinkImplementationClosure("");
 +    std::vector<cmGeneratorTarget const*>::const_iterator li;
 +    std::vector<std::string> staticPlugins;
 +    for (li = libTargets.begin(); li != libTargets.end(); ++li) {
@@ -82,63 +140,74 @@ index b02d872a4..999b96913 100644
 +      }
 +    }
 +
-+    if (staticPlugins.size()) {
-+      std::string static_plugins_output_dir = target->GetSupportDirectory();
-+      cmSystemTools::MakeDirectory(static_plugins_output_dir.c_str());
-+      std::string static_plugins_output_file = static_plugins_output_dir;
-+      static_plugins_output_file +=
-+        "/" + target->GetName() + "_plugin_import.cpp";
-+      cmGeneratedFileStream staticPluginsFileStream(
-+        static_plugins_output_file.c_str());
-+      if (staticPluginsFileStream) {
-+        staticPluginsFileStream << "// This file is autogenerated by cmake. "
-+                                   "It imports static plugin classes for"
++    std::string static_plugins_output_file = this->DirBuild + "/plugin_import.cpp";
++    cmGeneratedFileStream staticPluginsFileStream(
++      static_plugins_output_file.c_str());
++    if (staticPluginsFileStream) {
++      staticPluginsFileStream << "// This file is autogenerated by cmake. "
++                                 "It imports static plugin classes for"
++                              << std::endl;
++      staticPluginsFileStream
++        << "// static plugins specified using QTPLUGIN and "
++           "QT_PLUGIN_CLASS.<plugin> variables."
++        << std::endl;
++      staticPluginsFileStream << "#include <QtPlugin>" << std::endl;
++      for (std::vector<std::string>::const_iterator spti =
++             staticPlugins.begin();
++           spti != staticPlugins.end(); ++spti) {
++        staticPluginsFileStream << "Q_IMPORT_PLUGIN(" << *spti << ")"
 +                                << std::endl;
-+        staticPluginsFileStream
-+          << "// static plugins specified using QTPLUGIN and "
-+             "QT_PLUGIN_CLASS.<plugin> variables."
-+          << std::endl;
-+        staticPluginsFileStream << "#include <QtPlugin>" << std::endl;
-+        for (std::vector<std::string>::const_iterator spti =
-+               staticPlugins.begin();
-+             spti != staticPlugins.end(); ++spti) {
-+          staticPluginsFileStream << "Q_IMPORT_PLUGIN(" << *spti << ")"
-+                                  << std::endl;
-+        }
-+        staticPluginsFileStream.Close();
-+        makefile->AppendProperty("ADDITIONAL_MAKE_CLEAN_FILES",
-+                                 static_plugins_output_file.c_str(), false);
-+        target->AddSource(static_plugins_output_file);
 +      }
++      staticPluginsFileStream.Close();
 +    }
 +  }
-   AddDefinitionEscaped(makefile, "_qt_rcc_executable",
-                        RccGetExecutable(digest.Target, digest.QtVersionMajor));
-   AddDefinitionEscaped(makefile, "_rcc_files", rccFiles);
+ }
+ 
+ void cmQtAutoGenInitializer::SetupCustomTargetsMoc()
+diff --git a/Source/cmQtAutoGenInitializer.h b/Source/cmQtAutoGenInitializer.h
+index 2a47e46a4..1f21b3476 100644
+--- a/Source/cmQtAutoGenInitializer.h
++++ b/Source/cmQtAutoGenInitializer.h
+@@ -47,6 +47,7 @@ public:
+ public:
+   cmQtAutoGenInitializer(cmGeneratorTarget* target, bool mocEnabled,
+                          bool uicEnabled, bool rccEnabled,
++                         bool staticPluginsEnabled,
+                          std::string const& qtVersionMajor);
+ 
+   void InitCustomTargets();
+@@ -70,6 +71,7 @@ private:
+   bool MocEnabled;
+   bool UicEnabled;
+   bool RccEnabled;
++  bool StaticPluginsEnabled;
+   bool MultiConfig;
+   // Qt
+   std::string QtVersionMajor;
 diff --git a/Source/cmTarget.cxx b/Source/cmTarget.cxx
-index c6cd5026f..44d584e61 100644
+index cd11c4b14..1b0bfbdcd 100644
 --- a/Source/cmTarget.cxx
 +++ b/Source/cmTarget.cxx
-@@ -244,6 +244,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
+@@ -247,6 +247,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
      this->SetPropertyDefault("AUTOMOC", nullptr);
      this->SetPropertyDefault("AUTOUIC", nullptr);
      this->SetPropertyDefault("AUTORCC", nullptr);
 +    this->SetPropertyDefault("AUTOSTATICPLUGINS", nullptr);
+     this->SetPropertyDefault("AUTOGEN_PARALLEL", nullptr);
      this->SetPropertyDefault("AUTOMOC_COMPILER_PREDEFINES", nullptr);
      this->SetPropertyDefault("AUTOMOC_DEPEND_FILTERS", nullptr);
-     this->SetPropertyDefault("AUTOMOC_MACRO_NAMES", nullptr);
 diff --git a/Source/cmTargetPropertyComputer.cxx b/Source/cmTargetPropertyComputer.cxx
-index 1d2520d4b..85a521a5f 100644
+index 06ce0b1e6..0e7ccb34e 100644
 --- a/Source/cmTargetPropertyComputer.cxx
 +++ b/Source/cmTargetPropertyComputer.cxx
-@@ -58,6 +58,7 @@ bool cmTargetPropertyComputer::WhiteListedInterfaceProperty(
-     builtIns.insert("EXPORT_NAME");
+@@ -66,6 +66,7 @@ bool cmTargetPropertyComputer::WhiteListedInterfaceProperty(
      builtIns.insert("IMPORTED");
+     builtIns.insert("IMPORTED_GLOBAL");
      builtIns.insert("NAME");
 +    builtIns.insert("STATIC_PLUGINS");
      builtIns.insert("TYPE");
    }
  
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0005-Do-not-install-Qt-bundle-in-cmake-gui.patch
+++ b/mingw-w64-cmake/0005-Do-not-install-Qt-bundle-in-cmake-gui.patch
@@ -1,4 +1,4 @@
-From 0397045ba92fdd421e07c84d0e617ae867665adf Mon Sep 17 00:00:00 2001
+From 2e24fbb53c90dcb7112f1b0b6c49a93559afee44 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 14 Feb 2017 09:30:36 -0600
 Subject: [PATCH 5/8] Do not install Qt bundle in cmake-gui
@@ -8,10 +8,10 @@ Subject: [PATCH 5/8] Do not install Qt bundle in cmake-gui
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Source/QtDialog/CMakeLists.txt b/Source/QtDialog/CMakeLists.txt
-index b38797bca..4a2777a35 100644
+index 330b74729..ac25d23a9 100644
 --- a/Source/QtDialog/CMakeLists.txt
 +++ b/Source/QtDialog/CMakeLists.txt
-@@ -238,7 +238,7 @@ if(APPLE)
+@@ -242,7 +242,7 @@ if(APPLE)
    " ${COMPONENT})
  endif()
  
@@ -21,5 +21,5 @@ index b38797bca..4a2777a35 100644
    # if a system Qt is used (e.g. installed in /usr/lib/), it will not be included in the installation
    set(fixup_exe "\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/cmake-gui${CMAKE_EXECUTABLE_SUFFIX}")
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch
+++ b/mingw-w64-cmake/0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch
@@ -1,4 +1,4 @@
-From d50da761f3fdc3b2d3ca13bffa167541b95a0478 Mon Sep 17 00:00:00 2001
+From 04954fa9efc95810ed55d4ac1f6737161a938179 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 14 Feb 2017 09:34:39 -0600
 Subject: [PATCH 6/8] pkg-config: Add --dont-define-prefix when
@@ -9,10 +9,10 @@ Subject: [PATCH 6/8] pkg-config: Add --dont-define-prefix when
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/Modules/FindPkgConfig.cmake b/Modules/FindPkgConfig.cmake
-index 76afa8a5d..a92f8b079 100644
+index 952ca9265..f77c9b6d8 100644
 --- a/Modules/FindPkgConfig.cmake
 +++ b/Modules/FindPkgConfig.cmake
-@@ -55,8 +55,13 @@ endmacro()
+@@ -58,8 +58,13 @@ endmacro()
  macro(_pkgconfig_invoke _pkglist _prefix _varname _regexp)
    set(_pkgconfig_invoke_result)
  
@@ -28,5 +28,5 @@ index 76afa8a5d..a92f8b079 100644
      RESULT_VARIABLE _pkgconfig_failed
      OUTPUT_STRIP_TRAILING_WHITESPACE)
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0007-Do-not-generate-import-libs-for-exes.patch
+++ b/mingw-w64-cmake/0007-Do-not-generate-import-libs-for-exes.patch
@@ -1,4 +1,4 @@
-From 2192468c78db42199f859e8b05312156671b0509 Mon Sep 17 00:00:00 2001
+From 071655c9a2d11ac4a2d94a8663c19b1edd4c6527 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 14 Feb 2017 09:35:40 -0600
 Subject: [PATCH 7/8] Do not generate import libs for exes
@@ -21,5 +21,5 @@ index f0e04cb56..5892108e7 100644
    list(APPEND CMAKE_${lang}_ABI_FILES "Platform/Windows-GNU-${lang}-ABI")
  
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/0008-Output-line-numbers-in-callstacks.patch
+++ b/mingw-w64-cmake/0008-Output-line-numbers-in-callstacks.patch
@@ -1,4 +1,4 @@
-From dcde43eeba14bad40e7daad3e127bfe1007aa9d5 Mon Sep 17 00:00:00 2001
+From 82b5a7cafe82deb3655dffd169c24458ea61e79d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Mon, 3 Aug 2015 22:00:17 +0100
 Subject: [PATCH 8/8] Output line numbers in callstacks
@@ -9,10 +9,10 @@ Now just a marker for where to add the new code.
  1 file changed, 3 insertions(+)
 
 diff --git a/Source/cmMakefile.cxx b/Source/cmMakefile.cxx
-index 5643c978d..ac5d69d86 100644
+index b46820822..245f88492 100644
 --- a/Source/cmMakefile.cxx
 +++ b/Source/cmMakefile.cxx
-@@ -3640,6 +3640,9 @@ std::string cmMakefile::FormatListFileStack() const
+@@ -3725,6 +3725,9 @@ std::string cmMakefile::FormatListFileStack() const
    cmStateSnapshot snp = this->StateSnapshot;
    while (snp.IsValid()) {
      listFiles.push_back(snp.GetExecutionListFile());
@@ -23,5 +23,5 @@ index 5643c978d..ac5d69d86 100644
    }
    std::reverse(listFiles.begin(), listFiles.end());
 -- 
-2.11.1.windows.1
+2.16.2.windows.1
 

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.10.2
+pkgver=3.11.1
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -31,14 +31,14 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('80d0faad4ab56de07aa21a7fc692c88c4ce6156d42b0579c6962004a70a3218b'
-            '5f9f13286ab701d89a0080427acc5f823e4a7fa46474df012e85da8d20c1d3f6'
-            '2c7fbff6326141de993ea1d29805152990a46d7a215e827e55d05506cbdf726a'
-            'e38b2a66f1a562d6347a25c7bcec469e5ff202f87f0cc02ade3d08ae78b0b662'
-            '3585b75044002f48cc0e7571fce3505d6cf7b1d254a7ec65ef4bf3bb7852c774'
-            'f0e39d352557f3b5ff40aa6ac962e780aa7d5aef5c1e122f937b9d32c702e26f'
-            '283781204de5f4089fcc89d0a7b6ca49db134cf00378aa883363d5ca685ac8bc'
-            '46a41974daa960b6cad72f020e5a4c539186ecb07c30ffbeae923d4e25243889')
+sha256sums=('57bebc6ca4d1d42c6385249d148d9216087e0fda57a47dc5c858790a70217d0c'
+            'e747f6a2de187d1ad469872432a2afd15252dafe4babf5b2c713372c864ef8ba'
+            '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
+            '4402730b932e94630beecbc596fe33868338b162f200e8c0464ac71acf4b0fbe'
+            '7eb60d12b610c70413412521dcc860d1948c169e721f3525d9be99b3913dc37e'
+            'b3905abed55c012108b0254c69cb4027a739f15772500b0a99c400d9dfdf50a7'
+            'c6c312f488cd8bb0c73d026c3fbbafedf64e8d01469fc94799edea0660915164'
+            '6123b49887fb09c110b2223e9230f0a84824a5d191aaa8971a6a11339c76cf52')
 
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
The patch series was recreated by applying it to a CMake git checkout at
v3.10.1, and then rebasing it onto v3.11.0.

Patch 0004-Implement-Qt5-static-plugin-support.patch had to be
extensively redone, to support a refactoring in the Qt5 auto-gen support
in CMake 3.11.0. The rest of the patches are changed only due to
artifacts of this rebasing.