### PR TITLE
http-parser: update to 2.8.1

### DIFF
--- a/mingw-w64-http-parser/PKGBUILD
+++ b/mingw-w64-http-parser/PKGBUILD
@@ -1,39 +1,43 @@
 # Maintainer: Martell Malone <martellmalone@gmail.com>
 # Contributor: Alethea Rose <alethea@alethearose.com>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=http-parser
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.7.1
-pkgrel=2
-pkgdesc='Parser for HTTP Request/Response written in C (mingw-w64)'
+pkgver=2.8.1
+pkgrel=1
+pkgdesc="Parser for HTTP Request/Response written in C (mingw-w64)"
 arch=('any')
 url='https://github.com/joyent/http-parser'
 license=('MIT')
 source=(${_realname}-${pkgver}.tar.gz::"https://github.com/joyent/http-parser/archive/v${pkgver}.tar.gz")
 options=('strip' 'staticlibs')
-sha256sums=('70409ad324e5de2da6a0f39e859e566d497c1ff0a249c0c38a5012df91b386b3')
+sha256sums=('51615f68b8d67eadfd2482decc63b3e55d749ce0055502bbb5b0032726d22d96')
 
 build() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  cp -R ${srcdir}/${_realname}-${pkgver}/. "${srcdir}"/build-${CARCH}
 
-  CC=gcc \
-  AR=ar \
+  CC=${MINGW_PREFIX}/bin/gcc \
+  AR=${MINGW_PREFIX}/bin/ar \
   SONAME=libhttp_parser-2.dll \
+  LIBNAME=libhttp_parser-2.dll \
   LDFLAGS+=' -Wl,--out-implib=libhttp_parser.dll.a' \
   make -j1 \
     library package
 }
 
 check() {
-  cd ${srcdir}/${_realname}-${pkgver}
+  cd "${srcdir}"/build-${CARCH}
   make test
 }
 
 package() {
-  cd ${srcdir}/${_realname}-${pkgver}
-  mkdir -p ${pkgdir}/${MINGW_PREFIX}/{bin,include,lib}
-  install -Dm644 http_parser.h "${pkgdir}/${MINGW_PREFIX}/include/http_parser.h"
-  cp *.a ${pkgdir}/${MINGW_PREFIX}/lib/
-  cp *.dll ${pkgdir}/${MINGW_PREFIX}/bin/
+  cd "${srcdir}"/build-${CARCH}
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/{bin,include,lib}
+  install -Dm644 http_parser.h "${pkgdir}${MINGW_PREFIX}/include/http_parser.h"
+  cp *.a ${pkgdir}${MINGW_PREFIX}/lib/
+  cp *.dll ${pkgdir}${MINGW_PREFIX}/bin/
 }


### PR DESCRIPTION
This updates http-parser to 2.8.1 and adds a missing import library for the dll.