### PR TITLE
libsodium - 1.0.16 - Update to latest version and use minisgn tool si…

### DIFF
--- a/mingw-w64-libsodium/PKGBUILD
+++ b/mingw-w64-libsodium/PKGBUILD
@@ -10,16 +10,8 @@ arch=("any")
 url="https://github.com/jedisct1/libsodium"
 license=('custom:ISC')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=("${MINGW_PACKAGE_PREFIX}-minisign")
-source=("https://download.libsodium.org/libsodium/releases/${_realname}-${pkgver}.tar.gz"{,.minisig})
-validpgpkeys=('54A2B8892CC3D6A597B92B6C210627AABA709FE1') #Frank Denis (Jedi/Sector One) <pgp@pureftpd.org>
-sha256sums=('eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533'
-            '0a5ec3d5a44c07b33ad337c4690827459be5e5500dee612101a6a0b333051849')
-_validminisignkey='RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-
-prepare() {
-  minisign -Vm ${_realname}-$pkgver.tar.gz -P $_validminisignkey
-}
+source=("https://download.libsodium.org/libsodium/releases/${_realname}-${pkgver}.tar.gz")
+sha256sums=('eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533')
 
 build() {
   rm -rf "${srcdir}/build-${MINGW_CHOST}"

--- a/mingw-w64-libsodium/PKGBUILD
+++ b/mingw-w64-libsodium/PKGBUILD
@@ -3,17 +3,23 @@
 _realname=libsodium
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.12
+pkgver=1.0.16
 pkgrel=1
 pkgdesc="P(ortable|ackageable) NaCl-based crypto library (mingw-w64)"
 arch=("any")
 url="https://github.com/jedisct1/libsodium"
 license=('custom:ISC')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-source=("https://download.libsodium.org/libsodium/releases/${_realname}-${pkgver}.tar.gz"{,.sig})
+makedepends=("${MINGW_PACKAGE_PREFIX}-minisign")
+source=("https://download.libsodium.org/libsodium/releases/${_realname}-${pkgver}.tar.gz"{,.minisig})
 validpgpkeys=('54A2B8892CC3D6A597B92B6C210627AABA709FE1') #Frank Denis (Jedi/Sector One) <pgp@pureftpd.org>
-sha256sums=('b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95'
-            'SKIP')
+sha256sums=('eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533'
+            '0a5ec3d5a44c07b33ad337c4690827459be5e5500dee612101a6a0b333051849')
+_validminisignkey='RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+
+prepare() {
+  minisign -Vm ${_realname}-$pkgver.tar.gz -P $_validminisignkey
+}
 
 build() {
   rm -rf "${srcdir}/build-${MINGW_CHOST}"

--- a/mingw-w64-minisign/PKGBUILD
+++ b/mingw-w64-minisign/PKGBUILD
@@ -1,0 +1,48 @@
+# $Id$
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=minisign
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=0.8
+pkgrel=1
+pkgdesc="A dead simple tool to sign files and verify digital signatures. (mingw-w64)"
+arch=('any')
+url="https://github.com/jedisct1/minisign"
+license=('custom:ISC')
+depends=("${MINGW_PACKAGE_PREFIX}-libsodium")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+source=("${_realname}-$pkgver.tar.gz::https://github.com/jedisct1/minisign/archive/$pkgver.tar.gz")
+sha512sums=('79bf626d0c15e39ce3bdf53600038028c0b22904b648074bf516a9ea6962c9486c41244e80637a5fbac090cce1ed9b4b3d57b8a02632646e01b43aa413cd8bd9')
+
+prepare() {
+  mkdir -p build
+}
+
+build() {
+  cd "$srcdir"/${_realname}-${pkgver}
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      "${extra_config[@]}" \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  make install DESTDIR="${pkgdir}"
+  install -Dm644 ${srcdir}/minisign-$pkgver/LICENSE "$pkgdir"/${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}


### PR DESCRIPTION
…nce it's now impossible to retreive the GPG key for libsodium

minisign - 1.0.8 - Used by libsodium package to verify libsodium distribution.  New package