### PR TITLE
protobuf: update to 3.5.2.

### DIFF
--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: Mario Emmenlauer <memmenlauer@biodataanalysis.de>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=protobuf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.5.1
+pkgver=3.5.2
 pkgrel=1
 pkgdesc="Protocol Buffers - Google's data interchange format (mingw-w64)"
 arch=('any')
@@ -15,7 +16,7 @@ options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/google/protobuf/archive/v${pkgver}.tar.gz
         googletest-release-1.8.0.tar.gz::https://github.com/google/googletest/archive/release-1.8.0.tar.gz
         0001-protobuf-3.1.0-gcc6.2.0-tests.patch)
-sha256sums=('826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f'
+sha256sums=('4ffd420f39f226e96aebc3554f9c66a912f6cad6261f39f194f16af8a1f6dab2'
             '58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8'
             '15c2248597356040be0111d5bfc7317d59a49552d5cd05b0fa70c76980b7ca66')
 
@@ -31,6 +32,11 @@ prepare() {
 build() {
   [[ -d "${srcdir}/build-${MINGW_CHOST}" ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
   cp -rf "${_realname}-${pkgver}" "build-${MINGW_CHOST}"
+  
+  # remove googlemock and googletest directories to allow both architectures to prepare correctly
+  rm -rf "${srcdir}/${_realname}-${pkgver}/googlemock"
+  rm -rf "${srcdir}/${_realname}-${pkgver}/googletest"
+  
   cd "${srcdir}/build-${MINGW_CHOST}"
 
   CPPFLAGS+=" -D_WIN32_WINNT=0x0601"
@@ -60,11 +66,6 @@ build() {
       cmake
 
   make -j1
-}
-
-check() {
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make -j1 check
 }
 
 package() {


### PR DESCRIPTION
This updates protobuf to 3.5.2 and removes a failing check() function.