### PR TITLE
libcerf: fix shared build

### DIFF
--- a/mingw-w64-libcerf/0001-libcerf-1.5-fix-shared-lib.patch
+++ b/mingw-w64-libcerf/0001-libcerf-1.5-fix-shared-lib.patch
@@ -1,0 +1,22 @@
+unchanged:
+--- libcerf-1.5/configure.ac.orig	2018-04-28 20:47:08.757676400 -0400
++++ libcerf-1.5/configure.ac	2018-04-28 20:47:12.254681200 -0400
+@@ -30,6 +30,7 @@
+ AM_INIT_AUTOMAKE([foreign]) # don't insert GNU standard text files
+ LT_INIT([disable-static])
+ 
++AC_LIBTOOL_WIN32_DLL
+ AC_PROG_CC_C99
+ AC_SUBST(AM_CFLAGS,"-pedantic -Wall")
+ AC_CONFIG_HEADERS([config.h]) # to avoid endless -D options
+only in patch2:
+unchanged:
+--- libcerf-1.5/lib/Makefile.am.orig	2018-04-28 20:44:58.774923500 -0400
++++ libcerf-1.5/lib/Makefile.am	2018-04-28 20:45:05.520091000 -0400
+@@ -22,4 +22,4 @@
+ lib_LTLIBRARIES = libcerf.la
+ include_HEADERS = cerf.h
+ libcerf_la_SOURCES = cerf.h im_w_of_x.c erfcx.c w_of_z.c err_fcts.c 
+-libcerf_la_LDFLAGS = -version-info $(VERSION)
+\ No newline at end of file
++libcerf_la_LDFLAGS = -no-undefined -version-info $(VERSION)

--- a/mingw-w64-libcerf/PKGBUILD
+++ b/mingw-w64-libcerf/PKGBUILD
@@ -18,7 +18,7 @@ sha256sums=('e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86'
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
   patch -Np1 -i "${srcdir}/0001-libcerf-1.5-fix-shared-lib.patch"
-
+  autoreconf -fiv
 }
 
 build() {

--- a/mingw-w64-libcerf/PKGBUILD
+++ b/mingw-w64-libcerf/PKGBUILD
@@ -1,24 +1,28 @@
 # Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+# Contributor: Andrew Sun <adsun701@gmail.com>
 
 _realname=libcerf
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Complex error functions, Dawson, Faddeeva, and Voigt function (mingw-w64)"
 arch=('any')
 url='http://apps.jcns.fz-juelich.de/doku/sc/libcerf'
 license=('MIT')
-source=("http://apps.jcns.fz-juelich.de/src/${_realname}/${_realname}-${pkgver}.tgz")
-sha256sums=('e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86')
+source=("http://apps.jcns.fz-juelich.de/src/${_realname}/${_realname}-${pkgver}.tgz"
+        "0001-libcerf-1.5-fix-shared-lib.patch")
+sha256sums=('e36dc147e7fff81143074a21550c259b5aac1b99fc314fc0ae33294231ca5c86'
+            '9e76eb52ad0af076e948792a5cf4b04a407f43e2a4e7203b7412bdac1136ac97')
 
 prepare() {
-  cd $srcdir/${_realname}-${pkgver}
-#  patch -p1 -i ${srcdir}/0001-A-fix.patch
+  cd "${srcdir}/${_realname}-${pkgver}"
+  patch -Np1 -i "${srcdir}/0001-libcerf-1.5-fix-shared-lib.patch"
+
 }
 
 build() {
-  cd "$srcdir"/${_realname}-${pkgver}
+  cd "${srcdir}/${_realname}-${pkgver}"
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
   mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
   ../${_realname}-${pkgver}/configure \
@@ -40,6 +44,5 @@ check() {
 package() {
   cd "${srcdir}"/build-${CARCH}
   make install DESTDIR="${pkgdir}"
-  mkdir -p ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
-  install -m 644 -p ${srcdir}/${_realname}-${pkgver}/COPYING ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
Previously the libcerf dll and its import library failed to build due to a lack of a -no-undefined flag. This commit fixes it.