### PR TITLE
wineditline: update to 2.205

### DIFF
--- a/mingw-w64-wineditline/001-fix-installing.patch
+++ b/mingw-w64-wineditline/001-fix-installing.patch
@@ -1,14 +1,17 @@
---- wineditline-2.101/src/CMakeLists.txt.orig	2014-07-18 09:19:28.189800000 +0400
-+++ wineditline-2.101/src/CMakeLists.txt	2014-07-18 09:25:07.037800000 +0400
-@@ -14,8 +14,8 @@
+--- wineditline-2.205/src/CMakeLists.txt.orig	2018-04-29 18:12:25.635939900 -0400
++++ wineditline-2.205/src/CMakeLists.txt	2018-04-29 18:13:45.431152000 -0400
+@@ -14,11 +14,11 @@
  target_link_libraries(edit_test edit)
  add_executable(edit_test_dll libedit_test_dll.c)
  install (TARGETS edit edit_test edit_test_dll
 -  DESTINATION "${CMAKE_SOURCE_DIR}/bin${LIB_SUFFIX}")
-+   RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
++  RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
  install (TARGETS edit_static
 -  DESTINATION "${CMAKE_SOURCE_DIR}/lib${LIB_SUFFIX}")
 +  DESTINATION lib)
  install (FILES editline/readline.h
 -  DESTINATION "${CMAKE_SOURCE_DIR}/include/editline")
 +  DESTINATION "include/editline")
+ string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+ if (MSVC AND uppercase_CMAKE_BUILD_TYPE MATCHES "DEBUG")
+   install (FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/edit_static.dir/edit_static.pdb

--- a/mingw-w64-wineditline/PKGBUILD
+++ b/mingw-w64-wineditline/PKGBUILD
@@ -3,28 +3,32 @@
 _realname=wineditline
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.201
+pkgver=2.205
 pkgrel=1
 pkgdesc="port of the NetBSD Editline library (mingw-w64)"
 arch=('any')
 license=('BSD')
 url="https://mingweditline.sourceforge.io/"
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-cmake" "dos2unix")
 options=('staticlibs')
 source=("https://sourceforge.net/projects/mingweditline/files/${_realname}-${pkgver}.tar.bz2"
         '001-fix-installing.patch'
         '002-fix-exports.patch'
         '003-dont-link-with-def.patch')
-sha256sums=('df042d4766bc8cd579c3c8a10337388be64a02a9980442fec6ebbececef7c13a'
-            '92987daf0c67eecdfc62702c3adaa025e0363039cda58aa9ae0a66852341a737'
+sha256sums=('dc8b25cbd503dd41241b8de0146af20182b552ac31cf0fc7e103b83aec25e448'
+            '821d0a36115832a76497dc6d7ea4b6e45e4ce73621030a59865f851309f8db34'
             '38e779fbdebf2f29038b598920e733a4a51638834013c3cc73fb85a7d50cffd2'
             '19077726758de7780cd68f3f47d8353516fd864ede1903d55280a1fb3dbe408d')
 
 prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/001-fix-installing.patch
-  patch -p1 -i ${srcdir}/002-fix-exports.patch
-  patch -p1 -i ${srcdir}/003-dont-link-with-def.patch
+  cd ${srcdir}/${_realname}-${pkgver}
+  
+  # Get rid of crlf endings
+  find . -type f -exec dos2unix {} \;
+  
+  patch -Np1 -i ${srcdir}/001-fix-installing.patch
+  patch -Np1 -i ${srcdir}/002-fix-exports.patch
+  patch -Np1 -i ${srcdir}/003-dont-link-with-def.patch
 
   rm -rf bin32 bin64 lib32 lib64
 }


### PR DESCRIPTION
This updates wineditline to 2.205 and adds dos2unix as makedepends due
to troublesome crlf endings.