### PR TITLE
add ffcall (version 2.1)

### DIFF
--- a/mingw-w64-ffcall/PKGBUILD
+++ b/mingw-w64-ffcall/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Andrew Sun <adsun701@gmail.com>
+
+_realname=ffcall
+pkgbase=mingw-w64-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.1
+pkgrel=1
+pkgdesc="C library for implementing foreign function calls in embedded interpreters (mingw-w64)"
+arch=('any')
+url="https://www.gnu.org/software/libffcall/"
+license=('GPL2')
+options=('!makeflags' 'staticlibs')
+source=("https://ftp.gnu.org/gnu/libffcall/lib${_realname}-${pkgver}.tar.gz")
+sha256sums=('a091fb8bbabf17c94a2dae2d41161b96a08ab92b5f75d3364157a2c34d538c47')
+
+build() {
+  cd "${srcdir}/lib${_realname}-${pkgver}"
+  [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
+  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+  ../lib${_realname}-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --enable-static \
+    --enable-shared
+
+  make
+}
+
+check() {
+  cd "${srcdir}"/build-${CARCH}
+  make check
+}
+
+package() {
+  cd "${srcdir}"/build-${CARCH}
+  install -d "${pkgdir}"${MINGW_PREFIX}/share/{man,doc/ffcall}
+  make install DESTDIR="${pkgdir}" htmldir=${MINGW_PREFIX}/share/doc/ffcall
+}


### PR DESCRIPTION
This adds ffcall (version 2.1).

I know that #2958 already has libffcall 2.0, but somehow it never got merged.