### PR TITLE
gst-libav: switch back to using an internal ffmpeg build. See #3668

### DIFF
--- a/mingw-w64-gst-libav/PKGBUILD
+++ b/mingw-w64-gst-libav/PKGBUILD
@@ -4,15 +4,15 @@ _realname=gst-libav
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GStreamer libav (mingw-w64)"
 arch=('any')
 url="https://gstreamer.freedesktop.org/"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gobject-introspection"
-             "${MINGW_PACKAGE_PREFIX}-gtk-doc")
-depends=("${MINGW_PACKAGE_PREFIX}-gst-plugins-base"
-         "${MINGW_PACKAGE_PREFIX}-ffmpeg")
+             "${MINGW_PACKAGE_PREFIX}-gtk-doc"
+             "${MINGW_PACKAGE_PREFIX}-nasm")
+depends=("${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
 options=(!libtool strip staticlibs)
 source=(${url}/src/${_realname}/${_realname}-${pkgver}.tar.xz)
 sha256sums=('fb134b4d3e054746ef8b922ff157b0c7903d1fdd910708a45add66954da7ef89')
@@ -37,7 +37,7 @@ build() {
     --enable-shared \
     --enable-silent-rules \
     --disable-gtk-doc \
-    --with-system-libav
+    --without-system-libav
   make
 }
 


### PR DESCRIPTION
gst-libav does not support ffmpeg 4.0 yet, see #3668