### PR TITLE
freetype: Update to 2.9.1

### DIFF
--- a/mingw-w64-freetype/PKGBUILD
+++ b/mingw-w64-freetype/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=freetype
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.9
+pkgver=2.9.1
 pkgrel=1
 pkgdesc="TrueType font rendering library (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ source=(https://downloads.sourceforge.net/sourceforge/freetype/freetype-${pkgver
         freetype-2.7-enable-valid.patch
         freetype-2.5.1-enable-spr.patch
         freetype-2.5.1-enable-sph.patch)
-sha256sums=('e6ffba3c8cef93f557d1f767d7bc3dee860ac7a3aaff588a521e081bc36f4c8a'
+sha256sums=('db8d87ea720ea9d5edc5388fc7a0497bb11ba9fe972245e0f7f4c7e8b1e1e84d'
             '975d5a6eb1f6041fe5a497d7658f2e1ca2cfe5610dbd2e94ab375ad481b279d1'
             '3ee5690d4d7cb48b8862e203d09b530805066cdfda0f51716b8ae2a47eef8b2d'
             '324012ad68388d22c63368314721d2360b48dd40daa808d0383699a281d931b0')
@@ -54,7 +54,8 @@ build() {
     --with-zlib \
     --with-bzip2 \
     --with-png \
-    --with-harfbuzz
+    --with-harfbuzz \
+    --enable-freetype-config
 
   make
 }


### PR DESCRIPTION
It no longer provides freetype-config by default, but some msys2 packages
use it, so re-enable with --enable-freetype-config for now as suggested in
the changelog.