### PR TITLE
gdb-git: Fix crash when using `info register` on Win64.

### DIFF
--- a/mingw-w64-gdb-git/0008-Avert-the-crash-when-using-info-register-on-Windows-.patch
+++ b/mingw-w64-gdb-git/0008-Avert-the-crash-when-using-info-register-on-Windows-.patch
@@ -1,0 +1,30 @@
+From 3cbd78e2cba49732c2d7694a8e01e4624dab204a Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Thu, 3 May 2018 19:20:58 +0800
+Subject: [PATCH] Avert the crash when using 'info register' on Windows x64.
+
+Reference: https://sourceware.org/bugzilla/show_bug.cgi?id=22854
+---
+ gdb/arch/amd64.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gdb/arch/amd64.c b/gdb/arch/amd64.c
+index d31d8f1f75..ebc9aa563b 100644
+--- a/gdb/arch/amd64.c
++++ b/gdb/arch/amd64.c
+@@ -55,9 +55,10 @@ amd64_create_target_description (uint64_t xcr0, bool is_x32, bool is_linux)
+     regnum = create_feature_i386_64bit_core (tdesc, regnum);
+ 
+   regnum = create_feature_i386_64bit_sse (tdesc, regnum);
+-  if (is_linux)
++  if (is_linux) {
+     regnum = create_feature_i386_64bit_linux (tdesc, regnum);
+-  regnum = create_feature_i386_64bit_segments (tdesc, regnum);
++    regnum = create_feature_i386_64bit_segments (tdesc, regnum);
++  }
+ 
+   if (xcr0 & X86_XSTATE_AVX)
+     regnum = create_feature_i386_64bit_avx (tdesc, regnum);
+-- 
+2.17.0
+

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}-git
-pkgver=r93981.1a74e49bb6
+pkgver=r94080.07784cb5da
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -34,7 +34,8 @@ source=("${_realname}"::"git+https://sourceware.org/git/binutils-gdb.git#branch=
         0004-GDB-performance.patch
         0005-Mitigate-gdb-bug-21057.patch
         0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
-        0007-Make-GDB-compile-on-MinGW-targets-again.patch)
+        0007-Make-GDB-compile-on-MinGW-targets-again.patch
+        0008-Avert-the-crash-when-using-info-register-on-Windows-.patch)
 sha256sums=('SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
             '9f02f6740fc5a8e0900e2ec0196bb5851f5a5f06a4da162434646dff7fef4e54'
@@ -43,7 +44,8 @@ sha256sums=('SKIP'
             '238e6099343854ef664bbf10a4109873d6a52a0d2f0515899db4821f1734a23e'
             '9d2aa8b97952e92973b4c306aafbf338c1cd6c1bb1f75f81bdf85751464a9750'
             '4b21429e3583866b25ca4feb6ae57daab81d8735d1eb52ab61338184f58bc2fb'
-            '11f37b0bcd840ef74530092bedda33d41d0820d46af1f252f36bdb12d9b4e712')
+            '11f37b0bcd840ef74530092bedda33d41d0820d46af1f252f36bdb12d9b4e712'
+            '41e464ea41aa3d2c603a4c411d029036d47745e43f569db3b5e6e457180eab10')
 
 pkgver() {
   cd "$srcdir/$_realname"
@@ -59,6 +61,7 @@ prepare() {
   git am "${srcdir}"/0005-Mitigate-gdb-bug-21057.patch
   git am "${srcdir}"/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
   git am "${srcdir}"/0007-Make-GDB-compile-on-MinGW-targets-again.patch
+  git am "${srcdir}"/0008-Avert-the-crash-when-using-info-register-on-Windows-.patch
 }
 
 build() {


### PR DESCRIPTION
Reference: https://sourceware.org/bugzilla/show_bug.cgi?id=22854
Signed-off-by: Liu Hao <lh_mouse@126.com>