### PR TITLE
mingw-w64-libiconv - 1.15 - Add patch to a fix an issue where I got w…

### DIFF
--- a/mingw-w64-libiconv/PKGBUILD
+++ b/mingw-w64-libiconv/PKGBUILD
@@ -6,15 +6,17 @@ pkgbase=mingw-w64-${_realname}
 pkgname=(${MINGW_PACKAGE_PREFIX}-${_realname}
          ${MINGW_PACKAGE_PREFIX}-iconv)
 pkgver=1.15
-pkgrel=1
+pkgrel=2
 arch=('any')
 url='https://www.gnu.org/software/libiconv/'
 source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         0001-compile-relocatable-in-gnulib.mingw.patch
-        0002-fix-cr-for-awk-in-configure.all.patch)
+        0002-fix-cr-for-awk-in-configure.all.patch
+        fix-pointer-buf.patch)
 sha256sums=('ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178'
             '7e905d21d670672b8a6a3bd80e5b8244b38bb7021a15fc7bdd0229125a3a68ee'
-            'a649f925223addc44966624c5fe630fdb46e04ceaf94ed6b965a8d18ca55b5a0')
+            'a649f925223addc44966624c5fe630fdb46e04ceaf94ed6b965a8d18ca55b5a0'
+            'fc1921f9d8ae21be0d1ee8a037fbb89aa066865f193a4883aa6e673827abba88')
 options=('!libtool' 'staticlibs')
 makedepends=(${MINGW_PACKAGE_PREFIX}-gcc)
 
@@ -22,6 +24,7 @@ prepare() {
   cd $srcdir/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-compile-relocatable-in-gnulib.mingw.patch
   patch -p1 -i ${srcdir}/0002-fix-cr-for-awk-in-configure.all.patch
+  patch -p1 -i ${srcdir}/fix-pointer-buf.patch
 }
 
 build() {

--- a/mingw-w64-libiconv/fix-pointer-buf.patch
+++ b/mingw-w64-libiconv/fix-pointer-buf.patch
@@ -1,0 +1,1156 @@
+--- libiconv-1.15/lib/canonical.h.orig	2018-05-03 18:08:04.741325300 -0400
++++ libiconv-1.15/lib/canonical.h	2018-05-03 18:12:48.021023400 -0400
+@@ -1,3 +1,117 @@
++#ifdef _WIN32
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str392,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str389,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str258,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str436,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str285,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str222,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str418,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str267,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str361,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str567,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str416,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str512,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str690,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str539,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str689,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str320,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str750,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str302,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str732,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str64,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str811,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str134,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str186,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str324,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str150,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str154,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str130,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str466,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str166,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str170,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str322,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str142,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str332,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str158,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str162,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str138,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str236,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str574,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str580,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str268,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str88,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str140,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str278,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str104,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str108,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str84,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str420,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str120,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str250,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str110,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str54,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str147,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str476,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str463,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str442,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str562,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str813,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str248,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str749,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str591,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str702,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str796,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str680,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str430,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str448,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str311,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str391,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str446,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str312,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str286,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str121,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str176,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str375,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str337,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str282,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str242,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str206,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str211,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str536,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str651,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str683,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str613,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str329,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str426,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str89,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str344,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str479,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str548,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str209,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str661,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str608,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str634,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str610,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str72,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str388,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str153,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str443,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str254,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str281,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str78,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str437,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str210,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str252,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str710,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str692,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str700,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str495,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str243,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str106,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str869,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str425,
++
++#else
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str392,
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str389,
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str258,
+@@ -109,3 +223,4 @@
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str106,
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str869,
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str425,
++#endif
+--- libiconv-1.15/lib/iconv.c.orig	2018-05-03 23:18:55.997221700 -0400
++++ libiconv-1.15/lib/iconv.c	2018-05-03 23:26:47.611682700 -0400
+@@ -170,12 +170,21 @@ static const struct stringpool2_t string
+ #include "aliases2.h"
+ #undef S
+ };
++#ifdef _WIN32
++#define stringpool2 ((const char *) &stringpool2_contents)
++static const struct alias sysdep_aliases[] = {
++#define S(tag,name,encoding_index) { (intptr_t)&((struct stringpool2_t *)0)->stringpool_##tag, encoding_index },
++#include "aliases2.h"
++#undef S
++};
++#else
+ #define stringpool2 ((const char *) &stringpool2_contents)
+ static const struct alias sysdep_aliases[] = {
+ #define S(tag,name,encoding_index) { (int)(long)&((struct stringpool2_t *)0)->stringpool_##tag, encoding_index },
+ #include "aliases2.h"
+ #undef S
+ };
++#endif
+ #ifdef __GNUC__
+ __inline
+ #else
+--- libiconv-1.15/lib/canonical_dos.h.orig	2018-05-03 23:43:25.989261000 -0400
++++ libiconv-1.15/lib/canonical_dos.h	2018-05-04 03:58:58.249471000 -0400
+@@ -1,3 +1,20 @@
++#if _WIN32
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_0,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_4,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_5,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_8,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_12,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_13,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_17,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_21,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_22,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_26,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_31,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_35,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_38,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_42,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_dos_47,
++#else
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_0,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_4,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_5,
+@@ -13,3 +30,4 @@
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_38,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_42,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_dos_47,
++#endif
+--- libiconv-1.15/lib/canonical_extra.h.orig	2018-05-04 02:29:32.597607300 -0400
++++ libiconv-1.15/lib/canonical_extra.h	2018-05-04 02:32:41.106714500 -0400
+@@ -1,3 +1,12 @@
++#ifdef _WIN32
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_0,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_2,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_4,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_6,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_7,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_9,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_extra_11,
++#else
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_0,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_2,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_4,
+@@ -5,3 +14,4 @@
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_7,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_9,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_extra_11,
++#endif
+--- libiconv-1.15/lib/canonical_local.h.orig	2018-05-04 03:11:42.513359000 -0400
++++ libiconv-1.15/lib/canonical_local.h	2018-05-04 03:12:53.411675000 -0400
+@@ -1,2 +1,7 @@
++#ifdef _WIN32
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str193,
++  (intptr_t)&((struct stringpool_t *)0)->stringpool_str496,
++#else
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str193,
+   (int)(long)&((struct stringpool_t *)0)->stringpool_str496,
++#endif
+--- libiconv-1.15/lib/canonical_osf1.h.orig	2018-05-04 03:14:38.385210300 -0400
++++ libiconv-1.15/lib/canonical_osf1.h	2018-05-04 03:15:44.688973300 -0400
+@@ -1,2 +1,7 @@
++#if _WIN32
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_osf1_0,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_osf1_1,
++#else
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_osf1_0,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_osf1_1,
++#endif
+--- libiconv-1.15/lib/canonical_aix.h.orig	2018-05-04 03:17:14.179561200 -0400
++++ libiconv-1.15/lib/canonical_aix.h	2018-05-04 03:52:18.987329300 -0400
+@@ -1,3 +1,14 @@
++#ifdef _WIN32
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_0,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_1,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_2,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_3,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_4,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_5,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_6,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_10,
++  (intptr_t)&((struct stringpool2_t *)0)->stringpool_aix_14,
++#else
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_0,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_1,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_2,
+@@ -7,3 +18,4 @@
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_6,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_10,
+   (int)(long)&((struct stringpool2_t *)0)->stringpool_aix_14,
++#endif
+--- libiconv-1.15/lib/aliases.h.orig	2018-05-04 04:35:49.533753000 -0400
++++ libiconv-1.15/lib/aliases.h	2018-05-04 04:40:34.999821800 -0400
+@@ -810,6 +810,906 @@ static const struct stringpool_t stringp
+   };
+ #define stringpool ((const char *) &stringpool_contents)
+ 
++#ifdef _WIN32
++static const struct alias aliases[] =
++  {
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 134 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str15, ei_iso8859_10},
++    {-1},
++#line 60 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str17, ei_iso8859_1},
++    {-1}, {-1},
++#line 288 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str20, ei_iso646_cn},
++    {-1}, {-1}, {-1}, {-1},
++#line 84 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str25, ei_iso8859_4},
++    {-1},
++#line 126 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str27, ei_iso8859_9},
++    {-1}, {-1},
++#line 227 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str30, ei_hp_roman8},
++    {-1}, {-1},
++#line 151 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str33, ei_iso8859_14},
++#line 308 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str34, ei_sjis},
++    {-1},
++#line 207 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str36, ei_cp866},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 68 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str43, ei_iso8859_2},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 16 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str51, ei_ascii},
++    {-1}, {-1},
++#line 205 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str54, ei_cp866},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 51 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str64, ei_c99},
++#line 252 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str65, ei_tis620},
++#line 320 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str66, ei_euc_cn},
++#line 133 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str67, ei_iso8859_10},
++    {-1}, {-1},
++#line 236 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str70, ei_pt154},
++#line 59 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str71, ei_iso8859_1},
++#line 319 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str72, ei_euc_cn},
++    {-1},
++#line 91 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str74, ei_iso8859_5},
++    {-1},
++#line 286 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str76, ei_iso646_cn},
++    {-1},
++#line 332 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str78, ei_hz},
++#line 264 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str79, ei_iso646_jp},
++    {-1}, {-1}, {-1}, {-1},
++#line 189 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str84, ei_cp1256},
++    {-1}, {-1},
++#line 83 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str87, ei_iso8859_4},
++#line 174 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str88, ei_cp1251},
++#line 294 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str89, ei_isoir165},
++    {-1},
++#line 125 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str91, ei_iso8859_9},
++#line 203 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str92, ei_cp862},
++#line 107 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str93, ei_iso8859_7},
++    {-1},
++#line 90 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str95, ei_iso8859_5},
++#line 57 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str96, ei_iso8859_1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 150 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str103, ei_iso8859_14},
++#line 183 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str104, ei_cp1254},
++#line 291 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str105, ei_gb2312},
++#line 353 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str106, ei_cp949},
++    {-1},
++#line 186 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str108, ei_cp1255},
++    {-1},
++#line 201 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str110, ei_cp862},
++#line 124 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str111, ei_iso8859_9},
++#line 76 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str112, ei_iso8859_3},
++#line 158 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str113, ei_iso8859_15},
++#line 293 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str114, ei_gb2312},
++#line 299 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str115, ei_ksc5601},
++    {-1},
++#line 283 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str117, ei_jisx0212},
++    {-1},
++#line 163 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str119, ei_iso8859_16},
++#line 195 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str120, ei_cp1258},
++#line 234 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str121, ei_pt154},
++    {-1},
++#line 67 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str123, ei_iso8859_2},
++#line 102 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str124, ei_iso8859_6},
++#line 149 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str125, ei_iso8859_14},
++    {-1}, {-1},
++#line 62 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str128, ei_iso8859_1},
++#line 152 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str129, ei_iso8859_14},
++#line 94 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str130, ei_iso8859_6},
++#line 95 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str131, ei_iso8859_6},
++#line 166 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str132, ei_iso8859_16},
++    {-1},
++#line 53 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str134, ei_iso8859_1},
++#line 54 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str135, ei_iso8859_1},
++#line 139 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str136, ei_iso8859_11},
++    {-1},
++#line 160 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str138, ei_iso8859_16},
++#line 161 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str139, ei_iso8859_16},
++#line 177 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str140, ei_cp1252},
++    {-1},
++#line 137 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str142, ei_iso8859_11},
++#line 138 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str143, ei_iso8859_11},
++#line 86 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str144, ei_iso8859_4},
++#line 356 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str145, ei_johab},
++#line 162 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str146, ei_iso8859_16},
++#line 209 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str147, ei_cp1131},
++#line 93 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str148, ei_iso8859_5},
++    {-1},
++#line 79 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str150, ei_iso8859_4},
++#line 80 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str151, ei_iso8859_4},
++#line 153 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str152, ei_iso8859_14},
++#line 325 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str153, ei_cp936},
++#line 87 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str154, ei_iso8859_5},
++#line 88 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str155, ei_iso8859_5},
++#line 159 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str156, ei_iso8859_15},
++#line 212 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str157, ei_mac_roman},
++#line 146 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str158, ei_iso8859_14},
++#line 147 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str159, ei_iso8859_14},
++#line 120 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str160, ei_iso8859_8},
++#line 66 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str161, ei_iso8859_2},
++#line 154 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str162, ei_iso8859_15},
++#line 155 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str163, ei_iso8859_15},
++#line 128 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str164, ei_iso8859_9},
++    {-1},
++#line 114 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str166, ei_iso8859_8},
++#line 115 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str167, ei_iso8859_8},
++    {-1}, {-1},
++#line 121 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str170, ei_iso8859_9},
++#line 122 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str171, ei_iso8859_9},
++#line 148 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str172, ei_iso8859_14},
++    {-1},
++#line 156 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str174, ei_iso8859_15},
++    {-1},
++#line 239 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str176, ei_rk1048},
++    {-1}, {-1},
++#line 109 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str179, ei_iso8859_7},
++#line 70 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str180, ei_iso8859_2},
++    {-1},
++#line 206 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str182, ei_cp866},
++#line 144 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str183, ei_iso8859_13},
++#line 21 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str184, ei_ascii},
++    {-1},
++#line 63 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str186, ei_iso8859_2},
++#line 64 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str187, ei_iso8859_2},
++    {-1}, {-1},
++#line 282 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str190, ei_jisx0212},
++    {-1}, {-1},
++#line 359 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str193, ei_local_char},
++    {-1}, {-1},
++#line 235 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str196, ei_pt154},
++#line 74 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str197, ei_iso8859_3},
++#line 117 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str198, ei_iso8859_8},
++#line 354 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str199, ei_cp949},
++    {-1}, {-1},
++#line 13 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str202, ei_ascii},
++    {-1},
++#line 176 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str204, ei_cp1251},
++#line 165 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str205, ei_iso8859_16},
++#line 255 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str206, ei_viscii},
++    {-1}, {-1},
++#line 311 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str209, ei_cp932},
++#line 337 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str210, ei_ces_big5},
++#line 258 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str211, ei_tcvn},
++#line 318 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str212, ei_iso2022_jpms},
++    {-1}, {-1}, {-1},
++#line 338 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str216, ei_ces_big5},
++#line 173 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str217, ei_cp1250},
++    {-1}, {-1},
++#line 199 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str220, ei_cp850},
++    {-1},
++#line 33 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str222, ei_ucs4},
++#line 22 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str223, ei_ascii},
++#line 58 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str224, ei_iso8859_1},
++#line 257 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str225, ei_viscii},
++    {-1},
++#line 321 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str227, ei_euc_cn},
++#line 269 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str228, ei_jisx0201},
++#line 342 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str229, ei_ces_big5},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 341 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str235, ei_ces_big5},
++#line 167 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str236, ei_koi8_r},
++#line 351 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str237, ei_euc_kr},
++#line 202 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str238, ei_cp862},
++#line 238 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str239, ei_pt154},
++#line 35 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str240, ei_ucs4},
++#line 14 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str241, ei_ascii},
++#line 253 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str242, ei_cp874},
++#line 350 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str243, ei_euc_kr},
++#line 256 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str244, ei_viscii},
++    {-1},
++#line 15 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str246, ei_ascii},
++    {-1},
++#line 218 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str248, ei_mac_cyrillic},
++#line 168 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str249, ei_koi8_r},
++#line 197 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str250, ei_cp850},
++#line 82 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str251, ei_iso8859_4},
++#line 343 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str252, ei_cp950},
++    {-1},
++#line 329 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str254, ei_iso2022_cn},
++#line 295 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str255, ei_isoir165},
++    {-1},
++#line 237 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str257, ei_pt154},
++#line 24 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str258, ei_ucs2},
++#line 164 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str259, ei_iso8859_16},
++#line 275 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str260, ei_jisx0208},
++#line 75 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str261, ei_iso8859_3},
++    {-1},
++#line 330 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str263, ei_iso2022_cn},
++#line 131 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str264, ei_iso8859_10},
++    {-1}, {-1},
++#line 37 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str267, ei_ucs4le},
++#line 171 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str268, ei_cp1250},
++    {-1}, {-1},
++#line 135 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str271, ei_iso8859_10},
++    {-1},
++#line 142 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str273, ei_iso8859_13},
++#line 326 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str274, ei_cp936},
++#line 61 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str275, ei_iso8859_1},
++#line 247 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str276, ei_tis620},
++    {-1},
++#line 180 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str278, ei_cp1253},
++    {-1}, {-1},
++#line 331 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str281, ei_iso2022_cn_ext},
++#line 246 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str282, ei_tis620},
++    {-1}, {-1},
++#line 31 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str285, ei_ucs2le},
++#line 233 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str286, ei_koi8_t},
++    {-1}, {-1}, {-1},
++#line 92 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str290, ei_iso8859_5},
++#line 85 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str291, ei_iso8859_4},
++    {-1}, {-1}, {-1},
++#line 127 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str295, ei_iso8859_9},
++#line 29 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str296, ei_ucs2be},
++    {-1}, {-1}, {-1}, {-1},
++#line 110 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str301, ei_iso8859_7},
++#line 49 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str302, ei_ucs4internal},
++    {-1},
++#line 30 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str304, ei_ucs2be},
++    {-1},
++#line 26 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str306, ei_ucs2},
++#line 249 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str307, ei_tis620},
++    {-1}, {-1}, {-1},
++#line 229 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str311, ei_nextstep},
++#line 232 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str312, ei_georgian_ps},
++    {-1}, {-1}, {-1},
++#line 136 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str316, ei_iso8859_10},
++    {-1},
++#line 78 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str318, ei_iso8859_3},
++    {-1},
++#line 47 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str320, ei_ucs2internal},
++    {-1},
++#line 129 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str322, ei_iso8859_10},
++#line 130 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str323, ei_iso8859_10},
++#line 71 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str324, ei_iso8859_3},
++#line 72 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str325, ei_iso8859_3},
++#line 145 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str326, ei_iso8859_13},
++#line 69 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str327, ei_iso8859_2},
++    {-1},
++#line 285 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str329, ei_iso646_cn},
++    {-1}, {-1},
++#line 140 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str332, ei_iso8859_13},
++#line 141 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str333, ei_iso8859_13},
++    {-1}, {-1}, {-1},
++#line 244 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str337, ei_cp1133},
++    {-1},
++#line 179 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str339, ei_cp1252},
++    {-1},
++#line 56 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str341, ei_iso8859_1},
++    {-1}, {-1},
++#line 296 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str344, ei_ksc5601},
++    {-1}, {-1}, {-1}, {-1},
++#line 211 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str349, ei_mac_roman},
++    {-1}, {-1},
++#line 322 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str352, ei_euc_cn},
++    {-1},
++#line 208 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str354, ei_cp866},
++#line 34 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str355, ei_ucs4},
++    {-1},
++#line 81 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str357, ei_iso8859_4},
++    {-1},
++#line 89 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str359, ei_iso8859_5},
++    {-1},
++#line 38 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str361, ei_utf16},
++    {-1},
++#line 241 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str363, ei_rk1048},
++#line 226 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str364, ei_hp_roman8},
++#line 116 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str365, ei_iso8859_8},
++#line 32 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str366, ei_ucs2le},
++    {-1}, {-1},
++#line 123 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str369, ei_iso8859_9},
++    {-1}, {-1},
++#line 265 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str372, ei_iso646_jp},
++#line 25 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str373, ei_ucs2},
++    {-1},
++#line 243 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str375, ei_mulelao},
++#line 242 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str376, ei_rk1048},
++#line 157 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str377, ei_iso8859_15},
++#line 198 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str378, ei_cp850},
++    {-1},
++#line 248 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str380, ei_tis620},
++    {-1},
++#line 98 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str382, ei_iso8859_6},
++    {-1}, {-1}, {-1},
++#line 298 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str386, ei_ksc5601},
++    {-1},
++#line 324 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str388, ei_ces_gbk},
++#line 23 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str389, ei_utf8},
++    {-1},
++#line 230 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str391, ei_armscii_8},
++#line 12 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str392, ei_ascii},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 108 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str398, ei_iso8859_7},
++#line 323 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str399, ei_euc_cn},
++    {-1}, {-1}, {-1},
++#line 143 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str403, ei_iso8859_13},
++#line 301 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str404, ei_ksc5601},
++#line 287 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str405, ei_iso646_cn},
++    {-1}, {-1},
++#line 188 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str408, ei_cp1255},
++#line 266 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str409, ei_iso646_jp},
++    {-1},
++#line 276 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str411, ei_jisx0208},
++    {-1},
++#line 132 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str413, ei_iso8859_10},
++    {-1}, {-1},
++#line 40 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str416, ei_utf16le},
++    {-1},
++#line 36 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str418, ei_ucs4be},
++    {-1},
++#line 192 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str420, ei_cp1257},
++#line 18 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str421, ei_ascii},
++    {-1}, {-1},
++#line 352 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str424, ei_euc_kr},
++#line 357 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str425, ei_iso2022_kr},
++#line 290 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str426, ei_gb2312},
++    {-1}, {-1},
++#line 97 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str429, ei_iso8859_6},
++#line 224 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str430, ei_mac_thai},
++#line 335 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str431, ei_euc_tw},
++    {-1},
++#line 304 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str433, ei_euc_jp},
++#line 358 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str434, ei_iso2022_kr},
++    {-1},
++#line 27 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str436, ei_ucs2be},
++#line 334 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str437, ei_euc_tw},
++    {-1},
++#line 17 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str439, ei_ascii},
++#line 111 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str440, ei_iso8859_7},
++    {-1},
++#line 215 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str442, ei_mac_iceland},
++#line 328 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str443, ei_gb18030},
++#line 73 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str444, ei_iso8859_3},
++#line 101 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str445, ei_iso8859_6},
++#line 231 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str446, ei_georgian_academy},
++    {-1},
++#line 225 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str448, ei_hp_roman8},
++    {-1}, {-1}, {-1}, {-1},
++#line 251 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str453, ei_tis620},
++    {-1},
++#line 28 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str455, ei_ucs2be},
++    {-1}, {-1}, {-1},
++#line 260 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str459, ei_tcvn},
++#line 113 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str460, ei_iso8859_7},
++#line 289 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str461, ei_iso646_cn},
++    {-1},
++#line 214 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str463, ei_mac_centraleurope},
++#line 112 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str464, ei_iso8859_7},
++#line 77 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str465, ei_iso8859_3},
++#line 103 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str466, ei_iso8859_7},
++#line 104 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str467, ei_iso8859_7},
++#line 45 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str468, ei_utf7},
++#line 19 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str469, ei_ascii},
++#line 333 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str470, ei_hz},
++    {-1}, {-1},
++#line 303 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str473, ei_euc_jp},
++#line 46 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str474, ei_utf7},
++    {-1},
++#line 210 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str476, ei_mac_roman},
++#line 259 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str477, ei_tcvn},
++    {-1},
++#line 302 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str479, ei_euc_jp},
++    {-1}, {-1}, {-1},
++#line 263 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str483, ei_iso646_jp},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 348 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str489, ei_big5hkscs2008},
++#line 292 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str490, ei_gb2312},
++    {-1},
++#line 190 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str492, ei_cp1256},
++    {-1},
++#line 175 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str494, ei_cp1251},
++#line 347 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str495, ei_big5hkscs2008},
++#line 360 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str496, ei_local_wchar_t},
++#line 96 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str497, ei_iso8859_6},
++    {-1},
++#line 55 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str499, ei_iso8859_1},
++    {-1}, {-1},
++#line 184 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str502, ei_cp1254},
++    {-1},
++#line 187 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str504, ei_cp1255},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 196 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str510, ei_cp1258},
++    {-1},
++#line 41 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str512, ei_utf32},
++    {-1}, {-1}, {-1},
++#line 119 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str516, ei_iso8859_8},
++#line 228 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str517, ei_hp_roman8},
++    {-1},
++#line 284 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str519, ei_jisx0212},
++#line 178 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str520, ei_cp1252},
++    {-1},
++#line 240 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str522, ei_rk1048},
++    {-1}, {-1},
++#line 65 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str525, ei_iso8859_2},
++    {-1}, {-1}, {-1},
++#line 100 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str529, ei_iso8859_6},
++#line 213 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str530, ei_mac_roman},
++    {-1}, {-1}, {-1},
++#line 297 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str534, ei_ksc5601},
++    {-1},
++#line 262 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str536, ei_iso646_jp},
++#line 277 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str537, ei_jisx0208},
++    {-1},
++#line 43 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str539, ei_utf32le},
++    {-1}, {-1}, {-1},
++#line 250 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str543, ei_tis620},
++    {-1}, {-1},
++#line 245 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str546, ei_cp1133},
++#line 307 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str547, ei_sjis},
++#line 306 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str548, ei_sjis},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 204 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str555, ei_cp862},
++    {-1},
++#line 340 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str557, ei_ces_big5},
++    {-1}, {-1},
++#line 300 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str560, ei_ksc5601},
++    {-1},
++#line 216 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str562, ei_mac_croatian},
++#line 339 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str563, ei_ces_big5},
++    {-1}, {-1},
++#line 327 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str566, ei_cp936},
++#line 39 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str567, ei_utf16be},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 169 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str574, ei_koi8_u},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 170 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str580, ei_koi8_ru},
++    {-1}, {-1}, {-1},
++#line 172 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str584, ei_cp1250},
++#line 182 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str585, ei_cp1253},
++    {-1}, {-1}, {-1},
++#line 181 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str589, ei_cp1253},
++    {-1},
++#line 220 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str591, ei_mac_greek},
++#line 200 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str592, ei_cp850},
++    {-1},
++#line 106 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str594, ei_iso8859_7},
++    {-1},
++#line 274 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str596, ei_jisx0208},
++#line 20 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str597, ei_ascii},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1},
++#line 314 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str608, ei_iso2022_jp1},
++    {-1},
++#line 317 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str610, ei_iso2022_jpms},
++    {-1}, {-1},
++#line 279 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str613, ei_jisx0212},
++    {-1}, {-1}, {-1}, {-1},
++#line 336 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str618, ei_euc_tw},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 310 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str624, ei_sjis},
++#line 118 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str625, ei_iso8859_8},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 315 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str634, ei_iso2022_jp2},
++#line 99 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str635, ei_iso8859_6},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 316 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str642, ei_iso2022_jp2},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 267 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str651, ei_jisx0201},
++    {-1}, {-1}, {-1},
++#line 254 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str655, ei_cp874},
++    {-1}, {-1}, {-1}, {-1},
++#line 193 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str660, ei_cp1257},
++#line 312 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str661, ei_iso2022_jp},
++    {-1}, {-1}, {-1},
++#line 105 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str665, ei_iso8859_7},
++#line 278 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str666, ei_jisx0208},
++    {-1}, {-1}, {-1},
++#line 313 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str670, ei_iso2022_jp},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 223 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str680, ei_mac_arabic},
++    {-1}, {-1},
++#line 271 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str683, ei_jisx0208},
++#line 268 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str684, ei_jisx0201},
++    {-1}, {-1}, {-1}, {-1},
++#line 44 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str689, ei_utf7},
++#line 42 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str690, ei_utf32be},
++    {-1},
++#line 345 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str692, ei_big5hkscs2001},
++    {-1},
++#line 281 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str694, ei_jisx0212},
++    {-1}, {-1},
++#line 280 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str697, ei_jisx0212},
++    {-1}, {-1},
++#line 346 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str700, ei_big5hkscs2004},
++    {-1},
++#line 221 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str702, ei_mac_turkish},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 349 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str708, ei_big5hkscs2008},
++    {-1},
++#line 344 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str710, ei_big5hkscs1999},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1},
++#line 185 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str725, ei_cp1254},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 50 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str732, ei_ucs4swapped},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 219 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str749, ei_mac_ukraine},
++#line 48 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str750, ei_ucs2swapped},
++    {-1},
++#line 261 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str752, ei_tcvn},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1},
++#line 273 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str774, ei_jisx0208},
++    {-1}, {-1}, {-1}, {-1},
++#line 272 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str779, ei_jisx0208},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 222 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str796, ei_mac_hebrew},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 191 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str803, ei_cp1256},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 52 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str811, ei_java},
++    {-1},
++#line 217 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str813, ei_mac_romania},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1},
++#line 309 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str827, ei_sjis},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 194 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str837, ei_cp1257},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1},
++#line 305 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str866, ei_euc_jp},
++    {-1}, {-1},
++#line 355 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str869, ei_johab},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++    {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
++#line 270 "lib/aliases.gperf"
++    {(intptr_t)&((struct stringpool_t *)0)->stringpool_str921, ei_jisx0201}
++  };
++#else
+ static const struct alias aliases[] =
+   {
+     {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
+@@ -1708,6 +2608,7 @@ static const struct alias aliases[] =
+ #line 270 "lib/aliases.gperf"
+     {(int)(long)&((struct stringpool_t *)0)->stringpool_str921, ei_jisx0201}
+   };
++#endif
+ 
+ #ifdef __GNUC__
+ __inline


### PR DESCRIPTION
…arnings about typecasting a pointer to an "(int)(long)".  In Win64, that is 4-bytes wide but a pointer is 8-bytes wide.  This really should be addressed upstream, but in the meantime, I'm putting it here.