### PR TITLE
osg: fix copy license when pkgver contains dash

### DIFF
--- a/mingw-w64-OpenSceneGraph/PKGBUILD
+++ b/mingw-w64-OpenSceneGraph/PKGBUILD
@@ -94,7 +94,7 @@ package_release() {
   cd Release-${MINGW_CHOST}
   make DESTDIR=${pkgdir} -j1 install
 
-  install -Dm644 ${srcdir}/${_realname}-${_realname}-${pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${_realname}-${_pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 }
 
 package_debug() {
@@ -109,7 +109,7 @@ package_debug() {
   rm -rf ${pkgdir}${MINGW_PREFIX}/lib/pkgconfig
   rm -rf ${pkgdir}${MINGW_PREFIX}/share
 
-  install -Dm644 ${srcdir}/${_realname}-${_realname}-${pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}-debug/LICENSE
+  install -Dm644 ${srcdir}/${_realname}-${_realname}-${_pkgver}/LICENSE.txt "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}-debug/LICENSE
 }
 
 package_mingw-w64-i686-OpenSceneGraph() {


### PR DESCRIPTION
no need to rebuild