### PR TITLE
mingw-w64-python-wheel - 0.31.0 - fix issue with optional ${MINGW_PAC…

### DIFF
--- a/mingw-w64-python-wheel/PKGBUILD
+++ b/mingw-w64-python-wheel/PKGBUILD
@@ -7,7 +7,7 @@ _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.31.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A built-package format for Python (mingw-w64)"
 arch=('any')
 url="https://pypi.python.org/pypi/wheel"
@@ -53,8 +53,8 @@ check() {
 
 package_python3-wheel() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-python-keyring: for wheel.signatures")
-  optdepends=("${MINGW_PACKAGE_PREFIX}-python-xdg: for wheel.signatures")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-keyring: for wheel.signatures")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-xdg: for wheel.signatures")
 
   install=${_realname}3-${CARCH}.install
 


### PR DESCRIPTION
…KAGE_PREFIX}-python3-xdg.  The 3 was missing and that could mislead people to try to download an incorrect package name.