### PR TITLE
pngcrush: update to 1.8.13

### DIFF
--- a/mingw-w64-pngcrush/PKGBUILD
+++ b/mingw-w64-pngcrush/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pngcrush
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.8.10
+pkgver=1.8.13
 pkgrel=1
 pkgdesc="A tool for optimizing the compression of PNG files (mingw-w64)"
 arch=('any')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-zlib")
 source=("https://downloads.sourceforge.net/pmt/${_realname}-${pkgver}-nolib.tar.gz"
         LICENSE)
-sha256sums=('4d6818929fcfa41c35c868ff422885c22e04546e621495ff121aeee2f7887fb1'
+sha256sums=('fed0aaf5c098aa8c7f78c75365cd18d7341417326ecbdba547876b7b4f3df4be'
             '5628338f1b1c711b2b2e82d14124bc3001b37216a66f00b18d0b3b9c7e016720')
 
 prepare() {


### PR DESCRIPTION
This updates pngcrush to 1.8.13.