### PR TITLE
x265: update to 2.7

### DIFF
--- a/mingw-w64-x265/PKGBUILD
+++ b/mingw-w64-x265/PKGBUILD
@@ -4,24 +4,31 @@
 _realname=x265
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.5
+pkgver=2.7
 pkgrel=1
 pkgdesc='Open Source H265/HEVC video encoder (mingw-w64)'
 arch=('any')
 license=('GPL')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
-makedepends=('yasm' "${MINGW_PACKAGE_PREFIX}-cmake")
+makedepends=("${MINGW_PACKAGE_PREFIX}-nasm" "${MINGW_PACKAGE_PREFIX}-cmake")
 options=('strip')
 url='https://bitbucket.org/multicoreware/x265'
-source=("${_realname}-${pkgver}.tar.bz2"::"${url}/get/${pkgver}.tar.bz2"
+source=("${_realname}-${pkgver}.tar.gz"::"https://bitbucket.org/multicoreware/x265/downloads/${_realname}_${pkgver}.tar.gz"
         "0001-winxp-condition-var.mingw.patch")
-sha256sums=('635be581968a3b10b1463eb7f566c9a77d478b215a8b44ca53e344530dd589c8'
+sha256sums=('d5e75fa62ffe6ed49e691f8eb8ab8c1634ffcc0725dd553c6fdb4d5443b494a2'
             'c71016ca51eb6d8916de9ef48f14048412569ae89e149f3d372158af6378e0e4')
 
 
 prepare() {
-  cd "${srcdir}"/multicoreware-x265-*
+  cd "${srcdir}"/x265_${pkgver}
   patch -Np1 -i ${srcdir}/0001-winxp-condition-var.mingw.patch
+  
+  for d in 8 10 12; do
+    if [[ -d ${srcdir}/build-${CARCH}-${d} ]]; then
+      rm -rf ${srcdir}/build-${CARCH}-${d}
+    fi
+    mkdir -p ${srcdir}/build-${CARCH}-${d}
+  done
 }
 
 
@@ -33,47 +40,62 @@ build() {
     _ENABLE_ASM=ON
     _WINXP_SUPPORT=FALSE
   fi
-
-  # Build 8 bit-depth lib and exe.
-  cd "${srcdir}"/multicoreware-x265-*/build/msys
-  if [ -d 8bit ]; then
-    rm -fr 8bit
-  fi
-  mkdir -p 8bit
-  cd 8bit
-
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
-    ../../../source
-  make
-
-  # Build 10 bit-depth dll for x265_api_get.
-  if [ -d ../10bit ]; then
-    rm -fr ../10bit
-  fi
-  mkdir -p ../10bit
-  cd ../10bit
-
+  
+  # 12-bit
+  cd "${srcdir}/build-${CARCH}-12"
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake \
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
     -DHIGH_BIT_DEPTH=ON \
-    -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
+    -DMAIN12=ON \
+    -DEXPORT_C_API=OFF \
     -DENABLE_CLI=OFF \
-    ../../../source
+    -DENABLE_SHARED=OFF \
+    -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
+  ../x265_${pkgver}/source
+  make
+  
+  # 10-bit
+  cd "${srcdir}/build-${CARCH}-10"
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
+    -DHIGH_BIT_DEPTH=ON \
+    -DEXPORT_C_API=OFF \
+    -DENABLE_CLI=OFF \
+    -DENABLE_SHARED=OFF \
+    -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
+  ../x265_${pkgver}/source
+  make
+  
+  # 8-bit
+  cd "${srcdir}/build-${CARCH}-8"
+  ln -s ../build-${CARCH}-10/libx265.a libx265_main10.a
+  ln -s ../build-${CARCH}-12/libx265.a libx265_main12.a
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DWINXP_SUPPORT=${_WINXP_SUPPORT} \
+    -DENABLE_SHARED=ON \
+    -DENABLE_ASSEMBLY=${_ENABLE_ASM} \
+    -DENABLE_HDR10_PLUS=ON \
+    -DEXTRA_LIB='x265_main10.a;x265_main12.a' \
+    -DEXTRA_LINK_FLAGS='-L .' \
+    -DLINKED_10BIT=ON \
+    -DLINKED_12BIT=ON \
+  ../x265_${pkgver}/source
   make
 }
 
 package() {
-  cd "${srcdir}"/multicoreware-x265-*/build/msys/8bit
+  cd "${srcdir}/build-${CARCH}-8"
   make DESTDIR=${pkgdir} install
-
-  # Install 10 bit-depth dll.
-  cd "${srcdir}"/multicoreware-x265-*/build/msys/10bit
-  install -m 755 libx265.dll "${pkgdir}"/${MINGW_PREFIX}/bin/libx265_main10.dll
+  
+  # Properly install missing libhdr10plus.dll
+  install -Dm644 libhdr10plus.dll "${pkgdir}${MINGW_PREFIX}/bin/libhdr10plus.dll"
 }


### PR DESCRIPTION
This updates x265 to 2.7 and enables all bit depths as well as dynamic HDR10.