### PR TITLE
New package: python-backcall

### DIFF
--- a/mingw-w64-python-backcall/PKGBUILD
+++ b/mingw-w64-python-backcall/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=backcall
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Backwards compatible callback APIs (mingw-w64)"
+arch=('any')
+url='https://github.com/takluyver/backcall'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+
+source=("${_realname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/84/71/c8ca4f5bb1e08401b916c68003acf0a0655df935d74d93bf3f3364b310e0/${_realname}-${pkgver}.tar.gz")
+sha256sums=('38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4')
+
+prepare() {
+  cd "$srcdir"/
+  for pver in {2,3}; do
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+}
+
+build() {
+  for pver in {2,3}; do
+    msg "Python ${pver} build for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py check
+  done
+}
+
+package_python3-backcall() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_python2-backcall() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_mingw-w64-i686-python2-backcall() {
+  package_python2-backcall
+}
+
+package_mingw-w64-i686-python3-backcall() {
+  package_python3-backcall
+}
+
+package_mingw-w64-x86_64-python2-backcall() {
+  package_python2-backcall
+}
+
+package_mingw-w64-x86_64-python3-backcall() {
+  package_python3-backcall
+}


### PR DESCRIPTION
It seems to me that the new `ipython `version requires this package. without that `ipython --version `gave me an error:
```
$ ipython --version
Traceback (most recent call last):
  File "C:/msys64/mingw64/bin/ipython", line 4, in <module>
    from IPython import start_ipython
  File "C:/msys64/mingw64/lib/python3.6/site-packages\IPython\__init__.py", line 55, in <module>
    from .terminal.embed import embed
  File "C:/msys64/mingw64/lib/python3.6/site-packages\IPython\terminal\embed.py", line 15, in <module>
    from IPython.core.interactiveshell import DummyMod, InteractiveShell
  File "C:/msys64/mingw64/lib/python3.6/site-packages\IPython\core\interactiveshell.py", line 41, in <module>
    from IPython.core.events import EventManager, available_events
  File "C:/msys64/mingw64/lib/python3.6/site-packages\IPython\core\events.py", line 16, in <module>
    from backcall import callback_prototype
ModuleNotFoundError: No module named 'backcall'

```
Having this package installed solves the problem.

Can somebody more knowledgeable with python check this, pls?