### PR TITLE
cython: fix .install file mixup

### DIFF
--- a/mingw-w64-cython/PKGBUILD
+++ b/mingw-w64-cython/PKGBUILD
@@ -5,7 +5,7 @@ _realname=cython
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-cython" "${MINGW_PACKAGE_PREFIX}-cython2")
 pkgver=0.28.2
-pkgrel=1
+pkgrel=2
 pkgdesc="C-Extensions for Python (mingw-w64)"
 arch=('any')
 url="http://www.cython.org"
@@ -70,7 +70,7 @@ package_cython2() {
 }
 
 package_mingw-w64-i686-cython() {
-  install=${_realname}2-${CARCH}.install
+  install=${_realname}-${CARCH}.install
   package_cython
 }
 
@@ -80,7 +80,7 @@ package_mingw-w64-i686-cython2() {
 }
 
 package_mingw-w64-x86_64-cython() {
-  install=${_realname}2-${CARCH}.install
+  install=${_realname}-${CARCH}.install
   package_cython
 }
 


### PR DESCRIPTION
This should fix a problem where cython .install scripts got mixed up. This fixes #3759.