### PR TITLE
libgpg-error: update to 1.31

### DIFF
--- a/mingw-w64-libgpg-error/PKGBUILD
+++ b/mingw-w64-libgpg-error/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libgpg-error
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.29
+pkgver=1.31
 pkgrel=1
 pkgdesc="Support library for libgcrypt (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '46CC730865BB5C78EBABADCF04376F3EE0856959'
               '031EC2536E580D8EA286A9F22071B08A33BD3F06'
               'D238EA65D64C67ED4C3073F28A861B1C7EFD60D9')
-sha256sums=('ece926fa5719d17a7ad8da618712cfa2f8a796ab2f2af9d544c5bb093383b1ea'
+sha256sums=('40d0a823c9329478063903192a1f82496083b277265904878f4bc09e0db7a4ef'
             'SKIP'
             '252349e58d418adfec5621af1e09753db52b1bf39983aa3bc398d636afb9b495'
             '364da17febff3f6eeffee5a5f1e3ed1b644adeb5ca48a972c5c4675c10238a91'


### PR DESCRIPTION
This updates libgpg-error to 1.31.