### PR TITLE
python-setuptools-scm: update to 2.1.0.

### DIFF
--- a/mingw-w64-python-setuptools-scm/PKGBUILD
+++ b/mingw-w64-python-setuptools-scm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=setuptools-scm
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.0.0
+pkgver=2.1.0
 pkgrel=1
 pkgdesc='Handles managing your python package versions in scm metadata (mingw-w64)'
 url='https://github.com/pypa/setuptools_scm'
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
             )
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz")
-sha256sums=('638627655ec4625b7a055a5b65f44e88121fce05a281a1597abd6a9f8c04139b')
+sha256sums=('a767141fecdab1c0b3c8e4c788ac912d7c94a0d6c452d40777ba84f918316379')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-setuptools-scm to 2.1.0.