### PR TITLE
python-cffi: update to 1.11.5

### DIFF
--- a/mingw-w64-python-cffi/PKGBUILD
+++ b/mingw-w64-python-cffi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cffi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.10.0
+pkgver=1.11.5
 pkgrel=1
 pkgdesc="Foreign Function Interface for Python calling C code (mingw-w64)"
 url='https://cffi.readthedocs.io/'


### PR DESCRIPTION
This updates python-cffi to 1.11.5.