### PR TITLE
python-wrapt: fix depends

### DIFF
--- a/mingw-w64-python-wrapt/PKGBUILD
+++ b/mingw-w64-python-wrapt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=wrapt
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.10.11
-pkgrel=1
+pkgrel=2
 pkgdesc="A Python module for decorators, wrappers and monkey patching (mingw-w64)"
 arch=('any')
 url="https://pypi.python.org/pypi/wrapt"
@@ -35,8 +35,7 @@ build() {
 }
 
 package_python3-wrapt() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3"
-           "${MINGW_PACKAGE_PREFIX}-python3-six")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -47,8 +46,7 @@ package_python3-wrapt() {
 }
 
 package_python2-wrapt() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2"
-           "${MINGW_PACKAGE_PREFIX}-python2-six")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
This fixes an unnecessary depends on python-six for python-wrapt.