### PR TITLE
python-dateutil: update to 2.7.3

### DIFF
--- a/mingw-w64-python-dateutil/PKGBUILD
+++ b/mingw-w64-python-dateutil/PKGBUILD
@@ -4,21 +4,21 @@ _realname=dateutil
 _pyname=python-dateutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=2.6.0
-pkgrel=3
+pkgver=2.7.3
+pkgrel=1
 pkgdesc="Provides powerful extensions to the standard datetime module (mingw-w64)"
 arch=('any')
-license=('custom:PYTHON')
-url="https://labix.org/python-dateutil"
-makedepends=(
-            "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-            "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-            "${MINGW_PACKAGE_PREFIX}-python2-six"
-            "${MINGW_PACKAGE_PREFIX}-python3-six"
-)
-source=(https://github.com/dateutil/dateutil/releases/download/$pkgver/${_pyname}-$pkgver.tar.gz{,.asc})
+license=('BSD' 'Apache')
+url="https://github.com/dateutil/dateutil"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python3-six")
+source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz"{,.asc})
 validpgpkeys=("6B49ACBADCF6BD1CA20667ABCD54FCE3D964BEFB")
-sha256sums=('62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2'
+sha256sums=('e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'
             'SKIP')
 
 prepare() {
@@ -37,13 +37,6 @@ build() {
   done  
 }
 
-check() {  
-  for pver in {2,3}; do  
-    msg "Python ${pver} test for ${CARCH}"  
-    cd "${srcdir}/python${pver}-build-${CARCH}"
-    ${MINGW_PREFIX}/bin/python${pver} setup.py test
-  done  
-}
 
 package_python3-dateutil() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3-six")


### PR DESCRIPTION
This updates python-dateutil to 2.7.3 and adds a missing
python-setuptools-scm build dependency.