### PR TITLE
glib-networking: update to 2.56.1.

### DIFF
--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=glib-networking
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.56.0
-pkgrel=2
+pkgver=2.56.1
+pkgrel=1
 pkgdesc="Network-related GIO modules for glib (mingw-w64)"
 arch=(any)
 url="https://download.gnome.org/sources/libsoup"
@@ -24,8 +24,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 options=('staticlibs' 'strip')
 source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz"
         0002-relative-system-ca-file.mingw.patch)
-md5sums=('f9e720a79014cc7d07eabd02ade0ae4e'
-         '825799ce0deb324f96aeb369a6e00960')
+sha256sums=('df47b0e0a037d2dcf6b1846cbdf68dd4b3cc055e026bb40c4a55f19f29f635c8'
+            'adb974f425095b82bcc1436405833c187e406a7dec2fee474b53b702bbea49fd')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
This updates glib-networking to 2.56.1.