### PR TITLE
python-numpy: Update to 1.14.3

### DIFF
--- a/mingw-w64-python-numpy/0003-gfortran-better-version-check.patch
+++ b/mingw-w64-python-numpy/0003-gfortran-better-version-check.patch
@@ -1,11 +1,11 @@
 --- numpy-1.10.2/numpy/distutils/fcompiler/gnu.py.orig	2014-08-28 15:49:10.742000000 +0400
 +++ numpy-1.10.2/numpy/distutils/fcompiler/gnu.py	2014-08-28 15:50:44.903600000 +0400
-@@ -60,7 +60,7 @@
-             m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
-             if m:
-                 return ('gfortran', m.group(1))
--            m = re.search(r'GNU Fortran.*?\-?([0-9-.]+)', version_string)
+@@ -63,7 +63,7 @@
+                     return ('gfortran', m.group(1))
+         else:
+             # Output probably from --version, try harder:
+-            m = re.search(r'GNU Fortran\s+95.*?([0-9-.]+)', version_string)
 +            m = re.search(r'GNU Fortran.*?\-?(\d*(?:\.\d+)+)', version_string)
              if m:
-                 v = m.group(1)
-                 if v.startswith('0') or v.startswith('2') or v.startswith('3'):
+                 return ('gfortran', m.group(1))
+             m = re.search(

--- a/mingw-w64-python-numpy/0008-detect-mingw-environment2.patch
+++ b/mingw-w64-python-numpy/0008-detect-mingw-environment2.patch
@@ -1,0 +1,11 @@
+--- numpy-orig/numpy/core/setup.py	2018-04-25 23:12:01.000000000 +0200
++++ numpy/numpy/core/setup.py	2018-05-25 21:58:05.675465800 +0200
+@@ -688,7 +688,7 @@
+                        ]
+     
+     # Must be true for CRT compilers but not MinGW/cygwin. See gh-9977.
+-    is_msvc = platform.system() == 'Windows'
++    is_msvc = platform.system() == 'Windows' and not 'GCC' in sys.version
+     config.add_installed_library('npymath',
+             sources=npymath_sources + [get_mathlib_info],
+             install_dir='lib',

--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=numpy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.13.0
+pkgver=1.14.3
 pkgrel=1
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
@@ -25,15 +25,17 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0004-fix-testsuite.patch
         0005-mincoming-stack-boundary-32bit-optimized-64bit.patch
         0006-disable-visualcompaq-for-mingw.patch
-        0007-disable-64bit-experimental-warning.patch)
-sha256sums=('779dd7846dd1d864eb1e239916d25ec57c4889ad92de8ab364306bed84b7237f'
+        0007-disable-64bit-experimental-warning.patch
+        0008-detect-mingw-environment2.patch)
+sha256sums=('cfcfc7a9a8ba4275c60a815c683d59ac5e7aa9362d76573b6cc4324ffb1235fa'
             '94e48602f59a69a9d56886e5b1dab62ffc4fb30b00c5d62d2a818d67d4fd079a'
             'cbe3c59fe4a4182112c88070ff8dbea8198a5d4f7c43336621eb352d475b171b'
-            '77c342fbb13de981d682bdc1889709d9d2507a1566d5ee63004f0b764a62a988'
+            '3b640625b56b158465d6628f75fadce90af8825259d04af1b1af09fef53a720c'
             '1f9783c356196327a424113e9a5d39c04fc70fef5529fd0d43288ff5274494f4'
             '429d3379e6840dd39763c629488a687a04dc3c4540e58565e75f9809e57f778d'
             'e8f2c52131e79a4e36c98f499efa85bc56254e577fae11ebce0093422114a306'
-            '00eac381f73172cb03f54fc71a845a3e72a998d78e88cbce752cf52672fc6bd1')
+            '00eac381f73172cb03f54fc71a845a3e72a998d78e88cbce752cf52672fc6bd1'
+            '5f59d7f0435af8933cd66659599d277cedfb499e036b7a3e4391db6ddd08dd72')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -46,6 +48,7 @@ prepare() {
   patch -Np1 -i ${srcdir}/0005-mincoming-stack-boundary-32bit-optimized-64bit.patch
   patch -Np1 -i ${srcdir}/0006-disable-visualcompaq-for-mingw.patch
   patch -Np1 -i ${srcdir}/0007-disable-64bit-experimental-warning.patch
+  patch -Np1 -i ${srcdir}/0008-detect-mingw-environment2.patch
   cd ..
 
   cp -a numpy-${pkgver} ${_realname}-py2-${CARCH}


### PR DESCRIPTION
`numpy.test()` is similar to previous version:
```
----------------------------------------------------------------------
Ran 6416 tests in 29.883s

FAILED (KNOWNFAIL=29, SKIP=23, errors=1, failures=13)

```