### PR TITLE
atk: update to 2.28.1 and add missing makedepends

### DIFF
--- a/mingw-w64-atk/PKGBUILD
+++ b/mingw-w64-atk/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=atk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.28.0
+pkgver=2.28.1
 pkgrel=1
 pkgdesc="A library providing a set of interfaces for accessibility (mingw-w64)"
 arch=('any')
@@ -13,12 +13,13 @@ license=(LGPL2)
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
             "${MINGW_PACKAGE_PREFIX}-pkg-config"
             "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+            "${MINGW_PACKAGE_PREFIX}-gtk-doc"
             "autoconf-archive")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2>=2.46.0")
 options=('strip' 'staticlibs')
 source=("https://download.gnome.org/sources/atk/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('2016b61b8ed54da46e8dcbd2c4b0f6cd9c668f229eb966821d5680926a91ba3f')
+sha256sums=('cd3a1ea6ecc268a2497f0cd018e970860de24a6d42086919d6bf6c8e8d53f4fc')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -26,8 +27,8 @@ prepare() {
 }
 
 build() {
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}"/build-${MINGW_CHOST} && cd "${srcdir}"/build-${MINGW_CHOST}
 
   mkdir -p docs/html
   cp -rf ../${_realname}-${pkgver}/docs/html/* docs/html


### PR DESCRIPTION
This updates atk to 2.28.1 and adds gtk-doc to makedepends.