### PR TITLE
glib2: backport fix for the gtk3 file chooser not listing drives. Fixes #3584

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.56.1
-pkgrel=1
+pkgrel=2
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -32,14 +32,16 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0017-glib-use-gnu-print-scanf.patch
         0023-print-in-binary-more-for-testing.all.patch
         0028-inode_directory.patch
-        pyscript2exe.py)
+        pyscript2exe.py
+        W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch)
 sha256sums=('40ef3f44f2c651c7a31aedee44259809b6f03d3d20be44545cd7d177221c0b8d'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
             'e916e4913632485b314269a5c8888e2eff25bb7034f244bc235c08ba7f28b5ea'
             'd1d35bb7865527422e28635ed373731e800c30ff5732c7bf8c66be37158509fb'
             'f7f06a90156fe0a308412512c359072922f7f0d19dd4bed30d863db18e48940b'
-            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3')
+            'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3'
+            '865ee7a847a1cb44fefa8d55aab9721f5e8efa54bb4db70363771a49f7a33160')
 
 
 prepare() {
@@ -50,6 +52,8 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0017-glib-use-gnu-print-scanf.patch
   patch -Np1 -i "${srcdir}"/0023-print-in-binary-more-for-testing.all.patch
   patch -Np1 -i "${srcdir}"/0028-inode_directory.patch
+  # https://github.com/Alexpux/MINGW-packages/issues/3584
+  patch -Np1 -i "${srcdir}"/W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }

--- a/mingw-w64-glib2/W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch
+++ b/mingw-w64-glib2/W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch
@@ -1,0 +1,58 @@
+From 96904149e20a04066290bc1592469930c2f57ed0 Mon Sep 17 00:00:00 2001
+From: Руслан Ижбулатов <lrn1986@gmail.com>
+Date: Wed, 11 Apr 2018 11:11:24 +0000
+Subject: [PATCH] W32 gstdio: Don't try to get reparse tag unconditionally
+
+We do not need to use FindFirstFileW() to get a reparse tag if the
+file that is being examined is not a reparse point.
+
+This is a quick and relatively painless fix for the fact that
+FindFirstFileW() fails on root directories. Since root directories
+are unlikely to be reparse points (is it even possible?), not using
+this function on non-reparse-points just sidesteps the issue.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=795153
+---
+ glib/gstdio.c | 23 ++++++++++++++---------
+ 1 file changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/glib/gstdio.c b/glib/gstdio.c
+index 9b674d7..a374d9a 100644
+--- a/glib/gstdio.c
++++ b/glib/gstdio.c
+@@ -210,18 +210,23 @@ _g_win32_stat_utf16_no_trailing_slashes (const gunichar2    *filename,
+    */
+   if (fd < 0)
+     {
+-      HANDLE tmp = FindFirstFileW (filename,
+-                                   &finddata);
++      memset (&finddata, 0, sizeof (finddata));
+ 
+-      if (tmp == INVALID_HANDLE_VALUE)
++      if (handle_info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+         {
+-          error_code = GetLastError ();
+-          errno = w32_error_to_errno (error_code);
+-          CloseHandle (file_handle);
+-          return -1;
+-        }
++          HANDLE tmp = FindFirstFileW (filename,
++                                       &finddata);
+ 
+-      FindClose (tmp);
++          if (tmp == INVALID_HANDLE_VALUE)
++            {
++              error_code = GetLastError ();
++              errno = w32_error_to_errno (error_code);
++              CloseHandle (file_handle);
++              return -1;
++            }
++
++          FindClose (tmp);
++        }
+ 
+       if (is_symlink && !for_symlink)
+         {
+--
+libgit2 0.27.0
+


### PR DESCRIPTION
#3584