### PR TITLE
Add two helper macros to the PKGBUILD templates.  apply_patch_with_ms…

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-github-git
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-github-git
@@ -22,6 +22,25 @@ sha256sums=('SKIP'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 pkgver() {
   cd "${srcdir}"/${_realname}
   printf "%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.CMake-tarball
@@ -19,11 +19,29 @@ sha256sums=('SKIP'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/0001-A-really-important-fix.patch
-  patch -p1 -i ${srcdir}/0002-A-less-important-fix.patch
+  apply_patch_with_msg 0001-A-really-important-fix.patch \
+    0002-A-less-important-fix.patch
 }
 
 build() {

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.autotools-tarball
@@ -15,6 +15,25 @@ source=("https://www.somepackage.org/${_realname}/${_realname}-${pkgver}.tar.gz"
 sha256sums=('SKIP'
             'SKIP')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0001-A-fix.patch

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
@@ -18,12 +18,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
-#older Python packages software might use this instead
-#source=("https://pypi.python.org/packages/source/P/${_realname}/${_realname}-${pkgver}.tar.gz")
-@_dtoken would be the part of the URL between the /package and filename.
-# I did this to make it so you could just update the token a new version instead of the complete
-# download URL.
+#Ideally, you should download the sources from github or some other place besides
+#pypi, but that ideal is not always possible.
 _dtoken='aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+#Some Python packages software might use this instead
+#source=("https://pypi.python.org/packages/source/[first letter of the packages]/${_realname}/${_realname}-${pkgver}.tar.gz")
+@_dtoken would be the part of the URL between the /package and filename.
+# I did this to make it so you could just update the token to a new version instead of the complete
+# download URL.
 source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"
         "0002-A-less-important-fix.patch")

--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
@@ -18,18 +18,43 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("https://pypi.python.org/packages/source/P/${_realname}/${_realname}-${pkgver}.tar.gz")
+#older Python packages software might use this instead
+#source=("https://pypi.python.org/packages/source/P/${_realname}/${_realname}-${pkgver}.tar.gz")
+@_dtoken would be the part of the URL between the /package and filename.
+# I did this to make it so you could just update the token a new version instead of the complete
+# download URL.
+_dtoken='aa/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz"
         "0001-An-important-fix.patch"
         "0002-A-less-important-fix.patch")
 sha256sums=('SKIP'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
 
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
 prepare() {
   cd "${srcdir}"
-  patch -p1 -i ${srcdir}/0001-A-really-important-fix.patch
-  patch -p1 -i ${srcdir}/0002-A-less-important-fix.patch
-  for builddir in python{2,3}-build; do
+  apply_patch_with_msg 0001-A-really-important-fix.patch \
+    0002-A-less-important-fix.patch
+  for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
   done
@@ -50,7 +75,7 @@ build() {
 check() {
   for pver in {2,3}; do
     msg "Python ${pver} test for ${CARCH}"
-    cd "${srcdir}/python${pver}-build"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
     ${MINGW_PREFIX}/bin/python${pver} setup.py check
   done
 }
@@ -58,7 +83,7 @@ check() {
 package_python3-somepackage() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
-  cd "${srcdir}/python3-build"
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build


### PR DESCRIPTION
…g applies a patch ensuring a backup is made and with an output message showing the patch being applied to help with debugging.  del_file_exists delets files and is meant for where a patch creates new files.  Those added files may not be deleted if the PKGBUILD is reran causing patch to fail saying it's already been applied.

Fix the setup-py template to use a _dtoken variable for part of the URL in pypi.  Those use a download token for each software package and is unique to EVERY version.  Also, use python${pver}-build-${CARCH} consistantly.  The CARCH allows us to have for binary versions so that they could be examined if a build problem were to occur and speed up the build.