### PR TITLE
Patch fixing stability typo in libgtksourceview-3.0-1.dll's DllMain

### DIFF
--- a/mingw-w64-gtksourceview3/0007-fix-dllmain-typo-thread-to-process.patch
+++ b/mingw-w64-gtksourceview3/0007-fix-dllmain-typo-thread-to-process.patch
@@ -1,0 +1,11 @@
+--- gtksourceview-3.24.6/gtksourceview/gtksourceview-init.c.orig	2017-05-17 18:50:16.000000000 +0300
++++ gtksourceview-3.24.6/gtksourceview/gtksourceview-init.c	2018-06-01 16:07:27.943777400 +0300
+@@ -166,7 +166,7 @@
+ 			gtksourceview_init ();
+ 			break;
+ 
+-		case DLL_THREAD_DETACH:
++		case DLL_PROCESS_DETACH:
+ 			gtksourceview_shutdown ();
+ 			break;
+ 

--- a/mingw-w64-gtksourceview3/PKGBUILD
+++ b/mingw-w64-gtksourceview3/PKGBUILD
@@ -20,13 +20,15 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-libxml2")
 options=(!libtool strip staticlibs)
 source=("https://download.gnome.org/sources/gtksourceview/${pkgver%.*}/gtksourceview-${pkgver}.tar.xz"
-        0006-hack-convert-path-back-to-unix.patch)
+        0006-hack-convert-path-back-to-unix.patch 0007-fix-dllmain-typo-thread-to-process.patch)
 sha256sums=('7aa6bdfebcdc73a763dddeaa42f190c40835e6f8495bb9eb8f78587e2577c188'
-            '83cf1b41b7b4cfadaf8bf66b0508a68462e1d2865825c8c49d3ded29604f218a')
+            '83cf1b41b7b4cfadaf8bf66b0508a68462e1d2865825c8c49d3ded29604f218a'
+            'ce97e4784bee4e02931bbd59dcc95c9cd8ce43955b4b1e308128505f536d82ca')
 
 prepare() {
   cd ${_realname}-${pkgver}
   patch -p1 -i ${srcdir}/0006-hack-convert-path-back-to-unix.patch
+  patch -p1 -i ${srcdir}/0007-fix-dllmain-typo-thread-to-process.patch
 
   autoreconf -fi
 }

--- a/mingw-w64-gtksourceview3/PKGBUILD
+++ b/mingw-w64-gtksourceview3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtksourceview
 pkgbase=mingw-w64-${_realname}3
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}3"
 pkgver=3.24.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A text widget adding syntax highlighting and more to GNOME (mingw-w64)"
 arch=('any')
 url="https://www.gnome.org"
@@ -20,7 +20,8 @@ depends=("${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-libxml2")
 options=(!libtool strip staticlibs)
 source=("https://download.gnome.org/sources/gtksourceview/${pkgver%.*}/gtksourceview-${pkgver}.tar.xz"
-        0006-hack-convert-path-back-to-unix.patch 0007-fix-dllmain-typo-thread-to-process.patch)
+        0006-hack-convert-path-back-to-unix.patch
+        0007-fix-dllmain-typo-thread-to-process.patch)
 sha256sums=('7aa6bdfebcdc73a763dddeaa42f190c40835e6f8495bb9eb8f78587e2577c188'
             '83cf1b41b7b4cfadaf8bf66b0508a68462e1d2865825c8c49d3ded29604f218a'
             'ce97e4784bee4e02931bbd59dcc95c9cd8ce43955b4b1e308128505f536d82ca')


### PR DESCRIPTION
Release of global resources was accidently performed
on any thread exit instead of process exit/dll unload.
Premature releasing caused different stability problems.

This fixes https://github.com/Alexpux/MINGW-packages/issues/3510