### PR TITLE
gettext: Fix envsubst bug of newline being CR/LF (MSYS2 bug 735)

### DIFF
--- a/mingw-w64-gettext/122-Use-LF-as-newline-in-envsubst.patch
+++ b/mingw-w64-gettext/122-Use-LF-as-newline-in-envsubst.patch
@@ -1,0 +1,36 @@
+From 60d853ccaa4c926430e536b36d8b0f1be19360c1 Mon Sep 17 00:00:00 2001
+From: Tim S <stahta01@users.sourceforge.net>
+Date: Sat, 26 May 2018 19:28:17 -0400
+Subject: [PATCH] Use LF as newline in envsubst
+
+---
+ gettext-runtime/src/envsubst.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gettext-runtime/src/envsubst.c b/gettext-runtime/src/envsubst.c
+index 941452b03..5bc482a75 100644
+--- a/gettext-runtime/src/envsubst.c
++++ b/gettext-runtime/src/envsubst.c
+@@ -27,6 +27,8 @@
+ #include <string.h>
+ #include <locale.h>
+ 
++#include <fcntl.h>
++
+ #include "closeout.h"
+ #include "error.h"
+ #include "progname.h"
+@@ -282,7 +282,10 @@ static void
+ print_variable (const char *var_ptr, size_t var_len)
+ {
+   fwrite (var_ptr, var_len, 1, stdout);
++  setmode(fileno(stdout),O_BINARY);
+   putchar ('\n');
++  fflush(stdout);
++  setmode(fileno(stdout),O_TEXT);
+ }
+ 
+ /* Print the variables contained in STRING to stdout, each one followed by a
+-- 
+2.16.2.windows.1
+

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.8.1
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
@@ -13,7 +13,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-expat"
          "${MINGW_PACKAGE_PREFIX}-libiconv"
          #"${MINGW_PACKAGE_PREFIX}-termcap"
         )
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-ncurses")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-ncurses" "git")
 options=('strip' 'staticlibs')
 
 # GPL3 for the package as a whole and LGPL for some parts, see the license files
@@ -29,7 +29,8 @@ source=("https://ftp.gnu.org/pub/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"
         07-fix-asprintf-conflict.mingw.patch
         08-vs-compatible.patch
         09-asm-underscore-mingw.patch
-        121-keep-posix-path.patch)
+        121-keep-posix-path.patch
+        122-Use-LF-as-newline-in-envsubst.patch)
 sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             'SKIP'
             '1741536dd342ae8ceaea15518d4f3b561ac1db981b6f6738e21c72035994c93a'
@@ -40,7 +41,8 @@ sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             '3b85e4d0b771b47a168c629a65463f5b87a5d5627b5f05000a45c3d2df96b66d'
             '522715ac22936943a85b4b78274302a6058f4f5371439cf491193ed53d8fc729'
             '2ffc73f1b8d66d88ff5ce640be211e5a927daba13788cb2319b97fc885444eac'
-            '051bf975687a92da8a5acc09a367632396570c2609c5ecc1eba06c60c7135ad6')
+            '051bf975687a92da8a5acc09a367632396570c2609c5ecc1eba06c60c7135ad6'
+            '095b5de0883cbdda9b0de8360996f2e3fc677f9181cd61c89eb658ebee9d148b')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') #Daiki Ueno
 
 prepare() {
@@ -69,6 +71,7 @@ prepare() {
   patch -p1 -i ${srcdir}/09-asm-underscore-mingw.patch
   patch -p1 -i ${srcdir}/120-Fix-Woe32-link-errors-when-compiling-with-O0.patch
   #patch -p1 -i ${srcdir}/121-keep-posix-path.patch
+  patch -p1 -i ${srcdir}/122-Use-LF-as-newline-in-envsubst.patch
 
   libtoolize --automake --copy --force
   WANT_AUTOMAKE=latest ./autogen.sh --skip-gnulib


### PR DESCRIPTION
Add 122-Use-LF-as-newline-in-envsubst.patch
Also, adds "git" to makedepends; it is needed by "autogen.sh".

Tim S.
