### PR TITLE
intel-tbb: update to 2018_20180312

### DIFF
--- a/mingw-w64-intel-tbb/PKGBUILD
+++ b/mingw-w64-intel-tbb/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=intel-tbb
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2018_20171205
-_pkgver=2018_U2
+pkgver=2018_20180312
+_pkgver=2018_U3
 pkgrel=1
 epoch=1
 pkgdesc='High level abstract threading library (mingw-w64)'
@@ -16,7 +16,7 @@ url='https://www.threadingbuildingblocks.org/'
 license=('Apache')
 source=(https://github.com/01org/tbb/archive/${_pkgver}.tar.gz
         'tbb-disable_windows_api.patch')
-sha256sums=('78bb9bae474736d213342f01fe1a6d00c6939d5c75b367e2e43e7bf29a6d8eca'
+sha256sums=('23793c8645480148e9559df96b386b780f92194c80120acce79fcdaae0d81f45'
             '413e75118518074da634258ccdb57ff134f4ec234ca1ae17dd5a2decf8c677f6')
 
 


### PR DESCRIPTION
This updates intel-tbb to 2018_20180312.