### PR TITLE
python3: fix typos

### DIFF
--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.6
 pkgver=${_pybasever}.5
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -234,7 +234,7 @@ prepare() {
     0640-mingw-x86_64-size_t-format-specifier-pid_t.patch \
     0650-cross-dont-add-multiarch-paths-if-cross-compiling.patch \
     0660-mingw-use-backslashes-in-compileall-py.patch \
-    0670-msys-convert_path-fix-and-root-hack.patch
+    0670-msys-convert_path-fix-and-root-hack.patch \
     0690-allow-static-tcltk.patch
   #patch -Np1 -i "${srcdir}"/0710-CROSS-properly-detect-WINDOW-_flags-for-different-nc.patch
   apply_patch_with_msg \
@@ -261,9 +261,9 @@ prepare() {
     0940-mingw-w64-Also-define-_Py_BEGIN_END_SUPPRESS_IPH-when-Py_BUILD_CORE_MODULE.patch \
     0950-mingw-w64-XP3-compat-GetProcAddress-GetTickCount64.patch \
     0960-mingw-w64-XP3-compat-GetProcAddress-GetFinalPathNameByHandleW.patch \
-    0970-Add-AMD64-to-sys-config-so-msvccompiler-get_build_version-works.patch
-    0980-mingw-readline-features-skip.patch
-    0990-MINGW-link-with-additional-library.patch
+    0970-Add-AMD64-to-sys-config-so-msvccompiler-get_build_version-works.patch \
+    0980-mingw-readline-features-skip.patch \
+    0990-MINGW-link-with-additional-library.patch \
     1010-install-msilib.patch
 
   plain "Apply patch contributed by Frode Solheim from FS-UAE project (1)"


### PR DESCRIPTION
This formula didn't build because it is missing continuation characters.