### PR TITLE
rhash: do not install to system root while building

### DIFF
--- a/mingw-w64-rhash/PKGBUILD
+++ b/mingw-w64-rhash/PKGBUILD
@@ -4,7 +4,7 @@ _realname=rhash
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.3.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Great utility for computing hash sums (mingw-w64)"
 arch=('any')
 url='https://sourceforge.net/projects/rhash/'
@@ -42,7 +42,7 @@ check() {
 package() {
   cd "${srcdir}"/build-${CARCH}
   make -j1 install DESTDIR="${pkgdir}"
-  make -j1 install install-gmo
+  make -j1 install install-gmo DESTDIR="${pkgdir}"
 
   # license
   # fully qualify path for this because there might be switch in


### PR DESCRIPTION
This package was failing build because it would install straight to the system `/mingw32` instead of the local package directory.