### PR TITLE
ninja: use python3 to build

### DIFF
--- a/mingw-w64-ninja/PKGBUILD
+++ b/mingw-w64-ninja/PKGBUILD
@@ -4,14 +4,14 @@ _realname=ninja
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.8.2
-pkgrel=1
+pkgrel=2
 pkgdesc="Ninja is a small build system with a focus on speed (mingw-w64)"
 arch=('any')
 url="https://ninja-build.org"
 license=('Apache')
 depends=()
 options=('strip' 'staticlibs')
-makedepends=("python2" "re2c")
+makedepends=("re2c" "${MINGW_PACKAGE_PREFIX}-python3")
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/ninja-build/ninja/archive/v${pkgver}.tar.gz")
 sha256sums=('86b8700c3d0880c2b44c2ff67ce42774aaf8c28cbf57725cb881569288c1c6f4')
 
@@ -24,7 +24,7 @@ prepare () {
 build() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/bin
   cd ${srcdir}/ninja-${pkgver}
-  ./configure.py --bootstrap --platform mingw
+  ${MINGW_PREFIX}/bin/python3 configure.py --bootstrap --platform mingw
 }
 
 package() {


### PR DESCRIPTION
This package no longer builds with msys2 'python' so we use mingw-w64-python3 just like we do for the related mingw-w64-meson package.