### PR TITLE
python3-ipython: add missing deps

### DIFF
--- a/mingw-w64-python3-ipython/PKGBUILD
+++ b/mingw-w64-python3-ipython/PKGBUILD
@@ -15,7 +15,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-sqlite3"
          "${MINGW_PACKAGE_PREFIX}-python3-simplegeneric"
          "${MINGW_PACKAGE_PREFIX}-python3-pickleshare"
          "${MINGW_PACKAGE_PREFIX}-python3-prompt_toolkit"
-         "${MINGW_PACKAGE_PREFIX}-python3-win_unicode_console")
+         "${MINGW_PACKAGE_PREFIX}-python3-win_unicode_console"
+         "${MINGW_PACKAGE_PREFIX}-python3-backcall"
+         "${MINGW_PACKAGE_PREFIX}-python3-colorama")
 optdepends=("${MINGW_PACKAGE_PREFIX}-python3-nose: for IPython's test suite"
             "${MINGW_PACKAGE_PREFIX}-python3-pyqt4: for ipython qtconsole"
             "${MINGW_PACKAGE_PREFIX}-python3-sip: for ipython qtconsole"


### PR DESCRIPTION
ipython attempts imports of the following missing runtime deps:
python3-backcall
python3-colorama