### PR TITLE
gdb-git: Update patch due to upstream changes.

### DIFF
--- a/mingw-w64-gdb-git/0005-Mitigate-gdb-bug-21057.patch
+++ b/mingw-w64-gdb-git/0005-Mitigate-gdb-bug-21057.patch
@@ -1,4 +1,4 @@
-From 63fdece7d71ca3986b78655a251b6e8adc666199 Mon Sep 17 00:00:00 2001
+From 96af58c2b0e16eda9b455e4b2d113049e13a8767 Mon Sep 17 00:00:00 2001
 From: Peter Foley <>
 Date: Sat, 18 Feb 2017 11:50:55 +0800
 Subject: [PATCH] Mitigate gdb bug 21057
@@ -12,7 +12,7 @@ See https://sourceware.org/bugzilla/show_bug.cgi?id=21057.
  4 files changed, 6 insertions(+), 22 deletions(-)
 
 diff --git a/gdb/ada-exp.y b/gdb/ada-exp.y
-index 1eea454670..c318d2bfd8 100644
+index 864f9bc754..521d6d0126 100644
 --- a/gdb/ada-exp.y
 +++ b/gdb/ada-exp.y
 @@ -33,6 +33,8 @@
@@ -36,7 +36,7 @@ index 1eea454670..c318d2bfd8 100644
  struct name_info {
    struct symbol *sym;
    struct minimal_symbol *msym;
-@@ -708,21 +705,6 @@ primary	:	'*' primary		%prec '.'
+@@ -704,21 +701,6 @@ primary	:	'*' primary		%prec '.'
  /* yylex defined in ada-lex.c: Reads one token, getting characters */
  /* through lexptr.  */
  
@@ -59,10 +59,10 @@ index 1eea454670..c318d2bfd8 100644
  
  /* The following kludge was found necessary to prevent conflicts between */
 diff --git a/gdb/ada-lang.c b/gdb/ada-lang.c
-index ea60df20e7..656df62bb8 100644
+index b34efa919e..eea5ac3ff2 100644
 --- a/gdb/ada-lang.c
 +++ b/gdb/ada-lang.c
-@@ -13988,7 +13988,7 @@ const struct language_defn ada_language_defn = {
+@@ -14360,7 +14360,7 @@ extern const struct language_defn ada_language_defn = {
    ada_extensions,
    &ada_exp_descriptor,
    parse,
@@ -72,10 +72,10 @@ index ea60df20e7..656df62bb8 100644
    ada_printchar,                /* Print a character constant */
    ada_printstr,                 /* Function to print string constant */
 diff --git a/gdb/ada-lang.h b/gdb/ada-lang.h
-index 5f97a6cdcc..480366a1cd 100644
+index 8e7bd50cd2..7d7bd26a21 100644
 --- a/gdb/ada-lang.h
 +++ b/gdb/ada-lang.h
-@@ -159,7 +159,7 @@ extern int ada_get_field_index (const struct type *type,
+@@ -166,7 +166,7 @@ extern int ada_get_field_index (const struct type *type,
  
  extern int ada_parse (struct parser_state *);    /* Defined in ada-exp.y */
  
@@ -85,7 +85,7 @@ index 5f97a6cdcc..480366a1cd 100644
                          /* Defined in ada-typeprint.c */
  extern void ada_print_type (struct type *, const char *, struct ui_file *, int,
 diff --git a/gdb/ada-lex.l b/gdb/ada-lex.l
-index fe97352d85..fa3e1b6407 100644
+index 621ebb2a95..98bf65a2a7 100644
 --- a/gdb/ada-lex.l
 +++ b/gdb/ada-lex.l
 @@ -39,6 +39,8 @@ OPER    ([-+*/=<>&]|"<="|">="|"**"|"/="|"and"|"or"|"xor"|"not"|"mod"|"rem"|"abs"
@@ -96,7 +96,7 @@ index fe97352d85..fa3e1b6407 100644
 +
  %{
  
- #include "common/diagnostics.h"
+ #include "diagnostics.h"
 -- 
-2.13.0
+2.17.1
 

--- a/mingw-w64-gdb-git/0009-Revert-changes-in-5045b3d-on-doc-gdb.texinfo.patch
+++ b/mingw-w64-gdb-git/0009-Revert-changes-in-5045b3d-on-doc-gdb.texinfo.patch
@@ -1,0 +1,51 @@
+From 83f9ea2c0ae8dbe4faa2e6c1f427add3602aa9e7 Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Sun, 10 Jun 2018 22:50:37 +0800
+Subject: [PATCH] Revert changes in 5045b3d on doc/gdb.texinfo
+
+Signed-off-by: Liu Hao <lh_mouse@126.com>
+---
+ gdb/doc/gdb.texinfo | 20 --------------------
+ 1 file changed, 20 deletions(-)
+
+diff --git a/gdb/doc/gdb.texinfo b/gdb/doc/gdb.texinfo
+index 2c0ac33f8b..4968b374af 100644
+--- a/gdb/doc/gdb.texinfo
++++ b/gdb/doc/gdb.texinfo
+@@ -35547,15 +35547,6 @@ modify XML target descriptions.
+ Check that the target descriptions dynamically created by @value{GDBN}
+ equal the descriptions created from XML files found in @var{dir}.
+ 
+-@kindex maint check libthread-db
+-@item maint check libthread-db
+-Run integrity checks on the current inferior's thread debugging
+-library.  This exercises all @code{libthread_db} functionality used by
+-@value{GDBN} on GNU/Linux systems, and by extension also exercises the
+-@code{proc_service} functions provided by @value{GDBN} that
+-@code{libthread_db} uses.  Note that parts of the test may be skipped
+-on some platforms when debugging core files.
+-
+ @kindex maint print dummy-frames
+ @item maint print dummy-frames
+ Prints the contents of @value{GDBN}'s internal dummy-frame stack.
+@@ -35863,17 +35854,6 @@ number of blocks in the blockvector
+ @end enumerate
+ @end table
+ 
+-@kindex maint set check-libthread-db
+-@kindex maint show check-libthread-db
+-@item maint set check-libthread-db [on|off]
+-@itemx maint show check-libthread-db
+-Control whether @value{GDBN} should run integrity checks on inferior
+-specific thread debugging libraries as they are loaded.  The default
+-is not to perform such checks.  If any check fails @value{GDBN} will
+-unload the library and continue searching for a suitable candidate as
+-described in @ref{set libthread-db-search-path}.  For more information
+-about the tests, see @ref{maint check libthread-db}.
+-
+ @kindex maint space
+ @cindex memory used by commands
+ @item maint space @var{value}
+-- 
+2.17.1
+

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}-git
-pkgver=r94431.4a3cf67ece
+pkgver=r94463.169f5dc688
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -35,7 +35,8 @@ source=("${_realname}"::"git+https://sourceware.org/git/binutils-gdb.git#branch=
         0005-Mitigate-gdb-bug-21057.patch
         0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
         0007-Make-GDB-compile-on-MinGW-targets-again.patch
-        0008-Avert-the-crash-when-using-info-register-on-Windows-.patch)
+        0008-Avert-the-crash-when-using-info-register-on-Windows-.patch
+        0009-Revert-changes-in-5045b3d-on-doc-gdb.texinfo.patch)
 sha256sums=('SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
             '9f02f6740fc5a8e0900e2ec0196bb5851f5a5f06a4da162434646dff7fef4e54'
@@ -45,7 +46,8 @@ sha256sums=('SKIP'
             '24b294b6f60ae0c853361a3be4f98e8b73bac57690940ac2e380b07d9b9b93f2'
             '4b21429e3583866b25ca4feb6ae57daab81d8735d1eb52ab61338184f58bc2fb'
             '11f37b0bcd840ef74530092bedda33d41d0820d46af1f252f36bdb12d9b4e712'
-            '41e464ea41aa3d2c603a4c411d029036d47745e43f569db3b5e6e457180eab10')
+            '41e464ea41aa3d2c603a4c411d029036d47745e43f569db3b5e6e457180eab10'
+            '57cb2398192ac0108e93af94eea0d9c369b451134ce6257515d02b0e93b01857')
 
 pkgver() {
   cd "$srcdir/$_realname"
@@ -62,6 +64,7 @@ prepare() {
   git am "${srcdir}"/0006-Disable-checks-using-setenv-or-unsetenv-as-they-do-n.patch
   git am "${srcdir}"/0007-Make-GDB-compile-on-MinGW-targets-again.patch
   git am "${srcdir}"/0008-Avert-the-crash-when-using-info-register-on-Windows-.patch
+  git am "${srcdir}"/0009-Revert-changes-in-5045b3d-on-doc-gdb.texinfo.patch
 }
 
 build() {

--- a/mingw-w64-gdb-git/PKGBUILD
+++ b/mingw-w64-gdb-git/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=gdb
 _gcc_ver=$(gcc -v 2>&1 | grep "^gcc version" | head -n1 | cut -c 13- | sed -r "s/\\s.*$//")
 pkgbase=mingw-w64-${_realname}-git
-pkgver=r94080.07784cb5da
+pkgver=r94431.4a3cf67ece
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}=${pkgver}")
@@ -42,7 +42,7 @@ sha256sums=('SKIP'
             'c92183a52f53d82cb5ffddf2a18f5bddd350ccc0db01eff1e5918d98467ee8e3'
             'c8aab67618e05c31e3b60b59319d8fa3eeb7ca9dbf8de937a07c99533557dd5f'
             '238e6099343854ef664bbf10a4109873d6a52a0d2f0515899db4821f1734a23e'
-            '9d2aa8b97952e92973b4c306aafbf338c1cd6c1bb1f75f81bdf85751464a9750'
+            '24b294b6f60ae0c853361a3be4f98e8b73bac57690940ac2e380b07d9b9b93f2'
             '4b21429e3583866b25ca4feb6ae57daab81d8735d1eb52ab61338184f58bc2fb'
             '11f37b0bcd840ef74530092bedda33d41d0820d46af1f252f36bdb12d9b4e712'
             '41e464ea41aa3d2c603a4c411d029036d47745e43f569db3b5e6e457180eab10')


### PR DESCRIPTION
This makes patch 0005 apply again.
This only fixes the patch in question. At this moment gdbserver doesn't compile.

Signed-off-by: Liu Hao <lh_mouse@126.com>