### PR TITLE
quantlib: update to 1.13

### DIFF
--- a/mingw-w64-quantlib/PKGBUILD
+++ b/mingw-w64-quantlib/PKGBUILD
@@ -1,34 +1,35 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=quantlib
+_srcname=QuantLib
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.12.1
+pkgver=1.13
 pkgrel=1
 pkgdesc="QuantLib - A free/open-source library for quantitative finance (mingw-w64)"
 arch=('any')
-url='http://quantlib.org'
+url="http://quantlib.org"
 license=('BSD')
+depends=("${MINGW_PACKAGE_PREFIX}-boost")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost" "automake" "autoconf" "libtool")
 options=('staticlibs' 'strip')
-source=(https://dl.bintray.com/quantlib/releases/QuantLib-${pkgver}.tar.gz
-        no-undefined.patch)
-sha256sums=('92b92b3db842da20db6fc5eba1e75baecaa62f6b19f1eb1e6568ce7d7df927cc'
+source=("${_realname}-${pkgver}.tar.gz"::"https://dl.bintray.com/quantlib/releases/${_srcname}-${pkgver}.tar.gz"
+        "no-undefined.patch")
+sha256sums=('bb52df179781f9c19ef8e976780c4798b0cdc4d21fa72a7a386016e24d1a86e6'
             'e391fb490928fdf761c7dbb2ca4631d1ccbb092045de50b89fe37a1c5b9787e5')
 
 prepare() {
-  cd QuantLib-${pkgver}
-  patch -p1 -i ${srcdir}/no-undefined.patch
+  cd "${srcdir}/${_srcname}-${pkgver}"
+  patch -p1 -i "${srcdir}/no-undefined.patch"
 
   ./autogen.sh
 }
 
 build() {
-  rm -rf "${srcdir}/build-${MINGW_CHOST}"
-  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
-  cd "${srcdir}/build-${MINGW_CHOST}"
+  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}/build-${MINGW_CHOST}"
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
 
-  ../QuantLib-${pkgver}/configure \
+  ../${_srcname}-${pkgver}/configure \
     --disable-dependency-tracking \
     --enable-static \
     --enable-shared \
@@ -42,5 +43,5 @@ build() {
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   make DESTDIR="${pkgdir}" install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/LICENSE.TXT "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
+  install -Dm644 ${srcdir}/${_srcname}-${pkgver}/LICENSE.TXT "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 }


### PR DESCRIPTION
This updates quantlib to 1.13 and adds boost to depends as well as
makedepends.