### PR TITLE
dbus: Update to 1.12.8

### DIFF
--- a/mingw-w64-dbus/PKGBUILD
+++ b/mingw-w64-dbus/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dbus
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.10.18
+pkgver=1.12.8
 pkgrel=1
 arch=('any')
 pkgdesc="Freedesktop.org message bus system (mingw-w64)"
@@ -17,11 +17,13 @@ options=('strip' 'staticlibs')
 license=("BSD")
 url="https://www.freedesktop.org/wiki/Software/dbus"
 source=("https://dbus.freedesktop.org/releases/dbus/${_realname}-${pkgver}.tar.gz"{,.asc})
-sha256sums=('6049ddd5f3f3e2618f615f1faeda0a115104423a7996b7aa73e2f36e38cc514a'
+sha256sums=('e2dc99e7338303393b6663a98320aba6a63421bcdaaf571c8022f815e5896eb3'
             'SKIP')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+
+  sed -i "s/(MKDIR_P) -m 700 XDG_RUNTIME_DIR/(MKDIR_P) XDG_RUNTIME_DIR/" test/makefile.am
 }
 
 build() {


### PR DESCRIPTION
There are two test cases which are failing still, I'm not sure what was the result of the previous build. I'm not very familiar with `dbus`, let me know if we should investigate further before merging.

```
============================================================================
Testsuite summary for dbus 1.12.8
============================================================================
# TOTAL: 103
# PASS:  83
# SKIP:  18
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 2
============================================================================
```
Failing cases:
```
ERROR: test-dbus-daemon.exe - Bail out! ERROR:../../dbus-1.12.8/test/dbus-daemon.c:736:test_max_connections: assertion failed: (!ok)
ERROR: test-syslog.exe - Bail out! ERROR:../../dbus-1.12.8/test/internals/syslog.c:89:test_syslog_normal: stderr of child process (/syslog/normal) failed to match: *regression test for _dbus_log(): 42
```