### PR TITLE
gdb: Fix crash when using `info register` on Win64.

### DIFF
--- a/mingw-w64-gdb/PKGBUILD
+++ b/mingw-w64-gdb/PKGBUILD
@@ -7,7 +7,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 # Until https://gcc.gnu.org/bugzilla/show_bug.cgi?id=62279 is
 # fixed, we will stick with 7.6.2 which hasn't got this bug..
 pkgver=8.1
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Debugger (mingw-w64)"
 arch=('any')
 url="https://www.gnu.org/software/gdb/"
@@ -32,7 +32,8 @@ source=(https://ftp.gnu.org/gnu/gdb/${_realname}-${pkgver}.tar.xz{,.sig}
         'gdb-fix-using-gnu-print.patch'
         'gdb-7.12-dynamic-libs.patch'
         'gdb-py3-fixes.patch'
-        'python-configure-path-fixes.patch')
+        'python-configure-path-fixes.patch'
+        'gdb-Avert-the-crash-when-using-info-register-on-Windows.patch')
 validpgpkeys=('F40ADB902B24264AA42E50BF92EDB04BFF325CF3')
 sha256sums=('af61a0263858e69c5dce51eab26662ff3d2ad9aa68da9583e8143b5426be4b34'
             'SKIP'
@@ -43,7 +44,8 @@ sha256sums=('af61a0263858e69c5dce51eab26662ff3d2ad9aa68da9583e8143b5426be4b34'
             '264eba33ef71c4762514a634dcf94fdb778914dbba6ce99e63804fe063225d97'
             '4398bd83a798baa15c0f91878391a0882239a682cf523ef6551766cba7b03699'
             'bfe8985e806200e5a1007c4565bd60de0a297369d17d4a0178512f2df29b34fc'
-            'bdf6c2b51d6c8c84b7b20abb9d1702f110c0c0e06e3d68eb6aba817664354450')
+            'bdf6c2b51d6c8c84b7b20abb9d1702f110c0c0e06e3d68eb6aba817664354450'
+            '41e464ea41aa3d2c603a4c411d029036d47745e43f569db3b5e6e457180eab10')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -63,6 +65,7 @@ prepare() {
 
   patch -p1 -i ${srcdir}/gdb-py3-fixes.patch
   patch -p1 -i ${srcdir}/python-configure-path-fixes.patch
+  patch -p1 -i ${srcdir}/gdb-Avert-the-crash-when-using-info-register-on-Windows.patch
 
   # hack! - libiberty configure tests for header files using "$CPP $CPPFLAGS"
   sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure

--- a/mingw-w64-gdb/gdb-Avert-the-crash-when-using-info-register-on-Windows.patch
+++ b/mingw-w64-gdb/gdb-Avert-the-crash-when-using-info-register-on-Windows.patch
@@ -1,0 +1,30 @@
+From 3cbd78e2cba49732c2d7694a8e01e4624dab204a Mon Sep 17 00:00:00 2001
+From: Liu Hao <lh_mouse@126.com>
+Date: Thu, 3 May 2018 19:20:58 +0800
+Subject: [PATCH] Avert the crash when using 'info register' on Windows x64.
+
+Reference: https://sourceware.org/bugzilla/show_bug.cgi?id=22854
+---
+ gdb/arch/amd64.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/gdb/arch/amd64.c b/gdb/arch/amd64.c
+index d31d8f1f75..ebc9aa563b 100644
+--- a/gdb/arch/amd64.c
++++ b/gdb/arch/amd64.c
+@@ -55,9 +55,10 @@ amd64_create_target_description (uint64_t xcr0, bool is_x32, bool is_linux)
+     regnum = create_feature_i386_64bit_core (tdesc, regnum);
+ 
+   regnum = create_feature_i386_64bit_sse (tdesc, regnum);
+-  if (is_linux)
++  if (is_linux) {
+     regnum = create_feature_i386_64bit_linux (tdesc, regnum);
+-  regnum = create_feature_i386_64bit_segments (tdesc, regnum);
++    regnum = create_feature_i386_64bit_segments (tdesc, regnum);
++  }
+ 
+   if (xcr0 & X86_XSTATE_AVX)
+     regnum = create_feature_i386_64bit_avx (tdesc, regnum);
+-- 
+2.17.0
+


### PR DESCRIPTION
Because #3686 of `mingw-w64-gdb-git` has not been merged into `mingw-w64-gdb`, gdb will crash with `info reg` command.