### PR TITLE
python-numpy: update to 1.14.5

### DIFF
--- a/mingw-w64-python-numpy/PKGBUILD
+++ b/mingw-w64-python-numpy/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=numpy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.14.4
+pkgver=1.14.5
 pkgrel=1
 pkgdesc="Scientific tools for Python (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ source=(https://github.com/numpy/numpy/releases/download/v${pkgver}/${_realname}
         0006-disable-visualcompaq-for-mingw.patch
         0007-disable-64bit-experimental-warning.patch
         0008-detect-mingw-environment2.patch)
-sha256sums=('c9a83644685edf8b5383b7632daa37df115b41aa20ca6ec3139e707d88f7c903'
+sha256sums=('1b4a02758fb68a65ea986d808867f1d6383219c234aef553a8741818e795b529'
             '94e48602f59a69a9d56886e5b1dab62ffc4fb30b00c5d62d2a818d67d4fd079a'
             'cbe3c59fe4a4182112c88070ff8dbea8198a5d4f7c43336621eb352d475b171b'
             '3b640625b56b158465d6628f75fadce90af8825259d04af1b1af09fef53a720c'


### PR DESCRIPTION
This updates python-numpy to 1.14.5.