### PR TITLE
tesseract: download correct training data

### DIFF
--- a/mingw-w64-tesseract-ocr/PKGBUILD
+++ b/mingw-w64-tesseract-ocr/PKGBUILD
@@ -5,7 +5,7 @@ _realname=tesseract-ocr
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.05.02
-pkgrel=1
+pkgrel=2
 pkgdesc="Tesseract OCR (mingw-w64)"
 arch=('any')
 url="https://github.com/tesseract-ocr/tesseract"
@@ -19,7 +19,7 @@ depends=(${MINGW_PACKAGE_PREFIX}-cairo
          ${MINGW_PACKAGE_PREFIX}-zlib)
 options=('!libtool' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tesseract/archive/${pkgver}.tar.gz
-        https://github.com/tesseract-ocr/tessdata/raw/master/osd.traineddata
+        https://github.com/tesseract-ocr/tessdata/raw/3.04.00/osd.traineddata
         001-proper-include-thread.patch)
 sha256sums=('494d64ffa7069498a97b909a0e65a35a213989e0184f1ea15332933a90d43445'
             '9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff'


### PR DESCRIPTION
The V3 branch of tesseract requires training data from the v3 branch. The master branch of the training data is now serving data for the experimental tesseract v4.