### PR TITLE
gcc-git: Fix filesystem patch.

### DIFF
--- a/mingw-w64-gcc-git/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
+++ b/mingw-w64-gcc-git/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
@@ -1,4 +1,4 @@
-From 662be0f78e3f5831d5bd8e3ffd1da4646b57b333 Mon Sep 17 00:00:00 2001
+From ff9550c0761d269ac0b7a7423a15befc37946cac Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Sat, 23 Jun 2018 17:02:02 +0800
 Subject: [PATCH] Backport patches for std::filesystem from master.
@@ -20,7 +20,7 @@ Signed-off-by: Liu Hao <lh_mouse@126.com>
  libstdc++-v3/configure                        |  35 +++
  libstdc++-v3/configure.ac                     |   2 +
  libstdc++-v3/crossconfig.m4                   |   1 +
- libstdc++-v3/include/bits/fs_path.h           | 257 +++++++++--------
+ libstdc++-v3/include/bits/fs_path.h           | 251 +++++++++--------
  libstdc++-v3/include/bits/fstream.tcc         |  36 +++
  .../include/experimental/bits/fs_path.h       |  74 ++---
  libstdc++-v3/include/std/fstream              | 119 ++++++++
@@ -32,7 +32,7 @@ Signed-off-by: Liu Hao <lh_mouse@126.com>
  libstdc++-v3/src/filesystem/std-dir.cc        |   5 +-
  libstdc++-v3/src/filesystem/std-ops.cc        | 260 ++++++++++++------
  libstdc++-v3/src/filesystem/std-path.cc       | 105 +++++--
- 18 files changed, 934 insertions(+), 354 deletions(-)
+ 18 files changed, 929 insertions(+), 353 deletions(-)
 
 diff --git a/libstdc++-v3/config.h.in b/libstdc++-v3/config.h.in
 index 5a0f0678439..1fc10b511fb 100644
@@ -139,7 +139,7 @@ index 58f24f670f6..3c857272c57 100644
        sys_open(__c_file* __file, ios_base::openmode);
  
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
-index ba094be6f15..83cd6a54b71 100755
+index fbc9daeb195..3dd63c9631d 100755
 --- a/libstdc++-v3/configure
 +++ b/libstdc++-v3/configure
 @@ -28127,6 +28127,17 @@ eval as_val=\$$as_ac_var
@@ -178,7 +178,7 @@ index ba094be6f15..83cd6a54b71 100755
  fi
  done
  
-@@ -80012,6 +80034,19 @@ _ACEOF
+@@ -80025,6 +80047,19 @@ _ACEOF
  
  fi
  
@@ -219,7 +219,7 @@ index 0ef96270c9c..dde1c4da944 100644
  GLIBCXX_CHECK_FILESYSTEM_DEPS
  
 diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
-index fa56795b25e..f0a55c68404 100644
+index cb6e3afff3d..669d87f7602 100644
 --- a/libstdc++-v3/crossconfig.m4
 +++ b/libstdc++-v3/crossconfig.m4
 @@ -199,6 +199,7 @@ case "${host}" in
@@ -231,7 +231,7 @@ index fa56795b25e..f0a55c68404 100644
    *-netbsd*)
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
 diff --git a/libstdc++-v3/include/bits/fs_path.h b/libstdc++-v3/include/bits/fs_path.h
-index 3921d17be68..e3938d06d59 100644
+index 51af2891647..e3938d06d59 100644
 --- a/libstdc++-v3/include/bits/fs_path.h
 +++ b/libstdc++-v3/include/bits/fs_path.h
 @@ -37,11 +37,11 @@
@@ -436,12 +436,10 @@ index 3921d17be68..e3938d06d59 100644
    inline void swap(path& __lhs, path& __rhs) noexcept { __lhs.swap(__rhs); }
  
    size_t hash_value(const path& __p) noexcept;
-@@ -549,60 +519,56 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -555,58 +525,50 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+     return __result;
+   }
  
-   /// Append one path to another
-   inline path operator/(const path& __lhs, const path& __rhs)
--  { return path(__lhs) /= __rhs; }
--
 -  /// Write a path to a stream
 -  template<typename _CharT, typename _Traits>
 -    basic_ostream<_CharT, _Traits>&
@@ -466,12 +464,7 @@ index 3921d17be68..e3938d06d59 100644
 -	__p = std::move(__tmp);
 -      return __is;
 -    }
-+  {
-+    path __result(__lhs);
-+    __result /= __rhs;
-+    return __result;
-+  }
- 
+-
 -  template<typename _Source>
 +  template<typename _InputIterator>
      inline auto
@@ -534,7 +527,7 @@ index 3921d17be68..e3938d06d59 100644
  #endif
      }
  
-@@ -911,11 +877,16 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -915,11 +877,16 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      path::string(const _Allocator& __a) const
      {
        if constexpr (is_same_v<_CharT, value_type>)
@@ -553,7 +546,7 @@ index 3921d17be68..e3938d06d59 100644
        else
  	return _S_str_convert<_CharT, _Traits>(_M_pathname, __a);
      }
-@@ -1067,12 +1038,22 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -1071,12 +1038,22 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      return ext.first && ext.second != string_type::npos;
    }
  
@@ -577,7 +570,7 @@ index 3921d17be68..e3938d06d59 100644
    }
  
    inline path::iterator
-@@ -1083,6 +1064,38 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -1087,6 +1064,38 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      return iterator(this, true);
    }
  
@@ -664,7 +657,7 @@ index f23ff7af4eb..d9eff00823a 100644
      typename basic_filebuf<_CharT, _Traits>::__filebuf_type*
      basic_filebuf<_CharT, _Traits>::
 diff --git a/libstdc++-v3/include/experimental/bits/fs_path.h b/libstdc++-v3/include/experimental/bits/fs_path.h
-index 0e5777e8ac6..d318e37ac4c 100644
+index ada7c1791aa..653b4a3fe85 100644
 --- a/libstdc++-v3/include/experimental/bits/fs_path.h
 +++ b/libstdc++-v3/include/experimental/bits/fs_path.h
 @@ -79,8 +79,11 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
@@ -750,7 +743,7 @@ index 0e5777e8ac6..d318e37ac4c 100644
        }
  
      bool _S_is_dir_sep(value_type __ch)
-@@ -520,7 +533,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -524,7 +537,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
        auto __tmp = __p.string<_CharT, _Traits>();
        using __quoted_string
  	= std::__detail::_Quoted_string<decltype(__tmp)&, _CharT>;
@@ -759,7 +752,7 @@ index 0e5777e8ac6..d318e37ac4c 100644
        return __os;
      }
  
-@@ -532,7 +545,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -536,7 +549,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
        basic_string<_CharT, _Traits> __tmp;
        using __quoted_string
  	= std::__detail::_Quoted_string<decltype(__tmp)&, _CharT>;
@@ -768,7 +761,7 @@ index 0e5777e8ac6..d318e37ac4c 100644
  	__p = std::move(__tmp);
        return __is;
      }
-@@ -590,25 +603,6 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -594,25 +607,6 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      std::string _M_what = _M_gen_what();
    };
  
@@ -794,7 +787,7 @@ index 0e5777e8ac6..d318e37ac4c 100644
    struct path::_Cmpt : path
    {
      _Cmpt(string_type __s, _Type __t, size_t __pos)
-@@ -995,6 +989,16 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -999,6 +993,16 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      return ext.first && ext.second != string_type::npos;
    }
  

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -70,7 +70,7 @@ sha256sums=('SKIP'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
             'b1c3c20bf501cebbcb02b4a50f117a4f90eb4fb79eac7aa99c85e2c54c106790'
             '33392651e17b81609718873ff32606deee5f3fc5176c197bb96eedc3dada8912'
-            'c0c3d5330ec68ec33ff4162c2649a3a3690bce7766823a6f41c628aee8d74059')
+            '1a2309d027c3defd0257f50a3c82fa8d2b5ea825c9d880ed77ea8e43505112b2')
 
 _threads="posix"
 


### PR DESCRIPTION
This makes the patch in question apply again, which was broken by
~~r262404~~r262388 on GCC SVN.

Reference: https://gcc.gnu.org/viewcvs?rev=262388&root=gcc&view=rev
Signed-off-by: Liu Hao <lh_mouse@126.com>