### PR TITLE
Patch for error-free invocation of rake under bash #4021

### DIFF
--- a/mingw-w64-ruby/0005-rbinstall-rake-bash.patch
+++ b/mingw-w64-ruby/0005-rbinstall-rake-bash.patch
@@ -1,0 +1,17 @@
+diff -ur -U5 ruby-2.5.1.orig/tool/rbinstall.rb ruby-2.5.1/tool/rbinstall.rb
+--- ruby-2.5.1.orig/tool/rbinstall.rb	2017-10-30 05:45:20.000000000 +0000
++++ ruby-2.5.1/tool/rbinstall.rb	2018-07-05 19:06:58.963282600 +0100
+@@ -442,11 +442,11 @@
+ PROLOG_SCRIPT["exe"] = "#!#{bindir}/#{ruby_install_name}"
+ PROLOG_SCRIPT["cmd"] = <<EOS
+ :""||{ ""=> %q<-*- ruby -*-
+ @"%~dp0#{ruby_install_name}" -x "%~f0" %*
+ @exit /b %ERRORLEVEL%
+-};{#\n#{prolog_script.gsub(/(?=\n)/, ' #')}>,\n}
++};{ #\n#{prolog_script.gsub(/(?=\n)/, ' #')}>,\n}
+ EOS
+ PROLOG_SCRIPT.default = (load_relative || /\s/ =~ bindir) ?
+                           <<EOS : PROLOG_SCRIPT["exe"]
+ #!/bin/sh
+ # -*- ruby -*-
+

--- a/mingw-w64-ruby/PKGBUILD
+++ b/mingw-w64-ruby/PKGBUILD
@@ -7,7 +7,7 @@ _realname=ruby
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.5.1
-pkgrel=1
+pkgrel=2
 pkgdesc="An object-oriented language for quick and easy programming (mingw-w64)"
 arch=('any')
 url="https://www.ruby-lang.org/en"
@@ -28,12 +28,15 @@ source=("https://cache.ruby-lang.org/pub/ruby/${pkgver%.*}/${_realname}-${pkgver
         0001-mingw-w64-time-functions.patch
         0002-use-gnu-printf.patch
         0003-fix-check-types.patch
-        0004-rbinstall-destdir.patch)
+        0004-rbinstall-destdir.patch
+        0005-rbinstall-rake-bash.patch
+        )
 sha256sums=('0f5d20f012baca865381a055e73f22db814615fee3c68083182cb78a4b3b30cb'
             '329994d3bf7e692e18c1faffbedfbd076e5d00257b2100387a773b59b81ccd4e'
             '6e65ea1b039041720dd5d3742fd7f713569f9d4ac213ec2ecde3c31cfcdee2a1'
             'cbb083aece8e284fb1ae625e689f044a608aa9750bba9f7d399e895547eee39b'
-            '02382ec3b9e42d7dbb58edad3e41c361d98871711bb2f0320082c2acc6a82e2e')
+            '02382ec3b9e42d7dbb58edad3e41c361d98871711bb2f0320082c2acc6a82e2e'
+            '9fb5acb995255eedde0f0b0bf5cf2c02f00dc088d2538ff9ebb69627aafd1e42')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -59,7 +62,8 @@ prepare() {
 apply_patch_with_msg \
   0001-mingw-w64-time-functions.patch \
   0002-use-gnu-printf.patch \
-  0003-fix-check-types.patch
+  0003-fix-check-types.patch \
+  0005-rbinstall-rake-bash.patch
 #  patch -p1 -i ${srcdir}/0004-rbinstall-destdir.patch
   autoreconf -fi
 }


### PR DESCRIPTION
Patch to get rid of the error produced when invoking the mingw build of rake from bash.
Addresses issue https://github.com/Alexpux/MINGW-packages/issues/4021
