### PR TITLE
setuptools: remove hardcoded Python versions; fix build

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -5,10 +5,8 @@ _realname=setuptools
 pkgbase=mingw-w64-python-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-_py3_base=3.6
-_py2_base=2.7
 pkgver=39.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -30,9 +28,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0001-mingw-python-fix.patch
   patch -p1 -i ${srcdir}/0002-Allow-usr-bin-env-in-script.patch
   patch -p1 -i ${srcdir}/0003-MinGW-w64-Look-in-same-dir-as-script-for-exe.patch
-  if [ $(vercmp $2 6.9) -gt 0 ]; then
-    patch -p1 -i ${srcdir}/0004-dont-execute-msvc.patch
-  fi
+  patch -p1 -i ${srcdir}/0004-dont-execute-msvc.patch
 
   cd "${srcdir}"
 
@@ -71,6 +67,7 @@ package_python3-setuptools() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3>=3.3")
 
   local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
+  local _py3_base=$(${MINGW_PREFIX}/bin/python3 -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   cd "${srcdir}/setuptools-python3-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -90,6 +87,7 @@ package_python2-setuptools() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2>=2.7")
 
   local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
+  local _py2_base=$(${MINGW_PREFIX}/bin/python2 -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
 
   cd "${srcdir}/setuptools-python2-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
Looks like prepare() got passed the version at some point? It's at least
not happening here and breaks the build due to the patch not getting applied.