### PR TITLE
pytest: fix missing atomicwrites dependency

### DIFF
--- a/mingw-w64-python-atomicwrites/PKGBUILD
+++ b/mingw-w64-python-atomicwrites/PKGBUILD
@@ -1,0 +1,70 @@
+# Contributor: Christoph Reiter <reiter.christoph@gmail.com>
+
+_realname=atomicwrites
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.1.5
+pkgrel=1
+pkgdesc='Atomic file writes on POSIX (mingw-w64)'
+url='https://github.com/untitaker/python-atomicwrites'
+license=('MIT')
+arch=('any')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
+sha256sums=('240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585')
+
+prepare() {
+  cd "${srcdir}"
+
+  for builddir in python{2,3}-build-${CARCH}; do  
+    rm -rf $builddir | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+}
+
+build() {  
+  for pver in {2,3}; do  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+package_python3-atomicwrites() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
+}
+
+package_python2-atomicwrites() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+}
+
+package_mingw-w64-i686-python2-atomicwrites() {
+  package_python2-atomicwrites
+}
+
+package_mingw-w64-i686-python3-atomicwrites() {
+  package_python3-atomicwrites
+}
+
+package_mingw-w64-x86_64-python2-atomicwrites() {
+  package_python2-atomicwrites
+}
+
+package_mingw-w64-x86_64-python3-atomicwrites() {
+  package_python3-atomicwrites
+}

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -5,7 +5,7 @@ _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.6.3
-pkgrel=1
+pkgrel=2
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
 license=('MIT')
@@ -49,6 +49,7 @@ package_python3-pytest() {
            "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
            "${MINGW_PACKAGE_PREFIX}-python3-colorama"
            "${MINGW_PACKAGE_PREFIX}-python3-six"
+           "${MINGW_PACKAGE_PREFIX}-python3-atomicwrites"
            "${MINGW_PACKAGE_PREFIX}-python3-more-itertools"
            "${MINGW_PACKAGE_PREFIX}-python3-attrs")
 
@@ -74,6 +75,7 @@ package_python2-pytest() {
            "${MINGW_PACKAGE_PREFIX}-python2-colorama"
            "${MINGW_PACKAGE_PREFIX}-python2-funcsigs"
            "${MINGW_PACKAGE_PREFIX}-python2-six"
+           "${MINGW_PACKAGE_PREFIX}-python2-atomicwrites"
            "${MINGW_PACKAGE_PREFIX}-python2-more-itertools"
            "${MINGW_PACKAGE_PREFIX}-python2-attrs")
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "tests/runtests.py", line 9, in <module>
    import pytest
  File "C:\msys64\MINGW64\lib\python2.7\site-packages/pytest.py", line 9, in <module>
    from _pytest.config import main, UsageError, cmdline, hookspec, hookimpl
  File "C:\msys64\MINGW64\lib\python2.7\site-packages/_pytest/config/__init__.py", line 19, in <module>
    import _pytest.assertion
  File "C:\msys64\MINGW64\lib\python2.7\site-packages/_pytest/assertion/__init__.py", line 9, in <module>
    from _pytest.assertion import rewrite
  File "C:\msys64\MINGW64\lib\python2.7\site-packages/_pytest/assertion/rewrite.py", line 15, in <module>
    import atomicwrites
ImportError: No module named atomicwrites
```