### PR TITLE
 New package: python3-jupyter-notebook (Version: 5.5.0) 

### DIFF
--- a/mingw-w64-python3-jupyter-notebook/PKGBUILD
+++ b/mingw-w64-python3-jupyter-notebook/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=notebook
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.3.0
+pkgver=5.5.0
 pkgrel=1
 pkgdesc="The language-agnostic HTML notebook application for Project Jupyter"
 arch=('any')
@@ -31,7 +31,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              )
 
 source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/notebook/archive/$pkgver.tar.gz")
-sha256sums=('a674f74e612b435a1ec9372f8f583b0cd64d9db531534c3174f06a2a9087ed80')
+sha256sums=('9c0ad8efdd5b39f3fd7655c7b14e870fa9c5c36bf8370a4eb831522a5bd613d4')
 
 build() {
 

--- a/mingw-w64-python3-jupyter-notebook/PKGBUILD
+++ b/mingw-w64-python3-jupyter-notebook/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=notebook
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=5.3.0
+pkgrel=1
+pkgdesc="The language-agnostic HTML notebook application for Project Jupyter"
+arch=('any')
+url="https://github.com/jupyter/notebook"
+license=('BSD')
+
+depends=("${MINGW_PACKAGE_PREFIX}-python3"
+         "${MINGW_PACKAGE_PREFIX}-python3-jupyter_core"
+         "${MINGW_PACKAGE_PREFIX}-python3-jupyter_client"
+         "${MINGW_PACKAGE_PREFIX}-python3-jupyter-nbformat"
+         "${MINGW_PACKAGE_PREFIX}-python3-jupyter-nbconvert"
+         "${MINGW_PACKAGE_PREFIX}-python3-ipywidgets"
+         "${MINGW_PACKAGE_PREFIX}-python3-jinja"
+         "${MINGW_PACKAGE_PREFIX}-python3-traitlets"
+         "${MINGW_PACKAGE_PREFIX}-python3-tornado"
+         "${MINGW_PACKAGE_PREFIX}-python3-terminado"
+         "${MINGW_PACKAGE_PREFIX}-python3-send2trash"
+#         "${MINGW_PACKAGE_PREFIX}-mathjax"
+         )
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-nodejs"
+             "${MINGW_PACKAGE_PREFIX}-yarn"
+             "${MINGW_PACKAGE_PREFIX}-bower"
+             )
+
+source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/notebook/archive/$pkgver.tar.gz")
+sha256sums=('a674f74e612b435a1ec9372f8f583b0cd64d9db531534c3174f06a2a9087ed80')
+
+build() {
+
+  cd "$srcdir/${_realname}-$pkgver"
+
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+package() {
+
+  cd "$srcdir/${_realname}-$pkgver"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 COPYING.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}


### PR DESCRIPTION
Please note that can be built only without logging - a `bower `error will stop building if you use `-L` switch