### PR TITLE
meson: fix python module in case the official Python is installed

### DIFF
--- a/mingw-w64-meson/0004-python-find-path.patch
+++ b/mingw-w64-meson/0004-python-find-path.patch
@@ -1,0 +1,34 @@
+--- meson-0.47.1/mesonbuild/modules/python.py.orig	2018-07-02 19:41:43.000000000 +0200
++++ meson-0.47.1/mesonbuild/modules/python.py	2018-07-11 20:20:23.498385600 +0200
+@@ -437,18 +437,23 @@
+         super().__init__(*args, **kwargs)
+         self.snippets.add('find_installation')
+ 
+-    # https://www.python.org/dev/peps/pep-0397/
+     def _get_win_pythonpath(self, name_or_path):
+         if name_or_path not in ['python2', 'python3']:
+             return None
++
++        # https://www.python.org/dev/peps/pep-0397/
+         ver = {'python2': '-2', 'python3': '-3'}[name_or_path]
+-        cmd = ['py', ver, '-c', "import sysconfig; print(sysconfig.get_config_var('BINDIR'))"]
+-        _, stdout, _ = mesonlib.Popen_safe(cmd)
+-        dir = stdout.strip()
+-        if os.path.exists(dir):
+-            return os.path.join(dir, 'python')
+-        else:
+-            return None
++        for launcher_args in [[name_or_path], ['py', ver]]:
++            try:
++                p, stdout = mesonlib.Popen_safe(
++                    launcher_args + [
++                        'import sys; sys.stdout.write(sys.executable)'])[:2]
++            except OSError:
++                continue
++            else:
++                if p.returncode == 0:
++                    return stdout.strip()
++        return None
+ 
+     @permittedKwargs(['required'])
+     def find_installation(self, interpreter, state, args, kwargs):

--- a/mingw-w64-meson/PKGBUILD
+++ b/mingw-w64-meson/PKGBUILD
@@ -4,7 +4,7 @@ _realname=meson
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.47.1
-pkgrel=1
+pkgrel=2
 pkgdesc="High-productivity build system (mingw-w64)"
 arch=('any')
 url="http://mesonbuild.com/"
@@ -18,6 +18,7 @@ source=(https://github.com/mesonbuild/${_realname}/releases/download/${pkgver}/$
         '0002-Default-to-sys.prefix-as-the-default-prefix.patch'
         '0003-Strip-the-prefix-from-all-paths-when-installing-with.patch'
         '0001-gtk-doc-Use-LD_LIBRARY_PATH-to-modify-PATH-on-W32.patch'
+        '0004-python-find-path.patch'
         )
 sha256sums=('d673de79f7bab064190a5ea06140eaa8415efb386d0121ba549f6d66c555ada6'
             'edec6de6f5fa60f0737fdb25a3ac276a0187a6f961544289e5472bcb4194e954'
@@ -25,6 +26,7 @@ sha256sums=('d673de79f7bab064190a5ea06140eaa8415efb386d0121ba549f6d66c555ada6'
             '4ef1e6fb0e9bd927b4646e416631b8a0a9aece763d259dbba58168bcba93f673'
             '2093c617cf3146a4cea601e7c73400d8ec5fd52ac5cf642c4f5af2d6493b1cb1'
             'f956f44fef088177c27ad8cb449281253ce48fc6b4a87abcec4f8da83866583d'
+            '38c0f60d1e788310d8c0b50fa7a14f3ebc94dfe75e42b5c770befd3a9aac56f2'
            )
 
 prepare() {
@@ -38,6 +40,8 @@ prepare() {
 
   # https://github.com/mesonbuild/meson/issues/3307
   patch -Np1 -i "${srcdir}"/0001-gtk-doc-Use-LD_LIBRARY_PATH-to-modify-PATH-on-W32.patch
+
+  patch -Np1 -i "${srcdir}"/0004-python-find-path.patch
 }
 
 build() {


### PR DESCRIPTION
meson uses the py.exe to figure out the path of the default python2/3
but msys2 python doesn't install it. This leads to it finding the
system Python and getting the wrong path.

This fixes the gobject-introspection build with meson (not the default yet..)