### PR TITLE
Revisions to the mingw-w64-python package template.

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
@@ -60,6 +60,8 @@ prepare() {
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
   done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 }
 
 # Note that build() is sometimes skipped because it's done in 
@@ -92,11 +94,15 @@ package_python3-somepackage() {
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/COPYING"
 
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
   done
+#### end section ####
 }
 
 package_python2-somepackage() {
@@ -109,11 +115,27 @@ package_python2-somepackage() {
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
 
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
     sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
   done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in somepackage; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+#### end section ####
 }
 
 package_mingw-w64-i686-python2-somepackage() {


### PR DESCRIPTION
Add export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver to prepare for setuptools-scm if necessary.  That's required for release versions (not a git repository)
Clearly denote a section in the python2 and python3 install sections for .exe's and other scripts that are deployed in the /mingw*/bin directories  Also note what needs to removed for packages that do not do this.
For python2 scripts and .exe's, add code to rename scripts and executables to avoid a name conflict with python3 packages.