### PR TITLE
gcc: install plugins for binutils

### DIFF
--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -2,6 +2,7 @@
 # Contributor: Alexey Borzenkov <snaury@gmail.com>
 # Contributor: Ray Donnelly <mingw.android@gmail.com>
 # Contributor: Renato Silva <br.renatosilva@gmail.com>
+# Contributor: wirx6 <wirx654@gmail.com>
 
 _realname=gcc
 pkgbase=mingw-w64-${_realname}
@@ -336,6 +337,10 @@ package_mingw-w64-gcc() {
   cp share/man/man7/gfdl.7*                              ${pkgdir}${MINGW_PREFIX}/share/man/man1/
   cp share/man/man7/gpl.7*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
   cp share/man/man1/g++.1*                               ${pkgdir}${MINGW_PREFIX}/share/man/man1/
+
+  # install plugins for binutils
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins
+  cp lib/gcc/${MINGW_CHOST}/${pkgver}/*plugin*.dll       ${pkgdir}${MINGW_PREFIX}/lib/bfd-plugins/
 
   # install "custom" system gdbinit
   install -D -m644 ${srcdir}/gdbinit ${pkgdir}${MINGW_PREFIX}/etc/gdbinit


### PR DESCRIPTION
*makes binutils(except ld) support lto objects by default(liblto_plugin-0.dll)
*more info [here](https://github.com/bminor/binutils-gdb/blob/master/bfd/plugin.c#L329)