### PR TITLE
python-django - packages - Note that separate PKGBUILD recipies are p…

### DIFF
--- a/mingw-w64-mingw-w64-python2-django/PKGBUILD
+++ b/mingw-w64-mingw-w64-python2-django/PKGBUILD
@@ -1,0 +1,100 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+# 1.11.13 - This version supports both Python 2 and 3, but we want only the
+# the package for Python 2 because I am providing a separate package for
+# django 2.0.7 that does not support Python 2.
+
+_realname=django
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
+pkgver=1.11.13
+pkgrel=1
+pkgdesc="A high-level Python Web framework that encourages rapid development and clean design (mingw-w64)"
+arch=('any')
+url='http://www.djangoproject.com/'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-pytz"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("Django-$pkgver.tar.gz"::"https://www.djangoproject.com/download/$pkgver/tarball/")
+sha512sums=('9552b76f693d2e47681bc24cc8ee19c9c42e194a21e578f28d1705641b2490a1d9289d9870105fb480ebd3f7ad2746b1bee8382857c55ba632192d72426ada06')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python2-build-${CARCH}| true
+  cp -r "${_realname}-${pkgver}" "python2-build-${CARCH}"
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+    msg "Python 2 build for ${CARCH}"  
+    cd "${srcdir}/python2-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+check() {
+    msg "Python 2 test for ${CARCH}"
+    cd "${srcdir}/python2-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python2 setup.py check
+}
+
+package() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-pytz")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python2-mysql: for MySQL backend"
+              "${MINGW_PACKAGE_PREFIX}-python2-psycopg2: for PostgreSQL backend")
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+  done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in django-admin; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.py
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+#### end section ####
+}
+

--- a/mingw-w64-mingw-w64-python3-django/PKGBUILD
+++ b/mingw-w64-mingw-w64-python3-django/PKGBUILD
@@ -1,0 +1,95 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+# 2.0.7 - This version does NOT support Python 2.x so we have to have
+# a separate package for django 1.11.13 for Python2.
+#
+_realname=django
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=2.0.7
+pkgrel=1
+pkgdesc="A high-level Python Web framework that encourages rapid development and clean design (mingw-w64)"
+arch=('any')
+url='http://www.djangoproject.com/'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("Django-$pkgver.tar.gz"::"https://www.djangoproject.com/download/$pkgver/tarball/")
+sha512sums=('ef42d9046ce3e7b5067c5b85114c0cb5854b0ebb1d3bae526484f11da8abbf04864c83f176e9c6e498c9140b134c9a517968c7bb0bc087c49bf105b2aae8644c')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf python3-build-${CARCH} | true
+  cp -r "${_realname}-${pkgver}" "python3-build-${CARCH}"
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  msg "Python 3 build for ${CARCH}"  
+  cd "${srcdir}/python3-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+package() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-pytz")
+  optdepends=("${MINGW_PACKAGE_PREFIX}-python3-psycopg2: for PostgreSQL backend")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+  done
+#### end section ####
+
+# for Python3 packages, you want to copy the bin files to something with 3
+# as a suffix for consistancy with Archlinux's symlink.
+#  ln -s django-admin.py "$pkgdir"/usr/bin/django-admin3.py
+#  ln -s django-admin "$pkgdir"/usr/bin/django-admin3
+
+  for f in django-admin; do
+    cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}3.exe.manifest
+    fi
+    cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}.py
+    cp "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,3}-script.py
+  done
+#### end section ####
+}
+


### PR DESCRIPTION
…rovided because the django 2.x version does not support Python 2

python2-django - 1.11.13 - new package (python2 only)
python3-django - 2.0.7 - new package (supports Python3 ONLY).