### PR TITLE
qt5-static: fix #4081

### DIFF
--- a/mingw-w64-qt5-static/0036-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
+++ b/mingw-w64-qt5-static/0036-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
@@ -10,6 +10,6 @@
 +    set(_isExe $<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>)
 +    # INTERFACE_LINK_LIBRARIES is used to pass a linker flag (-static)
 +    #                                      and a library (ws2_32)
-+    set_target_properties(Qt5::Core PROPERTIES \"INTERFACE_LINK_LIBRARIES\" \"$<${_isExe}:-static;ws2_32>\")
++    set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"$<${_isExe}:-static;ws2_32>\")
 +    unset(_isExe)
 +endif()

--- a/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,16 +1,18 @@
 diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 --- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
 +++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
-@@ -64,14 +64,17 @@
+@@ -58,14 +58,19 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
 +    if (_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES)
 +        set(_list_sep \";\")
 +    endif()
++    set_property(TARGET Qt5::Core APPEND PROPERTY
++        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
-+        \"INTERFACE_LINK_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
          \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
  !!IF !isEmpty(CMAKE_LIB_SONAME)
          \"IMPORTED_SONAME_${Configuration}\" \"$${CMAKE_LIB_SONAME}\"

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.1
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -732,13 +732,13 @@ sha256sums=('39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b'
             '7f5e092a5062db776a96ab32758ff175c3689b79902f5d9656f31029c33f66dd'
             '1ada266bc6cd033d770bc40ad879527db222563fc20cf98cf2848b84b2a0e503'
             '27e9d402126d313ff647066207038578c26a3cf0f60833ae5d76157d53712eae'
-            '29f13f7b44476bebfc5280a8481fa24926185860476ed0fd05f6b5a959b801d8'
+            '799af493e184e2e3a070e80bedf62417ff617de8f02e18b9fa20c7563dd9d93c'
             'c114d2df071b66e47f4bd43d335d48868fd5bcf9670f276b557edacd53fa92c0'
             'b9939efea7792a960cdc9404a515c6f0a1cd42ffbdb018d52f2b0206fffe17f5'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            'f5454bc38d57a734e5b36f6c54310576339628298d810628443f0a58a46e7477'
+            '5cebf00614f3bc101642ea3a2f8d14644ab75ea5168f63c2b0f5f090adc61f8a'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'

--- a/mingw-w64-qt5/0036-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
+++ b/mingw-w64-qt5/0036-qt-5.3.2-win32-qt5-static-cmake-link-ws2_32-and--static.patch
@@ -10,6 +10,6 @@
 +    set(_isExe $<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>)
 +    # INTERFACE_LINK_LIBRARIES is used to pass a linker flag (-static)
 +    #                                      and a library (ws2_32)
-+    set_target_properties(Qt5::Core PROPERTIES \"INTERFACE_LINK_LIBRARIES\" \"$<${_isExe}:-static;ws2_32>\")
++    set_property(TARGET Qt5::Core APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"$<${_isExe}:-static;ws2_32>\")
 +    unset(_isExe)
 +endif()

--- a/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,16 +1,18 @@
 diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 --- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
 +++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
-@@ -64,14 +64,17 @@
+@@ -58,14 +58,19 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
 +    if (_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES)
 +        set(_list_sep \";\")
 +    endif()
++    set_property(TARGET Qt5::Core APPEND PROPERTY
++        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
-+        \"INTERFACE_LINK_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
          \"IMPORTED_LOCATION_${Configuration}\" ${imported_location}
  !!IF !isEmpty(CMAKE_LIB_SONAME)
          \"IMPORTED_SONAME_${Configuration}\" \"$${CMAKE_LIB_SONAME}\"

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.1
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -732,13 +732,13 @@ sha256sums=('39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b'
             '7f5e092a5062db776a96ab32758ff175c3689b79902f5d9656f31029c33f66dd'
             '1ada266bc6cd033d770bc40ad879527db222563fc20cf98cf2848b84b2a0e503'
             '27e9d402126d313ff647066207038578c26a3cf0f60833ae5d76157d53712eae'
-            '29f13f7b44476bebfc5280a8481fa24926185860476ed0fd05f6b5a959b801d8'
+            '799af493e184e2e3a070e80bedf62417ff617de8f02e18b9fa20c7563dd9d93c'
             'c114d2df071b66e47f4bd43d335d48868fd5bcf9670f276b557edacd53fa92c0'
             'b9939efea7792a960cdc9404a515c6f0a1cd42ffbdb018d52f2b0206fffe17f5'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            'f5454bc38d57a734e5b36f6c54310576339628298d810628443f0a58a46e7477'
+            '5cebf00614f3bc101642ea3a2f8d14644ab75ea5168f63c2b0f5f090adc61f8a'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'


### PR DESCRIPTION
actually set INTERFACE_LINK_LIBRARIES in patch 0042
append so subsequent calls for different configurations don’t reset each other
the only thing set was IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}
and that was overridden by a non-empty INTERFACE_LINK_LIBRARIES
i believe there never was a INTERFACE_LINK_LIBRARIES_${Configuration}

don’t overwrite but append INTERFACE_LINK_LIBRARIES in patch 0036