### PR TITLE
sfml: Update to 2.5.0

### DIFF
--- a/mingw-w64-sfml/PKGBUILD
+++ b/mingw-w64-sfml/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sfml
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.4.2
-pkgrel=2
+pkgver=2.5.0
+pkgrel=1
 cmake_ver=3.9
 pkgdesc="A simple, fast, cross-platform, and object-oriented multimedia API (mingw-w64)"
 arch=('any')
@@ -19,11 +19,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-flac"
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "patch"
              "unzip")
 source=("https://www.sfml-dev.org/files/SFML-${pkgver}-sources.zip"
         mingw-w64-msys2.patch)
-sha256sums=('8ba04f6fde6a7b42527d69742c49da2ac529354f71f553409f9f821d618de4b6'
-            'd7cf7f13f76f7e77bc759616d73fc81b97552132da99005b45ef538bcfdcc338')
+sha256sums=('a821918cf7fd28d0ca03b9de3313232b2cbf212ae787d904df25be1c67be259e'
+            '39cfb22d78c8ab66fd0a282027f1f56a9dfa135795b4ee6f065d90502fe50c52')
 noextract=(SFML-${pkgver}-sources.zip)
 
 prepare() {
@@ -54,6 +55,5 @@ package() {
   cd build-${MINGW_CHOST}
   make DESTDIR="${pkgdir}" install
 
-  install -Dm644 "${srcdir}/SFML-${pkgver}/cmake/Modules/FindSFML.cmake" "${pkgdir}${MINGW_PREFIX}/share/cmake-${cmake_ver}/Modules/FindSFML.cmake"
-  install -Dm644 "${srcdir}/SFML-${pkgver}/license.txt" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  install -Dm644 "${srcdir}/SFML-${pkgver}/license.md" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
 }

--- a/mingw-w64-sfml/mingw-w64-msys2.patch
+++ b/mingw-w64-sfml/mingw-w64-msys2.patch
@@ -1,30 +1,77 @@
---- sfml/CMakeLists.txt.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/CMakeLists.txt	2017-02-10 21:22:08.957827000 +0100
-@@ -202,7 +202,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bb30b46..2c4de2f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -142,7 +142,7 @@ endif()
+ # Install directories
+ # For miscellaneous files
+ if(SFML_OS_WINDOWS OR SFML_OS_IOS)
+-    set(DEFAULT_INSTALL_MISC_DIR .)
++    set(DEFAULT_INSTALL_MISC_DIR share/SFML)
+ elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD)
+     set(DEFAULT_INSTALL_MISC_DIR share/SFML)
+ elseif(SFML_OS_MACOSX)
+@@ -269,7 +269,7 @@ if(SFML_OS_MACOSX)
      set(XCODE_TEMPLATES_ARCH "\$(NATIVE_ARCH_ACTUAL)")
  endif()
  
--if(SFML_OS_LINUX OR SFML_OS_FREEBSD)
-+if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR MINGW)
+-if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD)
++if(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_OPENBSD OR MINGW)
      set(PKGCONFIG_DIR lib${LIB_SUFFIX}/pkgconfig)
-     if(SFML_OS_FREEBSD)
+     if(SFML_OS_FREEBSD OR SFML_OS_OPENBSD)
          set(PKGCONFIG_DIR libdata/pkgconfig)
-@@ -299,11 +299,11 @@
- install(FILES license.txt DESTINATION ${INSTALL_MISC_DIR})
- install(FILES readme.txt DESTINATION ${INSTALL_MISC_DIR})
- if(NOT SFML_OS_ANDROID)
--    install(FILES cmake/Modules/FindSFML.cmake DESTINATION ${INSTALL_MISC_DIR}/cmake/Modules)
-+    install(FILES cmake/Modules/FindSFML.cmake DESTINATION ${INSTALL_COMMON_DIR}/cmake/Modules)
- endif()
+@@ -425,7 +425,7 @@ install(FILES license.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
+ install(FILES readme.md DESTINATION ${SFML_MISC_INSTALL_PREFIX})
  
  # install 3rd-party libraries and tools
 -if(SFML_OS_WINDOWS)
 +if(SFML_OS_WINDOWS AND NOT MINGW)
  
-     # install the binaries of SFML dependencies
-     if(ARCH_32BITS)
---- sfml/src/SFML/CMakeLists.txt.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/src/SFML/CMakeLists.txt	2017-02-10 21:22:08.989244600 +0100
+     if(NOT SFML_USE_SYSTEM_DEPS)
+         # install the binaries of SFML dependencies
+diff --git a/cmake/Macros.cmake b/cmake/Macros.cmake
+index be52345..ecc8f98 100644
+--- a/cmake/Macros.cmake
++++ b/cmake/Macros.cmake
+@@ -59,7 +59,7 @@ macro(sfml_add_library target)
+             # on Windows/gcc get rid of "lib" prefix for shared libraries,
+             # and transform the ".dll.a" suffix into ".a" for import libraries
+             set_target_properties(${target} PROPERTIES PREFIX "")
+-            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
++            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".dll.a")
+         endif()
+     else()
+         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index 123b44c..02755b5 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -17,7 +17,7 @@ find_package(Doxygen REQUIRED)
+ 
+ # set the input and output documentation paths
+ set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR})
+-set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/doc)
++set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/share/doc/SFML)
+ 
+ # see if we can generate the CHM documentation
+ if(SFML_OS_WINDOWS)
+diff --git a/src/SFML/Audio/CMakeLists.txt b/src/SFML/Audio/CMakeLists.txt
+index 420e13b..c4ea0b3 100644
+--- a/src/SFML/Audio/CMakeLists.txt
++++ b/src/SFML/Audio/CMakeLists.txt
+@@ -56,7 +56,7 @@ set(CODECS_SRC
+ source_group("codecs" FILES ${CODECS_SRC})
+ 
+ # let CMake know about our additional audio libraries paths (on Windows and OSX)
+-if(SFML_OS_WINDOWS)
++if(SFML_OS_WINDOWS AND NOT MINGW)
+     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/AL")
+ elseif(SFML_OS_MACOSX)
+     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/Frameworks")
+diff --git a/src/SFML/CMakeLists.txt b/src/SFML/CMakeLists.txt
+index 25a5bb1..967f593 100644
+--- a/src/SFML/CMakeLists.txt
++++ b/src/SFML/CMakeLists.txt
 @@ -3,7 +3,7 @@
  include(${PROJECT_SOURCE_DIR}/cmake/Macros.cmake)
  
@@ -34,60 +81,16 @@
      set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers")
      if(SFML_COMPILER_GCC)
          if(ARCH_32BITS)
---- sfml/src/SFML/Audio/CMakeLists.txt.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/src/SFML/Audio/CMakeLists.txt	2017-02-10 21:22:09.020324800 +0100
-@@ -56,7 +56,7 @@
- source_group("codecs" FILES ${CODECS_SRC})
- 
- # let CMake know about our additional audio libraries paths (on Windows and OSX)
--if(SFML_OS_WINDOWS)
-+if(SFML_OS_WINDOWS AND NOT MINGW)
-     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/AL")
- elseif(SFML_OS_MACOSX)
-     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} "${PROJECT_SOURCE_DIR}/extlibs/libs-osx/Frameworks")
---- sfml/src/SFML/Graphics/CMakeLists.txt.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/src/SFML/Graphics/CMakeLists.txt	2017-02-10 21:22:09.067201700 +0100
-@@ -90,7 +90,7 @@
- include_directories("${PROJECT_SOURCE_DIR}/extlibs/headers/stb_image")
+diff --git a/src/SFML/Graphics/CMakeLists.txt b/src/SFML/Graphics/CMakeLists.txt
+index 883c758..3b53b43 100644
+--- a/src/SFML/Graphics/CMakeLists.txt
++++ b/src/SFML/Graphics/CMakeLists.txt
+@@ -100,7 +100,7 @@ target_link_libraries(sfml-graphics PUBLIC sfml-window)
+ target_include_directories(sfml-graphics PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/headers/stb_image")
  
  # let CMake know about our additional graphics libraries paths
 -if(SFML_OS_WINDOWS)
 +if(SFML_OS_WINDOWS AND NOT MINGW)
-     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/jpeg")
      set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/freetype2")
  elseif(SFML_OS_MACOSX)
---- sfml/doc/CMakeLists.txt.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/doc/CMakeLists.txt	2017-02-10 21:22:09.082829700 +0100
-@@ -17,7 +17,7 @@
- 
- # set the input and output documentation paths
- set(DOXYGEN_INPUT_DIR ${PROJECT_SOURCE_DIR})
--set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/doc)
-+set(DOXYGEN_OUTPUT_DIR ${PROJECT_BINARY_DIR}/share/doc/SFML)
- 
- # see if we can generate the CHM documentation
- if(SFML_OS_WINDOWS)
---- sfml/cmake/Config.cmake.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/cmake/Config.cmake	2017-02-10 21:22:09.207835300 +0100
-@@ -114,8 +114,9 @@
- endif()
- 
- # define the install directory for miscellaneous files
-+set(INSTALL_COMMON_DIR share)
- if(SFML_OS_WINDOWS OR SFML_OS_IOS)
--    set(INSTALL_MISC_DIR .)
-+    set(INSTALL_MISC_DIR share/SFML)
- elseif(SFML_OS_LINUX OR SFML_OS_FREEBSD OR SFML_OS_MACOSX)
-     set(INSTALL_MISC_DIR share/SFML)
- elseif(SFML_OS_ANDROID)
---- sfml/cmake/Macros.cmake.orig	2017-02-08 12:29:16.000000000 +0100
-+++ sfml/cmake/Macros.cmake	2017-02-10 21:22:09.270484800 +0100
-@@ -31,7 +31,7 @@
-             # on Windows/gcc get rid of "lib" prefix for shared libraries,
-             # and transform the ".dll.a" suffix into ".a" for import libraries
-             set_target_properties(${target} PROPERTIES PREFIX "")
--            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".a")
-+            set_target_properties(${target} PROPERTIES IMPORT_SUFFIX ".dll.a")
-         endif()
-     else()
-         set_target_properties(${target} PROPERTIES DEBUG_POSTFIX -s-d)
+     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} "${PROJECT_SOURCE_DIR}/extlibs/headers/freetype2")


### PR DESCRIPTION
This change updates sfml to 2.5.0. mingw-w64-msys2.patch has been adapted to the modifications of sfml 2.5.0, and patch has been added to makedepends in PKGBUILD.