### PR TITLE
zlib 1.2.11 - drop crypto.h internal headers - Fix from Archlinux - h…

### DIFF
--- a/mingw-w64-zlib/PKGBUILD
+++ b/mingw-w64-zlib/PKGBUILD
@@ -7,7 +7,7 @@ _realname=zlib
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=1.2.11
-pkgrel=3
+pkgrel=4
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP (mingw-w64)"
 arch=('any')
 license=(ZLIB)
@@ -83,4 +83,7 @@ package() {
   make install DESTDIR="${pkgdir}"
   popd > /dev/null
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+
+# https://github.com/madler/zlib/pull/229
+  rm ${pkgdir}${MINGW_PREFIX}/include/minizip/crypt.h
 }


### PR DESCRIPTION
…ttps://github.com/madler/zlib/pull/229 for discussion