### PR TITLE
python3-jupyter-notebook: Update to 5.6.0

### DIFF
--- a/mingw-w64-python-prometheus-client/PKGBUILD
+++ b/mingw-w64-python-prometheus-client/PKGBUILD
@@ -1,0 +1,76 @@
+# Maintainer: Peter Budai <peterbudai@hotmail.com>
+
+_realname=prometheus-client
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.2.0
+pkgrel=1
+pkgdesc="Prometheus instrumentation library for Python applications (mingw-w64)"
+arch=('any')
+url="https://github.com/prometheus/client_python"
+license=('APACHE')
+
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/prometheus/client_python/archive/v${pkgver}.tar.gz")
+sha256sums=('d270837133c3e808ac66a4f5f9ae1b671296c171b23d48a509cfa38c7017376d')
+
+prepare() {
+  cd "$srcdir"/
+
+  for pver in {2,3}; do
+    rm -rf python${pver}-build-${CARCH} | true
+    cp -r "client_python-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+
+}
+
+build() {
+  for pver in {2,3}; do
+    msg "Python ${pver} build for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+#check() {
+#  for pver in {2,3}; do
+#    msg "Python ${pver} test for ${CARCH}"
+#    cd "${srcdir}/python${pver}-build-${CARCH}"
+#    ${MINGW_PREFIX}/bin/python${pver} setup.py pytest
+#  done
+#}
+
+package_python3-prometheus-client() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_python2-prometheus-client() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+}
+
+package_mingw-w64-i686-python2-prometheus-client() {
+  package_python2-prometheus-client
+}
+
+package_mingw-w64-i686-python3-prometheus-client() {
+  package_python3-prometheus-client
+}
+
+package_mingw-w64-x86_64-python2-prometheus-client() {
+  package_python2-prometheus-client
+}
+
+package_mingw-w64-x86_64-python3-prometheus-client() {
+  package_python3-prometheus-client
+}

--- a/mingw-w64-python3-jupyter-notebook/PKGBUILD
+++ b/mingw-w64-python3-jupyter-notebook/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=notebook
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.5.0
+pkgver=5.6.0
 pkgrel=1
 pkgdesc="The language-agnostic HTML notebook application for Project Jupyter"
 arch=('any')
@@ -21,6 +21,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-python3"
          "${MINGW_PACKAGE_PREFIX}-python3-tornado"
          "${MINGW_PACKAGE_PREFIX}-python3-terminado"
          "${MINGW_PACKAGE_PREFIX}-python3-send2trash"
+         "${MINGW_PACKAGE_PREFIX}-python3-prometheus-client"
 #         "${MINGW_PACKAGE_PREFIX}-mathjax"
          )
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
@@ -31,7 +32,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              )
 
 source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/notebook/archive/$pkgver.tar.gz")
-sha256sums=('9c0ad8efdd5b39f3fd7655c7b14e870fa9c5c36bf8370a4eb831522a5bd613d4')
+sha256sums=('3d5b738bea8eaef944fffe261746b063e9ca5e89257b76d5f623cce816df4864')
 
 build() {
 
@@ -48,4 +49,12 @@ package() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 COPYING.md "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+  # Remove hard coded library paths in css map files
+  local TOKEN_TOREPLACE=$(cygpath -am ${srcdir}/${_realname}-$pkgver/${_realname}/static)
+
+  pushd "${pkgdir}${MINGW_PREFIX}/lib/python3.7/site-packages/notebook/static/style/" > /dev/null
+  sed -s "s|${TOKEN_TOREPLACE}|..|g" -i ./ipython.min.css.map
+  sed -s "s|${TOKEN_TOREPLACE}|..|g" -i ./style.min.css.map
+  popd > /dev/null
 }


### PR DESCRIPTION
There is also a new dependency (`python-prometheus-client`) which I have added:
- New package: python-prometheus-client (Version: 0.2.0)
- python3-jupyter-notebook: Update to 5.6.0

due to npm issue, build python3-jupyter-notebook without logging, ie: `makepkg -sCf`