### PR TITLE
python3: fix python3-config handling of multiple arguments

### DIFF
--- a/mingw-w64-python3/0500-add-python-config-sh.patch
+++ b/mingw-w64-python3/0500-add-python-config-sh.patch
@@ -1,6 +1,5 @@
-diff -Naur Python-3.7.0-orig/Misc/python-config.sh.in Python-3.7.0/Misc/python-config.sh.in
---- Python-3.7.0-orig/Misc/python-config.sh.in	2018-06-27 06:07:35.000000000 +0300
-+++ Python-3.7.0/Misc/python-config.sh.in	2018-07-12 10:21:39.811186000 +0300
+--- Python-3.7.0/Misc/python-config.sh.in.orig	2018-06-27 05:07:35.000000000 +0200
++++ Python-3.7.0/Misc/python-config.sh.in	2018-07-27 21:58:05.397283200 +0200
 @@ -1,32 +1,44 @@
  #!/bin/sh
  
@@ -92,8 +91,7 @@ diff -Naur Python-3.7.0-orig/Misc/python-config.sh.in Python-3.7.0/Misc/python-c
      esac
  done
  
--for ARG in "$@"
-+for ARG in "$*"
+ for ARG in "$@"
  do
 -    case "$ARG" in
 +    case $ARG in

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.0
-pkgrel=10
+pkgrel=11
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -475,7 +475,7 @@ sha256sums=('0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549'
             'a14d40567e6bf6d08fab55e95a56495eb6fcdfc9d06d80b959b487df26481190'
             'a8b2096f3b4a26d32a325e778ed47cd921d40a1ef481a0387a5ff3592d5d9c77'
             '67c132e02d8bd67d9b55c7a3f17329f52ee84a588314522c5f8763bd3e175700'
-            '0aa66f597647d4e497604ec0e6a020e3ebc19f36b75a1da6a868f604198697c9'
+            '4802eceab9a147fc1cddaadf84917839edfca0b3dcd33d3be92e4c2edde3c726'
             'f0d20525f42387153cf82e2d4a3139a7b7a39a7408833c8b02e9c072a9967674'
             '8bd4dddfda38e8dae700eca868693cba3b2fb766088b46a52a4ac475e9e6b25e'
             'a88ed0a61dcb0a860286ab1d6bf489b272a670625687924943713a58c6068a94'


### PR DESCRIPTION
"python3-config --ldflags --cflags" doesn't return anything because
"$*" results in one string, not sure why this was changed in the first place.

Switch it back to "$@" which expands to multiple words.

Noticed because I wondered why this patch is needed on Windows only:
https://github.com/Alexpux/MINGW-packages/blob/master/mingw-w64-gobject-introspection/0055-fix-python-detection.patch