### PR TITLE
ngraph-gtk new upstream version 6.07.07.

### DIFF
--- a/mingw-w64-ngraph-gtk/PKGBUILD
+++ b/mingw-w64-ngraph-gtk/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=ngraph-gtk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=6.07.06
+pkgver=6.07.07
 pkgrel=1
 arch=('any')
 pkgdesc="create scientific 2-dimensional graphs (mingw-w64)"
@@ -15,12 +15,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
          "${MINGW_PACKAGE_PREFIX}-gsl"
          "${MINGW_PACKAGE_PREFIX}-ruby")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+	     "intltool"
+	     "gettext-devel")
 options=('strip' 'staticlibs')
 license=("GPL")
 url="https://htrb.github.io/ngraph-gtk/"
 source=("https://github.com/htrb/ngraph-gtk/releases/download/v${pkgver}/ngraph-gtk-${pkgver}.tar.gz")
-sha256sums=("99d13f5b79fda26793b879534df2045dc1ed31ab91631f125a3b1d93027d4bbd")
+sha256sums=("26e779e839c816e48de58d4906fcef0c67574a6f640a6b6211d502278c8ba9e0")
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}


### PR DESCRIPTION
new upstream version 6.07.07 is released.