### PR TITLE
faac: Update to 1.29.9.2

### DIFF
--- a/mingw-w64-faac/PKGBUILD
+++ b/mingw-w64-faac/PKGBUILD
@@ -3,14 +3,14 @@
 _realname=faac
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.29.7.8
+pkgver=1.29.9.2
 pkgrel=1
 pkgdesc="FAAC is an AAC audio encoder (mingw-w64)"
 arch=('any')
 url='http://www.audiocoding.com/faac.html'
 license=('GPL2')
 source=("https://downloads.sourceforge.net/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('316fff598764b93485dc5fb41379768b8c69348bbbb87e0e30ce28b1da487251')
+sha256sums=('d45f209d837c49dae6deebcdd87b8cc3b04ea290880358faecf5e7737740c771')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -20,15 +20,16 @@ prepare() {
 
 build() {
   [[ -d "${srcdir}"/build-${CARCH} ]] && rm -rf "${srcdir}"/build-${CARCH}
-  mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
-  ../${_realname}-${pkgver}/configure \
+  cp -R "${_realname}-${pkgver}" "${srcdir}"/build-${CARCH}
+  cd "${srcdir}"/build-${CARCH}
+
+  ./configure \
     --prefix=${MINGW_PREFIX} \
     --build=${MINGW_CHOST} \
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --enable-static \
-    --enable-shared \
-    --without-mp4v2
+    --enable-shared
 
   make
 }


### PR DESCRIPTION
non-srcdir build is broken, so change to a srcdir build.
Remove --without-mp4v2, that option no longer exists.