### PR TITLE
Add universal pkgbuild for cross-binutils

### DIFF
--- a/mingw-w64-x86_64-cross-binutils/PKGBUILD
+++ b/mingw-w64-x86_64-cross-binutils/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: wirx6 <wirx654@gmail.com>
+
+_realname=binutils
+_targets=(i686-elf
+          x86_64-elf
+          arm-none-eabi)
+
+pkgname=()
+for target in ${_targets[@]}
+do
+  pkgname+=(${MINGW_PACKAGE_PREFIX}-${target}-${_realname})
+done
+
+pkgver=2.31.1
+pkgrel=1
+arch=('any')
+url="https://www.gnu.org/software/binutils/"
+license=('GPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
+options=(staticlibs)
+source=("https://mirrors.kernel.org/sources.redhat.com/${_realname}/releases/${_realname}-${pkgver}.tar.bz2")
+sha256sums=('SKIP')
+
+build() {
+  for target in ${_targets[@]}
+  do
+    plain "building ${MINGW_PACKAGE_PREFIX}-${target}-${_realname}"
+
+    cd ${srcdir}
+    [[ -d build-${MINGW_CHOST}-${target} ]] && rm -rf build-${MINGW_CHOST}-${target}
+    mkdir -p build-${MINGW_CHOST}-${target} && cd build-${MINGW_CHOST}-${target}
+
+    ../${_realname}-${pkgver}/configure \
+      --build="${MINGW_CHOST}" \
+      --host="${MINGW_CHOST}" \
+      --target="${target}" \
+      --prefix="${MINGW_PREFIX}" \
+      --with-sysroot="${MINGW_PREFIX}" \
+      --disable-nls \
+      --disable-rpath \
+      --disable-werror \
+      --enable-multilib \
+      --enable-interwork
+
+    make
+  done
+}
+
+package_target() {
+  pkgdesc="GNU Tools for ${1} target - Binutils (mingw-w64)"
+  groups=("${MINGW_PACKAGE_PREFIX}-${1}-toolchain")
+
+  cd ${srcdir}/build-${MINGW_CHOST}-${1}
+  make DESTDIR=${pkgdir} install
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share/info
+}
+
+for target in ${_targets[@]}
+do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${target}-${_realname}() {
+    package_target ${target}
+  }"
+done


### PR DESCRIPTION
*multiple packages are generated from _targets array
*built tools can be used with clang or gcc in cross-compilation
*ccache can be used to speed up building this