### PR TITLE
glib2: fix stack corruption by g_stat() for 64bit build. Fixes #4134

### DIFF
--- a/mingw-w64-glib2/0001-glib2-mr-226.patch
+++ b/mingw-w64-glib2/0001-glib2-mr-226.patch
@@ -1,0 +1,37 @@
+From 631893f750746fe7d873ab6dcd63a41ac66fad0a Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 5 Aug 2018 11:21:26 +0200
+Subject: [PATCH] gstdio: use _stat64 for GStatBuf on 64bit mingw. Fixes #1476
+
+The size of stat depends on various macros on Windows which leads to
+the problem of size mismatches when glib is built with a different configuration
+than a program using it.
+
+For example the autotools build defaults to _FILE_OFFSET_BITS=64 and a program
+not defining  _FILE_OFFSET_BITS will allocate a too small struct on the stack,
+leading to stack corruption when glib writes to it.
+
+To make the size the user sees always match the default mingw build define GStatBuf
+as _stat64 (same as _FILE_OFFSET_BITS=64) under mingw+64bit.
+---
+ glib/gstdio.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/glib/gstdio.h b/glib/gstdio.h
+index 15091b3e7..94f4fa36f 100644
+--- a/glib/gstdio.h
++++ b/glib/gstdio.h
+@@ -44,6 +44,10 @@ G_BEGIN_DECLS
+ 
+ typedef struct _stat32 GStatBuf;
+ 
++#elif defined(__MINGW64_VERSION_MAJOR) && defined(_WIN64)
++
++typedef struct _stat64 GStatBuf;
++
+ #else
+ 
+ typedef struct stat GStatBuf;
+-- 
+2.17.1
+

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.56.1
-pkgrel=2
+pkgrel=3
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -33,7 +33,8 @@ source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar
         0023-print-in-binary-more-for-testing.all.patch
         0028-inode_directory.patch
         pyscript2exe.py
-        W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch)
+        W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch
+        0001-glib2-mr-226.patch)
 sha256sums=('40ef3f44f2c651c7a31aedee44259809b6f03d3d20be44545cd7d177221c0b8d'
             'ef81e82e15fb3a71bad770be17fe4fea3f4d9cdee238d6caa39807eeea5da3e3'
             '7155b0cdba60a154901336cd231dc2bfc771dc2abfd7d5a577a79c29d5facbb4'
@@ -41,7 +42,8 @@ sha256sums=('40ef3f44f2c651c7a31aedee44259809b6f03d3d20be44545cd7d177221c0b8d'
             'd1d35bb7865527422e28635ed373731e800c30ff5732c7bf8c66be37158509fb'
             'f7f06a90156fe0a308412512c359072922f7f0d19dd4bed30d863db18e48940b'
             'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3'
-            '865ee7a847a1cb44fefa8d55aab9721f5e8efa54bb4db70363771a49f7a33160')
+            '865ee7a847a1cb44fefa8d55aab9721f5e8efa54bb4db70363771a49f7a33160'
+            '9ca57bb6fded518a44c2c29b0b3aed9923b8df61ad3792baa95feb60a55acc9d')
 
 
 prepare() {
@@ -54,6 +56,9 @@ prepare() {
   patch -Np1 -i "${srcdir}"/0028-inode_directory.patch
   # https://github.com/Alexpux/MINGW-packages/issues/3584
   patch -Np1 -i "${srcdir}"/W32-gstdio-Dont-try-to-get-reparse-tag-uncondition.patch
+
+  # https://gitlab.gnome.org/GNOME/glib/merge_requests/226
+  patch -Np1 -i "${srcdir}"/0001-glib2-mr-226.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }


### PR DESCRIPTION
Patch taken from https://gitlab.gnome.org/GNOME/glib/merge_requests/226

Requires a rebuild of the affected applications.