### PR TITLE
Add libvncserver/libvncclient.

### DIFF
--- a/mingw-w64-libvncserver/PKGBUILD
+++ b/mingw-w64-libvncserver/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Michael Hansen <zrax0111 gmail com>
+
+_realname=libvncserver
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.9.11
+pkgrel=1
+pkgdesc="Cross-platform C libraries that allow you to easily implement VNC server or client functionality (mingw-w64)"
+arch=('any')
+url="https://libvnc.github.io/"
+license=('GPL2')
+depends=("${MINGW_PACKAGE_PREFIX}-libpng" "${MINGW_PACKAGE_PREFIX}-libjpeg"
+         "${MINGW_PACKAGE_PREFIX}-gnutls" "${MINGW_PACKAGE_PREFIX}-libgcrypt"
+         "${MINGW_PACKAGE_PREFIX}-openssl" "${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
+options=('strip' 'staticlibs')
+source=("https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${pkgver}.tar.gz")
+sha256sums=('193d630372722a532136fd25c5326b2ca1a636cbb8bf9bb115ef869c804d2894')
+noextract=("LibVNCServer-${pkgver}.tar.gz")
+
+prepare() {
+    # bsdtar fails to extract libvncserver's tarball on Windows, because
+    # it puts symlinks before the target.  Workaround: extract it twice!
+    bsdtar xzf LibVNCServer-${pkgver}.tar.gz || true
+    bsdtar xzf LibVNCServer-${pkgver}.tar.gz
+
+    cd ${_realname}-LibVNCServer-${pkgver}
+    autoreconf -fiv
+}
+
+build() {
+    mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+    cd "${srcdir}/build-${MINGW_CHOST}"
+    ../${_realname}-LibVNCServer-${pkgver}/configure \
+        --prefix=${MINGW_PREFIX} \
+        --build=${MINGW_CHOST} \
+        --host=${MINGW_CHOST} \
+        --target=${MINGW_CHOST} \
+        --disable-shared \
+        --enable-static \
+        --without-tightvnc-filetransfer
+
+    make
+}
+
+package() {
+    cd ${srcdir}/build-${MINGW_CHOST}
+    make DESTDIR="${pkgdir}" install
+}


### PR DESCRIPTION
Note that shared libs are disabled currently since they don't build successfully on Windows yet.