### PR TITLE
libatomic_ops: update to 7.6.6

### DIFF
--- a/mingw-w64-libatomic_ops/PKGBUILD
+++ b/mingw-w64-libatomic_ops/PKGBUILD
@@ -3,18 +3,18 @@
 _realname=libatomic_ops
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=7.6.4
+pkgver=7.6.6
 pkgrel=1
 pkgdesc="Provides semi-portable access to hardware provided atomic memory operations (mingw-w64)"
 arch=('any')
 url="http://www.hboehm.info/gc"
 license=('GPL2' 'MIT')
 source=("https://github.com/ivmai/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('5b823d5a685dd70caeef8fc50da7d763ba7f6167fe746abca7762e2835b3dd4e')
+sha256sums=('99feabc5f54877f314db4fadeb109f0b3e1d1a54afb6b4b3dfba1e707e38e074')
 
 prepare(){
   cd ${srcdir}/${_realname}-${pkgver}
-
+  
   ./autogen.sh
 }
 
@@ -27,7 +27,8 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-    --disable-static
+	--enable-shared \
+	--enable-static
   make
 }
 


### PR DESCRIPTION
This updates libatomic_ops to 7.6.6. Both shared libraries and static libraries are now built.