### PR TITLE
python-lxml: update to 4.2.4

### DIFF
--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" 
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=4.2.3
+pkgver=4.2.4
 pkgrel=1
 arch=('any')
 license=('BSD' 'custom')
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 source=(https://pypi.io/packages/source/l/lxml/${_realname}-${pkgver}.tar.gz{,.asc}
         mingw-python-fix.patch
         use-distutils-get_platform.patch)
-sha256sums=('622f7e40faef13d232fb52003661f2764ce6cdef3edb0a59af7c1559e4cc36d1'
+sha256sums=('e2afbe403090f5893e254958d02875e0732975e73c4c0cdd33c1f009a61963ca'
             'SKIP'
             'd5811e7c0be65d7e9ce59ad925466ac7dc95bdca05439be0becf2cca7bb9602a'
             'd50fefc47295d8c6eecf1ca42d03af43dc79d3debb52caf8edbed3b56df2f672')


### PR DESCRIPTION
This updates python-lxml to 4.2.4.