### PR TITLE
python-numexpr: update to 2.6.7

### DIFF
--- a/mingw-w64-python-numexpr/PKGBUILD
+++ b/mingw-w64-python-numexpr/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=numexpr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=2.6.5
-pkgrel=2
+pkgver=2.6.7
+pkgrel=1
 pkgdesc="Fast numerical array expression evaluator for Python, NumPy, PyTables, pandas (mingw-w64)"
 arch=('any')
 url="https://github.com/pydata/numexpr"
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-numpy"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/pydata/numexpr/archive/v${pkgver}.tar.gz)
-sha256sums=('fe78a78e002806e87e012b6105f3b3d52d47fc7a72bafb56341fcec7ce02cfd7')
+sha256sums=('e81a1a13656712aff072d89f49ecf905fd3c6b6722544c1decb132903c54a967')
 
 prepare() {
   cp -a ${_realname}-${pkgver} $_realname-py2-${pkgver}


### PR DESCRIPTION
This updates python-numexpr to 2.6.7.