### PR TITLE
enchant: fix relocation support

### DIFF
--- a/mingw-w64-enchant/001_fix_relocation.patch
+++ b/mingw-w64-enchant/001_fix_relocation.patch
@@ -1,0 +1,17 @@
+diff -ru enchant-2.2.3_ori/src/lib.c enchant-2.2.3/src/lib.c
+--- enchant-2.2.3_ori/src/lib.c	2018-02-04 18:00:53.000000000 +0100
++++ enchant-2.2.3/src/lib.c	2018-08-14 16:26:44.587391300 +0200
+@@ -1006,6 +1006,13 @@
+ {
+ 	g_return_val_if_fail (g_module_supported (), NULL);
+
++#ifdef G_OS_WIN32
++    // gnulib's relocation does not work properly on win32 without setting the prefix explicitly
++    gchar *module_dir = g_win32_get_package_installation_directory_of_module(NULL);
++    enchant_set_prefix_dir(module_dir);
++    g_free(module_dir);
++#endif
++
+ 	EnchantBroker *broker = g_new0 (EnchantBroker, 1);
+ 	broker->dict_map = g_hash_table_new_full (g_str_hash, g_str_equal,
+ 						  g_free, enchant_dict_destroyed);

--- a/mingw-w64-enchant/PKGBUILD
+++ b/mingw-w64-enchant/PKGBUILD
@@ -5,7 +5,7 @@ _realname=enchant
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.2.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Enchanting Spell Checking Library (mingw-w64)"
 arch=('any')
 url="https://abiword.github.io/enchant/"
@@ -17,10 +17,14 @@ depends=(${MINGW_PACKAGE_PREFIX}-gcc-libs
          ${MINGW_PACKAGE_PREFIX}-hunspell
          ${MINGW_PACKAGE_PREFIX}-libvoikko)
 options=('!libtool' 'strip' '!debug' '!makeflags')
-source=("${_realname}-${pkgver}.tar.gz::https://github.com/AbiWord/enchant/archive/v${pkgver}.tar.gz")
-sha256sums=('f2c3e8d4afacf904a0e7eff349593719f01cdd646992e46d06f7ea355a5e1095')
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/AbiWord/enchant/archive/v${pkgver}.tar.gz"
+        001_fix_relocation.patch)
+sha256sums=('f2c3e8d4afacf904a0e7eff349593719f01cdd646992e46d06f7ea355a5e1095'
+            '2e9db75d668ad80c6867e8b32fdd966d1d569f509268b1332f439dd4f0575c43')
 
 prepare() {
+  patch -p0 -i ${srcdir}/001_fix_relocation.patch
+
   cd "${srcdir}/${_realname}-${pkgver}"
   ./bootstrap
 }
@@ -35,6 +39,7 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
+    --enable-relocatable \
     --with-ispell \
     --with-myspell \
     --with-aspell \


### PR DESCRIPTION
This fixes relocation support of enchant which was not working since the update to enchant-2 (#4008) and therefore rendered this package useless.