### PR TITLE
python-pystemmer: rebuild, fix build

### DIFF
--- a/mingw-w64-python-pystemmer/PKGBUILD
+++ b/mingw-w64-python-pystemmer/PKGBUILD
@@ -5,13 +5,15 @@ _realname=pystemmer
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Snowball stemming algorithms, for information retrieval (mingw-w64)"
 arch=('any')
 url="http://snowball.tartarus.org"
 license=('MIT' 'BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-cython2"
+             "${MINGW_PACKAGE_PREFIX}-cython"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
@@ -20,19 +22,22 @@ sha256sums=('d1ac14eb64978c1697fcfba76e3ac7ebe24357c9428e775390f634648947cb91')
 
 prepare() {  
   cd "${srcdir}"
-  for pver in {2,3}; do 
+  # Force cython rebuild
+  rm "${_pyname}-${pkgver}/src/Stemmer.c"
+
+  for pver in {2,3}; do
     rm -rf python${pver}-build-${CARCH} | true
     cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
-  done  
-}  
+  done
+}
   
 build() {
   cd "${srcdir}"
-  for pver in {2,3}; do  
-    msg "Python ${pver} build for ${CARCH}"  
+  for pver in {2,3}; do
+    msg "Python ${pver} build for ${CARCH}"
     cd "${srcdir}/python${pver}-build-${CARCH}"
     ${MINGW_PREFIX}/bin/python${pver} setup.py build
-  done  
+  done
 }
 
 package_python3-pystemmer() {


### PR DESCRIPTION
This rebuilds python-pystemmer against python 3.7, while adding cython to makedepends to fix building.