### PR TITLE
python-hypothesis: update to 3.67.1

### DIFF
--- a/mingw-w64-python-hypothesis/PKGBUILD
+++ b/mingw-w64-python-hypothesis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=hypothesis
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.66.1
+pkgver=3.67.1
 pkgrel=1
 pkgdesc="Advanced Quickcheck style testing library for Python (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python2-pandas")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/HypothesisWorks/hypothesis/archive/hypothesis-python-$pkgver.tar.gz")
-sha512sums=('b979e6c15a7a7c6f96f9addd49f4e308bd8d9e962187587508c332843d81acdb5ba490d7430fd10c703f013a3b250d5302fbc279d99ba89a2dcb20dc0efcbb26')
+sha512sums=('deffd43bab558e6b23cc929fee72281081113048b7b34d102a815d56bb97d3cffbb21003ab158741a22eea3fd18766ae91641423d81de52c38c7e412977839e2')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
This updates python-hypothesis to 3.67.1.