### PR TITLE
python-pillow: update to 5.2.0

### DIFF
--- a/mingw-w64-python-pillow/PKGBUILD
+++ b/mingw-w64-python-pillow/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=Pillow
 pkgbase=mingw-w64-python-pillow
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-pillow" "${MINGW_PACKAGE_PREFIX}-python3-pillow")
-pkgver=5.1.0
-pkgrel=2
+pkgver=5.2.0
+pkgrel=1
 arch=('any')
 license=('custom')
 url="https://github.com/python-pillow/Pillow/"
@@ -25,7 +25,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/python-pillow/Pillow/a
         001-freeze-support.patch
         002-shared-openjpeg.patch
         dlopen-fix.patch)
-sha256sums=('de34dfb23981fd94fa8b4b3b5fd3641082de9e618b2a8bbd66ce846d09eba9a0'
+sha256sums=('26dfdcc23186f82139e9e6c0bd46828e5d1ba15463b9e35e32bd017ad0003c44'
             '6865da61534a45645fff71e139226bbce00c636a5f82ef824d13ad5a22efaac5'
             '581387337db4c6c0a7dae05d6462da92f47e822bd6b482a7a4e7c8637ca7e9f2'
             '46d7a5c146ec4cc7d0f359f0875570132ce70fec4836281976da586478a09258')


### PR DESCRIPTION
This updates python-pillow to 5.2.0.