### PR TITLE
libatomic_ops: replace tabs with spaces

### DIFF
--- a/mingw-w64-libatomic_ops/PKGBUILD
+++ b/mingw-w64-libatomic_ops/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libatomic_ops
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=7.6.6
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides semi-portable access to hardware provided atomic memory operations (mingw-w64)"
 arch=('any')
 url="http://www.hboehm.info/gc"
@@ -27,8 +27,8 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --prefix=${MINGW_PREFIX} \
-	--enable-shared \
-	--enable-static
+    --enable-shared \
+    --enable-static
   make
 }
 


### PR DESCRIPTION
This replaces erroneous tabs with spaces for the PKGBUILD for libatomic_ops.