### PR TITLE
python-certifi: update to 2018.8.13

### DIFF
--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=certifi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2018.4.16
-pkgrel=2
+pkgver=2018.8.13
+pkgrel=1
 pkgdesc="Python package for providing Mozilla's CA Bundle (mingw-w64)"
 url='https://pypi.python.org/pypi/certifi'
 license=('GPL')
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
             )
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7')
+sha256sums=('4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-certifi to 2018.8.13.