### PR TITLE
python-more-itertools: update to 4.3.1

### DIFF
--- a/mingw-w64-python-more-itertools/PKGBUILD
+++ b/mingw-w64-python-more-itertools/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=more-itertools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.2.0
-pkgrel=2
+pkgver=4.3.1
+pkgrel=1
 pkgdesc="More routines for operating on iterables, beyond itertools (mingw-w64)"
 arch=('any')
 url="https://github.com/erikrose/more-itertools"
@@ -16,8 +16,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-six"
              "${MINGW_PACKAGE_PREFIX}-python3-six")
 options=('staticlibs' 'strip' '!debug')
-source=("${_realname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/source/m/more-itertools/${_realname}-${pkgver}.tar.gz")
-sha256sums=('2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/erikrose/more-itertools/archive/${pkgver}.tar.gz")
+sha256sums=('ad2a4f23bb8a45015a887d450ec995daf9da46a100a56432702a91c43a859b70')
 
 prepare() {  
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-more-itertools to 4.3.1.