### PR TITLE
python-pytest: update to 3.7.1

### DIFF
--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -4,8 +4,8 @@ _pyname=pytest
 _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.6.3
-pkgrel=3
+pkgver=3.7.1
+pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
 license=('MIT')
@@ -43,7 +43,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis"
 #              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/pytest/archive/${pkgver}.tar.gz")
-sha256sums=('0851e855cc6c263f1329e010cec8edd623d61476a9f2e5462e64b42121a266a0')
+sha256sums=('0278e5ea00a1b252521826ee9a26b9cddff9c7b3e800357e50c4d291ddf8ff48')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-pytest to 3.7.1.