### PR TITLE
python-cryptography: update to 2.3.1

### DIFF
--- a/mingw-w64-python-cryptography/PKGBUILD
+++ b/mingw-w64-python-cryptography/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=cryptography
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.2.2
-pkgrel=2
+pkgver=2.3.1
+pkgrel=1
 pkgdesc="A package designed to expose cryptographic recipes and primitives to Python developers (mingw-w64)"
 url='https://pypi.org/project/cryptography/'
 license=('Apache')
@@ -36,7 +36,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner"
               "${MINGW_PACKAGE_PREFIX}-python2-pytz"
               "${MINGW_PACKAGE_PREFIX}-python3-pytz")
 source=(https://pypi.io/packages/source/c/cryptography/${_realname}-${pkgver}.tar.gz)
-sha256sums=('9fc295bf69130a342e7a19a39d7bbeb15c0bcaabc7382ec33ef3b2b7d18d2f63')
+sha256sums=('8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-cryptography to 2.3.1.