### PR TITLE
two packages where one depends upon the other.

### DIFF
--- a/mingw-w64-harfbuzz/PKGBUILD
+++ b/mingw-w64-harfbuzz/PKGBUILD
@@ -5,7 +5,7 @@ _realname=harfbuzz
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.8.8
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine (mingw-w64)"
 arch=('any')
 url="https://www.freedesktop.org/wiki/Software/HarfBuzz"
@@ -15,11 +15,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-cairo"
-             "${MINGW_PACKAGE_PREFIX}-python2")
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-ragel")
 depends=("${MINGW_PACKAGE_PREFIX}-freetype"
          "${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-glib2"
          "${MINGW_PACKAGE_PREFIX}-graphite2")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-fonttools" 
+              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 options=('strip' 'staticlibs')
 optdepends=("${MINGW_PACKAGE_PREFIX}-icu: harfbuzz-icu support"
             "${MINGW_PACKAGE_PREFIX}-cairo: hb-view program")
@@ -50,6 +53,8 @@ build() {
     --enable-static=yes \
     --enable-introspection \
     --with-graphite2=yes \
+    --with-uniscribe=yes \
+    --with-directwrite=yes \
     --with-gobject
   make
   popd
@@ -65,6 +70,8 @@ build() {
     --enable-static=no \
     --enable-introspection \
     --with-graphite2=yes \
+    --with-uniscribe=yes \
+    --with-directwrite=yes \
     --with-gobject
   make
   popd

--- a/mingw-w64-python-fonttools/PKGBUILD
+++ b/mingw-w64-python-fonttools/PKGBUILD
@@ -1,0 +1,177 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=fonttools
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=3.29.0
+pkgrel=1
+pkgdesc="Converts OpenType and TrueType fonts to and from XML (mingw-w64)"
+arch=('any')
+url='https://github.com/fonttools/fonttools'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python2-numpy"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=(""https://github.com/fonttools/fonttools/releases/download/${pkgver}/fonttools-${pkgver}.zip"")
+sha256sums=('aab38c8c131670684321437d4857dcb4de1c775efd152a9ca9c4d81f1cb97fe7')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+#Enable tests when the dependencies are solved
+#check() {
+#  for pver in {2,3}; do
+#    msg "Python ${pver} test for ${CARCH}"
+#    cd "${srcdir}/python${pver}-build-${CARCH}"
+#    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+#  done
+#}
+
+package_python3-fonttools() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-numpy")
+  install=${_realname}3-${CARCH}.install
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _ff in ${pkgdir}${MINGW_PREFIX}/bin/*.py; do
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_ff}
+  done
+
+  install -D -m755 LICENSE "$pkgdir"${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE
+  chmod oga+r "$pkgdir"${MINGW_PREFIX}/share/man/man1/ttx.1
+}
+
+package_python2-fonttools() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-numpy")
+  install=${_realname}2-${CARCH}.install
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _ff in ${pkgdir}${MINGW_PREFIX}/bin/*.py; do
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_ff}
+  done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in fonttools; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+
+  for f in pyftinspect; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+
+  for f in pyftmerge; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+
+  for f in pyftsubset; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+
+  for f in ttx; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+    mv "${pkgdir}${MINGW_PREFIX}"/share/man/man1/${f}{,2}.1
+  done
+
+#### end section ####
+  install -D -m755 LICENSE "$pkgdir"${MINGW_PREFIX}/share/licenses/$pkgname/LICENSE
+  chmod oga+r "$pkgdir"${MINGW_PREFIX}/share/man/man1/ttx2.1
+}
+
+package_mingw-w64-i686-python2-fonttools() {
+  package_python2-fonttools
+}
+
+package_mingw-w64-i686-python3-fonttools() {
+  package_python3-fonttools
+}
+
+package_mingw-w64-x86_64-python2-fonttools() {
+  package_python2-fonttools
+}
+
+package_mingw-w64-x86_64-python3-fonttools() {
+  package_python3-fonttools
+}

--- a/mingw-w64-python-fonttools/fonttools2-i686.install
+++ b/mingw-w64-python-fonttools/fonttools2-i686.install
@@ -1,0 +1,30 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in fonttools2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftinspect2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftmerge2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftsubset2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in ttx2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-fonttools/fonttools2-x86_64.install
+++ b/mingw-w64-python-fonttools/fonttools2-x86_64.install
@@ -1,0 +1,30 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in fonttools2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftinspect2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftmerge2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftsubset2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in ttx2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-fonttools/fonttools3-i686.install
+++ b/mingw-w64-python-fonttools/fonttools3-i686.install
@@ -1,0 +1,30 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in fonttools; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftinspect; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftmerge; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in pyftsubset; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+  for _it in ttx; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-fonttools/fonttools3-x86_64.install
+++ b/mingw-w64-python-fonttools/fonttools3-x86_64.install
@@ -1,0 +1,30 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in fonttools; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftinspect; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftmerge; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in pyftsubset; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+  for _it in ttx; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
mingw-w64-harfbuzz - 1.8.8 - add python3-fonttools  as a test dependency - compile with both Uniscribe and DirectWrite support options
mingw-w64-python-fonttools - 3.29 - Converts OpenType and TrueType fonts to and from XML