### PR TITLE
python-scandir: update to 1.9.0

### DIFF
--- a/mingw-w64-python-scandir/PKGBUILD
+++ b/mingw-w64-python-scandir/PKGBUILD
@@ -4,8 +4,8 @@ _realname=scandir
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
-pkgver=1.7
-pkgrel=2
+pkgver=1.9.0
+pkgrel=1
 pkgdesc="A better directory iterator and faster os.walk() (mingw-w64)"
 url="https://github.com/benhoyt/scandir"
 arch=('any')
@@ -13,7 +13,7 @@ license=('BSD')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/benhoyt/scandir/archive/v${pkgver}.tar.gz)
-sha256sums=('76dd7b2ea15cad53b595ef334fffaeaa61c0da1c40d453eefd2dfe21fd0aaa0e')
+sha256sums=('813f19f975df2c2f496d431496ac831d1cb592b66f7826b22beaeb1186808f73')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-scandir to 1.9.0.