### PR TITLE
python-reportlab: update to 3.5.5

### DIFF
--- a/mingw-w64-python-reportlab/PKGBUILD
+++ b/mingw-w64-python-reportlab/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=reportlab
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.5.1
+pkgver=3.5.5
 pkgrel=1
 pkgdesc="A proven industry-strength PDF generating solution (mingw-w64)"
 arch=('any')
@@ -17,10 +17,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-pip"
              "${MINGW_PACKAGE_PREFIX}-python2-Pillow"
              "${MINGW_PACKAGE_PREFIX}-python3-Pillow")
-_dtoken="07/1c/77adf127977d727a9a25d35497285d36b42d52a7ae5897eba02640834da4"
+_dtoken="20/79/533165435ad718d6ab3cc5ec40c1ac31654809db8f6510329b5eb2ef50fd"
 source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz"
         "0001-Do-not-specialcase-quote-LIBART_VERSION-on-Windows.patch")
-sha256sums=('5345494df4f1563fdab5597f7f543eae44c0aeecce05bd4d93c199f34c4b8c0c'
+sha256sums=('d18485c5b7561519138fd94a29239d8361cb3e204d38342f98f40c8d7774b4a5'
             '084b3574f7cb83dc7c9412b9976d672fda0f5f20cef6c6f6b66a6cefc31220ef')
 
 prepare() {


### PR DESCRIPTION
This updates python-reportlab to 3.5.5.