### PR TITLE
gtk-vnc: update to 0.9.0

### DIFF
--- a/mingw-w64-gtk-vnc/PKGBUILD
+++ b/mingw-w64-gtk-vnc/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gtk-vnc
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.7.1
+pkgver=0.9.0
 pkgrel=1
 arch=('any')
 pkgdesc="VNC viewer widget for GTK+ (mingw-w64)"
@@ -24,7 +24,7 @@ license=("GPL 2.1")
 url="https://www.gnome.org"
 source=(https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         001-win.patch)
-sha256sums=('f34baa696615ef67666e8465b4d0ac563355e999a77d2cc42ad4625a24f7aab1'
+sha256sums=('3a9a88426809a5df2c14353cd9839b8c8163438cb708b31d8048c79d180fcab7'
             '503b12e64f6d843fd018e00e3b3221511656d03905516a80a410d44a2deccd40')
 
 prepare() {


### PR DESCRIPTION
This updates gtk-vnc to 0.9.0.