### PR TITLE
gdcm: update to 2.8.7

### DIFF
--- a/mingw-w64-gdcm/PKGBUILD
+++ b/mingw-w64-gdcm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=gdcm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.8.6
+pkgver=2.8.7
 pkgrel=1
 pkgdesc="The Grassroots DICOM library (mingw-w64)"
 arch=('any')
@@ -24,7 +24,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 options=('staticlibs' 'strip')
 source=("https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%20${pkgver}/gdcm-${pkgver}.tar.bz2"
         0003-fix-mingw-build.patch)
-sha256sums=('5e5ecddf52f7a886a0c24b146dff258d863a9671a59a372eb3dbcebbb1e0071f'
+sha256sums=('c25067536cad1d0482700dd525822054514b13ad05239faa94d0c111412654df'
             '31ffa7a0c1f367d5e1f0502055b804d902de3816c46b7d36ee7e62d812948605')
 
 prepare() {


### PR DESCRIPTION
This updates gdcm to 2.8.7.