### PR TITLE
pycairo: update to 1.17.1

### DIFF
--- a/mingw-w64-pycairo/PKGBUILD
+++ b/mingw-w64-pycairo/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pycairo
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-cairo" "${MINGW_PACKAGE_PREFIX}-python3-cairo")
-pkgver=1.17.0
-pkgrel=2
+pkgver=1.17.1
+pkgrel=1
 pkgdesc="Python bindings for the cairo graphics library (mingw-w64)"
 url="https://pycairo.readthedocs.io"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest"
               "${MINGW_PACKAGE_PREFIX}-python2-pytest")
 source=(https://github.com/pygobject/${_realname}/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.gz)
-sha256sums=('cdd4d1d357325dec3a21720b85d273408ef83da5f15c184f2eff3212ff236b9f')
+sha256sums=('0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This updates pycairo to 1.17.1.