### PR TITLE
protobuf: update to 3.6.1

### DIFF
--- a/mingw-w64-protobuf/PKGBUILD
+++ b/mingw-w64-protobuf/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=protobuf
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.6.0.1
+pkgver=3.6.1
 pkgrel=1
 pkgdesc="Protocol Buffers - Google's data interchange format (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ options=('staticlibs' 'strip')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/google/protobuf/archive/v${pkgver}.tar.gz
         googletest-release-1.8.0.tar.gz::https://github.com/google/googletest/archive/release-1.8.0.tar.gz
         0001-protobuf-3.1.0-gcc6.2.0-tests.patch)
-sha256sums=('1144ef1fa9c50d3c04880f363b988df6ca6a66e337a945f1661cf4256ffba749'
+sha256sums=('3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b'
             '58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8'
             '15c2248597356040be0111d5bfc7317d59a49552d5cd05b0fa70c76980b7ca66')
 


### PR DESCRIPTION
This updates protobuf to 3.6.1.