### PR TITLE
gtk2: add patch from GIMP project

### DIFF
--- a/mingw-w64-gtk2/0013_fix_mouse_events.patch
+++ b/mingw-w64-gtk2/0013_fix_mouse_events.patch
@@ -1,0 +1,32 @@
+--- a/gdk/win32/gdkwindow-win32.c
++++ b/gdk/win32/gdkwindow-win32.c
+@@ -2767,6 +2767,10 @@ _gdk_windowing_window_at_pointer (GdkDisplay *display,
+        * WindowFromPoint() can find our windows, we follow similar logic
+        * here, and ignore invisible and disabled windows.
+        */
++      UINT cwp_flags = CWP_SKIPDISABLED  |
++                       CWP_SKIPINVISIBLE |
++                       CWP_SKIPTRANSPARENT;
++
+       hwnd = GetDesktopWindow ();
+       do {
+         window = gdk_win32_handle_table_lookup ((GdkNativeWindow) hwnd);
+@@ -2777,8 +2781,7 @@ _gdk_windowing_window_at_pointer (GdkDisplay *display,
+           break;
+ 
+         screen_to_client (hwnd, screen_pt, &client_pt);
+-        hwndc = ChildWindowFromPointEx (hwnd, client_pt, CWP_SKIPDISABLED  |
+-                                                         CWP_SKIPINVISIBLE);
++        hwndc = ChildWindowFromPointEx (hwnd, client_pt, cwp_flags);
+ 
+ 	/* Verify that we're really inside the client area of the window */
+ 	if (hwndc != hwnd)
+@@ -2789,6 +2792,8 @@ _gdk_windowing_window_at_pointer (GdkDisplay *display,
+ 	      hwndc = hwnd;
+ 	  }
+ 
++        /* Only ignore top-level transparent windows */
++        cwp_flags &= ~CWP_SKIPTRANSPARENT;
+       } while (hwndc != hwnd && (hwnd = hwndc, 1));
+ 
+     }

--- a/mingw-w64-gtk2/PKGBUILD
+++ b/mingw-w64-gtk2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gtk2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.24.32
-pkgrel=1
+pkgrel=2
 pkgdesc="GTK+ is a multi-platform toolkit (v2) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -39,6 +39,7 @@ source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar
         0010-put-gtk-dll-into-path.mingw.patch
         0011-gir-for-gdkwin32.mingw.patch
         0012-embed-manifest.all.patch
+        0013_fix_mouse_events.patch
         0019_use_g_stat_and_gstatbuf.patch)
 
 sha256sums=('b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e'
@@ -51,6 +52,7 @@ sha256sums=('b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e'
             '75f3bd1098c39ccf881508f4c9d23278465bcfe15beaed4bed2af4b00efa00f3'
             '10569e2bc2afe6ab320dcb4b0e708ddd8235244ec0daff05ca518cb8463f2924'
             '4bc70de68084585dcf2b5a7e4abe32a789360fc2be97a9c94ba3b52dac89ad93'
+            'f6d731acecf6e35e4ec9739a6d949d2d045c9396c4564283ee6ec935ec690e24'
             '2903708fda7b9f306a6a7b7b41518ce7a9ac7b9e622d4a1eed9ce30b945d5971')
 
 prepare() {
@@ -63,6 +65,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0010-put-gtk-dll-into-path.mingw.patch
   patch -p1 -i ${srcdir}/0011-gir-for-gdkwin32.mingw.patch
   #patch -p1 -i ${srcdir}/0012-embed-manifest.all.patch
+  patch -p1 -i ${srcdir}/0013_fix_mouse_events.patch
   patch -p1 -i ${srcdir}/0019_use_g_stat_and_gstatbuf.patch
 
   autoreconf -fi


### PR DESCRIPTION
This prevents transparent top-level windows from intercepting mouse events as often the case with screen capturing software (e.g, Skype), see https://bugzilla.gnome.org/show_bug.cgi?id=780979