### PR TITLE
python-greenlet: update to 0.4.14

### DIFF
--- a/mingw-w64-python-greenlet/PKGBUILD
+++ b/mingw-w64-python-greenlet/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=greenlet
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.4.13
-pkgrel=2
+pkgver=0.4.14
+pkgrel=1
 pkgdesc="Lightweight in-process concurrent programming (mingw-w64)"
 arch=('any')
 url="https://pypi.python.org/pypi/greenlet"
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz::https://files.pythonhosted.org/packages/source/g/greenlet/${_realname}-${pkgver}.tar.gz")
-sha256sums=('0fef83d43bf87a5196c91e73cb9772f945a4caaff91242766c5916d1dd1381e4')
+sha256sums=('f1cc268a15ade58d9a0c04569fe6613e19b8b0345b64453064e2c3c6d79051af')
 
 prepare() {  
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-greenlet to 0.4.14.