### PR TITLE
python-gmpy2 - 2.1.0a2 - Fix issue with bsdtar not handling symlinks …

### DIFF
--- a/mingw-w64-python-gmpy2/PKGBUILD
+++ b/mingw-w64-python-gmpy2/PKGBUILD
@@ -4,12 +4,11 @@ _realname=gmpy2
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2.1.0a2
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides C-coded Python modules for fast multiple-precision arithmetic. (mingw-w64)"
 arch=('any')
 url='https://github.com/aleaxit/gmpy'
 license=('LGPL2.1')
-validpgpkeys=('gpg_KEY')
 makedepends=("${MINGW_PACKAGE_PREFIX}-mpc"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
@@ -18,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-mpc"
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/aleaxit/gmpy/archive/${_realname}-$pkgver.tar.gz"
         "gmpy2-cython.patch"::"https://github.com/aleaxit/gmpy/commit/cb0d591e.patch")
-
+noextract=("${_realname}-$pkgver.tar.gz")
 sha256sums=('54702d5da8a5e0b074c9e34da49737027205f3aaf034d22d8b049adb553169a9'
             '457e29bc4441a868eabd5a1f2a45316d13b96e949c2616237f2700e5d3d5bf6c')
 
@@ -43,7 +42,13 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}"
+# bsd tar does not handle the symlinks in the distribution file
+# at least if you don't have admin privilleges.  This is just a workaround
+# for that.
+  tar zxf "${_realname}-$pkgver.tar.gz" || true
   pushd "gmpy-${_realname}-${pkgver}"
+  cp src/gmpy2.h gmpy2/gmpy2.h
+  cp src/gmpy2.pxd gmpy2/gmpy2.pxd
   apply_patch_with_msg gmpy2-cython.patch
   popd
   for builddir in python{2,3}-build-${CARCH}; do
@@ -96,8 +101,6 @@ package_python2-gmpy2() {
 
   install -d -m 755 $pkgdir${MINGW_PREFIX}//share/doc/python2-${_realname}
   install -m 644 -t $pkgdir${MINGW_PREFIX}//share/doc/python2-${_realname} docs/*
-
-
 }
 
 package_mingw-w64-i686-python2-gmpy2() {


### PR DESCRIPTION
…in distribution.