### PR TITLE
ruby-cairo: update to 1.15.14

### DIFF
--- a/mingw-w64-ruby-cairo/PKGBUILD
+++ b/mingw-w64-ruby-cairo/PKGBUILD
@@ -4,7 +4,7 @@ _gemname=cairo
 _realname=ruby-${_gemname}
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.15.12
+pkgver=1.15.14
 pkgrel=1
 pkgdesc="Ruby bindings for cairo (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-ruby"
 makedepends=("${MINGW_PACKAGE_PREFIX}-ruby-native-package-installer")
 source=("https://rubygems.org/downloads/${_gemname}-${pkgver}.gem")
 noextract=("${_gemname}-${pkgver}.gem")
-sha256sums=('c4f3240a3da1ff3962ab30bd58f17c717ad5b1cee89744a34f0442bdfbce26ea')
+sha256sums=('1620cb64f36f2c7ce63ad1c8ddbdba5e0a9472950e68e92e95489e082ae94301')
 
 package() {
   local _gemdir="$(ruby -e'puts Gem.default_dir')"


### PR DESCRIPTION
This updates ruby-cairo to 1.15.14.