### PR TITLE
python-ndg-httpsclient: update to 0.5.1

### DIFF
--- a/mingw-w64-python-ndg-httpsclient/PKGBUILD
+++ b/mingw-w64-python-ndg-httpsclient/PKGBUILD
@@ -4,8 +4,8 @@ _pyname=ndg_httpsclient
 _realname=ndg-httpsclient
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.5.0
-pkgrel=2
+pkgver=0.5.1
+pkgrel=1
 pkgdesc="Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL (mingw-w64)"
 url='https://pypi.python.org/pypi/ndg-httpsclient'
 license=('BSD')
@@ -16,9 +16,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-pyasn1"
              "${MINGW_PACKAGE_PREFIX}-python2-pyopenssl"
              "${MINGW_PACKAGE_PREFIX}-python3-pyopenssl")
-#_dtoken="6c/dd/4d4f1ad1158830b364beee70cb59f651018f36de24da80e52e47f80bc19f"
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/n/${_realname}/${_pyname}-${pkgver}.tar.gz")
-sha256sums=('c009f5430790936b3a97eaf9f968516664d97e146ab2bda991f0caadb7cc088b')
+sha256sums=('d72faed0376ab039736c2ba12e30695e2788c4aa569c9c3e3d72131de2592210')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-ndg-httpsclient to 0.5.1.