### PR TITLE
Fix issue where the wrong OpenJPEG configuration file was found causi…

### DIFF
--- a/mingw-w64-poppler/PKGBUILD
+++ b/mingw-w64-poppler/PKGBUILD
@@ -4,7 +4,7 @@ _realname=poppler
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.68.0
-pkgrel=1
+pkgrel=2
 pkgdesc="PDF rendering library based on xpdf 3.0 (mingw-w64)"
 arch=('any')
 url="https://poppler.freedesktop.org/"
@@ -53,11 +53,17 @@ build() {
   [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
   mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
 
+#If you have both OpenJPEG and OpenJPEG2, cmake will find OpenJPEG
+#instead of OpenJPEG2.
+  local OPENJP2=$(cygpath -m ${MINGW_PREFIX}/lib/openjpeg-2.3)
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   "${MINGW_PREFIX}/bin/cmake.exe" -Wno-dev \
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+    -DTESTDATADIR="${MINGW_PREFIX}/share/poppler" \
     -DENABLE_XPDF_HEADERS=ON \
+    -DOpenJPEG_DIR="${OPENJP2}" \
     -DENABLE_GTK_DOC=OFF \
     ../${_realname}-${pkgver}
 


### PR DESCRIPTION
…ng cmake to fail.  I also specified where the data is located.