### PR TITLE
python-reportlab: update to 3.5.6

### DIFF
--- a/mingw-w64-python-reportlab/PKGBUILD
+++ b/mingw-w64-python-reportlab/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=reportlab
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.5.5
+pkgver=3.5.6
 pkgrel=1
 pkgdesc="A proven industry-strength PDF generating solution (mingw-w64)"
 arch=('any')
@@ -17,10 +17,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-pip"
              "${MINGW_PACKAGE_PREFIX}-python2-Pillow"
              "${MINGW_PACKAGE_PREFIX}-python3-Pillow")
-_dtoken="20/79/533165435ad718d6ab3cc5ec40c1ac31654809db8f6510329b5eb2ef50fd"
+_dtoken="70/4c/19fe74b800e7d74b3dd636137aac6e8df4b19286e318c1a5b6d8ca4b17fd"
 source=("https://pypi.python.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz"
         "0001-Do-not-specialcase-quote-LIBART_VERSION-on-Windows.patch")
-sha256sums=('d18485c5b7561519138fd94a29239d8361cb3e204d38342f98f40c8d7774b4a5'
+sha256sums=('3836a49e7ea7bce458f437cbc094633c7fd4ac027180565875c18ecc726f261e'
             '084b3574f7cb83dc7c9412b9976d672fda0f5f20cef6c6f6b66a6cefc31220ef')
 
 prepare() {


### PR DESCRIPTION
This updates python-reportlab to 3.5.6.