### PR TITLE
gpgme: make mkdefsinc use CPPFLAGS

### DIFF
--- a/mingw-w64-gpgme/0007-mkdefsinc-use-CPPFLAGS.patch
+++ b/mingw-w64-gpgme/0007-mkdefsinc-use-CPPFLAGS.patch
@@ -1,0 +1,11 @@
+--- a/doc/Makefile.am	2016-08-10 20:19:02.000000000 +0600
++++ b/doc/Makefile.am	2018-08-15 14:54:01.497955600 +0600
+@@ -34,7 +34,7 @@
+ gpgme.texi : defs.inc
+ 
+ mkdefsinc: mkdefsinc.c Makefile ../config.h
+-	$(CC_FOR_BUILD) -I. -I.. -I$(srcdir) $(AM_CPPFLAGS) \
++	$(CC_FOR_BUILD) -I. -I.. -I$(srcdir) $(AM_CPPFLAGS) $(CPPFLAGS) \
+ 	   -o $@ $(srcdir)/mkdefsinc.c
+ 
+ dist-hook: defsincdate

--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gpgme
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.11.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
 arch=('any')
 url="https://gnupg.org/related_software/gpgme/"
@@ -25,7 +25,8 @@ options=('!emptydirs') # '!strip' 'debug')
 source=("https://www.gnupg.org/ftp/gcrypt/${_realname}/${_realname}-${pkgver}.tar.bz2"{,.sig}
         0004-gpgme-find-gnupg.patch
         0005-invoke-scripts-via-sh.patch
-        0006-fix-building-docs.patch)
+        0006-fix-building-docs.patch
+        0007-mkdefsinc-use-CPPFLAGS.patch)
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '46CC730865BB5C78EBABADCF04376F3EE0856959'
@@ -35,13 +36,15 @@ sha256sums=('2d1b111774d2e3dd26dcd7c251819ce4ef774ec5e566251eb9308fa7542fbd6f'
             'SKIP'
             '71763a209761afe6495d3d85e25bbe6ba76348450d426f8a2618a34a264e058a'
             'dd2cf257761781a1d8e5bfac7fcc09633e09928dd9a13cb509a5b76fd44aea2d'
-            'b56fe3e3da872ca84d08b4aa426e6f71b3227e2a253bc45bf6023abf1288ecc9')
+            'b56fe3e3da872ca84d08b4aa426e6f71b3227e2a253bc45bf6023abf1288ecc9'
+            '29878B63804AFB40808397CC884F5ADE3F7143E0887E4839E33F96592CD50208')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
   patch -p1 -i "${srcdir}"/0004-gpgme-find-gnupg.patch
   patch -p1 -i "${srcdir}"/0005-invoke-scripts-via-sh.patch
   patch -p1 -i "${srcdir}"/0006-fix-building-docs.patch
+  patch -p1 -i "${srcdir}"/0007-mkdefsinc-use-CPPFLAGS.patch
 
   autoreconf -ivf
 }


### PR DESCRIPTION
This fixes the build on the CI and some Windows systems

see #4165 

thanks to @vyache-slav for providing the patch