### PR TITLE
python-certifi: update to 2018.8.24

### DIFF
--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=certifi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2018.8.13
+pkgver=2018.8.24
 pkgrel=1
 pkgdesc="Python package for providing Mozilla's CA Bundle (mingw-w64)"
 url='https://pypi.python.org/pypi/certifi'
@@ -13,7 +13,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
             )
 source=("https://pypi.io/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4')
+sha256sums=('376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-certifi to 2018.8.24.