### PR TITLE
PKGBUILD.setup-py - fixes for patch and .EXE installs.

### DIFF
--- a/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
+++ b/mingw-w64-PKGBUILD-templates/PKGBUILD.setup-py-python-pkg
@@ -54,8 +54,10 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}"
-  apply_patch_with_msg 0001-A-really-important-fix.patch \
-    0002-A-less-important-fix.patch
+  pushd "${_realname}-${pkgver}"
+    apply_patch_with_msg 0001-A-really-important-fix.patch \
+      0002-A-less-important-fix.patch
+  popd 
   for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
@@ -86,6 +88,10 @@ check() {
 
 package_python3-somepackage() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  @This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname .
+  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -100,13 +106,17 @@ package_python3-somepackage() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 #### end section ####
 }
 
 package_python2-somepackage() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  @This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname
+  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -116,12 +126,12 @@ package_python2-somepackage() {
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/COPYING"
 
 # This entire section should be removed if the package does NOT install
-# anything in the /mingw*/bin directory.
+# anything in the /mingw*/bin directory. 
 ### begin section ###
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
 # for Python2 packages, you want to rename some stuff from the bin directory 

--- a/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage2-i686.install
+++ b/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage2-i686.install
@@ -1,0 +1,17 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+# "somepackage" should be replaced with the name of your .EXE w/o 2 and .exe ext
+# Like this:
+# For "myexe2.exe", it would be "myexe2" .
+  for _it in somepackage2; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage2-x86_64.install
+++ b/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage2-x86_64.install
@@ -1,0 +1,17 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+# "somepackage" should be replaced with the name of your .EXE w/o 2 and .exe ext
+# Like this:
+# For "myexe2.exe", it would be "myexe2" .
+  for _it in somepackage2; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage3-i686.install
+++ b/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage3-i686.install
@@ -1,0 +1,17 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+# "somepackage" should be replaced with the name of your .EXE w/o 2 and .exe ext
+# Like this:
+# For "myexe.exe", it would be "myexe" .
+  for _it in somepackage; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage3-x86_64.install
+++ b/mingw-w64-PKGBUILD-templates/python-exe-installs/somepackage3-x86_64.install
@@ -1,0 +1,17 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+# "somepackage" should be replaced with the name of your .EXE w/o 2 and .exe ext
+# Like this:
+# For "myexe.exe", it would be "myexe" .
+  for _it in somepackage; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
Fix for setup.py template, a fix for running python-compiled .EXE bin scripts.  zyjr /zrcr od do,[;u sm rmytu  [pomy.  Added a directory containing the installs to complete the fixup on the user's system so that the scrips have fully-qualified paths that differ from the packager.  This seems to be best way of doing this with packages such as whell and some other things I've working on.