### PR TITLE
nasm: fix build for gcc-8

### DIFF
--- a/mingw-w64-nasm/0001-Remove-invalid-pure_func-qualifiers.patch
+++ b/mingw-w64-nasm/0001-Remove-invalid-pure_func-qualifiers.patch
@@ -1,0 +1,27 @@
+From d0dabb46a821b2506681f882af0d5696d2c2bade Mon Sep 17 00:00:00 2001
+From: Michael Simacek <msimacek@redhat.com>
+Date: Thu, 8 Feb 2018 14:47:08 +0100
+Subject: [PATCH] Remove invalid pure_func qualifiers
+
+---
+ include/nasmlib.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/nasmlib.h b/include/nasmlib.h
+index 79e866b..c93cef0 100644
+--- a/include/nasmlib.h
++++ b/include/nasmlib.h
+@@ -191,8 +191,8 @@ int64_t readstrnum(char *str, int length, bool *warn);
+  * seg_init: Initialise the segment-number allocator.
+  * seg_alloc: allocate a hitherto unused segment number.
+  */
+-void pure_func seg_init(void);
+-int32_t pure_func seg_alloc(void);
++void seg_init(void);
++int32_t seg_alloc(void);
+ 
+ /*
+  * many output formats will be able to make use of this: a standard
+-- 
+2.14.3
+

--- a/mingw-w64-nasm/PKGBUILD
+++ b/mingw-w64-nasm/PKGBUILD
@@ -4,19 +4,22 @@ _realname=nasm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.13.03
-pkgrel=1
+pkgrel=2
 pkgdesc="An 80x86 assembler designed for portability and modularity (mingw-w64)"
 arch=('any')
 license=('BSD')
 url="http://www.nasm.us"
-depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 options=('strip' '!libtool' 'staticlibs' '!makeflags')
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
-source=(http://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('812ecfb0dcbc5bd409aaa8f61c7de94c5b8752a7b00c632883d15b2ed6452573')
+source=(http://www.nasm.us/pub/nasm/releasebuilds/${pkgver}/${_realname}-${pkgver}.tar.xz
+        0001-Remove-invalid-pure_func-qualifiers.patch)
+sha256sums=('812ecfb0dcbc5bd409aaa8f61c7de94c5b8752a7b00c632883d15b2ed6452573'
+            'ac9f315d204afa6b99ceefa1fe46d4eed2b8a23c7315d32d33c0f378d930e950')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
+  # Fix compilation with GCC 8: https://bugzilla.nasm.us/show_bug.cgi?id=3392461
+  patch -p1 -i ${srcdir}/0001-Remove-invalid-pure_func-qualifiers.patch
 }
 
 build() {


### PR DESCRIPTION
Fix compilation with GCC 8: https://bugzilla.nasm.us/show_bug.cgi?id=3392461