### PR TITLE
python-pytest: update to 3.7.3

### DIFF
--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -4,7 +4,7 @@ _pyname=pytest
 _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.7.2
+pkgver=3.7.3
 pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
@@ -43,7 +43,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis"
 #              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/pytest/archive/${pkgver}.tar.gz")
-sha256sums=('0cf77db5875ad7340c924b11f96d78f46e7ea48df6d3a9a11652b724a2b7078c')
+sha256sums=('8df704537983ae3088cceffc1fc98f734ffbf17804863e61c1cd67d72e65876c')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-pytest to 3.7.3.