### PR TITLE
python-json-rpc: update to 1.11.1

### DIFF
--- a/mingw-w64-python-json-rpc/PKGBUILD
+++ b/mingw-w64-python-json-rpc/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=json-rpc
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.11.0
-pkgrel=2
+pkgver=1.11.1
+pkgrel=1
 pkgdesc="JSON-RPC transport realisation (mingw-w64)"
 arch=('any')
 url="https://github.com/pavlov99/json-rpc"
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("https://pypi.python.org/packages/source/j/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('a5e53f80699e97754bfd8a29c86138aa144c4e6663fe80c0be5270fc6f177166')
+sha256sums=('aed797c8bf2b2c2349cc17a00534e9a7b69197bf0f35db4ca331c4d50e37357c')
 
 prepare() {  
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-json-rpc to 1.11.1.