### PR TITLE
python-numexpr: update to 2.6.8

### DIFF
--- a/mingw-w64-python-numexpr/PKGBUILD
+++ b/mingw-w64-python-numexpr/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=numexpr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=2.6.7
+pkgver=2.6.8
 pkgrel=1
 pkgdesc="Fast numerical array expression evaluator for Python, NumPy, PyTables, pandas (mingw-w64)"
 arch=('any')
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-numpy"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-gcc")
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/pydata/numexpr/archive/v${pkgver}.tar.gz)
-sha256sums=('e81a1a13656712aff072d89f49ecf905fd3c6b6722544c1decb132903c54a967')
+sha256sums=('1a9684008c5ff7d69a5aa2998a3186587ee89f6cc6c4966f76aed8c4ee9f5b92')
 
 prepare() {
   cp -a ${_realname}-${pkgver} $_realname-py2-${pkgver}


### PR DESCRIPTION
This updates python-numexpr to 2.6.8.