### PR TITLE
p11-kit: update to 0.23.14

### DIFF
--- a/mingw-w64-p11-kit/PKGBUILD
+++ b/mingw-w64-p11-kit/PKGBUILD
@@ -5,7 +5,7 @@
 _realname=p11-kit
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.23.13
+pkgver=0.23.14
 pkgrel=1
 pkgdesc="Library to work with PKCS#11 modules"
 arch=('any')
@@ -29,7 +29,7 @@ source=(https://github.com/p11-glue/p11-kit/releases/download/${pkgver}/${_realn
         0010-fix-transport-test.patch
         0011-p11-kit-spawn-external.patch)
 validpgpkeys=('C0F67099B808FB063E2C81117BFB1108D92765AF')
-sha256sums=('aa65403e3ac7c3aba17ca60f28db17b9c76d988b66b91789b8e8c145ae9922f1'
+sha256sums=('1cb9fa6d237539f25f62f4c3d4ec71a1c8e0772957ec45ec5af92134129e0d70'
             '195b2e8695f701caf545e2a468383ad29457febd9b1ee57de1986de04ad3c31c'
             'aa92f986d3f7dfc119e86f9a8f3987e6ac2562149921820eadbe09218c4df99c'
             'ea4593324db6d2d193733561f0352c6d679d1fb00aed0a2bae0d28aecbe92721'


### PR DESCRIPTION
This updates p11-kit to 0.23.14.