### PR TITLE
nss: update to 3.39

### DIFF
--- a/mingw-w64-nss/PKGBUILD
+++ b/mingw-w64-nss/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=nss
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.38
-_nsprver=4.19
+pkgver=3.39
+_nsprver=4.20
 pkgrel=1
 pkgdesc="Mozilla Network Security Services (mingw-w64)"
 arch=('any')
@@ -27,7 +27,7 @@ source=(https://ftp.mozilla.org/pub/security/nss/releases/NSS_${pkgver//./_}_RTM
         blank-key3.db
         blank-secmod.db
         nss-3.20.1-headers.patch)
-sha256sums=('2c643d3c08d6935f4d325f40743719b6990aa25a79ec2f8f712c99d086672f62'
+sha256sums=('6be64dd76f212415cc8bc34343ac1e7389048db4db9a023a84873c411dc5864b'
             '1894bc68a0badd6e6f68f66abc4c6cd8e222791dd194f6b631ce536011ab6707'
             'b9f1428ca2305bf30b109507ff335fa00bce5a7ce0434b50acd26ad7c47dd5bd'
             'e44ac5095b4d88f24ec7b2e6a9f1581560bd3ad41a3d198596d67ef22f67adb9'


### PR DESCRIPTION
This updates nss to 3.39, using nspr version 4.20.