### PR TITLE
python-hypothesis: update to 3.70.3

### DIFF
--- a/mingw-w64-python-hypothesis/PKGBUILD
+++ b/mingw-w64-python-hypothesis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=hypothesis
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.69.2
+pkgver=3.70.3
 pkgrel=1
 pkgdesc="Advanced Quickcheck style testing library for Python (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python2-pandas")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/HypothesisWorks/hypothesis/archive/hypothesis-python-$pkgver.tar.gz")
-sha512sums=('978bc26272150338cf72bb1f62bb0dd1fabdc3cbf8315f6e79cdcb0ffb48f490fc2fdd168f5d453089da8e29754ef9f03a546e8de0b54e61b32a6c2281ea3cca')
+sha512sums=('86b3799c12a657995695c0cf7a7dfc1316b0d53e778b57dfbd9c302b319c64c7968a94d8cc1d08b3a2da4ea1c86d9f7d84cf426cb268dc7ece2a821aed707343')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
This updates python-hypothesis to 3.70.3.