### PR TITLE
python-imagesize: update to 1.1.0

### DIFF
--- a/mingw-w64-python-imagesize/PKGBUILD
+++ b/mingw-w64-python-imagesize/PKGBUILD
@@ -3,17 +3,16 @@
 _realname=imagesize
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.0.0
-pkgrel=2
+pkgver=1.1.0
+pkgrel=1
 pkgdesc="Getting image size from png/jpeg/jpeg2000/gif file (mingw-w64)"
 url='https://github.com/shibukawa/imagesize_py'
 license=('MIT')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-#_dtoken="53/72/6c6f1e787d9cab2cc733cf042f125abec07209a58308831c9f292504e826"
 source=("https://files.pythonhosted.org/packages/source/i/imagesize/${_realname}-${pkgver}.tar.gz")
-sha256sums=('5b326e4678b6925158ccc66a9fa3122b6106d7c876ee32d7de6ce59385b96315')
+sha256sums=('f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-imagesize to 1.1.0.