### PR TITLE
glib2: remove internal static libs from .pc files. Fixes #4364

### DIFF
--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -7,7 +7,7 @@ _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.58.0
-pkgrel=1
+pkgrel=2
 url="https://www.gtk.org/"
 arch=('any')
 pkgdesc="Common C routines used by GTK+ 2.4 and other libs (mingw-w64)"
@@ -82,6 +82,11 @@ package() {
 
   for pcfile in  "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig/*.pc; do
     sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pcfile}"
+    # https://github.com/Alexpux/MINGW-packages/issues/4364
+    # https://gitlab.gnome.org/GNOME/glib/issues/1516
+    sed -s "s| -lgiowin32||g" -i "${pcfile}"
+    sed -s "s| -lgnulib||g" -i "${pcfile}"
+    sed -s "s| -lcharset||g" -i "${pcfile}"
   done
 
   sed -s "s|$(cygpath -m ${MINGW_PREFIX})|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/bin/glib-gettextize"


### PR DESCRIPTION
Filed upstream: https://gitlab.gnome.org/GNOME/glib/issues/1516