### PR TITLE
mingw-w64-curl - Update to 7.61.1

### DIFF
--- a/mingw-w64-curl/PKGBUILD
+++ b/mingw-w64-curl/PKGBUILD
@@ -12,7 +12,7 @@ fi
 _realname=curl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}${_namesuff}"
-pkgver=7.61.0
+pkgver=7.61.1
 pkgrel=2
 pkgdesc="Command line tool and library for transferring data with URLs. (mingw-w64)"
 arch=('any')
@@ -45,7 +45,7 @@ source=("${url}/download/${_realname}-${pkgver}.tar.bz2"{,.asc}
         "0001-Make-cURL-relocatable.patch"
         "0002-nghttp2-static.patch"
         "0003-libpsl-static-libs.patch")
-sha256sums=('5f6f336921cf5b84de56afbd08dfb70adeef2303751ffb3e570c936c6d656c9c'
+sha256sums=('a308377dbc9a16b2e994abd55455e5f9edca4e31666f8f8fcfe7a1a4aea419b9'
             'SKIP'
             '60b16ba70021623afb51580d45b1bb77d4a098294e585ddf60204517a9c19ec4'
             '80d2384802e42574e7b7ef0a8227d00c6585004dcfb80ff3c805b6ca9cf58ccc'

--- a/mingw-w64-nghttp2/PKGBUILD
+++ b/mingw-w64-nghttp2/PKGBUILD
@@ -3,13 +3,13 @@
 _realname=nghttp2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.32.0
+pkgver=1.33.0
 pkgrel=1
 pkgdesc="Framing layer of HTTP/2 is implemented as a reusable C library (mingw-w64)"
 arch=('any')
 url='https://nghttp2.org/'
 depends=("${MINGW_PACKAGE_PREFIX}-jansson"
-         #"${MINGW_PACKAGE_PREFIX}-jemalloc"
+         "${MINGW_PACKAGE_PREFIX}-jemalloc"
          #"${MINGW_PACKAGE_PREFIX}-libevent"
          #"${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-openssl"
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cunit")
 license=('MIT')
 source=("https://github.com/nghttp2/nghttp2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('700a89d59fcc55acc2b18184001bfb3220fa6a6e543486aca35f40801cba6f7d')
+sha256sums=('4879ce9ff3320f5344b910ee1c46ed5e366edc2272620cf17d8e762724d7df1e')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
mingw-w64-nghttp2 - Update to 1.33.0 -nghttp2 is used by curl for http2 support.