### PR TITLE
python-pytest: update to 3.7.4

### DIFF
--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -4,8 +4,8 @@ _pyname=pytest
 _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.7.3
-pkgrel=2
+pkgver=3.7.4
+pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
 license=('MIT')
@@ -43,7 +43,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis"
 #              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/pytest/archive/${pkgver}.tar.gz")
-sha256sums=('8df704537983ae3088cceffc1fc98f734ffbf17804863e61c1cd67d72e65876c')
+sha256sums=('1c41e5c0221187099a352761df6a050e2aa32de5cd22823149d077cff95bf03a')
 
 prepare() {
   cd ${srcdir}


### PR DESCRIPTION
This updates python-pytest to 3.7.4.