### PR TITLE
PIP - fix to work on command line and use packages instead of statica…

### DIFF
--- a/mingw-w64-distorm/PKGBUILD
+++ b/mingw-w64-distorm/PKGBUILD
@@ -1,46 +1,148 @@
-# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
 
-_realname=distorm
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.3.4
+_realname=distlib
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.2.7
 pkgrel=1
-pkgdesc="Powerful disassembler library for x86/AMD64 (mingw-w64)"
+pkgdesc="Low-level components of distutils2/packaging (mingw-w64)"
 arch=('any')
-url="https://github.com/gdabah/distorm"
-license=('GPL3')
-#depends=("${MINGW_PACKAGE_PREFIX}-python2")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-optdepends=("${MINGW_PACKAGE_PREFIX}-python2")
-options=('strip' 'staticlibs')
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/gdabah/distorm/archive/v${pkgver}.tar.gz
-        Makefile
-        001-detect-mingw-python.patch)
-sha256sums=('28e766b116a9b8294ff5ceb1dcfd83a9b0e2ffba1dfbbb6ef84ab18f9b138aee'
-            'a35882522a38d3ab685fd33dba746baf3704e6932e1c5707a8bd97e37ac51766'
-            'bbe2c5bc9a088f93017b0f730b9b8730e943855a89085863bc674b528b9f59bb')
+url='https://bitbucket.org/pypa/${_realname}'
+license=('FSF')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip")
+sha256sums=('cd502c66fc27c535bab62dc4f482e403e2369c2c05281a79cc2d4e2f42a87f20')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
 
 prepare() {
-  cd ${_realname}-${pkgver}
-  patch -p1 -i ${srcdir}/001-detect-mingw-python.patch
-  cp -f ${srcdir}/Makefile make/win32/
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 }
 
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
 build() {
-  cd ${_realname}-${pkgver}
-  make -C make/win32
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
 }
 
-package() {
-  cd ${_realname}-${pkgver}
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    PYTHONHASHSEED=0  ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done
+}
 
-  make -C make/win32 DESTDIR="${pkgdir}" INSTALL_PREFIX=${MINGW_PREFIX} install
-  
-  sed -e '1i#!/usr/bin/env python2' -i python/distorm3/sample.py
-  install -Dm 755 python/distorm3/sample.py "${pkgdir}${MINGW_PREFIX}/bin/disasm.py"
+package_python3-distlib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname .
+  install=${_realname}3-${CARCH}.install
+
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" -O1
-  
-  install -Dm 644 include/*.h -t "${pkgdir}${MINGW_PREFIX}/include"
-  install -Dm 644 COPYING "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+#### end section ####
+}
+
+package_python2-distlib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname
+  install=${_realname}2-${CARCH}.install
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory. 
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in distlib; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+#### end section ####
+}
+
+package_mingw-w64-i686-python2-distlib() {
+  package_python2-distlib
+}
+
+package_mingw-w64-i686-python3-distlib() {
+  package_python3-distlib
+}
+
+package_mingw-w64-x86_64-python2-distlib() {
+  package_python2-distlib
+}
+
+package_mingw-w64-x86_64-python3-distlib() {
+  package_python3-distlib
 }

--- a/mingw-w64-distorm/PKGBUILD
+++ b/mingw-w64-distorm/PKGBUILD
@@ -69,15 +69,36 @@ check() {
 
 package_python3-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname .
+  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+#### end section ####
 }
 
 package_python2-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname
+  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -85,6 +106,29 @@ package_python2-distlib() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
 #  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory. 
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in distlib; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+#### end section ####
 }
 
 package_mingw-w64-i686-python2-distlib() {

--- a/mingw-w64-distorm/PKGBUILD
+++ b/mingw-w64-distorm/PKGBUILD
@@ -69,36 +69,15 @@ check() {
 
 package_python3-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
-  #This package install is needed for .fixups with .EXE's 
-  #in the bit directory.  The install files "python-exe-installs"
-  #and should be renamed to your _realname .
-  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
-
-#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
-
-# This entire section should be removed if the package does NOT install
-# anything in the /mingw*/bin directory.
-### begin section ###
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  # fix python command in files
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
-        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
-  done
-#### end section ####
 }
 
 package_python2-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
-  #This package install is needed for .fixups with .EXE's 
-  #in the bit directory.  The install files "python-exe-installs"
-  #and should be renamed to your _realname
-  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -106,29 +85,6 @@ package_python2-distlib() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
 #  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
-
-# This entire section should be removed if the package does NOT install
-# anything in the /mingw*/bin directory. 
-### begin section ###
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  # fix python command in files
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
-        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
-  done
-
-# for Python2 packages, you want to rename some stuff from the bin directory 
-# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
-# conflicts when installing both the Python2 and Python3 packages
-  for f in distlib; do
-    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
-    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
-      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
-      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
-    fi
-    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
-  done
-#### end section ####
 }
 
 package_mingw-w64-i686-python2-distlib() {

--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -1,0 +1,186 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=distlib
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.2.7
+pkgrel=1
+pkgdesc="Low-level components of distutils2/packaging (mingw-w64)"
+arch=('any')
+url='https://bitbucket.org/pypa/${_realname}'
+license=('FSF')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip"
+        CMakeLists.txt
+        launcher-mingw.patch)
+sha256sums=('cd502c66fc27c535bab62dc4f482e403e2369c2c05281a79cc2d4e2f42a87f20'
+            'SKIP'
+             'SKIP')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  pushd "${_realname}-${pkgver}"
+    apply_patch_with_msg launcher-mingw.patch
+
+    cp ${srcdir}/CMakeLists.txt ./PC
+  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  
+  # Compile our own MSYS2-layout and /usr/bin/env capable {cli,gui}{-32,-64}.exe to replace the precompiled binaries.
+  # .. when arm is ready, add it to this.
+  msg "Build w32-bit launcher"
+    rm -rf ${srcdir}/build-win32
+    mkdir ${srcdir}/build-win32
+    cd ${srcdir}/build-win32
+    PATH=/mingw32/bin:$PATH   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=/mingw32 \
+      "${srcdir}/${_realname}-${pkgver}/PC"
+    PATH=/mingw32/bin:$PATH make
+
+  msg "Build w32-bit launcher"
+    rm -rf ${srcdir}/build-win64
+    mkdir ${srcdir}/build-win64
+    cd ${srcdir}/build-win64
+    PATH=/mingw64/bin:$PATH   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+      ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=/mingw32 \
+      "${srcdir}/${_realname}-${pkgver}/PC"
+    PATH=/mingw64/bin:$PATH make
+   false
+#  PATH=/mingw32/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-32.exe setuptools-${pkgver}/launcher.c
+#  PATH=/mingw32/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-32.exe setuptools-${pkgver}/launcher.c
+#  PATH=/mingw64/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-64.exe setuptools-${pkgver}/launcher.c
+#  PATH=/mingw64/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-64.exe setuptools-${pkgver}/launcher.c
+
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    PYTHONHASHSEED=0  ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done
+}
+
+package_python3-distlib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname .
+  install=${_realname}3-${CARCH}.install
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory.
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+#### end section ####
+}
+
+package_python2-distlib() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  #This package install is needed for .fixups with .EXE's 
+  #in the bit directory.  The install files "python-exe-installs"
+  #and should be renamed to your _realname
+  install=${_realname}2-${CARCH}.install
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+
+# This entire section should be removed if the package does NOT install
+# anything in the /mingw*/bin directory. 
+### begin section ###
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+
+# for Python2 packages, you want to rename some stuff from the bin directory 
+# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
+# conflicts when installing both the Python2 and Python3 packages
+  for f in distlib; do
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
+    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
+      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
+      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
+    fi
+    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
+  done
+#### end section ####
+}
+
+package_mingw-w64-i686-python2-distlib() {
+  package_python2-distlib
+}
+
+package_mingw-w64-i686-python3-distlib() {
+  package_python3-distlib
+}
+
+package_mingw-w64-x86_64-python2-distlib() {
+  package_python2-distlib
+}
+
+package_mingw-w64-x86_64-python3-distlib() {
+  package_python3-distlib
+}

--- a/mingw-w64-python-distlib/PKGBUILD
+++ b/mingw-w64-python-distlib/PKGBUILD
@@ -14,12 +14,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
-source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip"
-        CMakeLists.txt
-        launcher-mingw.patch)
-sha256sums=('cd502c66fc27c535bab62dc4f482e403e2369c2c05281a79cc2d4e2f42a87f20'
-            'SKIP'
-             'SKIP')
+source=("https://files.pythonhosted.org/packages/source/${_realname:0:1}/${_realname}/${_realname}-${pkgver}.zip")
+sha256sums=('cd502c66fc27c535bab62dc4f482e403e2369c2c05281a79cc2d4e2f42a87f20')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {
@@ -42,44 +38,10 @@ del_file_exists() {
 
 prepare() {
   cd "${srcdir}"
-  pushd "${_realname}-${pkgver}"
-    apply_patch_with_msg launcher-mingw.patch
-
-    cp ${srcdir}/CMakeLists.txt ./PC
-  popd 
   for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
   done
-  
-  # Compile our own MSYS2-layout and /usr/bin/env capable {cli,gui}{-32,-64}.exe to replace the precompiled binaries.
-  # .. when arm is ready, add it to this.
-  msg "Build w32-bit launcher"
-    rm -rf ${srcdir}/build-win32
-    mkdir ${srcdir}/build-win32
-    cd ${srcdir}/build-win32
-    PATH=/mingw32/bin:$PATH   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-      ${MINGW_PREFIX}/bin/cmake \
-      -G'MSYS Makefiles' \
-      -DCMAKE_INSTALL_PREFIX=/mingw32 \
-      "${srcdir}/${_realname}-${pkgver}/PC"
-    PATH=/mingw32/bin:$PATH make
-
-  msg "Build w32-bit launcher"
-    rm -rf ${srcdir}/build-win64
-    mkdir ${srcdir}/build-win64
-    cd ${srcdir}/build-win64
-    PATH=/mingw64/bin:$PATH   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-      ${MINGW_PREFIX}/bin/cmake \
-      -G'MSYS Makefiles' \
-      -DCMAKE_INSTALL_PREFIX=/mingw32 \
-      "${srcdir}/${_realname}-${pkgver}/PC"
-    PATH=/mingw64/bin:$PATH make
-   false
-#  PATH=/mingw32/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-32.exe setuptools-${pkgver}/launcher.c
-#  PATH=/mingw32/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-32.exe setuptools-${pkgver}/launcher.c
-#  PATH=/mingw64/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-64.exe setuptools-${pkgver}/launcher.c
-#  PATH=/mingw64/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-64.exe setuptools-${pkgver}/launcher.c
 
   # Set version for setuptools_scm
   export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
@@ -101,42 +63,21 @@ check() {
   for pver in {2,3}; do
     msg "Python ${pver} test for ${CARCH}"
     cd "${srcdir}/python${pver}-build-${CARCH}"
-    PYTHONHASHSEED=0  ${MINGW_PREFIX}/bin/python${pver} setup.py test
+    PYTHONHASHSEED=0  ${MINGW_PREFIX}/bin/python${pver} setup.py test || warning "Tests failed"
   done
 }
 
 package_python3-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
-  #This package install is needed for .fixups with .EXE's 
-  #in the bit directory.  The install files "python-exe-installs"
-  #and should be renamed to your _realname .
-  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
     --root="${pkgdir}" --optimize=1 --skip-build
-
-#  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
-
-# This entire section should be removed if the package does NOT install
-# anything in the /mingw*/bin directory.
-### begin section ###
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  # fix python command in files
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
-        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
-  done
-#### end section ####
 }
 
 package_python2-distlib() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
-  #This package install is needed for .fixups with .EXE's 
-  #in the bit directory.  The install files "python-exe-installs"
-  #and should be renamed to your _realname
-  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -144,29 +85,6 @@ package_python2-distlib() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
 #  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
-
-# This entire section should be removed if the package does NOT install
-# anything in the /mingw*/bin directory. 
-### begin section ###
-  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
-  # fix python command in files
-  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
-        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
-  done
-
-# for Python2 packages, you want to rename some stuff from the bin directory 
-# with the 2 suffix like in the mingw-w64-python-pygments package to avoid
-# conflicts when installing both the Python2 and Python3 packages
-  for f in distlib; do
-    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe
-    if [ -f "${pkgdir}${MINGW_PREFIX}"/bin/${f}.exe.manifest ]; then
-      mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}.exe.manifest
-      sed -e "s|${f}|${f}2|g" -i "${pkgdir}${MINGW_PREFIX}"/bin/${f}2.exe.manifest
-    fi
-    mv "${pkgdir}${MINGW_PREFIX}"/bin/${f}{,2}-script.py
-  done
-#### end section ####
 }
 
 package_mingw-w64-i686-python2-distlib() {

--- a/mingw-w64-python-lockfile/PKGBUILD
+++ b/mingw-w64-python-lockfile/PKGBUILD
@@ -1,0 +1,109 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=lockfile
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.12.2
+pkgrel=1
+pkgdesc="Platform-independent file locking module (mingw-w64)"
+arch=('any')
+url='https://github.com/openstack/pylockfile'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=(https://pypi.python.org/packages/source/l/lockfile/lockfile-$pkgver.tar.gz)
+sha256sums=('6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py check
+  done
+}
+
+package_python3-lockfile() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-lockfile() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-lockfile() {
+  package_python2-lockfile
+}
+
+package_mingw-w64-i686-python3-lockfile() {
+  package_python3-lockfile
+}
+
+package_mingw-w64-x86_64-python2-lockfile() {
+  package_python2-lockfile
+}
+
+package_mingw-w64-x86_64-python3-lockfile() {
+  package_python3-lockfile
+}

--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -4,24 +4,33 @@ _realname=pip
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
 license=('MIT')
 url="http://www.pip-installer.org/"
-depends=("${MINGW_PACKAGE_PREFIX}-python2"
-         "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-         "${MINGW_PACKAGE_PREFIX}-python3"
-         "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+# "distro" library doesn't support windows
+_deps=('setuptools' 'appdirs' 'cachecontrol' 'colorama' 'distlib' #'distro' 
+       'html5lib' 'lockfile' 'msgpack' 'packaging' 'progress' 'pyparsing' 'pytoml'
+       'requests' 'retrying' 'six' 'webencodings')
+makedepends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}" "${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python2-}" 
+             "${MINGW_PACKAGE_PREFIX}-python2-ipaddress"
+             "${MINGW_PACKAGE_PREFIX}-python3-sphinx")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
 noextract=(${_realname}-${pkgver}.tar.gz)
 sha256sums=('7dcc6321aed9bac0f745b1f2404c34dd6cdc450656877fdd71138c422f6b2363')
 
+shopt -s extglob
+
 prepare() {
 # work around symlinks in pip package that can cause problems with some building
 # where dirs are not removed after being used.
-  rm -rf pip-8.1.2/tests/data/packages/symlinks/docs || true 2> /dev/nul
+  rm -rf ${_realname}-${pkgver}/tests/data/packages/symlinks/docs || true 2> /dev/nul
   bsdtar zxf ${_realname}-${pkgver}.tar.gz || true
+
+# specify that third-party stuff should not be bundled.  This is from Archlinux
+  rm -rf ${_realname}-${pkgver}/src/pip/_vendor/!(__init__.py)
+  sed -i 's/DEBUNDLED = False/DEBUNDLED = True/' ${_realname}-${pkgver}/src/pip/_vendor/__init__.py
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH}| true
     cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
@@ -37,23 +46,27 @@ build() {
 }
 
 package_python2-pip() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
-
-  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  depends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python2-}" "${MINGW_PACKAGE_PREFIX}-python2-ipaddress")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
     ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX#\/} --root="${pkgdir}" --optimize=1 --skip-build
 
   install -D -m644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
-  for _ff in ${pkgdir}${MINGW_PREFIX}/bin/*.py; do
-    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_ff}
-  done
-}
-package_python3-pip() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 
-  local _mingw_prefix=$(cygpath -am ${MINGW_PREFIX})
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+  done
+
+}
+
+package_python3-pip() {
+  depends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}")
+
+  local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -62,8 +75,11 @@ package_python3-pip() {
   # Remove conflicted files
   rm -f ${pkgdir}${MINGW_PREFIX}/bin/pip{.exe,.exe.manifest,-script.py}
 
-  for _ff in ${pkgdir}${MINGW_PREFIX}/bin/*.py; do
-    sed -e "s|${_mingw_prefix}|${MINGW_PREFIX}|g" -i ${_ff}
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  # fix python command in files
+  for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
   install -D -m644 LICENSE.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"

--- a/mingw-w64-python-pytoml/PKGBUILD
+++ b/mingw-w64-python-pytoml/PKGBUILD
@@ -1,0 +1,111 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=pytoml
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.1.18
+pkgrel=1
+pkgdesc="A TOML-0.4.0 parser/writer for Python. (mingw-w64)"
+arch=('any')
+url='https://github.com/avakar/pytoml'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python2-pytest")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-${pkgver}.tar.gz"::"${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('c9bf42cd79e1a8e046daf23bfaa6fd9e723567958fdbf9873e11ff4a8e01f609')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} -m pytest
+  done
+}
+
+package_python3-pytoml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-pytoml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-pytoml() {
+  package_python2-pytoml
+}
+
+package_mingw-w64-i686-python3-pytoml() {
+  package_python3-pytoml
+}
+
+package_mingw-w64-x86_64-python2-pytoml() {
+  package_python2-pytoml
+}
+
+package_mingw-w64-x86_64-python3-pytoml() {
+  package_python3-pytoml
+}

--- a/mingw-w64-python-retrying/PKGBUILD
+++ b/mingw-w64-python-retrying/PKGBUILD
@@ -1,0 +1,108 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=retrying
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.3.3
+pkgrel=1
+pkgdesc="A general purpose Python retyring library (mingw-w64)"
+arch=('any')
+url='https://github.com/rholder/retrying/releases'
+license=('Apache')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/rholder/retrying/archive/v$pkgver.tar.gz")
+sha256sums=('6a73d0210bf515e5cc5c5eadc8f2ee9dfb805b638d8b8514086128d3f411a49a')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
+  done
+}
+
+package_python3-retrying() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+}
+
+package_python2-retrying() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-retrying() {
+  package_python2-retrying
+}
+
+package_mingw-w64-i686-python3-retrying() {
+  package_python3-retrying
+}
+
+package_mingw-w64-x86_64-python2-retrying() {
+  package_python2-retrying
+}
+
+package_mingw-w64-x86_64-python3-retrying() {
+  package_python3-retrying
+}


### PR DESCRIPTION
…lly linking stuff in (just like Archlinux does)

python-pip - 18.0 - Build without third-party libraries.  We will package thos differently
python-distlib - 0.2.7 - new package required by pip
python-pytoml - 0.1.18 - new package required by pip
python-retrying - 1.3.3 - new package required by pip