### PR TITLE
python-coverage - 4.5.1 - fix command line invocation.

### DIFF
--- a/mingw-w64-python-coverage/PKGBUILD
+++ b/mingw-w64-python-coverage/PKGBUILD
@@ -4,7 +4,7 @@ _realname=coverage
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=4.5.1
-pkgrel=2
+pkgrel=3
 pkgdesc='Code coverage measurement for Python (mingw-w64)'
 url='https://coverage.readthedocs.io/'
 license=('Apache 2.0')
@@ -37,6 +37,7 @@ build() {
 
 
 package_python3-coverage() {
+  install=${_realname}3-${CARCH}.install
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
@@ -46,11 +47,13 @@ package_python3-coverage() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 }
 
 package_python2-coverage() {
+  install=${_realname}2-${CARCH}.install
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
   ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
@@ -60,7 +63,8 @@ package_python2-coverage() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
+    sed -e "s|/usr/bin/env |${MINGW_PREFIX}|g" \
+        -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" -i ${_f}
   done
 
   for f in coverage; do


### PR DESCRIPTION
I don't know why the "install" lines were missing although I did find the *install files in git.  The problem is you need a fully qualified path in the shebang for the .EXE launcher to work.  That's why the .EXE's have to change it to a fully qualiffied path.