### PR TITLE
python-lxml: update to 4.2.5

### DIFF
--- a/mingw-w64-python-lxml/PKGBUILD
+++ b/mingw-w64-python-lxml/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" 
          "${MINGW_PACKAGE_PREFIX}-python3-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-python-${_realname}-docs")
-pkgver=4.2.4
+pkgver=4.2.5
 pkgrel=1
 arch=('any')
 license=('BSD' 'custom')
@@ -16,14 +16,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-libxslt"
              "${MINGW_PACKAGE_PREFIX}-python2-cssselect"
              "${MINGW_PACKAGE_PREFIX}-python3-cssselect")
-source=(https://pypi.io/packages/source/l/lxml/${_realname}-${pkgver}.tar.gz{,.asc}
-        mingw-python-fix.patch
-        use-distutils-get_platform.patch)
-sha256sums=('e2afbe403090f5893e254958d02875e0732975e73c4c0cdd33c1f009a61963ca'
-            'SKIP'
+source=("https://pypi.io/packages/source/l/lxml/${_realname}-${pkgver}.tar.gz"
+        "mingw-python-fix.patch"
+        "use-distutils-get_platform.patch")
+sha256sums=('36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f'
             'd5811e7c0be65d7e9ce59ad925466ac7dc95bdca05439be0becf2cca7bb9602a'
             'd50fefc47295d8c6eecf1ca42d03af43dc79d3debb52caf8edbed3b56df2f672')
-validpgpkeys=('1737D5FB8DACC53CA96A77AB0D3D536908D3A01E')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
This updates python-lxml to 4.2.5.

.asc file no longer exists, so removed from sources array.