### PR TITLE
gettext: Update 122-Use-LF-as-newline-in-envsubst.patch

### DIFF
--- a/mingw-w64-gettext/122-Use-LF-as-newline-in-envsubst.patch
+++ b/mingw-w64-gettext/122-Use-LF-as-newline-in-envsubst.patch
@@ -1,36 +1,54 @@
-From 60d853ccaa4c926430e536b36d8b0f1be19360c1 Mon Sep 17 00:00:00 2001
+From 89170435bde2d889dee8b20c74d7771e6af8f19e Mon Sep 17 00:00:00 2001
 From: Tim S <stahta01@users.sourceforge.net>
-Date: Sat, 26 May 2018 19:28:17 -0400
+Date: Sun, 16 Sep 2018 10:35:04 -0400
 Subject: [PATCH] Use LF as newline in envsubst
 
+Now using underline prefix in functions as stated at:
+  https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode
+And, change mode back to prior mode
+
 ---
- gettext-runtime/src/envsubst.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ gettext-runtime/src/envsubst.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
 
 diff --git a/gettext-runtime/src/envsubst.c b/gettext-runtime/src/envsubst.c
-index 941452b03..5bc482a75 100644
+index 941452b03..2afceb9ac 100644
 --- a/gettext-runtime/src/envsubst.c
 +++ b/gettext-runtime/src/envsubst.c
-@@ -27,6 +27,8 @@
+@@ -27,6 +27,11 @@
  #include <string.h>
  #include <locale.h>
  
-+#include <fcntl.h>
++#ifdef _WIN32
++# include <io.h>     /* for _setmode() */
++# include <fcntl.h>
++#endif
 +
  #include "closeout.h"
  #include "error.h"
  #include "progname.h"
-@@ -282,7 +282,10 @@ static void
+@@ -281,8 +286,21 @@ find_variables (const char *string,
+ static void
  print_variable (const char *var_ptr, size_t var_len)
  {
++  int oldmode;
++
    fwrite (var_ptr, var_len, 1, stdout);
-+  setmode(fileno(stdout),O_BINARY);
++#if defined(_WIN32)
++  /* Change to binary mode */
++  oldmode = _setmode( _fileno( stdout ), _O_BINARY );
++#endif
    putchar ('\n');
-+  fflush(stdout);
-+  setmode(fileno(stdout),O_TEXT);
++#if defined(_WIN32)
++  fflush(stdout); /* Must flush before changing mode back */
++  if ( oldmode != -1 )
++    {  /* Return to prior mode */
++       _setmode( _fileno( stdout ), oldmode );
++    }
++#endif
  }
  
  /* Print the variables contained in STRING to stdout, each one followed by a
 -- 
-2.16.2.windows.1
+2.19.0.windows.1
 

--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.8.1
-pkgrel=4
+pkgrel=5
 arch=('any')
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
@@ -42,7 +42,7 @@ sha256sums=('ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43'
             '522715ac22936943a85b4b78274302a6058f4f5371439cf491193ed53d8fc729'
             '2ffc73f1b8d66d88ff5ce640be211e5a927daba13788cb2319b97fc885444eac'
             '051bf975687a92da8a5acc09a367632396570c2609c5ecc1eba06c60c7135ad6'
-            '095b5de0883cbdda9b0de8360996f2e3fc677f9181cd61c89eb658ebee9d148b')
+            '2abfa598e1586abe14e982b867c8981790d8114e1ee575cb08b7ed49d4a46c74')
 validpgpkeys=('462225C3B46F34879FC8496CD605848ED7E69871') #Daiki Ueno
 
 prepare() {


### PR DESCRIPTION
This patch changes to binary mode to output linefeed and the changes back to prior mode.
The original patch changed to text mode after using binary mode.
After thinking about it, I decided this was wrong; and, changed the patch to restore the prior mode.

Tim S.
