### PR TITLE
mingw-w64-openssl - fix files left behind after build.  They were pla…

### DIFF
--- a/mingw-w64-openssl/PKGBUILD
+++ b/mingw-w64-openssl/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver=1.1.1
 # use a pacman compatible version scheme
 pkgver=${_ver/[a-z]/.${_ver//[0-9.]/}}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="The Open Source toolkit for Secure Sockets Layer and Transport Layer Security (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-ca-certificates" "${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-zlib")
@@ -110,7 +110,7 @@ package() {
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/lib/pkgconfig
   mkdir -p "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}
 
-  make -j1 DESTDIR="${pkgdir}" MANDIR=${MINGW_PREFIX}/share/man MANSUFFIX=ssl install
+  make -j1 DESTDIR="${pkgdir}" MANDIR="${pkgdir}/${MINGW_PREFIX}/share/man" MANSUFFIX=ssl install
   install -D -m644 "${srcdir}/${_realname}-${_ver}/LICENSE" \
          "${pkgdir}${MINGW_PREFIX}"/share/licenses/${_realname}/LICENSE
 


### PR DESCRIPTION
…ced in the wrong place.

BTW, I have reported the issue with OpenSSL and SOCKET type at: https://github.com/openssl/openssl/issues/7282 .  Hopefully, we can get some action on the matter.