### PR TITLE
libssh: update to 0.8.3

### DIFF
--- a/mingw-w64-libssh/PKGBUILD
+++ b/mingw-w64-libssh/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libssh
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.8.2
+pkgver=0.8.3
 pkgrel=1
 pkgdesc="Library for accessing ssh client services through C libraries (mingw-w64)"
 arch=('any')
@@ -21,7 +21,7 @@ source=("https://www.libssh.org/files/${pkgver%.*}/${_realname}-${pkgver}.tar.xz
         "https://www.libssh.org/files/${pkgver%.*}/${_realname}-${pkgver}.tar.xz.asc"
         "mingw-as-unix.patch"
         "mingw-DATADIR-conflict.patch")
-sha256sums=('8d1290f0fac4f8a75a9001dd404a8a093daba4e86c90c45ecf77d62f14c7b8a5'
+sha256sums=('302f31f606f2368cd3ce77d7a69f7464c18eae176e73e59102e0524401bd29d0'
             'SKIP'
             '8db580bf64d37f3d6b9a13558696eae8586edd3195eb2e930b7e326b98a9aef9'
             'a56298da4ff75d7c2a7f4c4068a814c67f34773ea23601b2c236b669de320af6')


### PR DESCRIPTION
This updates libssh to 0.8.3.