### PR TITLE
python-pycparser: update to 2.19

### DIFF
--- a/mingw-w64-python-pycparser/PKGBUILD
+++ b/mingw-w64-python-pycparser/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pycparser
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.18
-pkgrel=2
+pkgver=2.19
+pkgrel=1
 pkgdesc='Complete parser of the C language, written in pure Python (mingw-w64)'
 arch=('any')
 url='https://github.com/eliben/pycparser'
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3-ply"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 #_dtoken="be/64/1bb257ffb17d01f4a38d7ce686809a736837ad4371bcc5c42ba7a715c3ac"
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/eliben/pycparser/archive/release_v${pkgver}.tar.gz")
-sha256sums=('d5ead0f43ac5a8dd89e8475ada557037bbeb7ed709491861e84356ef17a3f8ac')
+sha256sums=('893ec3d0f26c0faa7d0b992979940353a1682f86b5cd1228740637055b112379')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-pycparser to 2.19.