### PR TITLE
allegro: depend on libwebp

### DIFF
--- a/mingw-w64-allegro/PKGBUILD
+++ b/mingw-w64-allegro/PKGBUILD
@@ -4,7 +4,7 @@ _realname=allegro
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.2.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Portable library mainly aimed at video game and multimedia programming (mingw-w64)"
 arch=(any)
 url="http://liballeg.org/"
@@ -17,6 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
              "${MINGW_PACKAGE_PREFIX}-libpng"
              "${MINGW_PACKAGE_PREFIX}-libvorbis"
+             "${MINGW_PACKAGE_PREFIX}-libwebp"
              "${MINGW_PACKAGE_PREFIX}-openal"
              "${MINGW_PACKAGE_PREFIX}-opusfile"
              "${MINGW_PACKAGE_PREFIX}-physfs"
@@ -29,6 +30,7 @@ optdepends=("${MINGW_PACKAGE_PREFIX}-dumb: allegro_audio"
             "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo: allegro_image"
             "${MINGW_PACKAGE_PREFIX}-libpng: allegro_image"
             "${MINGW_PACKAGE_PREFIX}-libvorbis: allegro_audio"
+            "${MINGW_PACKAGE_PREFIX}-libwebp: allegro_image"
             "${MINGW_PACKAGE_PREFIX}-openal: allegro_audio"
             "${MINGW_PACKAGE_PREFIX}-physfs: allegro_physfs")
 options=('strip' 'staticlibs')


### PR DESCRIPTION
WebP image support has been added to Allegro in 5.2.3