### PR TITLE
opusfile: remove http support (doesn't build with openssl 1.1)

### DIFF
--- a/mingw-w64-opusfile/PKGBUILD
+++ b/mingw-w64-opusfile/PKGBUILD
@@ -4,13 +4,13 @@ _realname=opusfile
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.11
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for opening, seeking, and decoding .opus files (mingw-w64)"
 arch=('any')
 url="https://www.opus-codec.org/"
 license=("BSD")
 depends=("${MINGW_PACKAGE_PREFIX}-libogg"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
+         # "${MINGW_PACKAGE_PREFIX}-openssl" # see --disable-http
          "${MINGW_PACKAGE_PREFIX}-opus")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc" "${MINGW_PACKAGE_PREFIX}-pkg-config")
 options=('strip' 'staticlibs')
@@ -31,7 +31,8 @@ build() {
     --host=${MINGW_CHOST} \
     --target=${MINGW_CHOST} \
     --enable-shared \
-    --enable-static
+    --enable-static \
+    --disable-http  # https://github.com/xiph/opusfile/issues/13
 
   make
 }


### PR DESCRIPTION
https://github.com/xiph/opusfile/issues/13