### PR TITLE
srt: don't include msvc compat headers for stdint/inttypes

### DIFF
--- a/mingw-w64-srt/0006-no-msvc-compat-headers.patch
+++ b/mingw-w64-srt/0006-no-msvc-compat-headers.patch
@@ -1,0 +1,11 @@
+--- srt-1.3.1/common/filelist_win32.maf.orig	2018-06-15 21:44:11.000000000 +0200
++++ srt-1.3.1/common/filelist_win32.maf	2018-09-25 20:26:36.903688700 +0200
+@@ -4,8 +4,6 @@
+ #
+ # These are included by platform_sys.h header contained in ../srtcore/filelist.maf
+ #
+-win/inttypes.h
+-win/stdint.h
+ win/unistd.h
+ 
+ SOURCES

--- a/mingw-w64-srt/PKGBUILD
+++ b/mingw-w64-srt/PKGBUILD
@@ -4,7 +4,7 @@ _realname=srt
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.3.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Secure Reliable Transport (SRT) (mingw-w64)"
 arch=('any')
 license=('MPLv2.0')
@@ -20,12 +20,14 @@ source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/Haivision/srt/archi
         0001-CMakeLists.txt-substitute-link-flags-for-package-nam.patch
         0003-add-implicit-link-libraries.patch
         0004-mingw-ws2_32-linking.patch
-        0005-mingw-w64-pthread.patch)
+        0005-mingw-w64-pthread.patch
+        0006-no-msvc-compat-headers.patch)
 sha256sums=('f202801d9e53cd8854fccc1ca010272076c32c318396c8f61fb9a61807c3dbea'
             'e127fcc9238e8947be9df3a95ed6c34db09cdb6177bc5087906e3d04fef96c07'
             'ea35b32907f264eab70a88537df76b54409304366050b0f62e3e778fc5fe47cf'
             '1dc63f94713c04cef613b37d1f31ccff3c685e431a6a73027045c4d158c3c0d9'
-            'fd1436b098844bcebae27dc0584a3b332226648abc3edcc57e503b62e18625bb')
+            'fd1436b098844bcebae27dc0584a3b332226648abc3edcc57e503b62e18625bb'
+            '75ce12dfecd3b44abac0609c1490beec4e20240ae06e814d5a15cf254db5b287')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -37,6 +39,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0003-add-implicit-link-libraries.patch
   patch -p1 -i ${srcdir}/0004-mingw-ws2_32-linking.patch
   patch -p1 -i ${srcdir}/0005-mingw-w64-pthread.patch
+  patch -p1 -i ${srcdir}/0006-no-msvc-compat-headers.patch
 }
 
 build() {


### PR DESCRIPTION
They error out if msvc isn't used and we are C99 compatible anyway.
This fixes the gst-plugins-bad build (at least some of it)