### PR TITLE
python3: fix openssl build checks

### DIFF
--- a/mingw-w64-python3/2100-configure-fix-openssl-checks.patch
+++ b/mingw-w64-python3/2100-configure-fix-openssl-checks.patch
@@ -1,0 +1,26 @@
+--- Python-3.7.0/configure.ac.orig	2018-09-25 20:37:44.457679900 +0200
++++ Python-3.7.0/configure.ac	2018-09-25 21:11:51.536017600 +0200
+@@ -5919,7 +5919,9 @@
+     CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+ 
+     AC_LINK_IFELSE([AC_LANG_PROGRAM([
+-        [#include <openssl/x509_vfy.h>]
++        [#define WIN32_LEAN_AND_MEAN 
++         #include <windows.h>
++         #include <openssl/x509_vfy.h>]
+     ], [
+         [X509_VERIFY_PARAM *p = X509_VERIFY_PARAM_new();]
+         [X509_VERIFY_PARAM_set1_host(p, "localhost", 0);]
+--- Python-3.7.0/m4/ax_check_openssl.m4.orig	2018-09-25 20:58:06.392520200 +0200
++++ Python-3.7.0/m4/ax_check_openssl.m4	2018-09-25 21:11:25.390371700 +0200
+@@ -106,7 +106,9 @@
+     LIBS="$OPENSSL_LIBS $LIBS"
+     CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+     AC_LINK_IFELSE(
+-        [AC_LANG_PROGRAM([#include <openssl/ssl.h>], [SSL_new(NULL)])],
++        [AC_LANG_PROGRAM([#define WIN32_LEAN_AND_MEAN 
++                          #include <windows.h>
++                          #include <openssl/ssl.h>], [SSL_new(NULL)])],
+         [
+             AC_MSG_RESULT([yes])
+             $1

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.0
-pkgrel=13
+pkgrel=14
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -125,6 +125,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1850-disable-readline.patch
         1860-fix-isselectable.patch
         2000-warnings-fixes.patch
+        2100-configure-fix-openssl-checks.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -280,6 +281,8 @@ prepare() {
     1860-fix-isselectable.patch
 
   apply_patch_with_msg 2000-warnings-fixes.patch
+
+  apply_patch_with_msg 2100-configure-fix-openssl-checks.patch
 
   autoreconf -vfi
 
@@ -525,4 +528,5 @@ sha256sums=('0382996d1ee6aafe59763426cf0139ffebe36984474d0ec4126dd1c40a8b3549'
             '3262ce24714dc6cfea5b18d528d7f1a333128eadf5aa9c3a026131c34f082e1f'
             'bd9b934e8c1f92573115efaef6b6b04966e3222ba769511e006366d1217d34d6'
             '30d507205b3d99e877bf7418b9ad7a181d747758bcc8e96fd296da72e8cd8758'
+            '98352f0f2114cb6cce1eee76dad531e453d4214f2cc8f49f9b97f639195d1a9a'
             '846ceef71ae4001df68a1040e865d54e3688d7cc657927febc2344dcee8e1852')


### PR DESCRIPTION
openssl no longer includes windows.h and requires the user to do so first.

with those checks failing python gets built without openssl support.