### PR TITLE
Fix the problem of gcc-8.2.0 about std::swap on std::variant

### DIFF
--- a/mingw-w64-gcc/0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch
+++ b/mingw-w64-gcc/0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch
@@ -1,0 +1,101 @@
+--- a/libstdc++-v3/include/std/variant	2018-07-04 19:46:39.000000000 +0800
++++ b/libstdc++-v3/include/std/variant	2018-09-28 13:37:10.380321400 +0800
+@@ -506,6 +506,20 @@
+ 	  }
+       }
+ 
++      void _M_destructive_move(_Move_ctor_base&& __rhs)
++      {
++	this->~_Move_ctor_base();
++	__try
++	  {
++	    ::new (this) _Move_ctor_base(std::move(__rhs));
++	  }
++	__catch (...)
++	  {
++	    this->_M_index = variant_npos;
++	    __throw_exception_again;
++	  }
++      }
++
+       _Move_ctor_base(const _Move_ctor_base&) = default;
+       _Move_ctor_base& operator=(const _Move_ctor_base&) = default;
+       _Move_ctor_base& operator=(_Move_ctor_base&&) = default;
+@@ -516,6 +530,12 @@
+     {
+       using _Base = _Copy_ctor_alias<_Types...>;
+       using _Base::_Base;
++
++      void _M_destructive_move(_Move_ctor_base&& __rhs)
++      {
++	this->~_Move_ctor_base();
++	::new (this) _Move_ctor_base(std::move(__rhs));
++      }
+     };
+ 
+   template<typename... _Types>
+@@ -538,22 +558,14 @@
+ 	      {
+ 		static constexpr void (*_S_vtable[])(void*, void*) =
+ 		  { &__erased_assign<_Types&, const _Types&>... };
+-		_S_vtable[__rhs._M_index](this->_M_storage(), __rhs._M_storage());
++		_S_vtable[__rhs._M_index](this->_M_storage(),
++					  __rhs._M_storage());
+ 	      }
+ 	  }
+ 	else
+ 	  {
+ 	    _Copy_assign_base __tmp(__rhs);
+-	    this->~_Copy_assign_base();
+-	    __try
+-	      {
+-		::new (this) _Copy_assign_base(std::move(__tmp));
+-	      }
+-	    __catch (...)
+-	      {
+-		this->_M_index = variant_npos;
+-		__throw_exception_again;
+-	      }
++	    this->_M_destructive_move(std::move(__tmp));
+ 	  }
+ 	__glibcxx_assert(this->_M_index == __rhs._M_index);
+ 	return *this;
+@@ -582,20 +594,6 @@
+       using _Base = _Copy_assign_alias<_Types...>;
+       using _Base::_Base;
+ 
+-      void _M_destructive_move(_Move_assign_base&& __rhs)
+-      {
+-	this->~_Move_assign_base();
+-	__try
+-	  {
+-	    ::new (this) _Move_assign_base(std::move(__rhs));
+-	  }
+-	__catch (...)
+-	  {
+-	    this->_M_index = variant_npos;
+-	    __throw_exception_again;
+-	  }
+-      }
+-
+       _Move_assign_base&
+       operator=(_Move_assign_base&& __rhs)
+ 	  noexcept(_Traits<_Types...>::_S_nothrow_move_assign)
+@@ -613,16 +611,7 @@
+ 	else
+ 	  {
+ 	    _Move_assign_base __tmp(std::move(__rhs));
+-	    this->~_Move_assign_base();
+-	    __try
+-	      {
+-		::new (this) _Move_assign_base(std::move(__tmp));
+-	      }
+-	    __catch (...)
+-	      {
+-		this->_M_index = variant_npos;
+-		__throw_exception_again;
+-	      }
++	    this->_M_destructive_move(std::move(__tmp));
+ 	  }
+ 	__glibcxx_assert(this->_M_index == __rhs._M_index);
+ 	return *this;

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -13,7 +13,7 @@ pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-ada"
          "${MINGW_PACKAGE_PREFIX}-${_realname}-objc")
 pkgver=8.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="GCC for the MinGW-w64"
 arch=('any')
 url="https://gcc.gnu.org"
@@ -51,7 +51,8 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}/${_realname}-${pkgve
         0019-gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch
         0130-libstdc++-in-out.patch
         0140-gcc-8.2.0-diagnostic-color.patch
-        0300-ada-tools-build.patch)
+        0300-ada-tools-build.patch
+		0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch)
 sha256sums=('196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080'
             'SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
@@ -69,7 +70,8 @@ sha256sums=('196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080'
             '1a2309d027c3defd0257f50a3c82fa8d2b5ea825c9d880ed77ea8e43505112b2'
             'ba2f77db605577d08e4079f08a7a9556c975b5416be8610c5be31e915637feb7'
             'e467f0ac68b349de826c79b00a45c5ad9e7c5a55d06b9b9fa7afd94c597f6376'
-            'ecf58edd60509a1d0ba554ff4824c999fb22b449ea3649790588c1377e80f10b')
+            'ecf58edd60509a1d0ba554ff4824c999fb22b449ea3649790588c1377e80f10b'
+			'7999073ba0827b1d61b3d60fed9efcf2f8f250997b9fcc865184f1c2fe2083dc')
 
 _threads="posix"
 
@@ -112,7 +114,8 @@ prepare() {
     0010-Fix-using-large-PCH.patch \
     0011-Enable-shared-gnat-implib.patch \
     0014-clone_function_name_1-Retain-any-stdcall-suffix.patch \
-    0019-gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch
+    0019-gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch \
+	0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch
 
   apply_patch_with_msg \
     0130-libstdc++-in-out.patch

--- a/mingw-w64-gcc/PKGBUILD
+++ b/mingw-w64-gcc/PKGBUILD
@@ -52,7 +52,7 @@ source=("https://ftp.gnu.org/gnu/gcc/${_realname}-${pkgver}/${_realname}-${pkgve
         0130-libstdc++-in-out.patch
         0140-gcc-8.2.0-diagnostic-color.patch
         0300-ada-tools-build.patch
-		0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch)
+        0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch)
 sha256sums=('196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080'
             'SKIP'
             'dea2bbad4967280910559c6a11b865aeec19cab34647fb5894cb498b24b14462'
@@ -71,7 +71,7 @@ sha256sums=('196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080'
             'ba2f77db605577d08e4079f08a7a9556c975b5416be8610c5be31e915637feb7'
             'e467f0ac68b349de826c79b00a45c5ad9e7c5a55d06b9b9fa7afd94c597f6376'
             'ecf58edd60509a1d0ba554ff4824c999fb22b449ea3649790588c1377e80f10b'
-			'7999073ba0827b1d61b3d60fed9efcf2f8f250997b9fcc865184f1c2fe2083dc')
+            '7999073ba0827b1d61b3d60fed9efcf2f8f250997b9fcc865184f1c2fe2083dc')
 
 _threads="posix"
 
@@ -115,7 +115,7 @@ prepare() {
     0011-Enable-shared-gnat-implib.patch \
     0014-clone_function_name_1-Retain-any-stdcall-suffix.patch \
     0019-gcc-8.2.0-Backport-patches-for-std-filesystem-from-master.patch \
-	0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch
+    0020-gcc-8.2.0-Backport-patches-for-std-variant-_M_destructive_move.patch
 
   apply_patch_with_msg \
     0130-libstdc++-in-out.patch


### PR DESCRIPTION
Fix the problem of gcc-8.2.0 about std::swap on std::variant

The problem is reported at:
https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg581872.html

This is fixed by replacing a header using the version fetched from gcc 8.2.1
So this patch has to be removed when we move to real 8.2.1

See issue #4477 