### PR TITLE
qt5 fixes (fix #4455)

### DIFF
--- a/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -8,8 +8,8 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 +    if (_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES)
 +        set(_list_sep \";\")
 +    endif()
-+    set_property(TARGET Qt5::Core APPEND PROPERTY
-+        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++    set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY
++        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}>\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
 +    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"

--- a/mingw-w64-qt5-static/0301-remove-evr-declaration.patch
+++ b/mingw-w64-qt5-static/0301-remove-evr-declaration.patch
@@ -1,0 +1,27 @@
+--- x86_64/qtmultimedia/src/plugins/common/evr/evrdefs.h.orig	2018-08-24 09:36:46.124193600 +0300
++++ x86_64/qtmultimedia/src/plugins/common/evr/evrdefs.h	2018-08-24 09:37:45.363581900 +0300
+@@ -83,14 +83,6 @@
+ #define MF_E_TRANSFORM_NEED_MORE_INPUT ((HRESULT)0xC00D6D72L)
+ #endif
+ 
+-#ifdef __GNUC__
+-typedef struct MFVideoNormalizedRect {
+-    float left;
+-    float top;
+-    float right;
+-    float bottom;
+-} MFVideoNormalizedRect;
+-#endif
+ 
+ #include <initguid.h>
+ 
+--- x86_64/qtmultimedia/src/plugins/directshow/directshow.pro.orig	2018-08-24 20:27:17.612908800 +0300
++++ x86_64/qtmultimedia/src/plugins/directshow/directshow.pro	2018-08-24 20:27:55.017048200 +0300
+@@ -14,6 +14,7 @@
+ mingw {
+     DEFINES -= WINVER=0x0601 _WIN32_WINNT=0x0601
+     DEFINES += NO_DSHOW_STRSAFE
++    LIBS_PRIVATE += -lamstrmid
+ }
+ 
+ include(common/common.pri)

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -740,7 +740,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            '5cebf00614f3bc101642ea3a2f8d14644ab75ea5168f63c2b0f5f090adc61f8a'
+            'dbad9a04b7cd9ac7767a388e40d22141cfbf0c461c66e252254706a0af0b96b1'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'

--- a/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -8,8 +8,8 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 +    if (_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES)
 +        set(_list_sep \";\")
 +    endif()
-+    set_property(TARGET Qt5::Core APPEND PROPERTY
-+        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++    set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY
++        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}>\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
 +    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -740,7 +740,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            '5cebf00614f3bc101642ea3a2f8d14644ab75ea5168f63c2b0f5f090adc61f8a'
+            'dbad9a04b7cd9ac7767a388e40d22141cfbf0c461c66e252254706a0af0b96b1'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'


### PR DESCRIPTION
collect deps for Qt5::$${CMAKE_MODULE_NAME} instead of Qt5::Core
(regression from 796a15ede3e71a56282c5553b87ca0fbe8fcba64)

appaned multiple items instead of using _list_sep manually

add missing 0301 patch for qt5-static