### PR TITLE
python-markdown: update to 3.0.1

### DIFF
--- a/mingw-w64-python-markdown/PKGBUILD
+++ b/mingw-w64-python-markdown/PKGBUILD
@@ -4,7 +4,7 @@ _realname=markdown
 _pyname=Markdown
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2.6.11
+pkgver=3.0.1
 pkgrel=1
 pkgdesc="Python implementation of John Gruber's Markdown (mingw-w64)"
 url='https://pypi.python.org/pypi/Markdown'
@@ -13,16 +13,17 @@ arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 source=("https://pypi.io/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz")
-sha256sums=('a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81')
+sha256sums=('d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c')
 
 prepare() {
-  cd ${srcdir}
-  cp -r ${_realname}-${pkgver} python2-build-${CARCH}
-  cp -r ${_realname}-${pkgver} python3-build-${CARCH}
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
 }
 
 build() {
-  cd "${srcdir}"
   for pver in {2,3}; do  
     msg "Python ${pver} build for ${CARCH}"  
     cd "${srcdir}/python${pver}-build-${CARCH}"


### PR DESCRIPTION
This updates python-markdown to 3.0.1.