### PR TITLE
qt5 fix configurations that are neither debug nor release (fix #4495)

### DIFF
--- a/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5-static/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,7 +1,7 @@
 diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 --- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
 +++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
-@@ -58,14 +58,19 @@
+@@ -58,14 +58,24 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
@@ -9,7 +9,7 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 +        set(_list_sep \";\")
 +    endif()
 +    set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY
-+        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}>\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++        INTERFACE_LINK_LIBRARIES \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
 +    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
@@ -21,6 +21,11 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 -        \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
 +        \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
      )
++    # provide static plugins for MINSIZEREL and RELWITHDEBINFO too
++    set_target_properties(${_Qt5$${CMAKE_MODULE_NAME} PROPERTIES
++        MAP_IMPORTED_CONFIG_MINSIZEREL Release
++        MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
++    )
  
  !!IF !isEmpty(CMAKE_WINDOWS_BUILD)
 @@ -238,17 +241,31 @@

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -740,7 +740,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            'dbad9a04b7cd9ac7767a388e40d22141cfbf0c461c66e252254706a0af0b96b1'
+            '2ed8fa715d7459df66bdbb938d098df8ae64209b5ba65957d754eeef09c8f995'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'

--- a/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
+++ b/mingw-w64-qt5/0042-qt-5.4.0-static-cmake-also-link-plugins-and-plugin-deps.patch
@@ -1,7 +1,7 @@
 diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in
 --- qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:31:26.194016900 +0100
 +++ qt-everywhere-opensource-src-5.6.0/qtbase/mkspecs/features/data/cmake/Qt5BasicConfig.cmake.in	2015-08-26 15:21:30.905016900 +0100
-@@ -58,14 +58,19 @@
+@@ -58,14 +58,24 @@
      set(imported_location \"$${CMAKE_DLL_DIR}${LIB_LOCATION}\")
  !!ENDIF
      _qt5_$${CMAKE_MODULE_NAME}_check_file_exists(${imported_location})
@@ -9,7 +9,7 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 +        set(_list_sep \";\")
 +    endif()
 +    set_property(TARGET Qt5::$${CMAKE_MODULE_NAME} APPEND PROPERTY
-+        INTERFACE_LINK_LIBRARIES \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}>\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
++        INTERFACE_LINK_LIBRARIES \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}\" \"$<$<CONFIG:${Configuration}>:${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}>\"
 +    )
      set_target_properties(Qt5::$${CMAKE_MODULE_NAME} PROPERTIES
 -        \"INTERFACE_LINK_LIBRARIES\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
@@ -21,6 +21,11 @@ diff -urN qt-everywhere-opensource-src-5.6.0.orig/qtbase/mkspecs/features/data/c
 -        \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
 +        \"IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration}\" \"${_Qt5$${CMAKE_MODULE_NAME}_LIB_DEPENDENCIES}${_list_sep}${_Qt5$${CMAKE_MODULE_NAME}_STATIC_${Configuration}_LIB_DEPENDENCIES}\"
      )
++    # provide static plugins for MINSIZEREL and RELWITHDEBINFO too
++    set_target_properties(${_Qt5$${CMAKE_MODULE_NAME} PROPERTIES
++        MAP_IMPORTED_CONFIG_MINSIZEREL Release
++        MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release
++    )
  
  !!IF !isEmpty(CMAKE_WINDOWS_BUILD)
 @@ -238,17 +241,31 @@

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=2
+pkgrel=3
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -740,7 +740,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '3ae9d64fb683036b3b1f91036378791e1ec4a10205c59e78761d22d8479c0540'
             'd720ac76035d56caea1f045dfb468a25865f9d4b22016cec5414f1c639a7697a'
             '914051840e01bf453e3db710d4471e6758e39e2cb87f8ffe3072fb90218c9f83'
-            'dbad9a04b7cd9ac7767a388e40d22141cfbf0c461c66e252254706a0af0b96b1'
+            '2ed8fa715d7459df66bdbb938d098df8ae64209b5ba65957d754eeef09c8f995'
             '29ed4566d4c1853b70a5173c6391ed90f123c5121b5836f2d16f8478f6354f0a'
             '7d7a99ff45c6ae4f39be663d52bafc125970787f364e84593117e6a7d79f7eae'
             '72e46178f2f694d8408f22684d1a7d39394056cb574fc4855c1f38c9d51e7e6c'


### PR DESCRIPTION
add the basic dependencies independent of the configuration (they are the same for all configuration anyway)

since _populate_$${CMAKE_MODULE_NAME}_target_properties is called twice – for DEBUG and RELEASE – and we APPEND here, they are duplicated in the end, which isn’t nice, but also unproblematic
originally the second call overwrites the configuration independent values with the second call, which is kinda stupid

however, the static dependencies _are_ configuration dependent, which requires MAP_IMPORTED_CONFIG_<CONFIG> to be set for MINSIZEREL and RELWITHDEBINFO to work

for these 2 special configuration, this actually makes the first change redundant

configurations other than the 4 default ones (also an empty CMAKE_BUILD_TYPE) will work with the first change for the shared version – as they do with upstream, but the static plugins are not configurable for this

this only worked before because it always fell back on (the deprecated) IMPORTED_LINK_INTERFACE_LIBRARIES_${Configuration} which has an implicit fallback similar to MAP_IMPORTED_CONFIG_<CONFIG>
in 796a15ede3e71a56282c5553b87ca0fbe8fcba64 INTERFACE_LINK_LIBRARIES was only set for Qt5::Core (so it didn’t overwrite for i.e. Qt5::Widgets)
and initially, in 3334a6ae6533816c0ba0c908347aec3ce9240ad6, INTERFACE_LINK_LIBRARIES_${Configuration} was set, which doesn’t exist