### PR TITLE
Fixes for gpgme++

### DIFF
--- a/mingw-w64-gpgme/PKGBUILD
+++ b/mingw-w64-gpgme/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gpgme
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.11.1
-pkgrel=3
+pkgrel=4
 pkgdesc="A C wrapper library for GnuPG (mingw-w64)"
 arch=('any')
 url="https://gnupg.org/related_software/gpgme/"
@@ -26,7 +26,9 @@ source=("https://www.gnupg.org/ftp/gcrypt/${_realname}/${_realname}-${pkgver}.ta
         0004-gpgme-find-gnupg.patch
         0005-invoke-scripts-via-sh.patch
         0006-fix-building-docs.patch
-        0007-mkdefsinc-use-CPPFLAGS.patch)
+        0007-mkdefsinc-use-CPPFLAGS.patch
+        relocatable-cmake.patch
+        gpgmepp-portable-types.patch)
 #These might be signed by any of these keys https://gnupg.org/signature_key.html
 validpgpkeys=('D8692123C4065DEA5E0F3AB5249B39D24F25E3B6'
               '46CC730865BB5C78EBABADCF04376F3EE0856959'
@@ -37,7 +39,9 @@ sha256sums=('2d1b111774d2e3dd26dcd7c251819ce4ef774ec5e566251eb9308fa7542fbd6f'
             '71763a209761afe6495d3d85e25bbe6ba76348450d426f8a2618a34a264e058a'
             'dd2cf257761781a1d8e5bfac7fcc09633e09928dd9a13cb509a5b76fd44aea2d'
             'b56fe3e3da872ca84d08b4aa426e6f71b3227e2a253bc45bf6023abf1288ecc9'
-            '29878B63804AFB40808397CC884F5ADE3F7143E0887E4839E33F96592CD50208')
+            '29878B63804AFB40808397CC884F5ADE3F7143E0887E4839E33F96592CD50208'
+            '32465eb5f99015d06a0b89c30c69a7c4208ab32c287275b729cf9bec08c4474c'
+            '12fbb051881b77cbc99fa46c09892c6d301bfed9a030172660f10cdf02b77ef4')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
@@ -45,6 +49,8 @@ prepare() {
   patch -p1 -i "${srcdir}"/0005-invoke-scripts-via-sh.patch
   patch -p1 -i "${srcdir}"/0006-fix-building-docs.patch
   patch -p1 -i "${srcdir}"/0007-mkdefsinc-use-CPPFLAGS.patch
+  patch -p1 -i "${srcdir}"/relocatable-cmake.patch
+  patch -p1 -i "${srcdir}"/gpgmepp-portable-types.patch
 
   autoreconf -ivf
 }

--- a/mingw-w64-gpgme/gpgmepp-portable-types.patch
+++ b/mingw-w64-gpgme/gpgmepp-portable-types.patch
@@ -1,0 +1,137 @@
+diff --git a/configure.ac b/configure.ac
+index 1813cc57..1d9ceb4b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -893,7 +893,8 @@ AC_CONFIG_FILES(Makefile src/Makefile
+                 tests/opassuan/Makefile
+ 		doc/Makefile
+                 src/versioninfo.rc
+-                src/gpgme.h)
++                src/gpgme.h
++                lang/cpp/src/data.h)
+ AC_CONFIG_FILES(src/gpgme-config, chmod +x src/gpgme-config)
+ AC_CONFIG_FILES(lang/cpp/Makefile lang/cpp/src/Makefile)
+ AC_CONFIG_FILES(lang/cpp/src/GpgmeppConfig-w32.cmake.in)
+diff --git a/lang/cpp/src/Makefile.am b/lang/cpp/src/Makefile.am
+index 1e6bdc28..ccfb16b0 100644
+--- a/lang/cpp/src/Makefile.am
++++ b/lang/cpp/src/Makefile.am
+@@ -20,7 +20,7 @@
+ # 02111-1307, USA
+ 
+ EXTRA_DIST = GpgmeppConfig.cmake.in.in GpgmeppConfigVersion.cmake.in \
+-             gpgmepp_version.h.in GpgmeppConfig-w32.cmake.in.in
++             gpgmepp_version.h.in data.h.in GpgmeppConfig-w32.cmake.in.in
+ 
+ lib_LTLIBRARIES = libgpgmepp.la
+ 
+@@ -38,7 +38,7 @@ main_sources = \
+     vfsmountresult.cpp configuration.cpp tofuinfo.cpp swdbresult.cpp
+ 
+ gpgmepp_headers = \
+-    configuration.h context.h data.h decryptionresult.h \
++    configuration.h context.h decryptionresult.h \
+     defaultassuantransaction.h editinteractor.h encryptionresult.h \
+     engineinfo.h error.h eventloopinteractor.h exception.h global.h \
+     gpgadduserideditinteractor.h gpgagentgetinfoassuantransaction.h \
+@@ -60,7 +60,7 @@ interface_headers= \
+ gpgmeppincludedir = $(includedir)/gpgme++
+ gpgmeppinclude_HEADERS = $(gpgmepp_headers)
+ nobase_gpgmeppinclude_HEADERS = $(interface_headers)
+-nodist_gpgmeppinclude_HEADERS = gpgmepp_version.h
++nodist_gpgmeppinclude_HEADERS = gpgmepp_version.h data.h
+ 
+ libgpgmepp_la_SOURCES = $(main_sources) $(gpgmepp_headers) context_vanilla.cpp \
+                         $(interface_headers) $(private_gpgmepp_headers)
+@@ -106,4 +106,4 @@ install-data-local: install-cmake-files
+ uninstall-local: uninstall-cmake-files
+ 
+ CLEANFILES = GpgmeppConfig.cmake GpgmeppConfigVersion.cmake \
+-             gpgmepp_version.h GpgmeppConfig.cmake.in
++             gpgmepp_version.h data.h GpgmeppConfig.cmake.in
+diff --git a/lang/cpp/src/data.cpp b/lang/cpp/src/data.cpp
+index 2782aa79..1da0df52 100644
+--- a/lang/cpp/src/data.cpp
++++ b/lang/cpp/src/data.cpp
+@@ -217,17 +217,17 @@ GpgME::Error GpgME::Data::setFileName(const char *name)
+     return Error(gpgme_data_set_file_name(d->data, name));
+ }
+ 
+-ssize_t GpgME::Data::read(void *buffer, size_t length)
++gpgme_ssize_t GpgME::Data::read(void *buffer, size_t length)
+ {
+     return gpgme_data_read(d->data, buffer, length);
+ }
+ 
+-ssize_t GpgME::Data::write(const void *buffer, size_t length)
++gpgme_ssize_t GpgME::Data::write(const void *buffer, size_t length)
+ {
+     return gpgme_data_write(d->data, buffer, length);
+ }
+ 
+-off_t GpgME::Data::seek(off_t offset, int whence)
++gpgme_off_t GpgME::Data::seek(gpgme_off_t offset, int whence)
+ {
+     return gpgme_data_seek(d->data, offset, whence);
+ }
+diff --git a/lang/cpp/src/data.h b/lang/cpp/src/data.h.in
+similarity index 93%
+rename from lang/cpp/src/data.h
+rename to lang/cpp/src/data.h.in
+index df8607e7..1c909ef8 100644
+--- a/lang/cpp/src/data.h
++++ b/lang/cpp/src/data.h.in
+@@ -26,11 +26,13 @@
+ #include "global.h"
+ #include "key.h"
+ 
+-#include <sys/types.h> // for size_t, off_t
+ #include <cstdio> // FILE
+ #include <algorithm>
+ #include <memory>
+ 
++/* System specific typedefs.  */
++@INSERT__TYPEDEFS_FOR_GPGME_H@
++
+ namespace GpgME
+ {
+ 
+@@ -106,9 +108,9 @@ public:
+     char *fileName() const;
+     Error setFileName(const char *name);
+ 
+-    ssize_t read(void *buffer, size_t length);
+-    ssize_t write(const void *buffer, size_t length);
+-    off_t seek(off_t offset, int whence);
++    gpgme_ssize_t read(void *buffer, size_t length);
++    gpgme_ssize_t write(const void *buffer, size_t length);
++    gpgme_off_t seek(gpgme_off_t offset, int whence);
+ 
+     /* Convenience function to do a seek (0, SEEK_SET).  */
+     Error rewind();
+diff --git a/lang/qt/src/Makefile.am b/lang/qt/src/Makefile.am
+index 32251424..60f18b10 100644
+--- a/lang/qt/src/Makefile.am
++++ b/lang/qt/src/Makefile.am
+@@ -217,7 +217,7 @@ nodist_qgpgmeinclude_HEADERS = qgpgme_version.h
+ 
+ libqgpgme_la_SOURCES = $(qgpgme_sources) $(qgpgme_headers) $(private_qgpgme_headers)
+ 
+-AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
++AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
+               @GPGME_QT_CFLAGS@ @GPG_ERROR_CFLAGS@ @LIBASSUAN_CFLAGS@ \
+               -DBUILDING_QGPGME
+ 
+diff --git a/lang/qt/tests/Makefile.am b/lang/qt/tests/Makefile.am
+index bfe77ad5..7856a4f6 100644
+--- a/lang/qt/tests/Makefile.am
++++ b/lang/qt/tests/Makefile.am
+@@ -39,7 +39,7 @@ LDADD = ../../cpp/src/libgpgmepp.la ../src/libqgpgme.la \
+         ../../../src/libgpgme.la @GPGME_QT_LIBS@ @GPG_ERROR_LIBS@ \
+         @GPGME_QTTEST_LIBS@ -lstdc++
+ 
+-AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/src \
++AM_CPPFLAGS = -I$(top_srcdir)/lang/cpp/src -I$(top_builddir)/lang/cpp/src -I$(top_builddir)/src \
+               @GPG_ERROR_CFLAGS@ @GPGME_QT_CFLAGS@ @GPG_ERROR_CFLAGS@ \
+               @LIBASSUAN_CFLAGS@ @GPGME_QTTEST_CFLAGS@ -DBUILDING_QGPGME \
+               -I$(top_srcdir)/lang/qt/src \

--- a/mingw-w64-gpgme/relocatable-cmake.patch
+++ b/mingw-w64-gpgme/relocatable-cmake.patch
@@ -1,0 +1,75 @@
+diff --git a/lang/cpp/src/GpgmeppConfig-w32.cmake.in.in b/lang/cpp/src/GpgmeppCo
+nfig-w32.cmake.in.in
+index 12826760..df1d4c9a 100644
+--- a/lang/cpp/src/GpgmeppConfig-w32.cmake.in.in
++++ b/lang/cpp/src/GpgmeppConfig-w32.cmake.in.in
+@@ -58,18 +58,27 @@ unset(_targetsDefined)
+ unset(_targetsNotDefined)
+ unset(_expectedTargets)
+ 
++get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++if(_IMPORT_PREFIX STREQUAL "/")
++  set(_IMPORT_PREFIX "")
++endif()
++
+ # Create imported target Gpgmepp
+ add_library(Gpgmepp SHARED IMPORTED)
+ 
+ set_target_properties(Gpgmepp PROPERTIES
+-  IMPORTED_IMPLIB "@resolved_libdir@/libgpgmepp.dll.a"
+-  INTERFACE_INCLUDE_DIRECTORIES "@resolved_includedir@/gpgme++;@resolved_includedir@"
+-  INTERFACE_LINK_LIBRARIES "pthread;@resolved_libdir@/libgpgme.dll.a;@LIBASSUAN_LIBS@"
+-  IMPORTED_LOCATION "@resolved_bindir@/libgpgmepp-6.dll"
++  IMPORTED_IMPLIB "${_IMPORT_PREFIX}/lib/libgpgmepp.dll.a"
++  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/gpgme++;${_IMPORT_PREFIX}/include"
++  INTERFACE_LINK_LIBRARIES "pthread;${_IMPORT_PREFIX}/lib/libgpgme.dll.a;@LIBASSUAN_LIBS@"
++  IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/libgpgmepp-6.dll"
+ )
+ list(APPEND _IMPORT_CHECK_TARGETS Gpgmepp )
+-list(APPEND _IMPORT_CHECK_FILES_FOR_Gpgmepp "@resolved_libdir@/libgpgmepp.dll.a" "@resolved_bindir@/libgpgmepp-6.dll" )
++list(APPEND _IMPORT_CHECK_FILES_FOR_Gpgmepp "${_IMPORT_PREFIX}/lib/libgpgmepp.dll.a" "${_IMPORT_PREFIX}/bin/libgpgmepp-6.dll" )
+ 
++set(_IMPORT_PREFIX)
+ 
+ if(CMAKE_VERSION VERSION_LESS 2.8.12)
+   message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")
+diff --git a/lang/qt/src/QGpgmeConfig-w32.cmake.in.in b/lang/qt/src/QGpgmeConfig-w32.cmake.in.in
+index b8978053..8f7a2d43 100644
+--- a/lang/qt/src/QGpgmeConfig-w32.cmake.in.in
++++ b/lang/qt/src/QGpgmeConfig-w32.cmake.in.in
+@@ -58,18 +58,28 @@ unset(_targetsDefined)
+ unset(_targetsNotDefined)
+ unset(_expectedTargets)
+ 
++get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
++if(_IMPORT_PREFIX STREQUAL "/")
++  set(_IMPORT_PREFIX "")
++endif()
++
+ # Create imported target QGpgme
+ add_library(QGpgme SHARED IMPORTED)
+ 
+ set_target_properties(QGpgme PROPERTIES
+-  IMPORTED_IMPLIB_RELEASE "@resolved_libdir@/libqgpgme.dll.a"
+-  INTERFACE_INCLUDE_DIRECTORIES "@resolved_includedir@/qgpgme;@resolved_includedir@"
++  IMPORTED_IMPLIB_RELEASE "${_IMPORT_PREFIX}/lib/libqgpgme.dll.a"
++  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include/qgpgme;${_IMPORT_PREFIX}/include"
+   INTERFACE_LINK_LIBRARIES "Gpgmepp;Qt5::Core"
+-  IMPORTED_LOCATION "@resolved_libdir@/libqgpgme-7.dll"
++  IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/libqgpgme-7.dll"
+ )
+ 
+ list(APPEND _IMPORT_CHECK_TARGETS QGgpme )
+-list(APPEND _IMPORT_CHECK_FILES_FOR_Qgpgme "@resolved_libdir@/libqgpgme.dll.a" "@resolved_bindir@/libqgpgme-7.dll" )
++list(APPEND _IMPORT_CHECK_FILES_FOR_Qgpgme "${_IMPORT_PREFIX}/lib/libqgpgme.dll.a" "${_IMPORT_PREFIX}/bin/libqgpgme-7.dll" )
++
++set(_IMPORT_PREFIX)
+ 
+ if(CMAKE_VERSION VERSION_LESS 2.8.12)
+   message(FATAL_ERROR "This file relies on consumers using CMake 2.8.12 or greater.")


### PR DESCRIPTION
* Use computed relative paths in CMake files instead of absolute MSYS paths
* Use portable `gpgme_off_t` and `gpgme_ssize_t` to fix link issues in clients