### PR TITLE
codelite-git: Move "${MINGW_PACKAGE_PREFIX}-clang" to run-time depends

### DIFF
--- a/mingw-w64-codelite-git/PKGBUILD
+++ b/mingw-w64-codelite-git/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=12.0.287.ge34dc76cb
+pkgver=12.0.623.gd7fa329ea
 pkgrel=1
 pkgdesc="Open-source, cross platform IDE for the C/C++ programming languages (mingw-w64)"
 arch=('any')
@@ -15,13 +15,14 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-hunspell"
          "${MINGW_PACKAGE_PREFIX}-libssh"
          "${MINGW_PACKAGE_PREFIX}-drmingw"
+         "${MINGW_PACKAGE_PREFIX}-clang"      # libclang
          "${MINGW_PACKAGE_PREFIX}-wxWidgets"
          "${MINGW_PACKAGE_PREFIX}-sqlite3"
          )
 optdepends=("${MINGW_PACKAGE_PREFIX}-clang")
 makedepends=("${MINGW_PACKAGE_PREFIX}-boost"
              "${MINGW_PACKAGE_PREFIX}-cmake"
-             "${MINGW_PACKAGE_PREFIX}-clang"
+#             "${MINGW_PACKAGE_PREFIX}-clang"
              "git")
 options=(strip staticlibs !debug)
 source=("${_realname}::git+https://github.com/eranif/codelite.git"


### PR DESCRIPTION
CodeLite requires libclang during run-time.
