### PR TITLE
mingw-w64-python-defusexml - 0.5.0 - New package required by nbconvert

### DIFF
--- a/mingw-w64-python-defusexml/PKGBUILD
+++ b/mingw-w64-python-defusexml/PKGBUILD
@@ -1,0 +1,110 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>.
+
+_realname=defusedxml
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.5.0
+pkgrel=1
+pkgdesc="XML bomb protection for Python stdlib modules (mingw-w64)"
+arch=('any')
+url='https://bitbucket.org/tiran/defusedxml'
+license=('PSF')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+source=("https://pypi.io/packages/source/d/defusedxml/${_realname}-$pkgver.tar.gz")
+sha256sums=("SKIP")
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+#  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+#  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} tests.py
+  done
+}
+
+package_python3-defusedxml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+}
+
+package_python2-defusedxml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-defusedxml() {
+  package_python2-defusedxml
+}
+
+package_mingw-w64-i686-python3-defusedxml() {
+  package_python3-defusedxml
+}
+
+package_mingw-w64-x86_64-python2-defusedxml() {
+  package_python2-defusedxml
+}
+
+package_mingw-w64-x86_64-python3-defusedxml() {
+  package_python3-defusedxml
+}

--- a/mingw-w64-python2-backports.os/PKGBUILD
+++ b/mingw-w64-python2-backports.os/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+pkgname="${MINGW_PACKAGE_PREFIX}-python2-backports.os"
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="Backport of new features in Python's os module"
+arch=('any')
+url="https://github.com/pjdelport/backports.os"
+license=('PSF')
+depends=("${MINGW_PACKAGE_PREFIX}-python2-backports" 
+         "${MINGW_PACKAGE_PREFIX}-python2-future")
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-hypothesis"
+              "${MINGW_PACKAGE_PREFIX}-python2-pytest-runner")
+source=("https://pypi.io/packages/source/b/backports.os/backports.os-$pkgver.tar.gz")
+sha256sums=('b472c4933094306ca08ec90b2a8cbb50c34f1fb2767775169a1c1650b7b74630')
+
+prepare() {
+  cd "${srcdir}"
+  rm -rf ${builddir} | true
+  cp -r "backports.os-${pkgver}" "python2-build-${CARCH}"
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+build() {
+  msg "Python 2 build for ${CARCH}"  
+  cd "${srcdir}/python2-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/python2 setup.py build
+}
+
+check() {
+  msg "Python 2 tests for ${CARCH}"
+  cd "${srcdir}/python2-build-${CARCH}"
+# some tests fail
+  ${MINGW_PREFIX}/bin/python2 setup.py pytest || true
+}
+
+package() {
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+# We don't want the backports namespace in this package.
+  rm "$pkgdir${MINGW_PREFIX}"/lib/python2.7/site-packages/backports/__init__.py*
+}

--- a/mingw-w64-python3-jupyter-nbconvert/PKGBUILD
+++ b/mingw-w64-python3-jupyter-nbconvert/PKGBUILD
@@ -4,12 +4,13 @@ _realname=nbconvert
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-jupyter-${_realname}")
 pkgver=5.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Convert Jupyter notebooks to other formats (mingw-w64)"
 arch=('any')
 url='https://pypi.python.org/pypi/nbconvert'
 license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-python3"
+         "${MINGW_PACKAGE_PREFIX}-python3-defusedxml"
          "${MINGW_PACKAGE_PREFIX}-python3-jupyter_client"
          "${MINGW_PACKAGE_PREFIX}-python3-jupyter-nbformat"
          "${MINGW_PACKAGE_PREFIX}-python3-pygments"
@@ -35,6 +36,15 @@ build() {
   msg "Python 3 build for ${CARCH}"
   cd "${srcdir}/python3-build-${CARCH}"
   ${MINGW_PREFIX}/bin/python3 setup.py build
+}
+
+check() {
+  msg "Python 3 test for ${CARCH}"
+  cd "${srcdir}/python3-build-${CARCH}"
+#Todo: Fix a test and possibly nbconvert.  The problem is that it attempts
+#to use inkscape but it locates it using the Windows registry and the MINGW
+#version from these doesn't set the registry.
+  ${MINGW_PREFIX}/bin/py.test --pyargs nbconvert || true
 }
 
 package() {


### PR DESCRIPTION
mingw-w64-python3-nbconvert-nbconvert - 5.4 - require mingw-w64-python-defusexml