### PR TITLE
Fixed plplot qhull link and install dir

### DIFF
--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -11,7 +11,7 @@ _realname=plplot
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=5.13.0
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="Scientific plotting software (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
@@ -46,12 +46,16 @@ source=(https://downloads.sourceforge.net/sourceforge/plplot/${_realname}-${pkgv
         find-gd.patch
         Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
         pdf-linking-libharu.patch
-        fix-pkgconfig.patch)
+        fix-pkgconfig.patch
+		fix-qhull-lib.patch
+		fix-install-dir.patch)
 sha256sums=('ec36bbee8b03d9d1c98f8fd88f7dc3415560e559b53eb1aa991c2dcf61b25d2b'
             '57ad3a43d5ad467b89889a42d0b033e35cf322b9b83f2f41a62fe5d74a5d01b8'
             '9c81879ade97eb15bdefc04c476e986e5996ac52fff2428f90c136e16d54f275'
             'abf5ee33dad2108220d0973de4279ce04007b9fb429184d194a6cf951005c8be'
-            'fe7a7c0e888187a00c2df8e42c54ed964845de2aa5e8fc2fdf94868c0cfb148c')
+            'fe7a7c0e888187a00c2df8e42c54ed964845de2aa5e8fc2fdf94868c0cfb148c'
+			'f8fc77b0a89ce9f89a3e1c9df2f1e07c7c1cebf90e0d7e7791247270e090171e'
+			'e3b9baaedff4f0894bfc05206ce31521e9aaec361d9afb4c10102b0dbc667d30')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}
@@ -59,6 +63,8 @@ prepare() {
   patch -p1 -i ${srcdir}/Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
   patch -p1 -i ${srcdir}/pdf-linking-libharu.patch
   patch -p1 -i ${srcdir}/fix-pkgconfig.patch
+  patch -p1 -i ${srcdir}/fix-qhull-lib.patch
+  patch -p1 -i ${srcdir}/fix-install-dir.patch
 }
 
 build() {

--- a/mingw-w64-plplot/PKGBUILD
+++ b/mingw-w64-plplot/PKGBUILD
@@ -47,15 +47,15 @@ source=(https://downloads.sourceforge.net/sourceforge/plplot/${_realname}-${pkgv
         Include-wx-msw-wrapwin.h-instead-of-Windows.h.patch
         pdf-linking-libharu.patch
         fix-pkgconfig.patch
-		fix-qhull-lib.patch
-		fix-install-dir.patch)
+        fix-qhull-lib.patch
+        fix-install-dir.patch)
 sha256sums=('ec36bbee8b03d9d1c98f8fd88f7dc3415560e559b53eb1aa991c2dcf61b25d2b'
             '57ad3a43d5ad467b89889a42d0b033e35cf322b9b83f2f41a62fe5d74a5d01b8'
             '9c81879ade97eb15bdefc04c476e986e5996ac52fff2428f90c136e16d54f275'
             'abf5ee33dad2108220d0973de4279ce04007b9fb429184d194a6cf951005c8be'
             'fe7a7c0e888187a00c2df8e42c54ed964845de2aa5e8fc2fdf94868c0cfb148c'
-			'f8fc77b0a89ce9f89a3e1c9df2f1e07c7c1cebf90e0d7e7791247270e090171e'
-			'e3b9baaedff4f0894bfc05206ce31521e9aaec361d9afb4c10102b0dbc667d30')
+            'f8fc77b0a89ce9f89a3e1c9df2f1e07c7c1cebf90e0d7e7791247270e090171e'
+            'c11a37adea8134f9497fd45f24cd153cce18855ddff66ea5ba6ef8875da022fc')
 
 prepare() {
   cd ${srcdir}/${_realname}-${pkgver}

--- a/mingw-w64-plplot/fix-install-dir.patch
+++ b/mingw-w64-plplot/fix-install-dir.patch
@@ -1,0 +1,98 @@
+--- plplot-5.13.0/src/plctrl.c.orig
++++ plplot-5.13.0/src/plctrl.c
+@@ -56,6 +56,10 @@
+ #include <errno.h>
+ #endif
+ 
++#ifdef _WIN32
++#include <windows.h>
++#endif
++
+ // Random number generator (Mersenne Twister)
+ #include "mt19937ar.h"
+ 
+@@ -68,6 +72,10 @@
+ // work even in the single precision floating point case.
+ #define FUZZ_EPSILON    1.e-4
+ 
++#ifdef _WIN32
++static HMODULE handle_dll;
++#endif
++
+ // Static functions
+ 
+ // Used by any external init code to suggest a path
+@@ -124,6 +132,41 @@
+ #endif
+ 
+ #endif
++
++#ifdef _WIN32
++BOOL WINAPI
++DllMain (HINSTANCE hinstDLL,
++         DWORD     fdwReason,
++         LPVOID    lpvReserved)
++{
++  switch (fdwReason)
++    {
++    case DLL_PROCESS_ATTACH:
++      handle_dll = (HMODULE) hinstDLL;
++      break;
++    }
++
++  return TRUE;
++}
++
++char * plGetWinInstallDir()
++{
++	char *path;
++	char *p;
++	
++	path = (char*) malloc(MAX_PATH);
++	
++	GetModuleFileName(handle_dll, path, MAX_PATH);
++	
++	p = strrchr (path, '\\');
++	*p = '\0';
++	p = strrchr (path, '\\');
++	*p = '\0';
++	
++	return path;
++}
++#endif
++
+ 
+ //--------------------------------------------------------------------------
+ //  Routines that deal with colors & color maps.
+@@ -2189,6 +2232,14 @@
+         return fs;
+ #endif
+ 
++#ifdef _WIN32
++	dn = plGetWinInstallDir();
++	plGetName( dn, "bin", fn, &fs );
++	free(dn);
++    if ( !plFindName( fs ) )
++        return fs;
++#endif
++
+ // Crapped out
+ 
+     free_mem( fs );
+@@ -2323,6 +2374,15 @@
+     if ( file != NULL )
+         goto done;
+ #endif // macintosh
++
++#ifdef _WIN32
++	dn = plGetWinInstallDir();
++	plGetName( dn, "share\\plplot5.13.0", fn, &fs );
++	free(dn);
++	if ( ( file = pdf_fopen( fs, "rb" ) ) != NULL )
++		goto done;
++	fprintf( stderr, "WININSTALLDIR =\"%s\" ; file=\"%s\"\n", dn, fs ); // what IS set?
++#endif
+ 
+     if ( plplotLibDir != NULL )
+     {
+

--- a/mingw-w64-plplot/fix-install-dir.patch
+++ b/mingw-w64-plplot/fix-install-dir.patch
@@ -86,7 +86,7 @@
 +
 +#ifdef _WIN32
 +	dn = plGetWinInstallDir();
-+	plGetName( dn, "share\\plplot5.13.0", fn, &fs );
++	plGetName( dn, "share\\plplot" PLPLOT_VERSION, fn, &fs );
 +	free(dn);
 +	if ( ( file = pdf_fopen( fs, "rb" ) ) != NULL )
 +		goto done;

--- a/mingw-w64-plplot/fix-qhull-lib.patch
+++ b/mingw-w64-plplot/fix-qhull-lib.patch
@@ -1,0 +1,14 @@
+--- plplot-5.13.0/src/CMakeLists.txt.orig
++++ plplot-5.13.0/src/CMakeLists.txt
+@@ -263,9 +263,9 @@
+ if(PL_HAVE_QHULL)
+   list(APPEND libplplot_LINK_LIBRARIES csironn)
+   if(QHULL_RPATH)
+-    list(APPEND pc_libplplot_LINK_FLAGS -lcsironn -L${QHULL_RPATH} -lqhull)
++    list(APPEND pc_libplplot_LINK_FLAGS -lcsironn -L${QHULL_RPATH})
+   else(QHULL_RPATH)
+-    list(APPEND pc_libplplot_LINK_FLAGS -lcsironn -lqhull)
++    list(APPEND pc_libplplot_LINK_FLAGS -lcsironn)
+   endif(QHULL_RPATH)
+ 
+   # Needed by plgridd.c.


### PR DESCRIPTION
I add 2 patchs to plplot build to:
* Disable the link of qhull in pkg-config because it is statically link in plplot (see #2880).
* Add the support for reading the install directory of plplot to allow data files (e.g. fonts) to be retrieved.