### PR TITLE
python-scikit-learn: Update to 0.20.0

### DIFF
--- a/mingw-w64-python-scikit-learn/PKGBUILD
+++ b/mingw-w64-python-scikit-learn/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=scikit-learn
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.19.2
-pkgrel=2
+pkgver=0.20.0
+pkgrel=1
 pkgdesc="A set of python modules for machine learning and data mining (mingw-w64)"
 arch=('any')
 url='http://scikit-learn.sourceforge.net/'
@@ -19,7 +19,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-cython"
              )
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/scikit-learn/${_realname}/archive/${pkgver}.tar.gz")
-sha256sums=('3024e3dc85ca8b26de33c2c5aec7c7a5f1f4a750463cb1378f1c61b4dc28ec58')
+sha256sums=('6f0e84931af697d7c2841ccdf50110f69cc964788f503e2f43eeaf0240482dc0')
 
 prepare() {
   cd "$srcdir"/${_realname}-${pkgver}


### PR DESCRIPTION
There are deep directory structures, make sure your base directory is short when you build.