### PR TITLE
python3: fix ctypes module build. Fixes #4572

### DIFF
--- a/mingw-w64-python3/1900-ctypes-dont-depend-on-internal-libffi.patch
+++ b/mingw-w64-python3/1900-ctypes-dont-depend-on-internal-libffi.patch
@@ -1,0 +1,24 @@
+--- Python-3.7.1/Modules/_ctypes/callproc.c.orig	2018-10-21 20:21:21.305822500 +0200
++++ Python-3.7.1/Modules/_ctypes/callproc.c	2018-10-21 20:51:03.252890200 +0200
+@@ -701,6 +701,21 @@
+     }
+ }
+ 
++#ifdef __MINGW32__
++/*
++Per: https://msdn.microsoft.com/en-us/library/7572ztz4.aspx
++To be returned by value in RAX, user-defined types must have a length 
++of 1, 2, 4, 8, 16, 32, or 64 bits
++*/
++static int can_return_struct_as_int(size_t s)
++{
++  return s == 1 || s == 2 || s == 4;
++}
++static int can_return_struct_as_sint64(size_t s)
++{
++  return s == 8;
++}
++#endif
+ 
+ ffi_type *_ctypes_get_ffi_type(PyObject *obj)
+ {

--- a/mingw-w64-python3/PKGBUILD
+++ b/mingw-w64-python3/PKGBUILD
@@ -18,7 +18,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 _pybasever=3.7
 pkgver=${_pybasever}.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-level scripting language (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -125,6 +125,7 @@ source=("https://www.python.org/ftp/python/${pkgver%rc?}/Python-${pkgver}.tar.xz
         1850-disable-readline.patch
         1860-fix-isselectable.patch
         2000-warnings-fixes.patch
+        1900-ctypes-dont-depend-on-internal-libffi.patch
         smoketests.py)
 
 # Helper macros to help make tasks easier #
@@ -280,6 +281,9 @@ prepare() {
     1860-fix-isselectable.patch
 
   apply_patch_with_msg 2000-warnings-fixes.patch
+
+  # https://github.com/python/cpython/pull/9258
+  apply_patch_with_msg 1900-ctypes-dont-depend-on-internal-libffi.patch
 
   autoreconf -vfi
 
@@ -525,4 +529,5 @@ sha256sums=('fa7e2b8e8c9402f192ad56dc4f814089d1c4466c97d780f5e5acc02c04243d6d'
             '3262ce24714dc6cfea5b18d528d7f1a333128eadf5aa9c3a026131c34f082e1f'
             'bd9b934e8c1f92573115efaef6b6b04966e3222ba769511e006366d1217d34d6'
             'e91f897e43063e0c4e52d971f5de4b5e193d9eb6a35fc3acfca1dc057a2fcd65'
+            'e3b0171303b3e28a7347a81b1110dfe42df92a87d160caf624510304d5390728'
             'ea41f389324bf56277ef27a02f3510d22e5c88becbdb465468bdad9c15e0d229')


### PR DESCRIPTION
https://github.com/python/cpython/pull/9258 changed callproc to
use functions from the internal libffi which we don't use.
Just copy the functions into callproc directly instead.