### PR TITLE
build qt5-static with icu

### DIFF
--- a/mingw-w64-qt5-static/0056-qt-5.11-static_icu.patch
+++ b/mingw-w64-qt5-static/0056-qt-5.11-static_icu.patch
@@ -1,0 +1,15 @@
+diff --git b/qtbase/src/corelib/configure.json.orig a/qtbase/src/corelib/configure.json
+index dfb575da..dbfacf4d 100644
+--- b/qtbase/src/corelib/configure.json.orig
++++ a/qtbase/src/corelib/configure.json
+@@ -76,8 +76,8 @@
+             "sources": [
+                 {
+                     "builds": {
+-                        "debug": "-lsicuind -lsicuucd -lsicudtd",
+-                        "release": "-lsicuin -lsicuuc -lsicudt"
++                        "debug": "-licuin -licuuc -licudt",
++                        "release": "-licuin -licuuc -licudt"
+                     },
+                     "condition": "config.win32 && !features.shared"
+                 },

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -12,7 +12,7 @@ _build_mode=-debug-and-release
 # Tune the following to decide how and what to build
 if [ "${_variant}" = "-static" ]; then
   _namesuff="-static"
-  _with_icu=no
+  _with_icu=yes
   _with_fontconfig=no
   _with_openssl=yes
   _with_dbus=yes
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -226,6 +226,7 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0053-qt-5.11-documents-fix-regression.patch
         0054-win32-dont-need-flatpack-theme.patch
         0055-resolve-conflict-with-vectorcanbackend-static.patch
+        0056-qt-5.11-static_icu.patch
         0125-qt5-windeployqt-fixes.patch
         0300-qt-5.8.0-cast-errors.patch
         0301-remove-evr-declaration.patch
@@ -342,7 +343,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0053-qt-5.11-documents-fix-regression.patch
   patch -p1 -i ${srcdir}/0054-win32-dont-need-flatpack-theme.patch
   patch -p1 -i ${srcdir}/0055-resolve-conflict-with-vectorcanbackend-static.patch
-  
+  patch -p1 -i ${srcdir}/0056-qt-5.11-static_icu.patch
 
   pushd qttools > /dev/null
     patch -p1 -i ${srcdir}/0125-qt5-windeployqt-fixes.patch
@@ -760,6 +761,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             'de8d7f88ee987ed376226793350918a2a618a093cc3f56c37e1b3b9bf3e23d84'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'
+            'f414ceb01d4057147538f66b03f184be66a96d5b06f3dfd5aa086cd4de57ae0d'
             '353afa72d5f659213625d1af02653308ead2a74292023cc960b55f04d6a098af'
             'b38c912a1a0e94ea1a4f3706d84b5a6b2a46b72a9b3b5e6a821b123794fd5e07'
             '314a0c55c3ad45b46375c86717abaaa6cafd8a1cd41c09c77752503359ca6fb9'

--- a/mingw-w64-qt5/0056-qt-5.11-static_icu.patch
+++ b/mingw-w64-qt5/0056-qt-5.11-static_icu.patch
@@ -1,0 +1,15 @@
+diff --git b/qtbase/src/corelib/configure.json.orig a/qtbase/src/corelib/configure.json
+index dfb575da..dbfacf4d 100644
+--- b/qtbase/src/corelib/configure.json.orig
++++ a/qtbase/src/corelib/configure.json
+@@ -76,8 +76,8 @@
+             "sources": [
+                 {
+                     "builds": {
+-                        "debug": "-lsicuind -lsicuucd -lsicudtd",
+-                        "release": "-lsicuin -lsicuuc -lsicudt"
++                        "debug": "-licuin -licuuc -licudt",
++                        "release": "-licuin -licuuc -licudt"
+                     },
+                     "condition": "config.win32 && !features.shared"
+                 },

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -12,7 +12,7 @@ _build_mode=-debug-and-release
 # Tune the following to decide how and what to build
 if [ "${_variant}" = "-static" ]; then
   _namesuff="-static"
-  _with_icu=no
+  _with_icu=yes
   _with_fontconfig=no
   _with_openssl=yes
   _with_dbus=yes
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=3
+pkgrel=4
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -226,6 +226,7 @@ source=(#https://download.qt.io/development_releases/qt/${pkgver%.*}/${_ver_base
         0053-qt-5.11-documents-fix-regression.patch
         0054-win32-dont-need-flatpack-theme.patch
         0055-resolve-conflict-with-vectorcanbackend-static.patch
+        0056-qt-5.11-static_icu.patch
         0125-qt5-windeployqt-fixes.patch
         0300-qt-5.8.0-cast-errors.patch
         0301-remove-evr-declaration.patch
@@ -342,6 +343,7 @@ prepare() {
   patch -p1 -i ${srcdir}/0053-qt-5.11-documents-fix-regression.patch
   patch -p1 -i ${srcdir}/0054-win32-dont-need-flatpack-theme.patch
   patch -p1 -i ${srcdir}/0055-resolve-conflict-with-vectorcanbackend-static.patch
+  patch -p1 -i ${srcdir}/0056-qt-5.11-static_icu.patch
 
   pushd qttools > /dev/null
     patch -p1 -i ${srcdir}/0125-qt5-windeployqt-fixes.patch
@@ -759,6 +761,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             'de8d7f88ee987ed376226793350918a2a618a093cc3f56c37e1b3b9bf3e23d84'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'
+            'f414ceb01d4057147538f66b03f184be66a96d5b06f3dfd5aa086cd4de57ae0d'
             '353afa72d5f659213625d1af02653308ead2a74292023cc960b55f04d6a098af'
             'b38c912a1a0e94ea1a4f3706d84b5a6b2a46b72a9b3b5e6a821b123794fd5e07'
             '314a0c55c3ad45b46375c86717abaaa6cafd8a1cd41c09c77752503359ca6fb9'


### PR DESCRIPTION
remove the s prefix which isn’t present with msys2
remove the d suffix because the debug symbol names are different and it wont link
(probably needs a compile definition to alter the headers)