### PR TITLE
python-dateutil - 2.7.5 Update to latest version

### DIFF
--- a/mingw-w64-python-dateutil/PKGBUILD
+++ b/mingw-w64-python-dateutil/PKGBUILD
@@ -4,8 +4,8 @@ _realname=dateutil
 _pyname=python-dateutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=2.7.3
-pkgrel=2
+pkgver=2.7.5
+pkgrel=1
 pkgdesc="Provides powerful extensions to the standard datetime module (mingw-w64)"
 arch=('any')
 license=('BSD' 'Apache')
@@ -16,10 +16,16 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python2-six"
              "${MINGW_PACKAGE_PREFIX}-python3-six")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest" 
+              "${MINGW_PACKAGE_PREFIX}-python2-freezegun" 
+              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest" 
+              "${MINGW_PACKAGE_PREFIX}-python3-freezegun" 
+              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz"{,.asc})
 validpgpkeys=("6B49ACBADCF6BD1CA20667ABCD54FCE3D964BEFB")
-sha256sums=('e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8'
-            'SKIP')
+sha256sums=('88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02'
+            '88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02')
 
 prepare() {
   cd "${srcdir}"
@@ -27,14 +33,30 @@ prepare() {
     rm -rf python${pver}-build-${CARCH} | true
     cp -r "${_pyname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
+
 }
 
 build() {  
   for pver in {2,3}; do  
     msg "Python ${pver} build for ${CARCH}"  
     cd "${srcdir}/python${pver}-build-${CARCH}"
-    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
   done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    if [ "${pver}" = "2" ]; then
+      MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+        ${MINGW_PREFIX}/bin/pytest2 || warning "Tests failed"
+    else
+      MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+        ${MINGW_PREFIX}/bin/pytest || warning "Tests failed"
+    fi 
+  done
 }
 
 

--- a/mingw-w64-python-freezegun/PKGBUILD
+++ b/mingw-w64-python-freezegun/PKGBUILD
@@ -1,0 +1,120 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=freezegun
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.3.11
+pkgrel=1
+pkgdesc="Let your Python tests travel through time (mingw-w64)"
+arch=('any')
+url='https://github.com/spulec/freezegun'
+license=('Apache')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python2-dateutil"
+             "${MINGW_PACKAGE_PREFIX}-python3-dateutil"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-nose"
+              "${MINGW_PACKAGE_PREFIX}-python3-nose"
+              "${MINGW_PACKAGE_PREFIX}-python2-mock"
+              "${MINGW_PACKAGE_PREFIX}-python3-mock"
+              "${MINGW_PACKAGE_PREFIX}-python2-coverage"
+              "${MINGW_PACKAGE_PREFIX}-python3-coverage"
+              "${MINGW_PACKAGE_PREFIX}-python2-dateutil"
+              "${MINGW_PACKAGE_PREFIX}-python3-dateutil")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/spulec/freezegun/archive/$pkgver.tar.gz")
+sha512sums=('6cb5aa96ef400f62fb65d81f38a8a4cfa21f7ed755c071313ea0d6f02dd4aeaf167bcc122fb22aabe99e932af60d8c53a0dfe4d505ddc858ff14828dd98361a0')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+ # https://github.com/spulec/freezegun/issues/250
+   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+     ${MINGW_PREFIX}/bin/nosetests${pver} || warning "Tests failed"
+  done
+}
+
+package_python3-freezegun() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-dateutil")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-freezegun() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-dateutil")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-freezegun() {
+  package_python2-freezegun
+}
+
+package_mingw-w64-i686-python3-freezegun() {
+  package_python3-freezegun
+}
+
+package_mingw-w64-x86_64-python2-freezegun() {
+  package_python2-freezegun
+}
+
+package_mingw-w64-x86_64-python3-freezegun() {
+  package_python3-freezegun
+}

--- a/mingw-w64-python-hypothesis/PKGBUILD
+++ b/mingw-w64-python-hypothesis/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=hypothesis
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.79.3
+pkgver=3.80.0
 pkgrel=1
 pkgdesc="Advanced Quickcheck style testing library for Python (mingw-w64)"
 arch=('any')
@@ -42,7 +42,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
 #              "${MINGW_PACKAGE_PREFIX}-python2-pandas")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/HypothesisWorks/hypothesis/archive/hypothesis-python-$pkgver.tar.gz")
-sha512sums=('cb528699bb48344f9eb92735faa42d73dcf540fa099c441407b5dcf4702807064c719cd3f81fbee5a55839b094fb0f7298d534c52be36387628b134720d03659')
+sha512sums=('838d3b197e5772c5f19cc7017e842a0bff5e2ced2fb6648da3c068fa5c4b30ae469d702822981b8287b851d83b6b31cb099d092a9bfcd0b1bc18efcec4ffa0ac')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-pluggy/PKGBUILD
+++ b/mingw-w64-python-pluggy/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pluggy
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Plugin and hook calling mechanisms for python (mingw-w64)'
 url='https://github.com/pytest-dev/pluggy'
 license=('MIT')
@@ -12,14 +12,37 @@ arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz")
-sha256sums=('447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095')
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm" 
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest-runner" 
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest-runner")
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/pytest-dev/pluggy/archive/$pkgver.tar.gz")
+sha512sums=('06e5835069d2c198e5b983d07287822717484c7add306b3156451da0c6ba16c0c942f3f4b6e1eb20118e2c157d4d5403ae2b14453179c902684710edcbe5106d')
 
 prepare() {
   for pver in {2,3}; do
-    rm -rf python${pver}-build-${CARCH}| true
+    rm -rf python${pver}-build-${CARCH} | true
     cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
+  done
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+build() {
+  for pver in {2,3}; do
+    msg "Python ${pver} build for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py pytest
   done
 }
 
@@ -27,9 +50,8 @@ package_python3-pluggy() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
   cd ${srcdir}/python3-build-${CARCH}
-  ${MINGW_PREFIX}/bin/python3 setup.py build
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} -O1 --root="${pkgdir}" --skip-build
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
 }
@@ -38,9 +60,8 @@ package_python2-pluggy() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
   cd ${srcdir}/python2-build-${CARCH}
-  ${MINGW_PREFIX}/bin/python2 setup.py build
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} -O1 --root="${pkgdir}" --skip-build
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
 }

--- a/mingw-w64-python-pytest-xdist/PKGBUILD
+++ b/mingw-w64-python-pytest-xdist/PKGBUILD
@@ -1,0 +1,130 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=pytest-xdist
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.23.2
+pkgrel=1
+pkgdesc="py.test xdist plugin for distributed testing and loop-on-failing modes (mingw-w64)"
+arch=('any')
+url='https://bitbucket.org/pytest-dev/pytest-xdist'
+validpgpkeys=('gpg_KEY')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-pytest"
+             "${MINGW_PACKAGE_PREFIX}-python2-pytest"
+             "${MINGW_PACKAGE_PREFIX}-python3-pytest-forked"
+             "${MINGW_PACKAGE_PREFIX}-python2-pytest-forked"
+             "${MINGW_PACKAGE_PREFIX}-python3-execnet"
+             "${MINGW_PACKAGE_PREFIX}-python2-execnet"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm")
+options=('staticlibs' 'strip' '!debug')
+source=("${_realname}-$pkgver.tar.gz"::"https://github.com/pytest-dev/pytest-xdist/archive/v$pkgver.tar.gz")
+sha512sums=('cf8705beb182518864baa27fd2ac1344ee5020e9bffde268678847af8dd9e5e5b80f50c0a6b34aebbc1e5e7840b8b88e6edf73584821fce472083ed8d27c7a1b')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+#  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+#  popd 
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+# Hack entry points by installing it
+  local OLD_PYTHON_PATH=$PYTHONPATH
+  msg "Python 2 test for ${CARCH}"
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --root="$PWD/tmp_install" --optimize=1 --skip-build
+  _PATHONPATH1="${srcdir}/python2-build-${CARCH}/tmp_install${MINGW_PREFIX}/lib/python2.7/site-packages"
+  _PATHONPATH2="${OLD_PYTHON_PATH};${srcdir}/python2-build-${CARCH}/tests"
+  PYTHONPATH="${_PATHONPATH1};${_PATHONPATH2}" py.test2 || true
+
+  msg "Python 3 test for ${CARCH}"
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py install --root="$PWD/tmp_install" --optimize=1 --skip-build
+  _PATHONPATH1="${srcdir}/python3-build-${CARCH}/tmp_install${MINGW_PREFIX}/lib/python3.7/site-packages"
+  _PATHONPATH2="${OLD_PYTHON_PATH};${srcdir}/python3-build-${CARCH}/tests"
+  PYTHONPATH="${_PATHONPATH1};${_PATHONPATH2}" py.test || true
+
+}
+
+package_python3-pytest-xdist() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-pytest-xdist() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-pytest-xdist() {
+  package_python2-pytest-xdist
+}
+
+package_mingw-w64-i686-python3-pytest-xdist() {
+  package_python3-pytest-xdist
+}
+
+package_mingw-w64-x86_64-python2-pytest-xdist() {
+  package_python2-pytest-xdist
+}
+
+package_mingw-w64-x86_64-python3-pytest-xdist() {
+  package_python3-pytest-xdist
+}

--- a/mingw-w64-python-pytest/PKGBUILD
+++ b/mingw-w64-python-pytest/PKGBUILD
@@ -4,7 +4,7 @@ _pyname=pytest
 _realname=${_pyname}
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.9.2
+pkgver=3.9.3
 pkgrel=1
 pkgdesc='simple powerful testing with Python (mingw-w64)'
 url='https://pytest.org/'
@@ -12,38 +12,42 @@ license=('MIT')
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
-             "${MINGW_PACKAGE_PREFIX}-python3-py"
-             "${MINGW_PACKAGE_PREFIX}-python2-py"
-             "${MINGW_PACKAGE_PREFIX}-python3-pluggy"
-             "${MINGW_PACKAGE_PREFIX}-python2-pluggy"
-             "${MINGW_PACKAGE_PREFIX}-python3-attrs" 
-             "${MINGW_PACKAGE_PREFIX}-python2-attrs"
-             "${MINGW_PACKAGE_PREFIX}-python3-more-itertools"
-             "${MINGW_PACKAGE_PREFIX}-python2-more-itertools" 
-             "${MINGW_PACKAGE_PREFIX}-python3-atomicwrites"
-             "${MINGW_PACKAGE_PREFIX}-python2-atomicwrites"
+             "${MINGW_PACKAGE_PREFIX}-python2-py>=1.5.0"
+             "${MINGW_PACKAGE_PREFIX}-python3-py>=1.5.0"
+             "${MINGW_PACKAGE_PREFIX}-python2-six>=1.10.0"
+             "${MINGW_PACKAGE_PREFIX}-python3-six>=1.10.0"
+             "${MINGW_PACKAGE_PREFIX}-python2-pluggy>=0.7"
+             "${MINGW_PACKAGE_PREFIX}-python3-pluggy>=0.7"
+             "${MINGW_PACKAGE_PREFIX}-python3-attrs>=17.4.0" 
+             "${MINGW_PACKAGE_PREFIX}-python2-attrs>=17.4.0"
+             "${MINGW_PACKAGE_PREFIX}-python3-more-itertools>=4.0.0"
+             "${MINGW_PACKAGE_PREFIX}-python2-more-itertools>=4.0.0" 
+             "${MINGW_PACKAGE_PREFIX}-python3-atomicwrites>=1.0"
+             "${MINGW_PACKAGE_PREFIX}-python2-atomicwrites>=1.0"
              "${MINGW_PACKAGE_PREFIX}-python2-funcsigs"
+             "${MINGW_PACKAGE_PREFIX}-python2-pathlib2>=2.2.0"
+             "${MINGW_PACKAGE_PREFIX}-python2-colorama"
+             "${MINGW_PACKAGE_PREFIX}-python3-colorama"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm")
-#checkdepends=('lsof'
-#              "${MINGW_PACKAGE_PREFIX}-python3-nose"
-#              "${MINGW_PACKAGE_PREFIX}-python2-nose"
-#              "${MINGW_PACKAGE_PREFIX}-python3-mock"
-#              "${MINGW_PACKAGE_PREFIX}-python2-mock"
-#              "${MINGW_PACKAGE_PREFIX}-python3-tox"
-#              "${MINGW_PACKAGE_PREFIX}-python2-tox"
-#              "${MINGW_PACKAGE_PREFIX}-python3-yaml"
-#              "${MINGW_PACKAGE_PREFIX}-python2-yaml"
-#              "${MINGW_PACKAGE_PREFIX}-python3-pytest-xdist"
-#              "${MINGW_PACKAGE_PREFIX}-python2-pytest-xdist"
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-nose"
+              "${MINGW_PACKAGE_PREFIX}-python2-nose"
+              "${MINGW_PACKAGE_PREFIX}-python3-mock"
+              "${MINGW_PACKAGE_PREFIX}-python2-mock"
+              "${MINGW_PACKAGE_PREFIX}-python3-tox"
+              "${MINGW_PACKAGE_PREFIX}-python2-tox"
+              "${MINGW_PACKAGE_PREFIX}-python3-yaml"
+              "${MINGW_PACKAGE_PREFIX}-python2-yaml"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest-xdist"
+              "${MINGW_PACKAGE_PREFIX}-python2-pytest-xdist"
 #              "${MINGW_PACKAGE_PREFIX}-python3-twisted"
 #              "${MINGW_PACKAGE_PREFIX}-python2-twisted"
-#              "${MINGW_PACKAGE_PREFIX}-python3-requests"
-#              "${MINGW_PACKAGE_PREFIX}-python2-requests"
-#              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis"
-#              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis")
+              "${MINGW_PACKAGE_PREFIX}-python3-requests"
+              "${MINGW_PACKAGE_PREFIX}-python2-requests"
+              "${MINGW_PACKAGE_PREFIX}-python3-hypothesis"
+              "${MINGW_PACKAGE_PREFIX}-python2-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/pytest/archive/${pkgver}.tar.gz")
-sha256sums=('8c60f5a278f82eaed0f4518ac106d542e73e492b05625e3e328bb6472db8db6b')
+sha256sums=('aa9300503a6c05b8eaa2e7656c6d14b7c5ebba05b845abb14c82e27bca4fa08b')
 
 prepare() {
   cd ${srcdir}
@@ -68,6 +72,15 @@ build() {
     cd "${srcdir}/python${pver}-build-${CARCH}"
     MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
       ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    PYTHONPATH="$(pwd)/build/lib" \
+      ${MINGW_PREFIX}/bin/python${pver} src/pytest.py
   done
 }
 

--- a/mingw-w64-python-pytz/PKGBUILD
+++ b/mingw-w64-python-pytz/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=pytz
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=2018.5
+pkgver=2018.6
 pkgrel=1
 pkgdesc="Cross platform time zone library for Python (mingw-w64)"
 arch=('any')
@@ -11,33 +11,46 @@ url="https://pypi.python.org/pypi/pytz"
 license=("MIT")
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python2")
-#_dtoken="a4/09/c47e57fc9c7062b4e83b075d418800d322caa87ec0ac21e6308bd3a2d519"
 source=(https://pypi.io/packages/source/p/pytz/pytz-${pkgver}.tar.gz{,.asc})
-sha256sums=('ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277'
+sha256sums=('642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b'
             'SKIP')
+validpgpkeys=('C7ECC365AB6F255E1EB9BA1701FA998FBAC6374A')
 
 prepare() {
   cd "${srcdir}"
-  cp -r pytz-${pkgver} build-python2
-  cp -r pytz-${pkgver} build-python3
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "pytz-${pkgver}" "${builddir}"
+  done
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
 }
 
 check(){
-  cd ${srcdir}/build-python2/pytz/tests
-  ${MINGW_PREFIX}/bin/python2 test_tzinfo.py
-  cd ${srcdir}/build-python3/pytz/tests
-  ${MINGW_PREFIX}/bin/python3 test_tzinfo.py
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}/pytz/tests"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+     ${MINGW_PREFIX}/bin/python${pver} test_tzinfo.py
+  done
 }
 
 package_python3-pytz() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
-  cd ${srcdir}/build-python3
+  cd "${srcdir}/python3-build-${CARCH}"
   # Fix locale https://github.com/ipython/ipython/issues/2057
   export LC_ALL=en_US.UTF-8
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
 
   install -D LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE
 }
@@ -45,7 +58,7 @@ package_python3-pytz() {
 package_python2-pytz() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
-  cd ${srcdir}/build-python2
+  cd "${srcdir}/python2-build-${CARCH}"
   # Fix locale https://github.com/ipython/ipython/issues/2057
   export LC_ALL=en_US.UTF-8
 
@@ -53,7 +66,7 @@ package_python2-pytz() {
   sed -i 's_#!/usr/bin/env python_#!/usr/bin/env python2_' pytz/tzfile.py
 
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root=${pkgdir} --optimize=1
 
   install -D LICENSE.txt ${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE
 }


### PR DESCRIPTION
python-hypothesis - 2.80.0 - Update to latest version
python-pluggy - 0.8.0 - Clarified dependencies, enable testing
python-pytest - 2.9.3 - Update to latest version
python-pytz - 2018.6 - Update to latest version
python-freezegun - 0.3.11 - new package required for testing dateutils
python-pytest-xdist - 1.23.2 - required by python-coverage