### PR TITLE
tesseract-data: update to 4.0.0

### DIFF
--- a/mingw-w64-tesseract-data/PKGBUILD
+++ b/mingw-w64-tesseract-data/PKGBUILD
@@ -6,28 +6,29 @@
 # osd.traineddata (Orientation and script detection) is included with tesseract-ocr
 
 _langs=(afr amh ara asm aze aze_cyrl bel ben bod bos bul cat ceb ces
-chi_sim chi_tra chr cym dan dan_frak deu deu_frak dzo ell eng enm epo
-equ est eus fas fin fra frk frm gle glg grc guj hat heb hin hrv hun
-iku ind isl ita ita_old jav jpn kan kat kat_old kaz khm kir kor kur
+chi_sim chi_tra chr cym dan deu dzo ell eng enm epo
+est eus fas fin fra frk frm gle glg grc guj hat heb hin hrv hun
+iku ind isl ita ita_old jav jpn kan kat kat_old kaz khm kir kor
 lao lat lav lit mal mar mkd mlt msa mya nep nld nor ori pan pol
-por pus ron rus san sin slk slk_frak slv spa spa_old sqi srp srp_latn
-swa swe syr tam tel tgk tgl tha tir tur uig ukr urd uzb uzb_cyrl vie yid)
+por pus ron rus san sin slk slv spa spa_old sqi srp srp_latn
+swa swe syr tam tel tgk tha tir tur uig ukr urd uzb uzb_cyrl vie yid)
 
 _langs_deva=(hin mar nep san) 
 
 _realname=tesseract-data
 pkgbase=mingw-w64-${_realname}
 pkgname=($(for l in ${_langs[@]}; do echo ${MINGW_PACKAGE_PREFIX}-${_realname}-${l}; done) )
-pkgver=3.04.00
+tagver=4.0.0-beta.1
+pkgver=4.0.0
 pkgrel=1
 pkgdesc="Language tessdata for Tesseract OCR engine (mingw-w64)"
 arch=('any')
-url="https://github.com/tesseract-ocr/tessdata"
+url="https://github.com/tesseract-ocr/tessdata_fast"
 license=("Apache License 2.0")
 
 depends=()
-source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tessdata/archive/${pkgver}.tar.gz)
-sha256sums=('5dcb37198336b6953843b461ee535df1401b41008d550fc9e43d0edabca7adb1')
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/tesseract-ocr/tessdata_fast/archive/${tagver}.tar.gz)
+sha256sums=('cfae2d9e15887a719c995baad70c01ad8f68c0361f5f0a4f46e4aa9ed8a47120')
 
 build() {
   true
@@ -41,7 +42,7 @@ package_${MINGW_PACKAGE_PREFIX}-${_realname}-${l}(){
     groups=(${_realname})
 
     mkdir -p \${pkgdir}${MINGW_PREFIX}/share/tessdata
-    cp \${srcdir}/tessdata-${pkgver}/${l}.* \${pkgdir}${MINGW_PREFIX}/share/tessdata/
+    cp \${srcdir}/tessdata_fast-${tagver}/${l}.* \${pkgdir}${MINGW_PREFIX}/share/tessdata/
     find \${pkgdir}${MINGW_PREFIX}/share/tessdata -type f -exec chmod 0644 {} \;
 }
     "


### PR DESCRIPTION
The new version of tesseract (https://github.com/Alexpux/MINGW-packages/pull/4603) uses a new format for training data, see [tesseract wiki](https://github.com/tesseract-ocr/tesseract/wiki/Data-Files).
