### PR TITLE
Add cvode package

### DIFF
--- a/mingw-w64-cvode/PKGBUILD
+++ b/mingw-w64-cvode/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>
+
+_realname=cvode
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.2.1
+pkgrel=1
+pkgdesc="ordinary differential equation system solver (mingw-w64)"
+arch=('any')
+url="https://computation.llnl.gov/projects/sundials"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+source=("${_realname}-${pkgver}.tar.gz"::https://computation.llnl.gov/projects/sundials/download/${_realname}-${pkgver}.tar.gz)
+sha256sums=('aa4f5f3c5114e93ba246630cf107b1f73de5c1028a013602c114d3cde6564451')
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd build-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} install
+
+  # The DLLs must be in the bin runtime directory to be found
+  mkdir -p ${pkgdir}${MINGW_PREFIX}/bin
+  mv ${pkgdir}${MINGW_PREFIX}/lib/*.dll ${pkgdir}${MINGW_PREFIX}/bin/
+
+  # license
+  rm ${pkgdir}${MINGW_PREFIX}/include/sundials/LICENSE
+  install -D -m644 ${srcdir}/${_realname}-${pkgver}/LICENSE \
+  ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}
+


### PR DESCRIPTION
CVODE is a solver for systems of ordinary differential equations.

More info: https://computation.llnl.gov/projects/sundials/sundials-software

This package is straight forward. The only issue was the DLLs are installed in the lib directory. I move them in the package step from lib to bin. 

Signed-off-by: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>