### PR TITLE
Add CFD General Notation System tools and library

### DIFF
--- a/mingw-w64-cgns/0001-stat32i64-is-msvc-specific.patch
+++ b/mingw-w64-cgns/0001-stat32i64-is-msvc-specific.patch
@@ -1,0 +1,16 @@
+diff -rupN CGNS-3.3.1.orig/src/cgnstypes.h.in CGNS-3.3.1/src/cgnstypes.h.in
+--- CGNS-3.3.1.orig/src/cgnstypes.h.in	2017-07-17 17:51:06.000000000 -0400
++++ CGNS-3.3.1/src/cgnstypes.h.in	2018-11-01 10:31:34.578846500 -0400
+@@ -37,8 +37,10 @@
+ #define CG_MAX_INT32 0x7FFFFFFF
+ #ifdef _WIN32
+ # define CG_LONG_T __int64
+-#ifdef CG_BUILD_64BIT
+-#define stat _stat32i64
++#ifdef _MSC_VER
++# ifdef CG_BUILD_64BIT
++#  define stat _stat32i64
++# endif
+ #endif
+ #else
+ # define CG_LONG_T @CGLONGT@

--- a/mingw-w64-cgns/PKGBUILD
+++ b/mingw-w64-cgns/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>
+
+_realname=cgns
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=3.3.1
+pkgrel=1
+pkgdesc="CFD General Notation System library and tools (mingw-w64)"
+arch=('any')
+url="https://cgns.github.io"
+license=('zlib')
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake")
+depends=("${MINGW_PACKAGE_PREFIX}-hdf5")
+source=("${_realname}-${pkgver}.tar.gz"::https://github.com/CGNS/CGNS/archive/v${pkgver}.tar.gz
+        "0001-stat32i64-is-msvc-specific.patch")
+sha256sums=('81093693b2e21a99c5640b82b267a495625b663d7b8125d5f1e9e7aaa1f8d469'
+            'e9ea00604418e9704e6be0be1fe6740b4f1e17e8aa2000f2798673fd0fd6ff2b')
+
+prepare() {
+  cd ${srcdir}/${_realname}-${pkgver}
+  patch -p1 -i ${srcdir}/0001-stat32i64-is-msvc-specific.patch
+}
+
+build() {
+  [[ -d build-${MINGW_CHOST} ]] && rm -rf build-${MINGW_CHOST}
+  mkdir -p build-${MINGW_CHOST}
+  cd build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCGNS_ENABLE_HDF5=ON \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  cd build-${MINGW_CHOST}
+  make DESTDIR=${pkgdir} install
+
+  # license
+  install -D -m644 ${srcdir}/${_realname}-${pkgver}/license.txt \
+  ${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE
+}
+


### PR DESCRIPTION
The CGNS library and tools are used to store and process data related to
computational fluid dynamics.

I had to backport a small patch to fix an issue with compiling with MinGW. Other than that, this is a straight forward package.

Patch reference: https://github.com/CGNS/CGNS/commit/e22bbdb767d6d310d085c37f9bd55f4de16baa74

Signed-off-by: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>