### PR TITLE
python-tox - 3.5.3 - add some required dependencies I found with pip,…

### DIFF
--- a/mingw-w64-python-filelock/PKGBUILD
+++ b/mingw-w64-python-filelock/PKGBUILD
@@ -1,0 +1,116 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=filelock
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=3.0.9
+_commit=b71c3a494b1a9a84ddaa4a4d43bfd985a01e81e7
+pkgrel=1
+pkgdesc="A platform independent file lock (mingw-w64)"
+arch=('any')
+url='https://github.com/benediktschmitt/py-filelock'
+license=('custom:Unlicense')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest")
+source=("${_realname}-$_commit.tar.gz::https://github.com/benediktschmitt/py-filelock/archive/$_commit.tar.gz")
+sha512sums=('bf2c3a27488e4e0b0469599c5037658482b27eee08ef1844de5419865a67f01966b72f1f463ce7418660901c991ad06740a90f332db0b2d3d62967f0f270aba9')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+#  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+#  popd 
+  rm -rf py-filelock-$pkgver
+  mv py-${_realname}-{$_commit,$pkgver}
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "py-${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+    msg "Python 2 test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/pytest2 test.py
+
+    msg "Python 2 test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/pytest test.py
+}
+
+package_python3-filelock() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE.rst"
+}
+
+package_python2-filelock() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE.rst"
+}
+
+package_mingw-w64-i686-python2-filelock() {
+  package_python2-filelock
+}
+
+package_mingw-w64-i686-python3-filelock() {
+  package_python3-filelock
+}
+
+package_mingw-w64-x86_64-python2-filelock() {
+  package_python2-filelock
+}
+
+package_mingw-w64-x86_64-python3-filelock() {
+  package_python3-filelock
+}

--- a/mingw-w64-python-pytest-xdist/PKGBUILD
+++ b/mingw-w64-python-pytest-xdist/PKGBUILD
@@ -4,7 +4,7 @@ _realname=pytest-xdist
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.24.0
-pkgrel=1
+pkgrel=2
 pkgdesc="py.test xdist plugin for distributed testing and loop-on-failing modes (mingw-w64)"
 arch=('any')
 url='https://bitbucket.org/pytest-dev/pytest-xdist'
@@ -17,6 +17,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-pytest-forked"
              "${MINGW_PACKAGE_PREFIX}-python3-execnet"
              "${MINGW_PACKAGE_PREFIX}-python2-execnet"
+             "${MINGW_PACKAGE_PREFIX}-python2-filelock"
+             "${MINGW_PACKAGE_PREFIX}-python3-filelock"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
@@ -25,31 +27,8 @@ options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/pytest-dev/pytest-xdist/archive/v$pkgver.tar.gz")
 sha512sums=('90e86e09ae7ca6c0e8cab50cc72591f0d062b4457adddb3325ef10e5f899f160def60430b95aaf4efa84b12c403e063a1126cf231a576991c90b42ee04b3cbd4')
 
-# Helper macros to help make tasks easier #
-apply_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
-  done
-}
-
-del_file_exists() {
-  for _fname in "$@"
-  do
-    if [ -f $_fname ]; then
-      rm -rf $_fname
-    fi
-  done
-}
-# =========================================== #
-
 prepare() {
   cd "${srcdir}"
-#  pushd "${_realname}-${pkgver}"
-#    apply_patch_with_msg 0001-A-really-important-fix.patch \
-#      0002-A-less-important-fix.patch
-#  popd 
   for builddir in python{2,3}-build-${CARCH}; do
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
@@ -58,10 +37,6 @@ prepare() {
   export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
 }
 
-# Note that build() is sometimes skipped because it's done in 
-# the packages setup.py install for simplicity if you can do so.
-# but sometimes, you want to do a check before install which would
-# also trigger the build.
 build() {
   for pver in {2,3}; do  
     msg "Python ${pver} build for ${CARCH}"  
@@ -92,7 +67,9 @@ check() {
 }
 
 package_python3-pytest-xdist() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-pytest-forked" 
+           "${MINGW_PACKAGE_PREFIX}-python3-execnet")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -103,7 +80,9 @@ package_python3-pytest-xdist() {
 }
 
 package_python2-pytest-xdist() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-pytest-forked" 
+           "${MINGW_PACKAGE_PREFIX}-python2-execnet")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \

--- a/mingw-w64-python-toml/PKGBUILD
+++ b/mingw-w64-python-toml/PKGBUILD
@@ -1,0 +1,118 @@
+# Maintainer: J. Peter Mugaas <jpmugaas@suddenlink.net>
+
+_realname=toml
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=0.10.0
+pkgrel=1
+pkgdesc="A Python library for parsing and creating TOML (mingw-w64)"
+arch=('any')
+url='https://github.com/uiri/toml'
+license=('MIT')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest"
+              "${MINGW_PACKAGE_PREFIX}-python3-pytest")
+options=('staticlibs' 'strip' '!debug')
+source=("https://files.pythonhosted.org/packages/source/${_realname::1}/${_realname}/${_realname}-${pkgver}.tar.gz"
+        "https://raw.githubusercontent.com/uiri/toml/master/test.toml")
+sha512sums=('26f26c38ce9cd48305218c2c34c5a5407b00aefc25a933f044bb7be22c23cfdfa3b8cf2da952d17760c4b9038df62e405fa039cc7b63dd3e94c9c312f04f9182'
+            '47510e59f9e0bdaaf4052fc5edb570a36b8b173ed7b8e5fac52804f6619f409e545ae3c91f838dbaeefe3c7cfd1a835b699164ac631feaa61de971d2381ac246')
+
+# Helper macros to help make tasks easier #
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
+
+del_file_exists() {
+  for _fname in "$@"
+  do
+    if [ -f $_fname ]; then
+      rm -rf $_fname
+    fi
+  done
+}
+# =========================================== #
+
+prepare() {
+  cd "${srcdir}"
+#  pushd "${_realname}-${pkgver}"
+#    apply_patch_with_msg 0001-A-really-important-fix.patch \
+#      0002-A-less-important-fix.patch
+#  popd 
+  cp -v test.toml "${_realname}-$pkgver"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+}
+
+# Note that build() is sometimes skipped because it's done in 
+# the packages setup.py install for simplicity if you can do so.
+# but sometimes, you want to do a check before install which would
+# also trigger the build.
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  # disable useless tests
+    msg "Python 2 test for ${CARCH}"
+    cd "${srcdir}/python2-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/py.test2 tests -k 'not test_invalid_tests and not test_valid_tests'
+
+    msg "Python 3 test for ${CARCH}"
+    cd "${srcdir}/python3-build-${CARCH}"
+  ${MINGW_PREFIX}/bin/py.test tests -k 'not test_invalid_tests and not test_valid_tests'
+}
+
+package_python3-toml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+}
+
+package_python2-toml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-toml() {
+  package_python2-toml
+}
+
+package_mingw-w64-i686-python3-toml() {
+  package_python3-toml
+}
+
+package_mingw-w64-x86_64-python2-toml() {
+  package_python2-toml
+}
+
+package_mingw-w64-x86_64-python3-toml() {
+  package_python3-toml
+}

--- a/mingw-w64-python-tox/PKGBUILD
+++ b/mingw-w64-python-tox/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tox
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Python virtualenv management and testing tool (mingw-w64)"
 arch=('any')
 url="https://tox.readthedocs.io"
@@ -15,8 +15,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python2-filelock"
+             "${MINGW_PACKAGE_PREFIX}-python3-filelock"
+             "${MINGW_PACKAGE_PREFIX}-python2-toml"
+             "${MINGW_PACKAGE_PREFIX}-python3-toml"
              "${MINGW_PACKAGE_PREFIX}-python2-py"
              "${MINGW_PACKAGE_PREFIX}-python3-py"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python3-six"
              "${MINGW_PACKAGE_PREFIX}-python2-virtualenv"
              "${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
              "${MINGW_PACKAGE_PREFIX}-python2-pluggy"
@@ -43,13 +49,39 @@ build() {
   done  
 }
 
+#This hangs when I try this.
+#check() {
+#  (
+#    cd "${srcdir}/python2-build-${CARCH}" 
+#    msg "Python 2 build for ${CARCH}" 
+#    ${MINGW_PREFIX}/bin/virtualenv2 "$srcdir/pyvenv-py2" --system-site-packages
+#    . "$srcdir/pyvenv-py2/bin/activate"
+#    ${MINGW_PREFIX}/bin/python setup.py install
+#    ${MINGW_PREFIX}/bin/python setup.py pytest
+#  )
+#
+#(
+#    cd "${srcdir}/python3-build-${CARCH}" 
+#    msg "Python 3 build for ${CARCH}" 
+#    ${MINGW_PREFIX}/bin/virtualenv "$srcdir/pyvenv" --system-site-packages
+#    . "$srcdir/pyvenv/bin/activate"
+#    ${MINGW_PREFIX}/bin/python3 setup.py install
+#    ${MINGW_PREFIX}/bin/python3 setup.py pytest
+#  )
+#
+#}
+
 package_python3-tox() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-py"
+           "${MINGW_PACKAGE_PREFIX}-python2-six"
            "${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
            "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
            "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+           "${MINGW_PACKAGE_PREFIX}-python3-filelock"
+           "${MINGW_PACKAGE_PREFIX}-python3-toml"
            "${MINGW_PACKAGE_PREFIX}-python3-pluggy")
+  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -61,17 +93,21 @@ package_python3-tox() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}/bin/|${MINGW_PREFIX}/bin/|g" -i ${_f}
   done
 }
 
 package_python2-tox() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
            "${MINGW_PACKAGE_PREFIX}-python2-py"
+           "${MINGW_PACKAGE_PREFIX}-python2-six"
            "${MINGW_PACKAGE_PREFIX}-python2-virtualenv"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
+           "${MINGW_PACKAGE_PREFIX}-python2-filelock"
+           "${MINGW_PACKAGE_PREFIX}-python2-toml"
            "${MINGW_PACKAGE_PREFIX}-python2-pluggy")
+  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -83,7 +119,7 @@ package_python2-tox() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}/bin/|${MINGW_PREFIX}/bin/|g" -i ${_f}
   done
   
   rename -v "tox" "tox2" "${pkgdir}${MINGW_PREFIX}"/bin/*

--- a/mingw-w64-python-tox/tox2-i686.install
+++ b/mingw-w64-python-tox/tox2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox2 tox2-quickstart; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox2-x86_64.install
+++ b/mingw-w64-python-tox/tox2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox2 tox2-quickstart; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox3-i686.install
+++ b/mingw-w64-python-tox/tox3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox tox-quickstart; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox3-x86_64.install
+++ b/mingw-w64-python-tox/tox3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox tox-quickstart; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
… make .exe work

python-filelock - 3.0.9 - new package required for python-tox
python-toml - 0.10.0 - new package required for python-tox
python-pytest-xdist - 1.24.0 - add python-filelock as a makedependency since that is required.