### PR TITLE
python-tox - 3.5.3

### DIFF
--- a/mingw-w64-python-tox/PKGBUILD
+++ b/mingw-w64-python-tox/PKGBUILD
@@ -4,7 +4,7 @@ _realname=tox
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=3.5.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Python virtualenv management and testing tool (mingw-w64)"
 arch=('any')
 url="https://tox.readthedocs.io"
@@ -15,8 +15,14 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+             "${MINGW_PACKAGE_PREFIX}-python2-filelock"
+             "${MINGW_PACKAGE_PREFIX}-python3-filelock"
+             "${MINGW_PACKAGE_PREFIX}-python2-toml"
+             "${MINGW_PACKAGE_PREFIX}-python3-toml"
              "${MINGW_PACKAGE_PREFIX}-python2-py"
              "${MINGW_PACKAGE_PREFIX}-python3-py"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python3-six"
              "${MINGW_PACKAGE_PREFIX}-python2-virtualenv"
              "${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
              "${MINGW_PACKAGE_PREFIX}-python2-pluggy"
@@ -43,13 +49,39 @@ build() {
   done  
 }
 
+#This hangs when I try this.
+#check() {
+#  (
+#    cd "${srcdir}/python2-build-${CARCH}" 
+#    msg "Python 2 build for ${CARCH}" 
+#    ${MINGW_PREFIX}/bin/virtualenv2 "$srcdir/pyvenv-py2" --system-site-packages
+#    . "$srcdir/pyvenv-py2/bin/activate"
+#    ${MINGW_PREFIX}/bin/python setup.py install
+#    ${MINGW_PREFIX}/bin/python setup.py pytest
+#  )
+#
+#(
+#    cd "${srcdir}/python3-build-${CARCH}" 
+#    msg "Python 3 build for ${CARCH}" 
+#    ${MINGW_PREFIX}/bin/virtualenv "$srcdir/pyvenv" --system-site-packages
+#    . "$srcdir/pyvenv/bin/activate"
+#    ${MINGW_PREFIX}/bin/python3 setup.py install
+#    ${MINGW_PREFIX}/bin/python3 setup.py pytest
+#  )
+#
+#}
+
 package_python3-tox() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3"
            "${MINGW_PACKAGE_PREFIX}-python3-py"
+           "${MINGW_PACKAGE_PREFIX}-python2-six"
            "${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
            "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
            "${MINGW_PACKAGE_PREFIX}-python3-setuptools-scm"
+           "${MINGW_PACKAGE_PREFIX}-python3-filelock"
+           "${MINGW_PACKAGE_PREFIX}-python3-toml"
            "${MINGW_PACKAGE_PREFIX}-python3-pluggy")
+  install=${_realname}3-${CARCH}.install
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -61,17 +93,21 @@ package_python3-tox() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}/bin/|${MINGW_PREFIX}/bin/|g" -i ${_f}
   done
 }
 
 package_python2-tox() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2"
            "${MINGW_PACKAGE_PREFIX}-python2-py"
+           "${MINGW_PACKAGE_PREFIX}-python2-six"
            "${MINGW_PACKAGE_PREFIX}-python2-virtualenv"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
            "${MINGW_PACKAGE_PREFIX}-python2-setuptools-scm"
+           "${MINGW_PACKAGE_PREFIX}-python2-filelock"
+           "${MINGW_PACKAGE_PREFIX}-python2-toml"
            "${MINGW_PACKAGE_PREFIX}-python2-pluggy")
+  install=${_realname}2-${CARCH}.install
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -83,7 +119,7 @@ package_python2-tox() {
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   # fix python command in files
   for _f in "${pkgdir}${MINGW_PREFIX}"/bin/*.py; do
-    sed -e "s|${PREFIX_WIN}/bin/|/usr/bin/env |g" -i ${_f}
+    sed -e "s|${PREFIX_WIN}/bin/|${MINGW_PREFIX}/bin/|g" -i ${_f}
   done
   
   rename -v "tox" "tox2" "${pkgdir}${MINGW_PREFIX}"/bin/*

--- a/mingw-w64-python-tox/tox2-i686.install
+++ b/mingw-w64-python-tox/tox2-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox2 tox2-quickstart; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox2-x86_64.install
+++ b/mingw-w64-python-tox/tox2-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox2 tox2-quickstart; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox3-i686.install
+++ b/mingw-w64-python-tox/tox3-i686.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw32
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox tox-quickstart; do
+    sed -e "s|/mingw32|${_prefix}|g" \
+        -i mingw32/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}

--- a/mingw-w64-python-tox/tox3-x86_64.install
+++ b/mingw-w64-python-tox/tox3-x86_64.install
@@ -1,0 +1,14 @@
+post_install() {
+  cd mingw64
+  local _prefix=$(pwd -W)
+  cd -
+  local _it
+  for _it in tox tox-quickstart; do
+    sed -e "s|/mingw64|${_prefix}|g" \
+        -i mingw64/bin/${_it}-script.py
+  done
+}
+
+post_upgrade() {
+  post_install
+}


### PR DESCRIPTION
Add dependency on python-filelock and python-toml
add commented code for tests (those hang)
Make sure tox .exe's will run from MSYS command line.