### PR TITLE
python-pbr - 5.1.1 - Various fixes

### DIFF
--- a/mingw-w64-python-pbr/PKGBUILD
+++ b/mingw-w64-python-pbr/PKGBUILD
@@ -4,36 +4,75 @@ _realname=pbr
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=5.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Python Build Reasonableness (mingw-w64)"
-url="https://launchpad.net/pbr"
-license=("Apache License, Version 2.0")
+url="https://pypi.python.org/pypi/pbr"
+license=("Apache")
 arch=('any')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python2-six"
-             "${MINGW_PACKAGE_PREFIX}-python3-six")
-#_dtoken="d5/d6/f2bf137d71e4f213b575faa9eb426a8775732432edb67588a8ee836ecb80"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-stestr"
+              "${MINGW_PACKAGE_PREFIX}-python3-stestr"
+              "${MINGW_PACKAGE_PREFIX}-python2-testscenarios"
+              "${MINGW_PACKAGE_PREFIX}-python3-testscenarios"
+              "${MINGW_PACKAGE_PREFIX}-python2-testresources"
+              "${MINGW_PACKAGE_PREFIX}-python3-testresources"
+              "${MINGW_PACKAGE_PREFIX}-python2-testrepository"
+              "${MINGW_PACKAGE_PREFIX}-python3-testrepository"
+              "${MINGW_PACKAGE_PREFIX}-python2-mock"
+              "${MINGW_PACKAGE_PREFIX}-python3-mock"
+              "${MINGW_PACKAGE_PREFIX}-python2-virtualenv"
+              "${MINGW_PACKAGE_PREFIX}-python3-virtualenv"
+              "${MINGW_PACKAGE_PREFIX}-python2-wheel"
+              "${MINGW_PACKAGE_PREFIX}-python3-wheel"
+              "${MINGW_PACKAGE_PREFIX}-python2-sphinx"
+              "${MINGW_PACKAGE_PREFIX}-python3-sphinx")
 options=('!strip')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/openstack-dev/pbr/archive/${pkgver}.tar.gz")
 sha256sums=('d35da7575e3553a74eccafa650c8ae531914526652a9246eef059f5f2f7158c3')
 
 prepare() {
   cd ${srcdir}
+  sed -e 's/wheel.install/wheel.wheelfile/' \
+      -e 's/wheel_file.zipfile/wheel_file/' \
+      -i ${_realname}-$pkgver/pbr/tests/test_packaging.py
   for pver in {2,3}; do 
     rm -rf python${pver}-build-${CARCH}| true
     cp -r "${_realname}-${pkgver}" "python${pver}-build-${CARCH}"
   done
+  find "${srcdir}/python2-build-${CARCH}" -name \*.py -exec sed -i '1s/python$/&2/' {} +
+  find "${srcdir}/python2-build-${CARCH}" -name \*.py -exec sed -i '1s/python$/&3/' {} +
+  export PBR_VERSION=$pkgver
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}" 
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+      ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done
+}
+
+check() {
+  msg "Python ${pver} test for ${CARCH}"
+  cd "${srcdir}/python${pver}-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    PYTHON=python2 ${MINGW_PREFIX}/bin/stestr2 run || warning "Tests failed"
+
+  msg "Python 3 test for ${CARCH}"
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    PYTHON=python3 ${MINGW_PREFIX}/bin/stestr run || warning "Tests failed"
 }
 
 package_python3-pbr() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3-six")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
   install=${_realname}3-${CARCH}.install
 
   cd ${srcdir}/python3-build-${CARCH}
-  ${MINGW_PREFIX}/bin/python3 setup.py build
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
 
@@ -45,14 +84,12 @@ package_python3-pbr() {
 }
 
 package_python2-pbr() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2-six")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2-setuptools")
   install=${_realname}2-${CARCH}.install
 
   cd ${srcdir}/python2-build-${CARCH}
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py build
-  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE" "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
 


### PR DESCRIPTION
Update with new information
added tests
Fixup dependencies for tests and build.  Setuptools as a depends is NO typo
use PBR_VERSION to stamp build with proper version for consistency checks with pip.