### PR TITLE
python-setuptools: unvendor dependencies. Fixes #4623

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -6,7 +6,7 @@ pkgbase=mingw-w64-python-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 pkgver=40.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 license=('PSF')
@@ -74,11 +74,15 @@ build() {
   cd "${srcdir}"/setuptools-python2-${CARCH}
   ${MINGW_PREFIX}/bin/python2 bootstrap.py
   ${MINGW_PREFIX}/bin/python2 setup.py build
+  rm -rf build/lib/pkg_resources/_vendor
+  rm -rf build/lib/setuptools/_vendor
 
   # Build python 3 module
   cd "${srcdir}"/setuptools-python3-${CARCH}
   ${MINGW_PREFIX}/bin/python3 bootstrap.py
   ${MINGW_PREFIX}/bin/python3 setup.py build
+  rm -rf build/lib/pkg_resources/_vendor
+  rm -rf build/lib/setuptools/_vendor
 }
 
 #check() { (
@@ -96,7 +100,11 @@ build() {
 #)
 
 package_python3-setuptools() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3>=3.3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3>=3.3"
+           "${MINGW_PACKAGE_PREFIX}-python3-packaging"
+           "${MINGW_PACKAGE_PREFIX}-python3-pyparsing"
+           "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+           "${MINGW_PACKAGE_PREFIX}-python3-six")
 
   local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
   local _py3_base=$(${MINGW_PREFIX}/bin/python3 -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")
@@ -116,7 +124,11 @@ package_python3-setuptools() {
 }
 
 package_python2-setuptools() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2>=2.7")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2>=2.7"
+           "${MINGW_PACKAGE_PREFIX}-python2-packaging"
+           "${MINGW_PACKAGE_PREFIX}-python2-pyparsing"
+           "${MINGW_PACKAGE_PREFIX}-python2-appdirs"
+           "${MINGW_PACKAGE_PREFIX}-python2-six")
 
   local _mingw_prefix=$(cygpath -wm ${MINGW_PREFIX})
   local _py2_base=$(${MINGW_PREFIX}/bin/python2 -c "import sys;sys.stdout.write('.'.join(map(str, sys.version_info[:2])))")


### PR DESCRIPTION
Since pip got unvendored in #4379 the Python classes of system packages
and vendored packages clash. This removes the vendored packages from
setuptools so only system dependencies are used in both pip and setuptools.

The downside of this is that it's not officially supported by upstream
and this creates cyclic dependencies and makes bootstrapping harder.

If this turns out to be a problem we should probably revert this
and #4379.