### PR TITLE
Additional KF5 packages

### DIFF
--- a/mingw-w64-kcmutils-qt5/PKGBUILD
+++ b/mingw-w64-kcmutils-qt5/PKGBUILD
@@ -1,0 +1,50 @@
+_variant=-${KF5_VARIANT:-shared}
+source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
+_kde_f5_init_package "${_variant}" "kcmutils"
+pkgver=5.50.0
+pkgrel=1
+arch=('any')
+pkgdesc="Utilities for interacting with KCModules (mingw-w64-qt5${_namesuff})"
+license=('LGPL')
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
+						 "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+						 "${MINGW_PACKAGE_PREFIX}-doxygen")
+depends=("${MINGW_PACKAGE_PREFIX}-kdeclarative-qt5${_namesuff}")
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+groups=('kf5')
+source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
+sha256sums=('d70e08568a16cb294fae094383afdd4565f2fc39d8020fb347d35807c4453fe1')
+
+prepare() {
+  mkdir -p build-${CARCH}${_variant}
+}
+
+build() {
+  local -a extra_config
+  cd build-${CARCH}${_variant}
+  if [ "${_variant}" = "-static" ]; then
+    extra_config+=( -DBUILD_SHARED_LIBS=NO )
+    QT5_PREFIX=${MINGW_PREFIX}/qt5-static
+    export PATH=${QT5_PREFIX}/bin:"$PATH"
+  else
+    QT5_PREFIX=${MINGW_PREFIX}
+  fi
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;-DECM_MKSPECS_INSTALL_DIR=" \
+    cmake ../${_basename}-${pkgver} \
+      -DCMAKE_BUILD_TYPE=$(_kde_f5_CMAKE_BUILD_TYPE) \
+      -DCMAKE_INSTALL_PREFIX=${QT5_PREFIX} \
+      -DKDE_INSTALL_LIBDIR=lib \
+      -DECM_MKSPECS_INSTALL_DIR=${QT5_PREFIX}/share/qt5/mkspecs/modules \
+      -DBUILD_QCH=OFF \
+      -DBUILD_TESTING=OFF \
+      -DECM_DIR=${MINGW_PREFIX}/share/ECM \
+      "${extra_config[@]}" \
+      -G'MSYS Makefiles'
+  make
+}
+
+package() {
+  cd build-${CARCH}${_variant}
+  make DESTDIR="${pkgdir}" install
+}

--- a/mingw-w64-kcmutils-qt5/PKGBUILD
+++ b/mingw-w64-kcmutils-qt5/PKGBUILD
@@ -1,3 +1,4 @@
+# Maintainer: Christian Meurin (NebuHiiEjamu)
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kcmutils"
@@ -7,8 +8,8 @@ arch=('any')
 pkgdesc="Utilities for interacting with KCModules (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
-						 "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
-						 "${MINGW_PACKAGE_PREFIX}-doxygen")
+       "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+       "${MINGW_PACKAGE_PREFIX}-doxygen")
 depends=()
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdeclarative-qt5${_namesuff}"
 _kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"

--- a/mingw-w64-kdewebkit-qt5/PKGBUILD
+++ b/mingw-w64-kdewebkit-qt5/PKGBUILD
@@ -1,20 +1,18 @@
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
-_kde_f5_init_package "${_variant}" "kcmutils"
+_kde_f5_init_package "${_variant}" "kdewebkit"
 pkgver=5.50.0
 pkgrel=1
 arch=('any')
-pkgdesc="Utilities for interacting with KCModules (mingw-w64-qt5${_namesuff})"
+pkgdesc="KDE Integration for QtWebKit (mingw-w64-qt5${_namesuff})"
 license=('LGPL')
-makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}"
-						 "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
-						 "${MINGW_PACKAGE_PREFIX}-doxygen")
+makedepends=("${MINGW_PACKAGE_PREFIX}-extra-cmake-modules>=${pkgver}")
 depends=()
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kdeclarative-qt5${_namesuff}"
-_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-kparts-qt5${_namesuff}"
+_kde_f5_add_depends "${_variant}" "${MINGW_PACKAGE_PREFIX}-qtwebkit${_namesuff}"
 groups=('kf5')
 source=("https://download.kde.org/stable/frameworks/${pkgver%.*}/${_basename}-${pkgver}.tar.xz")
-sha256sums=('d70e08568a16cb294fae094383afdd4565f2fc39d8020fb347d35807c4453fe1')
+sha256sums=('1084793684c438385441ffcc7652223200d0e902661883fdca537ace2a2ab05c')
 
 prepare() {
   mkdir -p build-${CARCH}${_variant}

--- a/mingw-w64-kdewebkit-qt5/PKGBUILD
+++ b/mingw-w64-kdewebkit-qt5/PKGBUILD
@@ -1,3 +1,4 @@
+# Maintainer: Christian Meurin (NebuHiiEjamu)
 _variant=-${KF5_VARIANT:-shared}
 source "$(dirname ${BASH_SOURCE[0]})"/../mingw-w64-PKGBUILD-common/kde-frameworks5
 _kde_f5_init_package "${_variant}" "kdewebkit"


### PR DESCRIPTION
Unfortunately, Okteta and KDesignerPlugin can't be built because KDocTools errors with this message, but I was able to build the new KDEWebKit and KCMUtils dependencies

```
kf5.kdoctools: Error: Could not find kdoctools catalogs
```