### PR TITLE
mingw-w64-python-certifi - 2018.10.15 - rework to conform to pattern …

### DIFF
--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -4,7 +4,7 @@ _realname=certifi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=2018.10.15
-pkgrel=1
+pkgrel=2
 pkgdesc="Python package for providing Mozilla's CA Bundle (mingw-w64)"
 url='https://pypi.python.org/pypi/certifi'
 license=('GPL')
@@ -17,29 +17,41 @@ sha256sums=('6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a')
 
 prepare() {
   cd ${srcdir}
-  cp -r ${_realname}-${pkgver} build-python2
-  cp -r ${_realname}-${pkgver} build-python3
+
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_realname}-${pkgver}" "${builddir}"
+  done
+  # Set version for setuptools_scm
+  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
   
-  cd build-python2
+  cd python2-build-${CARCH}
   sed -i '1s|python$|python2|' certifi/core.py
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
 }
 
 package_python3-certifi() {
   depends=("${MINGW_PACKAGE_PREFIX}-python3")
-  cd ${srcdir}/build-python3
-  ${MINGW_PREFIX}/bin/python3 setup.py build
+
+  cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
 
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/python3-${_realname}/LICENSE
 }
 
 package_python2-certifi() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
-  cd ${srcdir}/build-python2
-  ${MINGW_PREFIX}/bin/python2 setup.py build
+  cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
 
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/python2-${_realname}/LICENSE
 }

--- a/mingw-w64-python-certifi/PKGBUILD
+++ b/mingw-w64-python-certifi/PKGBUILD
@@ -42,7 +42,7 @@ package_python3-certifi() {
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"  --optimize=1 --skip-build
 
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/python3-${_realname}/LICENSE
 }
@@ -51,7 +51,7 @@ package_python2-certifi() {
   depends=("${MINGW_PACKAGE_PREFIX}-python2")
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
-    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}"  --optimize=1 --skip-build
 
   install -D -m644 LICENSE "${pkgdir}${MINGW_PREFIX}"/share/licenses/python2-${_realname}/LICENSE
 }


### PR DESCRIPTION
…and keep architecture/python versions separate at all times.