### PR TITLE
qt5: fix 32 bit linking with clang 7.0 (#4593)

### DIFF
--- a/mingw-w64-qt5-static/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+++ b/mingw-w64-qt5-static/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
@@ -166,6 +166,17 @@
          else: \
              CLANG_LIBS += -lclang
      } else {
+@@ -123,9 +259,9 @@
+                         -lclangDaemon \
+                         -lclangDriver \
+                         -lclangDynamicASTMatchers \
+-                        -lclangEdit \
+                         -lclangFormat \
+                         -lclangFrontend \
++                        -lclangEdit \
+                         -lclangFrontendTool \
+                         -lclangHandleCXX \
+                         -lclangIncludeFixer \
 @@ -145,6 +281,7 @@
                          -lclangStaticAnalyzerCore \
                          -lclangStaticAnalyzerFrontend \

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=4
+pkgrel=5
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -757,7 +757,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             'f1ea27aa8b1febe7b806e775a928e2b03edc9a7045f6c03da3a7f57563b05e56'
             '234d1b207eb9ea11839f941799daf613028f33dbc89bebdf78b9a2dd4dd84dd2'
             '227940744aa3d87f51d9ea9d2fff0bfc11cda5f5055687bceb1c93ade5d5cdf6'
-            '13c85520e05379e2e5e7876c6c30fc0d4c88f152d5a1db7902bd8680955966cb'
+            '7e894d26cc3afab36265fa1dbe96e1c4de397c33dfef94d69d6c5f35f012cac7'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             'de8d7f88ee987ed376226793350918a2a618a093cc3f56c37e1b3b9bf3e23d84'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'

--- a/mingw-w64-qt5/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+++ b/mingw-w64-qt5/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
@@ -166,6 +166,17 @@
          else: \
              CLANG_LIBS += -lclang
      } else {
+@@ -123,9 +259,9 @@
+                         -lclangDaemon \
+                         -lclangDriver \
+                         -lclangDynamicASTMatchers \
+-                        -lclangEdit \
+                         -lclangFormat \
+                         -lclangFrontend \
++                        -lclangEdit \
+                         -lclangFrontendTool \
+                         -lclangHandleCXX \
+                         -lclangIncludeFixer \
 @@ -145,6 +281,7 @@
                          -lclangStaticAnalyzerCore \
                          -lclangStaticAnalyzerFrontend \

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.11.2
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=4
+pkgrel=5
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -757,7 +757,7 @@ sha256sums=('c6104b840b6caee596fa9a35bc5f57f67ed5a99d6a36497b6fe66f990a53ca81'
             'f1ea27aa8b1febe7b806e775a928e2b03edc9a7045f6c03da3a7f57563b05e56'
             '234d1b207eb9ea11839f941799daf613028f33dbc89bebdf78b9a2dd4dd84dd2'
             '227940744aa3d87f51d9ea9d2fff0bfc11cda5f5055687bceb1c93ade5d5cdf6'
-            '13c85520e05379e2e5e7876c6c30fc0d4c88f152d5a1db7902bd8680955966cb'
+            '7e894d26cc3afab36265fa1dbe96e1c4de397c33dfef94d69d6c5f35f012cac7'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             'de8d7f88ee987ed376226793350918a2a618a093cc3f56c37e1b3b9bf3e23d84'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'


### PR DESCRIPTION
g++ reports libclangEdit as a malformed archive.
Maybe a wrongly coded error message or a bug within the linker but libclangEdit.a seems to have no issue at all by itself.
Linking against the specific file (\<full path\>/libclangEdit.a) solve the issue.
Easily, moving -lclangEdit down within the clang libraries list (this PR) solve the issue as well.