### PR TITLE
gettext: Build with --enable-relocatable. Fixes #4392

### DIFF
--- a/mingw-w64-gettext/PKGBUILD
+++ b/mingw-w64-gettext/PKGBUILD
@@ -5,7 +5,7 @@ _realname=gettext
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.8.1
-pkgrel=6
+pkgrel=7
 arch=('any')
 pkgdesc="GNU internationalization library (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-expat"
@@ -94,6 +94,7 @@ build() {
     --disable-csharp \
     --enable-static \
     --enable-threads=win32 \
+    --enable-relocatable \
     --without-emacs \
     --disable-openmp \
     --without-cvs \


### PR DESCRIPTION
This makes xgettext find its data files (like .its rules)

Fixes #4392