### PR TITLE
nghttp2: update to 1.35.0

### DIFF
--- a/mingw-w64-nghttp2/PKGBUILD
+++ b/mingw-w64-nghttp2/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=nghttp2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.34.0
-pkgrel=2
+pkgver=1.35.0
+pkgrel=1
 pkgdesc="Framing layer of HTTP/2 is implemented as a reusable C library (mingw-w64)"
 arch=('any')
 url='https://nghttp2.org/'
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cunit")
 license=('MIT')
 source=("https://github.com/nghttp2/nghttp2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('ecb0c013141495e24bd6deca022b5a92097a7848a0c17c4e5af1243a97fa622e')
+sha256sums=('23610ddd446bf1a9ae12905b0e7f283afd46249794868b7acd581e693900544c')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
This updates nghttp2 to 1.35.0.