### PR TITLE
Add mingw-w64-python-biopython package

### DIFF
--- a/mingw-w64-python-biopython/PKGBUILD
+++ b/mingw-w64-python-biopython/PKGBUILD
@@ -1,0 +1,61 @@
+
+_realname=biopython
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.72
+pkgrel=1
+pkgdesc="A set of freely available tools for biological computation written in Python (mingw-w64)"
+arch=('any')
+license=()
+url="https://biopython.org/"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=(${_realname}-${pkgver}.tar.gz::http://biopython.org/DIST/${_realname}-${pkgver}.tar.gz)
+sha256sums=('AB6B492443ADB90C66267B3D24D602AE69A93C68F4B9F135BA01CB06D36CE5A2')
+
+build() {
+  cd "${srcdir}"
+  rm -rf python{2,3}-build
+  for builddir in python{2,3}-build; do
+    cp -r ${_realname}-${pkgver} ${builddir}
+    pushd $builddir
+    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
+    popd
+  done
+}
+
+package_python3-biopython() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3-numpy")
+
+  cd "${srcdir}/python3-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+}
+
+package_python2-biopython() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2-numpy")
+
+  cd "${srcdir}/python2-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+}
+
+package_mingw-w64-i686-python2-biopython() {
+  package_python2-biopython
+}
+
+package_mingw-w64-i686-python3-biopython() {
+  package_python3-biopython
+}
+
+package_mingw-w64-x86_64-python2-biopython() {
+  package_python2-biopython
+}
+
+package_mingw-w64-x86_64-python3-biopython() {
+  package_python3-biopython
+}


### PR DESCRIPTION
Biopython is a set of freely available tools for biological computation written in Python by an international team of developers.
It is a distributed collaborative effort to develop Python libraries and applications which address the needs of current and future work in bioinformatics. 