### PR TITLE
python-websocket-client - 0.54.0 - require mingw-w64-python2-backport…

### DIFF
--- a/mingw-w64-python-websocket-client/PKGBUILD
+++ b/mingw-w64-python-websocket-client/PKGBUILD
@@ -4,15 +4,18 @@ _realname=websocket-client
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=0.54.0
-pkgrel=1
+pkgrel=2
 pkgdesc="websocket client for python (mingw-w64)"
 arch=('any')
 url='https://github.com/websocket-client/websocket-client'
 license=('LGPL-2.1')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-backports.ssl_match_hostname"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
-             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+             "${MINGW_PACKAGE_PREFIX}-python3-six")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/websocket-client/websocket-client/archive/v${pkgver}.tar.gz")
 sha512sums=('be3b81b33522b2b860a48e616ce6607f064af28da341d540803c944521949421d665b07a21fa977a045d4d4bd5a4ef30959e36a3dea96ced5e24005c5f4214c7')
@@ -39,12 +42,13 @@ check() {
   for pver in {2,3}; do
     msg "Python ${pver} test for ${CARCH}"
     cd "${srcdir}/python${pver}-build-${CARCH}"
-    ${MINGW_PREFIX}/bin/python${pver} setup.py check
+    ${MINGW_PREFIX}/bin/python${pver} setup.py test
   done
 }
 
 package_python3-websocket-client() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-six")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -62,7 +66,9 @@ package_python3-websocket-client() {
 }
 
 package_python2-websocket-client() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-backports.ssl_match_hostname")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
…s.ssl_match_hostname in Python2, add six as requirement, and add tests