### PR TITLE
mypaint: brushes 2.0 and prep for 2.0 mypaint/libmypaint release

### DIFF
--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -4,12 +4,8 @@ _realname=libmypaint
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
 provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=(
-    "${MINGW_PACKAGE_PREFIX}-${_realname}"
-    "${MINGW_PACKAGE_PREFIX}-mypaint<1.3.0alpha"
-)
-pkgver=1.3.0
-pkgrel=1
+pkgver=2.0.0
+pkgrel=2
 pkgdesc="Brush engine used by MyPaint (git) (mingw-w64)"
 arch=('any')
 url="http://mypaint.org"

--- a/mingw-w64-mypaint-brushes2/PKGBUILD
+++ b/mingw-w64-mypaint-brushes2/PKGBUILD
@@ -1,19 +1,19 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=mypaint-brushes
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.0
-pkgrel=2
-pkgdesc="Brushes for MyPaint (mingw-w64)"
+pkgbase=mingw-w64-${_realname}2
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
+pkgver=2.0.0
+pkgrel=1
+pkgdesc="Brushes for MyPaint 2.x (mingw-w64)"
 arch=('any')
 url="https://github.com/mypaint/mypaint-brushes"
 license=("ISC")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-depends=("${MINGW_PACKAGE_PREFIX}-libmypaint")
+depends=("${MINGW_PACKAGE_PREFIX}-libmypaint-git")
 options=('strip' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mypaint/mypaint-brushes/archive/v${pkgver}.tar.gz)
-sha256sums=('704bb6420e65085acfd7a61d6050e96b0395c5eab078433f11406c355f16b214')
+sha256sums=('a3bc82204345d2b401571604b43aaa068073aa1e7ba0fe866ebc1774cead1bb5')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {

--- a/mingw-w64-mypaint-brushes2/PKGBUILD
+++ b/mingw-w64-mypaint-brushes2/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=mypaint-brushes
-pkgbase=mingw-w64-${_realname}2
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.0.0
 pkgrel=1
 pkgdesc="Brushes for MyPaint 2.x (mingw-w64)"
@@ -41,5 +41,5 @@ build() {
 package() {
   cd "${srcdir}"/build-${MINGW_CHOST}
   make -j1 DESTDIR="${pkgdir}" install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/Licenses.md "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/Licenses.md
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/Licenses.md "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/Licenses.md
 }

--- a/mingw-w64-mypaint-git/PKGBUILD
+++ b/mingw-w64-mypaint-git/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=mypaint
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=1.3.0alpha.d20170416.g64e90976
-pkgrel=1
+pkgver=2.0.0alpha
+pkgrel=2
 provides=(
     "${MINGW_PACKAGE_PREFIX}-${_realname}"
 )
@@ -26,6 +26,8 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-gcc-libs"
     "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
     "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
+    "${MINGW_PACKAGE_PREFIX}-mypaint-brushes2"
+    "${MINGW_PACKAGE_PREFIX}-pkg-config"
 )
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-swig"
@@ -33,6 +35,7 @@ makedepends=(
     "${MINGW_PACKAGE_PREFIX}-pygobject-devel"
     "${MINGW_PACKAGE_PREFIX}-python2"
     "${MINGW_PACKAGE_PREFIX}-python2-setuptools"
+    "${MINGW_PACKAGE_PREFIX}-mypaint-brushes2"
     "swig"
 )
 options=('!strip' 'debug' 'staticlibs')


### PR DESCRIPTION
MyPaint is preparing for a 2.0 release.  These updates will allow
the 1.3 and 2.0 brushes and libmypaint 1.3 and 2.0 to co-exist.
Mypaint 2.0 will soon depend on mypaint-brushes 2.x.

Also updated src repos to point to official mypaint github instead of Jehan.

libmypaint-git and mypaint-git have moved to 2.x on the master branches.