### PR TITLE
nim: Change to use posixy path even on Windows

### DIFF
--- a/mingw-w64-nim/0002-Fix-config-path.patch
+++ b/mingw-w64-nim/0002-Fix-config-path.patch
@@ -1,0 +1,12 @@
+diff --git a/compiler/nimconf.nim b/compiler/nimconf.nim
+index c0aeab7e3..491d23d88 100644
+--- a/compiler/nimconf.nim
++++ b/compiler/nimconf.nim
+@@ -227,6 +227,7 @@ proc getSystemConfigPath*(conf: ConfigRef; filename: RelativeFile): AbsoluteFile
+   # the UNIX way)
+   let p = getPrefixDir(conf)
+   result = p / RelativeDir"config" / filename
++  if not fileExists(result): result = p / RelativeDir"etc/nim" / filename
+   when defined(unix):
+     if not fileExists(result): result = p / RelativeDir"etc/nim" / filename
+     if not fileExists(result): result = AbsoluteDir"/etc/nim" / filename

--- a/mingw-w64-nim/0003-Fix-library-path.patch
+++ b/mingw-w64-nim/0003-Fix-library-path.patch
@@ -1,0 +1,14 @@
+diff --git a/compiler/options.nim b/compiler/options.nim
+index b4d2bb64e..05bc696e4 100644
+--- a/compiler/options.nim
++++ b/compiler/options.nim
+@@ -465,7 +465,8 @@ proc setDefaultLibpath*(conf: ConfigRef) =
+       else:
+         conf.libpath = prefix / RelativeDir"lib"
+     else:
+-      conf.libpath = prefix / RelativeDir"lib"
++      conf.libpath = prefix / RelativeDir"lib/nim"
++      if not existsDir(conf.libpath.string): conf.libpath = prefix / RelativeDir"lib"
+ 
+     # Special rule to support other tools (nimble) which import the compiler
+     # modules and make use of them.

--- a/mingw-w64-nim/0004-Fix-nimrtl-dll-name.patch
+++ b/mingw-w64-nim/0004-Fix-nimrtl-dll-name.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/system/inclrtl.nim b/lib/system/inclrtl.nim
+index f9e6754ef..0c062b1c4 100644
+--- a/lib/system/inclrtl.nim
++++ b/lib/system/inclrtl.nim
+@@ -36,7 +36,7 @@ when defined(createNimRtl):
+   {.pragma: compilerRtl, compilerproc, exportc: "nimrtl_$1", dynlib.}
+ elif defined(useNimRtl):
+   when defined(windows):
+-    const nimrtl* = "nimrtl.dll"
++    const nimrtl* = "libnimrtl.dll"
+   elif defined(macosx):
+     const nimrtl* = "libnimrtl.dylib"
+   else:

--- a/mingw-w64-nim/0005-Fix-pcre-dll-name.patch
+++ b/mingw-w64-nim/0005-Fix-pcre-dll-name.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/wrappers/pcre.nim b/lib/wrappers/pcre.nim
+index e9e11960c..7c9dbca5e 100644
+--- a/lib/wrappers/pcre.nim
++++ b/lib/wrappers/pcre.nim
+@@ -313,9 +313,9 @@ when not defined(usePcreHeader):
+     when defined(nimOldDlls):
+       const pcreDll = "pcre.dll"
+     elif defined(cpu64):
+-      const pcreDll = "pcre64.dll"
++      const pcreDll = "(pcre64|libpcre-1).dll"
+     else:
+-      const pcreDll = "pcre32.dll"
++      const pcreDll = "(pcre32|libpcre-1).dll"
+   elif hostOS == "macosx":
+     const pcreDll = "libpcre(.3|.1|).dylib"
+   else:

--- a/mingw-w64-nim/0006-Fix-sqlite3-dll-name.patch
+++ b/mingw-w64-nim/0006-Fix-sqlite3-dll-name.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/wrappers/sqlite3.nim b/lib/wrappers/sqlite3.nim
+index 0276a0a65..91a0dd91b 100644
+--- a/lib/wrappers/sqlite3.nim
++++ b/lib/wrappers/sqlite3.nim
+@@ -12,9 +12,9 @@ when defined(windows):
+   when defined(nimOldDlls):
+     const Lib = "sqlite3.dll"
+   elif defined(cpu64):
+-    const Lib = "sqlite3_64.dll"
++    const Lib = "(sqlite3_64|libsqlite3-0).dll"
+   else:
+-    const Lib = "sqlite3_32.dll"
++    const Lib = "(sqlite3_32|libsqlite3-0).dll"
+ elif defined(macosx):
+   const
+     Lib = "libsqlite3(|.0).dylib"

--- a/mingw-w64-nim/PKGBUILD
+++ b/mingw-w64-nim/PKGBUILD
@@ -6,7 +6,7 @@ _realname=nim
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.19.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Imperative, multi-paradigm, compiled programming language (mingw-w64)'
 arch=('any')
 url='https://nim-lang.org/'
@@ -15,10 +15,20 @@ makedepends=('git')
 options=(!emptydirs)
 source=("${_realname}-${pkgver}.tar.gz"::https://github.com/nim-lang/Nim/archive/v${pkgver}.tar.gz
         "${_realname}-csources-${pkgver}.tar.gz"::https://github.com/nim-lang/csources/archive/v${pkgver}.tar.gz
-        "0001-Use-unixy-filenames-even-on-Windows.patch")
+        "0001-Use-unixy-filenames-even-on-Windows.patch"
+        "0002-Fix-config-path.patch"
+        "0003-Fix-library-path.patch"
+        "0004-Fix-nimrtl-dll-name.patch"
+        "0005-Fix-pcre-dll-name.patch"
+        "0006-Fix-sqlite3-dll-name.patch")
 sha256sums=('f6a0b1c7bc227db1f7b8efa3bde0c6f23903c9184beebc99ff0094378c28e1ee'
             '68042afae0b24915acac813b52b9ee0a303219e990d3bfa05ca57fb6bbc51578'
-            '3010acbe7769ea214dd51f5889e3a26b44925001905deb04b060beaede2578f4')
+            '3010acbe7769ea214dd51f5889e3a26b44925001905deb04b060beaede2578f4'
+            'e4616080589f8140dbf4e4dc8afff1dddd95c93af51e2754bd84606cee415386'
+            'e66e869c7f39a0fa5fa98512ae1d2a02befface3ff2d4d36abc2b63616e24039'
+            '9d3efcc253986708cac461c8bd691b0edf660f63be5d77b85253402899ef784f'
+            'fa475808c100a86174ae348faaa4048d09e56406cb54c2f795da9d733605b003'
+            '008a090cf561124796daaab8390f495bc740a4ec8936eb96bc025cee6e017e3d')
 
 prepare() {
   cd "${srcdir}"
@@ -28,6 +38,11 @@ prepare() {
 
   cd "${_realname}-${pkgver}"
   patch -p1 -i "${srcdir}/0001-Use-unixy-filenames-even-on-Windows.patch"
+  patch -p1 -i "${srcdir}/0002-Fix-config-path.patch"
+  patch -p1 -i "${srcdir}/0003-Fix-library-path.patch"
+  patch -p1 -i "${srcdir}/0004-Fix-nimrtl-dll-name.patch"
+  patch -p1 -i "${srcdir}/0005-Fix-pcre-dll-name.patch"
+  patch -p1 -i "${srcdir}/0006-Fix-sqlite3-dll-name.patch"
 }
 
 build() {
@@ -70,9 +85,11 @@ package() {
   cp -a compiler "${pkgdir}${MINGW_PREFIX}/lib/nim"
 
   cp "compiler.nimble" "${pkgdir}${MINGW_PREFIX}/lib/nim/compiler"
-  cp "lib/libnimrtl.dll" "${pkgdir}${MINGW_PREFIX}/lib/"
 
-  install -Dm 644 config/* -t "${pkgdir}${MINGW_PREFIX}/etc"
+  mkdir -p "${pkgdir}${MINGW_PREFIX}/bin"
+  cp "lib/libnimrtl.dll" "${pkgdir}${MINGW_PREFIX}/bin"
+
+  install -Dm 644 config/* -t "${pkgdir}${MINGW_PREFIX}/etc/nim"
   install -Dm 755 bin/* tools/nimgrep nimsuggest/nimsuggest -t "${pkgdir}${MINGW_PREFIX}/bin"
 
   # Fix FS#50252, unusual placement of header files


### PR DESCRIPTION
There is a problem with the current `nim` package due to being installed in the path like posix. Therefore, problems such as failure to import system library occur. This PR is for correcting them.

- Change configuration files path to `%NIM%/etc/nim`.
- Change the system library path to `%NIM%/lib/nim`.
- Change DLL name from `nimrtl.dll` to `libnimrtl.dll`.
- Add DLL of MinGW to DLL name of pcre wrapper.
- Add DLL of MinGW to DLL name of sqlite3 wrapper.
- Change the installation destination of the configuration file to  `%NIM%/etc/nim`.
- Change the installation destination of the `nimrtl.dll` to `%NIM%/bin`.