### PR TITLE
sqlcipher: update to 4.4.0

### DIFF
--- a/mingw-w64-sqlcipher/01-fix_dep.diff
+++ b/mingw-w64-sqlcipher/01-fix_dep.diff
@@ -1,6 +1,6 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -1074,7 +1074,7 @@
+@@ -1159,7 +1159,7 @@
     $(TOP)/ext/fts5/fts5_varint.c \
     $(TOP)/ext/fts5/fts5_vocab.c  \
  

--- a/mingw-w64-sqlcipher/02-fix-tcl-find.patch
+++ b/mingw-w64-sqlcipher/02-fix-tcl-find.patch
@@ -1,11 +1,11 @@
---- sqlcipher-3.4.1/configure.ac.orig	2017-03-21 13:43:37.750719800 +0300
-+++ sqlcipher-3.4.1/configure.ac	2017-03-21 13:43:56.258099500 +0300
+--- a/configure.ac
++++ b/configure.ac
 @@ -120,7 +120,7 @@
  # if not, then we fall back to plain tclsh.
  # TODO: try other versions before falling back?
  # 
--AC_CHECK_PROGS(TCLSH_CMD, [tclsh8.6 tclsh8.5 tclsh], none)
-+AC_CHECK_PROGS(TCLSH_CMD, [tclsh8.6 tclsh86 tclsh8.5 tclsh85 tclsh], none)
+-AC_CHECK_PROGS(TCLSH_CMD, [tclsh8.7 tclsh8.6 tclsh8.5 tclsh], none)
++AC_CHECK_PROGS(TCLSH_CMD, [tclsh8.7 tclsh87 tclsh8.6 tclsh86 tclsh8.5 tclsh85 tclsh], none)
  if test "$TCLSH_CMD" = "none"; then
    # If we can't find a local tclsh, then building the amalgamation will fail.
    # We act as though --disable-amalgamation has been used.

--- a/mingw-w64-sqlcipher/PKGBUILD
+++ b/mingw-w64-sqlcipher/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=sqlcipher
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.4.2
-pkgrel=2
+pkgver=4.0.0
+pkgrel=1
 pkgdesc="SQLite extension that provides transparent 256-bit AES encryption of database files"
 arch=('any')
 url="https://www.zetetic.net/sqlcipher/"
@@ -12,23 +12,18 @@ license=('BSD')
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-openssl"
          "${MINGW_PACKAGE_PREFIX}-readline")
-makedepends=("${MINGW_PACKAGE_PREFIX}-tcl"
-             #"${MINGW_PACKAGE_PREFIX}-sqlite3"
-             )
-source=("${_realname}-${pkgver}.zip::https://github.com/${_realname}/${_realname}/archive/v${pkgver}.zip"
-        "https://www.zetetic.net/$_realname/verify/${pkgver}/${_realname}-${pkgver}.zip.sig"
+makedepends=("${MINGW_PACKAGE_PREFIX}-tcl")
+source=("${_realname}-${pkgver}.tar.gz::https://github.com/${_realname}/${_realname}/archive/v${pkgver}.tar.gz"
         "01-fix_dep.diff"
         "02-fix-tcl-find.patch")
-validpgpkeys=('D83F5F9EB811D6E6B4A0D9C5D1FA3A2A97ED25C2')   # Zetetic LLC <support@zetetic.net>
-sha256sums=('f2afbde554423fd3f8e234d21e91a51b6f6ba7fc4971e73fdf5d388a002f79f1'
-            'SKIP'
-            'e0cfe85705fd0d7d33b087dfd4cf2f807e1a75f2c9b15f5ceb8b9ff202f6ce5c'
-            '048b08a4ddc628111fe9a0f6559e5cf25f0b9414c86109917684115283ab8d6b')
+sha256sums=('c8f5fc6d800aae6107bf23900144804db5510c2676c93fbb269e4a0700837d68'
+            'a1a94b5c9e28e58ad449c75f51a2365840ed78d293ee6e9d5fb3069a9281d23c'
+            'd30c43a28eaeedcafde98d0f9a76fd8d676ee77732c9dc38e028147faa5adca0')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
 
-  # Debain patch
+  # Debian patch
   patch -p1 -i "${srcdir}"/01-fix_dep.diff
 
   patch -p1 -i "${srcdir}"/02-fix-tcl-find.patch
@@ -47,11 +42,17 @@ build() {
     --prefix=${MINGW_PREFIX} \
     --enable-tempstore=yes \
     --disable-tcl \
+    --enable-json1 \
+    --enable-fts4 \
+    --enable-fts5 \
+    --enable-rtree \
+    --enable-session \
     --disable-editline \
     --enable-readline \
     --with-readline-lib="-L${MINGW_PREFIX}/lib -lreadline" \
     --with-readline-inc="-I${MINGW_PREFIX}/include" \
-    CFLAGS="$CFLAGS -DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto"
+    CFLAGS="$CFLAGS -DSQLITE_HAS_CODEC -DSQLITE_ENABLE_COLUMN_METADATA" \
+    LDFLAGS="-lcrypto"
 
   make
 }


### PR DESCRIPTION
Upstream update to 4.4.0
Enable more extensions to match the sqlite3 package.
Remove the signing key as it is not used for the github archive.
see https://github.com/sqlcipher/sqlcipher/issues/291
