### PR TITLE
Add mingw-w64-python-xlwt

### DIFF
--- a/mingw-w64-python-xlwt/PKGBUILD
+++ b/mingw-w64-python-xlwt/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: gym603 <gui_yuan_miao@163.com>
+
+_realname=xlwt
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=1.3.0
+pkgrel=1
+pkgdesc="Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS files, on any platform (mingw-w64)"
+arch=('any')
+license=('custom')
+url="https://github.com/python-excel/xlwt"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+source=(${_realname}-${pkgver}.tar.gz::https://github.com/python-excel/xlwt/archive/${pkgver}.tar.gz)
+sha256sums=('1961682C6A3CEDB44E6A96FF6ED099D80AF8DA9A669DBBBC1D1959E8398122D6')
+
+build() {
+  cd "${srcdir}"
+  rm -rf python{2,3}-build
+  for builddir in python{2,3}-build; do
+    cp -r ${_realname}-${pkgver} ${builddir}
+    pushd $builddir
+    ${MINGW_PREFIX}/bin/${builddir%-build} setup.py build
+    popd
+  done
+}
+
+package_python3-xlwt() {
+  depends=()
+
+  cd "${srcdir}/python3-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 docs/licenses.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/licenses.rst"
+}
+
+package_python2-xlwt() {
+  depends=()
+
+  cd "${srcdir}/python2-build"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+    ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} --root="${pkgdir}" -O1
+
+  install -Dm644 docs/licenses.rst "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/licenses.rst"
+}
+
+package_mingw-w64-i686-python2-xlwt() {
+  package_python2-xlwt
+}
+
+package_mingw-w64-i686-python3-xlwt() {
+  package_python3-xlwt
+}
+
+package_mingw-w64-x86_64-python2-xlwt() {
+  package_python2-xlwt
+}
+
+package_mingw-w64-x86_64-python3-xlwt() {
+  package_python3-xlwt
+}

--- a/mingw-w64-python-xlwt/PKGBUILD
+++ b/mingw-w64-python-xlwt/PKGBUILD
@@ -26,7 +26,7 @@ build() {
 }
 
 package_python3-xlwt() {
-  depends=()
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
 
   cd "${srcdir}/python3-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -36,7 +36,7 @@ package_python3-xlwt() {
 }
 
 package_python2-xlwt() {
-  depends=()
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
 
   cd "${srcdir}/python2-build"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS files, on any platform (mingw-w64)