### PR TITLE
Mypaint Brushes: add 2.0 and update 1.3 src repo to official

### DIFF
--- a/mingw-w64-mypaint-brushes2/PKGBUILD
+++ b/mingw-w64-mypaint-brushes2/PKGBUILD
@@ -1,19 +1,19 @@
 # Maintainer: Alexey Pavlov <alexpux@gmail.com>
 
 _realname=mypaint-brushes
-pkgbase=mingw-w64-${_realname}
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.3.0
-pkgrel=2
-pkgdesc="Brushes for MyPaint (mingw-w64)"
+pkgbase=mingw-w64-${_realname}2
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}2"
+pkgver=2.0.0
+pkgrel=1
+pkgdesc="Brushes for MyPaint 2.0 (mingw-w64)"
 arch=('any')
 url="https://github.com/mypaint/mypaint-brushes"
 license=("ISC")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
-depends=("${MINGW_PACKAGE_PREFIX}-libmypaint")
+depends=("${MINGW_PACKAGE_PREFIX}-libmypaint-git")
 options=('strip' '!debug')
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/mypaint/mypaint-brushes/archive/v${pkgver}.tar.gz)
-sha256sums=('704bb6420e65085acfd7a61d6050e96b0395c5eab078433f11406c355f16b214')
+sha256sums=('a3bc82204345d2b401571604b43aaa068073aa1e7ba0fe866ebc1774cead1bb5')
 noextract=(${_realname}-${pkgver}.tar.gz)
 
 prepare() {
@@ -41,5 +41,5 @@ build() {
 package() {
   cd "${srcdir}"/build-${MINGW_CHOST}
   make -j1 DESTDIR="${pkgdir}" install
-  install -Dm644 ${srcdir}/${_realname}-${pkgver}/Licenses.md "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/Licenses.md
+  install -Dm644 ${srcdir}/${_realname}-${pkgver}/Licenses.md "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/Licenses.md
 }


### PR DESCRIPTION
Mypaint 2.0 will depend on 2.0 brushes.  Also update the 1.3 brushes to point to official repo.

Not sure if I have realname proper.  I just appended "2" to pkgbase and pkgname.  Is this ok?  Thanks!

