### PR TITLE
tcl/tk: update to 8.6.9

### DIFF
--- a/mingw-w64-tcl/004-use-system-zlib.mingw.patch
+++ b/mingw-w64-tcl/004-use-system-zlib.mingw.patch
@@ -6,7 +6,7 @@ diff -Naur tcl8.6.5-orig/win/configure.in tcl8.6.5/win/configure.in
  ])
  AS_IF([test "$tcl_ok" = "yes"], [
 -  AC_SUBST(ZLIB_DLL_FILE,[\${ZLIB_DLL_FILE}])
--  AS_IF([test "$do64bit" = "yes"], [
+-  AS_IF([test "$do64bit" != "no"], [
 -    AS_IF([test "$GCC" == "yes"],[
 -      AC_SUBST(ZLIB_LIBS,[\${ZLIB_DIR_NATIVE}/win64/libz.dll.a])
 -    ], [

--- a/mingw-w64-tcl/010-dont-link-shared-with--static-libgcc.patch
+++ b/mingw-w64-tcl/010-dont-link-shared-with--static-libgcc.patch
@@ -1,6 +1,6 @@
-diff -Naur tcl8.6.8-orig/pkgs/itcl4.1.1/tclconfig/tcl.m4 tcl8.6.8/pkgs/itcl4.1.1/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/itcl4.1.1/tclconfig/tcl.m4	2016-03-01 04:59:33.000000000 +0300
-+++ tcl8.6.8/pkgs/itcl4.1.1/tclconfig/tcl.m4	2016-03-03 08:47:51.861097900 +0300
+diff -Naur tcl8.6.9-orig/pkgs/itcl4.1.2/tclconfig/tcl.m4 tcl8.6.9/pkgs/itcl4.1.2/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/itcl4.1.2/tclconfig/tcl.m4	2016-03-01 04:59:33.000000000 +0300
++++ tcl8.6.9/pkgs/itcl4.1.2/tclconfig/tcl.m4	2016-03-03 08:47:51.861097900 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -11,9 +11,9 @@ diff -Naur tcl8.6.8-orig/pkgs/itcl4.1.1/tclconfig/tcl.m4 tcl8.6.8/pkgs/itcl4.1.1
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/sqlite3.21.0/configure tcl8.6.8/pkgs/sqlite3.21.0/configure
---- tcl8.6.8/pkgs/sqlite3.21.0/configure.orig	2016-10-06 01:33:13.323973100 -0400
-+++ tcl8.6.8/pkgs/sqlite3.21.0/configure	2016-10-06 04:43:23.176595300 -0400
+diff -Naur tcl8.6.9-orig/pkgs/sqlite3.25.3/configure tcl8.6.9/pkgs/sqlite3.25.3/configure
+--- tcl8.6.9/pkgs/sqlite3.25.3/configure.orig	2016-10-06 01:33:13.323973100 -0400
++++ tcl8.6.9/pkgs/sqlite3.25.3/configure	2016-10-06 04:43:23.176595300 -0400
 @@ -8890,9 +8890,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -24,9 +24,9 @@ diff -Naur tcl8.6.8-orig/pkgs/sqlite3.21.0/configure tcl8.6.8/pkgs/sqlite3.21.0/
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/sqlite3.21.0/tclconfig/tcl.m4 tcl8.6.8/pkgs/sqlite3.21.0/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/sqlite3.21.0/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
-+++ tcl8.6.8/pkgs/sqlite3.21.0/tclconfig/tcl.m4	2016-03-03 08:47:51.902093800 +0300
+diff -Naur tcl8.6.9-orig/pkgs/sqlite3.25.3/tclconfig/tcl.m4 tcl8.6.9/pkgs/sqlite3.25.3/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/sqlite3.25.3/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
++++ tcl8.6.9/pkgs/sqlite3.25.3/tclconfig/tcl.m4	2016-03-03 08:47:51.902093800 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -37,9 +37,9 @@ diff -Naur tcl8.6.8-orig/pkgs/sqlite3.21.0/tclconfig/tcl.m4 tcl8.6.8/pkgs/sqlite
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbc1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbc1.0.6/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/tdbc1.0.6/tclconfig/tcl.m4	2015-10-13 14:57:48.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbc1.0.6/tclconfig/tcl.m4	2016-03-03 08:47:51.940090000 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbc1.1.0/tclconfig/tcl.m4 tcl8.6.9/pkgs/tdbc1.1.0/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/tdbc1.1.0/tclconfig/tcl.m4	2015-10-13 14:57:48.000000000 +0300
++++ tcl8.6.9/pkgs/tdbc1.1.0/tclconfig/tcl.m4	2016-03-03 08:47:51.940090000 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -50,9 +50,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbc1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbc1.0.6
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbcmysql1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbcmysql1.0.6/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/tdbcmysql1.0.6/tclconfig/tcl.m4	2015-10-13 14:57:39.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbcmysql1.0.6/tclconfig/tcl.m4	2016-03-03 08:47:51.957088300 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbcmysql1.1.0/tclconfig/tcl.m4 tcl8.6.9/pkgs/tdbcmysql1.1.0/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/tdbcmysql1.1.0/tclconfig/tcl.m4	2015-10-13 14:57:39.000000000 +0300
++++ tcl8.6.9/pkgs/tdbcmysql1.1.0/tclconfig/tcl.m4	2016-03-03 08:47:51.957088300 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -63,9 +63,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbcmysql1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbc
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbcodbc1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbcodbc1.0.6/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/tdbcodbc1.0.6/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbcodbc1.0.6/tclconfig/tcl.m4	2016-03-03 08:47:52.006083400 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbcodbc1.1.0/tclconfig/tcl.m4 tcl8.6.9/pkgs/tdbcodbc1.1.0/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/tdbcodbc1.1.0/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
++++ tcl8.6.9/pkgs/tdbcodbc1.1.0/tclconfig/tcl.m4	2016-03-03 08:47:52.006083400 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -76,9 +76,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbcodbc1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbco
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/configure tcl8.6.8/pkgs/tdbcpostgres1.0.6/configure
---- tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/configure	2016-01-28 21:07:18.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbcpostgres1.0.6/configure	2016-03-03 08:47:52.078076200 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbcpostgres1.1.0/configure tcl8.6.9/pkgs/tdbcpostgres1.1.0/configure
+--- tcl8.6.9-orig/pkgs/tdbcpostgres1.1.0/configure	2016-01-28 21:07:18.000000000 +0300
++++ tcl8.6.9/pkgs/tdbcpostgres1.1.0/configure	2016-03-03 08:47:52.078076200 +0300
 @@ -9446,9 +9446,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -89,9 +89,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/configure tcl8.6.8/pkgs/tdbcpost
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbcpostgres1.0.6/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbcpostgres1.0.6/tclconfig/tcl.m4	2016-03-03 08:47:52.275056500 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbcpostgres1.1.0/tclconfig/tcl.m4 tcl8.6.9/pkgs/tdbcpostgres1.1.0/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/tdbcpostgres1.1.0/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
++++ tcl8.6.9/pkgs/tdbcpostgres1.1.0/tclconfig/tcl.m4	2016-03-03 08:47:52.275056500 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -102,9 +102,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbcpostgres1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/t
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/tdbcsqlite3-1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/tdbcsqlite3-1.0.6/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/tdbcsqlite3-1.0.6/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
-+++ tcl8.6.8/pkgs/tdbcsqlite3-1.0.6/tclconfig/tcl.m4	2016-03-03 08:47:52.327051300 +0300
+diff -Naur tcl8.6.9-orig/pkgs/tdbcsqlite3-1.1.0/tclconfig/tcl.m4 tcl8.6.9/pkgs/tdbcsqlite3-1.1.0/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/tdbcsqlite3-1.1.0/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
++++ tcl8.6.9/pkgs/tdbcsqlite3-1.1.0/tclconfig/tcl.m4	2016-03-03 08:47:52.327051300 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -115,9 +115,9 @@ diff -Naur tcl8.6.8-orig/pkgs/tdbcsqlite3-1.0.6/tclconfig/tcl.m4 tcl8.6.8/pkgs/t
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/pkgs/thread2.8.2/tclconfig/tcl.m4 tcl8.6.8/pkgs/thread2.8.2/tclconfig/tcl.m4
---- tcl8.6.8-orig/pkgs/thread2.8.2/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
-+++ tcl8.6.8/pkgs/thread2.8.2/tclconfig/tcl.m4	2016-03-03 08:47:52.387045300 +0300
+diff -Naur tcl8.6.9-orig/pkgs/thread2.8.4/tclconfig/tcl.m4 tcl8.6.9/pkgs/thread2.8.4/tclconfig/tcl.m4
+--- tcl8.6.9-orig/pkgs/thread2.8.4/tclconfig/tcl.m4	2016-03-01 04:59:34.000000000 +0300
++++ tcl8.6.9/pkgs/thread2.8.4/tclconfig/tcl.m4	2016-03-03 08:47:52.387045300 +0300
 @@ -3377,9 +3377,6 @@
  		SHLIB_LD_LIBS="${SHLIB_LD_LIBS} \"`${CYGPATH} ${TK_BIN_DIR}/${TK_STUB_LIB_FILE}`\""
  	    fi
@@ -128,9 +128,9 @@ diff -Naur tcl8.6.8-orig/pkgs/thread2.8.2/tclconfig/tcl.m4 tcl8.6.8/pkgs/thread2
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${SHARED_LIB_SUFFIX}"
  	else
  	    eval eval "PKG_LIB_FILE=${PACKAGE_LIB_PREFIX}${PACKAGE_NAME}${UNSHARED_LIB_SUFFIX}"
-diff -Naur tcl8.6.8-orig/win/tcl.m4 tcl8.6.8/win/tcl.m4
---- tcl8.6.8-orig/win/tcl.m4	2016-03-03 08:47:49.442339800 +0300
-+++ tcl8.6.8/win/tcl.m4	2016-03-03 08:47:52.451038900 +0300
+diff -Naur tcl8.6.9-orig/win/tcl.m4 tcl8.6.9/win/tcl.m4
+--- tcl8.6.9-orig/win/tcl.m4	2016-03-03 08:47:49.442339800 +0300
++++ tcl8.6.9/win/tcl.m4	2016-03-03 08:47:52.451038900 +0300
 @@ -635,7 +635,6 @@
  
      if test "${GCC}" = "yes" ; then

--- a/mingw-w64-tcl/PKGBUILD
+++ b/mingw-w64-tcl/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=tcl
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6.8
+pkgver=8.6.9
 pkgrel=1
 pkgdesc="The Tcl scripting language (mingw-w64)"
 arch=('any')
@@ -25,16 +25,16 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/tcl${pkgver}-src.tar.
         009-fix-using-gnu-print.patch
         010-dont-link-shared-with--static-libgcc.patch)
 
-sha256sums=('c43cb0c1518ce42b00e7c8f6eaddd5195c53a98f94adc717234a65cbcfd3f96a'
+sha256sums=('ad0cd2de2c87b9ba8086b43957a0de3eb2eb565c7159d5f53ccbba3feb915f4e'
             'cfcf9b3816f8bb063b514ac7f63a5ba73108f27e16fdf8e8312dc5f0683083f6'
             '70bf0d8e84985f4e8ee63447ad37d5e50376eaf35ace51112761cacbbd596c4c'
-            '931485d71969096c1d03c8bed24fae3922d143fe50820d913e2567492ad6ac41'
+            '4e0e421a148a8e74ce0b1e52d80c0be8d04ec064bb45cdb762e8e6264de41a6a'
             '2b0f41f6704aa964dbfafa0a65dd5ce0ab97e82ff5cbbe2a95a2e8d644cc5550'
             '5c0162fbb018c03b3e4b907bd0098ab5282314bc212e3929a0416126637e1350'
             'f1833c3164229b017417d2ab2ce4cb066252fc1ad256de2313f0239481c7cc37'
             '3ec2702efb1be6873d6ffd2ffb357637588f835f8817ae65cf0373020fcc7359'
             '9c66ffe2de1d543f5291367d562ed5ee94e7e67345b281605788d7d9e02b8e7b'
-            '2cd861f04321622722c87f7247a0586e547e4daf95a7dfe94ecd2cbfe45c37fd')
+            'a1cf109d6be2812f68a686f7aaa4e4d4d90989cfb4ad792b4b5acc0eb11edbb0')
 
 prepare() {
   cd "${srcdir}/tcl${pkgver}"
@@ -70,7 +70,7 @@ build() {
     ${extra_config} \
     ${enable64bit}
 
-  make -j1
+  make
 }
 
 package() {
@@ -90,8 +90,8 @@ package() {
   local _libver=${pkgver%.*}
   _libver=${_libver//./}
 
-  local _odbc_ver=1.0.6
-  local _itcl_ver=4.1.1
+  local _odbc_ver=1.1.0
+  local _itcl_ver=4.1.2
   sed \
     -e "s|^\(TCL_BUILD_LIB_SPEC\)='.*|\1='-Wl,${MINGW_PREFIX}/lib/libtcl${_libver}.dll.a'|" \
     -e "s|^\(TCL_SRC_DIR\)='.*'|\1='${MINGW_PREFIX}/include/tcl${pkgver%.*}/tcl-private'|" \

--- a/mingw-w64-tk/PKGBUILD
+++ b/mingw-w64-tk/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=tk
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=8.6.8
+pkgver=8.6.9
 pkgrel=1
 pkgdesc="A windowing toolkit for use with tcl (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ source=("https://downloads.sourceforge.net/sourceforge/tcl/${_realname}${pkgver}
         004-install-man.mingw.patch
         006-prevent-tclStubsPtr-segfault.patch
         008-dont-link-shared-with--static-libgcc.patch)
-sha256sums=('49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33'
+sha256sums=('d3f9161e8ba0f107fe8d4df1f6d3a14c30cc3512dfc12a795daa367a27660dac'
             '441f2f5bdf1ee2bf6697569365207d554130bd5a2bac01e10a6e1a37738d8006'
             '5347487af0e736dbb51425b22ed308840faf75b44c070623baa55f78dac3d053'
             '8516749dd73c084ece7b9df6d1ba5708e652e8ba39cad59120c7f909f61747f0'


### PR DESCRIPTION
Recent changes on MSYS2 makes pkg to fail for mingw-w64-tcl. The changes on this PR were tested on MSYS2 20180531.