### PR TITLE
mypaint2: prepare for dependency on brush package

### DIFF
--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -3,13 +3,12 @@
 _realname=libmypaint
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+provides=("${MINGW_PACKAGE_PREFIX}-${_realname}2")
+pkgver=2.0.0alpha
 conflicts=(
-    "${MINGW_PACKAGE_PREFIX}-${_realname}"
-    "${MINGW_PACKAGE_PREFIX}-mypaint<1.3.0alpha"
+    "${MINGW_PACKAGE_PREFIX}-${_realname}2"
 )
-pkgver=1.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Brush engine used by MyPaint (git) (mingw-w64)"
 arch=('any')
 url="http://mypaint.org"
@@ -63,5 +62,5 @@ build() {
 package() {
   cd "${srcdir}"/build-${MINGW_CHOST}
   make -j1 DESTDIR="${pkgdir}" install
-  install -Dm644 "${srcdir}"/${_realname}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/COPYING
+  install -Dm644 "${srcdir}"/${_realname}2/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/COPYING
 }

--- a/mingw-w64-libmypaint-git/PKGBUILD
+++ b/mingw-w64-libmypaint-git/PKGBUILD
@@ -62,5 +62,5 @@ build() {
 package() {
   cd "${srcdir}"/build-${MINGW_CHOST}
   make -j1 DESTDIR="${pkgdir}" install
-  install -Dm644 "${srcdir}"/${_realname}2/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/COPYING
+  install -Dm644 "${srcdir}"/${_realname}/COPYING "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}2/COPYING
 }

--- a/mingw-w64-mypaint-git/PKGBUILD
+++ b/mingw-w64-mypaint-git/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=mypaint
 pkgbase=mingw-w64-${_realname}-git
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=1.3.0alpha.d20170416.g64e90976
+pkgver=2.0.0alpha
 pkgrel=1
 provides=(
     "${MINGW_PACKAGE_PREFIX}-${_realname}"
@@ -14,7 +14,7 @@ conflicts=(
 arch=('any')
 pkgdesc="Simple drawing & painting program that works well with Wacom-style graphics tablets (git)"
 depends=(
-    "${MINGW_PACKAGE_PREFIX}-libmypaint"
+    "${MINGW_PACKAGE_PREFIX}-libmypaint-git"
     "${MINGW_PACKAGE_PREFIX}-gtk3"
     "${MINGW_PACKAGE_PREFIX}-python2-numpy"
     "${MINGW_PACKAGE_PREFIX}-json-c"
@@ -26,6 +26,7 @@ depends=(
     "${MINGW_PACKAGE_PREFIX}-gcc-libs"
     "${MINGW_PACKAGE_PREFIX}-gsettings-desktop-schemas"
     "${MINGW_PACKAGE_PREFIX}-hicolor-icon-theme"
+    "${MINGW_PACKAGE_PREFIX}-mypaint-brushes2"
 )
 makedepends=(
     "${MINGW_PACKAGE_PREFIX}-swig"


### PR DESCRIPTION
mypaint-git and libmypaint-git are now both at 2.x alpha

libmypaint2 should not conflict with libmypaint1.x

mypaint-git should depend on libmypaint-git and mypaint-brushes2