### PR TITLE
armadillo: Fix hard coded path in armadillo_bits/config.hpp

### DIFF
--- a/mingw-w64-armadillo/PKGBUILD
+++ b/mingw-w64-armadillo/PKGBUILD
@@ -4,7 +4,7 @@ _realname=armadillo
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=9.200.5
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ linear algebra library (mingw-w64)"
 arch=('any')
 url="https://arma.sourceforge.io/"
@@ -50,4 +50,8 @@ package() {
 
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/LICENSE.txt" \
     "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE.txt"
+
+  # Remove builders local installation path
+  local _prefix_win=$(cygpath -m ${MINGW_PREFIX})
+  sed -s "s|${_prefix_win}|${MINGW_PREFIX}|g" -i "${pkgdir}${MINGW_PREFIX}/include/armadillo_bits/config.hpp"
 }

--- a/mingw-w64-armadillo/armadillo-i686.install
+++ b/mingw-w64-armadillo/armadillo-i686.install
@@ -2,6 +2,8 @@ post_install() {
   local _prefix="/mingw32"
   local _prefix_win="$(cygpath -m "${_prefix}")"
   sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/share/Armadillo/CMake/"*.cmake
+  # Add installers local installation path
+  sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/include/armadillo_bits/config.hpp"
 }
 
 post_upgrade() {

--- a/mingw-w64-armadillo/armadillo-x86_64.install
+++ b/mingw-w64-armadillo/armadillo-x86_64.install
@@ -2,6 +2,8 @@ post_install() {
   local _prefix="/mingw64"
   local _prefix_win="$(cygpath -m "${_prefix}")"
   sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/share/Armadillo/CMake/"*.cmake
+  # Add installers local installation path
+  sed -s "s|${_prefix}|${_prefix_win}|g" -i "${_prefix}/include/armadillo_bits/config.hpp"
 }
 
 post_upgrade() {


### PR DESCRIPTION
When using the unmodified library  I get "fatal error: C:/building/msys64/mingw64/include/hdf5.h: No such file or directory"; when trying to build example code. This patch fixes that error.

Tim S.