### PR TITLE
arm-none-eabi-toolchain: Change download to 7-2018-q2-update

### DIFF
--- a/mingw-w64-arm-none-eabi-binutils/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-binutils/PKGBUILD
@@ -6,7 +6,7 @@ _target=arm-none-eabi
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
-pkgver=2.24
+pkgver=2.31.1
 pkgrel=1
 pkgdesc="GNU Tools for ARM Embedded Processors - Binutils (mingw-w64)"
 arch=('any')
@@ -16,7 +16,7 @@ groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs')
 source=("https://mirrors.kernel.org/sources.redhat.com/${_realname}/releases/${_realname}-${pkgver}.tar.bz2")
-sha256sums=('e5e8c5be9664e7f7f96e0d09919110ab5ad597794f5b1809871177a0f0f14137')
+sha256sums=('ffcc382695bf947da6135e7436b8ed52d991cf270db897190f19d6f9838564d0')
 
 build() {
   if check_option "debug" "y"; then

--- a/mingw-w64-arm-none-eabi-gcc/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gcc/PKGBUILD
@@ -3,10 +3,12 @@
 
 _realname=gcc
 _target=arm-none-eabi
+_download_version=7-2018q2
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
-pkgver=8.2.0
+# pkgver=7.2.1    # 7-2017q4
+pkgver=7.3.1    # 7-2018q2
 pkgrel=1
 pkgdesc="GNU Tools for ARM Embedded Processors - GCC (mingw-w64)"
 arch=('any')
@@ -17,32 +19,26 @@ depends=("${MINGW_PACKAGE_PREFIX}-${_target}-newlib"
          "${MINGW_PACKAGE_PREFIX}-${_target}-binutils")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' '!debug' '!strip')
-source=('gcc-arm-embedded.tar.bz2::https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-src.tar.bz2'
-	'010-gcc-isl-0.13.patch'
-	'020-gcc-auto-host-screwup.patch')
-sha256sums=('09519946642d5366ab739a89d3388b2ea333cd7dc50192bab3736a9593af83e6'
-            '8e8da71e6e6b347dd7fc7f7938bf9af22be031ad8916749fa6c368f87d8891f0'
-            'b5e826a0dc477f04233e68cc7d0dfc4f498c36e16c5cc3751cb52bcd9a7f0c24')
-noextract=('gcc-arm-embedded.tar.bz2')
+source=("gcc-arm-embedded-${_download_version}.tar.bz2"::"https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-src.tar.bz2?revision=bf2e4a67-c08c-49d5-b97d-17757cc8a77e")
+sha256sums=('965c5755edffbab0320736285d17de3f4189bee1801099a17f6c9aeb0218acf0')
+noextract=("gcc-arm-embedded-${_download_version}.tar.bz2")
 
 prepare() {
   # Extract packages from archive
   rm -rf ${srcdir}/tmp
   mkdir ${srcdir}/tmp && cd ${srcdir}/tmp
-  tar xf ../../gcc-arm-embedded.tar.bz2 --strip-components=2
+  tar xvf ../../gcc-arm-embedded-${_download_version}.tar.bz2 --strip-components=2
 
   # Copy and extract GCC package
   cp gcc.tar.bz2 ${srcdir}
   cd ${srcdir}
   [ -d gcc ] && rm -rf gcc
-  tar xf gcc.tar.bz2
+  tar xf gcc.tar.bz2 --checkpoint=100
 
-  # GCC: Compatibility with isl>=0.12.2
+  # GCC
   cd "${srcdir}/gcc"
-  patch -p0 -i "${srcdir}/010-gcc-isl-0.13.patch"
-
   # GCC: deal with auto-host.h hack in crtstuff.c
-  patch -p1 -i "${srcdir}/020-gcc-auto-host-screwup.patch"
+  # patch -p1 -i "${srcdir}/020-gcc-auto-host-screwup.patch"
 }
 
 build() {
@@ -84,10 +80,9 @@ build() {
     --with-system-zlib \
     --with-python-dir="share/${_target}-${_realname}" \
     --with-libelf \
-    --with-{gmp,mpfr,mpc,isl,cloog}="${MINGW_PREFIX}" \
+    --with-{gmp,mpfr,mpc,isl}="${MINGW_PREFIX}" \
+    --without-cloog \
     --disable-isl-version-check \
-    --disable-cloog-version-check \
-    --with-multilib-list="armv6-m,armv7-m,armv7e-m,armv7-r" \
     --with-host-libstdcxx="-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm" \
     --with-sysroot="${MINGW_PREFIX}"
   make

--- a/mingw-w64-arm-none-eabi-gdb/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-gdb/PKGBUILD
@@ -3,10 +3,11 @@
 
 _realname=gdb
 _target=arm-none-eabi
+_download_version=7-2018q2
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
-pkgver=7.6.0
+pkgver=8.1.0
 pkgrel=1
 pkgdesc="GNU Tools for ARM Embedded Processors - GDB (mingw-w64)"
 arch=('any')
@@ -17,25 +18,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-readline"
          "${MINGW_PACKAGE_PREFIX}-zlib")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' '!debug' 'strip')
-source=('gcc-arm-embedded.tar.bz2::https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-src.tar.bz2'
-        '10-remove-duplicate-tputs.patch')
-sha256sums=('09519946642d5366ab739a89d3388b2ea333cd7dc50192bab3736a9593af83e6'
-            '80c719e0d91b4c712e03a2dd7f2d5197a16d32465d4514d904f4c910cfddb997')
-noextract=('gcc-arm-embedded.tar.bz2')
+source=("gcc-arm-embedded-${_download_version}.tar.bz2"::"https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-src.tar.bz2?revision=bf2e4a67-c08c-49d5-b97d-17757cc8a77e")
+sha256sums=('965c5755edffbab0320736285d17de3f4189bee1801099a17f6c9aeb0218acf0')
+noextract=("gcc-arm-embedded-${_download_version}.tar.bz2")
 
 prepare() {
   # Extract packages from archive
   rm -rf ${srcdir}/tmp
   mkdir ${srcdir}/tmp && cd ${srcdir}/tmp
-  tar  xvf ../../gcc-arm-embedded.tar.bz2 --strip-components=2
+  tar  xvf ../../gcc-arm-embedded-${_download_version}.tar.bz2 --strip-components=2
 
   # Copy and extract GDB package
   cp gdb.tar.bz2 ${srcdir}
   cd ${srcdir}
-  tar xvf gdb.tar.bz2
-
-  # GDB: remove duplicate tputs
-  patch -p1 -i "${srcdir}/10-remove-duplicate-tputs.patch"
+  tar -xf gdb.tar.bz2 --checkpoint=100
 }
 
 build() {
@@ -57,6 +53,26 @@ build() {
 package() {
   cd ${srcdir}/build-${MINGW_CHOST}
   make -j1 DESTDIR=${pkgdir} install
+
+  # Remove files that conflict with arm-none-eabi-binutils
+  rm -rf ${pkgdir}${MINGW_PREFIX}/share/man/man1
+  rm -rf ${pkgdir}${MINGW_PREFIX}/arm-none-eabi
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-addr2line.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-ar.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-as.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-c++filt.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-elfedit.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-gprof.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-ld.bfd.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-ld.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-nm.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-objcopy.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-objdump.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-ranlib.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-readelf.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-size.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-strings.exe
+  rm -f ${pkgdir}${MINGW_PREFIX}/bin/arm-none-eabi-strip.exe
 
   # Remove files that conflict with host
   rm -rf "${pkgdir}${MINGW_PREFIX}/share/info"

--- a/mingw-w64-arm-none-eabi-newlib/PKGBUILD
+++ b/mingw-w64-arm-none-eabi-newlib/PKGBUILD
@@ -3,10 +3,12 @@
 
 _realname=newlib
 _target=arm-none-eabi
+_download_version=7-2018q2
 
 pkgbase=mingw-w64-${_target}-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_target}-${_realname}")
-pkgver=2.1.0
+# pkgver=2.5.0    # 7-2017q4
+pkgver=3.0.0    # 7-2018q2
 pkgrel=1
 pkgdesc="GNU Tools for ARM Embedded Processors - Newlib (mingw-w64)"
 arch=('any')
@@ -16,21 +18,17 @@ groups=("${MINGW_PACKAGE_PREFIX}-${_target}-toolchain")
 depends=("${MINGW_PACKAGE_PREFIX}-${_target}-binutils")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 options=('staticlibs' '!strip' '!emptydirs')
-source=('gcc-arm-embedded.tar.bz2::https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q3-update/+download/gcc-arm-none-eabi-4_8-2014q3-20140805-src.tar.bz2'
-        '10-newlib-arm-dynamic-reent.patch'
-        '20-newlib-libgloss-configure-fix.patch'
-	'99-gcc-isl-0.13.patch')
-sha256sums=('09519946642d5366ab739a89d3388b2ea333cd7dc50192bab3736a9593af83e6'
-            '7522f26659a69e2f02eb37d3557f8dca08bc32ada8c797b6a812ad131c87b0ef'
-            '3222e2910068d413c23b2830cf2c9b7b2db210c9b98c5644db5934fee84d9808'
-            '8e8da71e6e6b347dd7fc7f7938bf9af22be031ad8916749fa6c368f87d8891f0')
-noextract=('gcc-arm-embedded.tar.bz2')
+source=("gcc-arm-embedded-${_download_version}.tar.bz2"::"https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-src.tar.bz2?revision=bf2e4a67-c08c-49d5-b97d-17757cc8a77e"
+        '10-newlib-arm-dynamic-reent.patch')
+sha256sums=('965c5755edffbab0320736285d17de3f4189bee1801099a17f6c9aeb0218acf0'
+            '7522f26659a69e2f02eb37d3557f8dca08bc32ada8c797b6a812ad131c87b0ef')
+noextract=("gcc-arm-embedded-${_download_version}.tar.bz2")
 
 prepare() {
   # Extract packages from archive
   rm -rf ${srcdir}/tmp
   mkdir ${srcdir}/tmp && cd ${srcdir}/tmp
-  tar xf ../../gcc-arm-embedded.tar.bz2 --strip-components=2
+  tar xvf ../../gcc-arm-embedded-${_download_version}.tar.bz2 --strip-components=2
 
   # Copy and extract GCC and Newlib packages
   cp gcc.tar.bz2 ${srcdir}
@@ -38,17 +36,15 @@ prepare() {
   cd ${srcdir}
   [ -d gcc ] && rm -rf gcc
   [ -d newlib ] && rm -rf newlib
-  tar xf gcc.tar.bz2
-  tar xf newlib.tar.bz2
+  tar xf gcc.tar.bz2     --checkpoint=100
+  tar xf newlib.tar.bz2  --checkpoint=100
 
   # Newlib
   cd ${srcdir}/${_realname}
   patch -p1 -i "${srcdir}/10-newlib-arm-dynamic-reent.patch"
-  patch -p2 -i "${srcdir}/20-newlib-libgloss-configure-fix.patch"
 
-  # GCC: Compatibility with isl>=0.12.2
+  # GCC
   cd "${srcdir}/gcc"
-  patch -p0 -i "${srcdir}/99-gcc-isl-0.13.patch"
 
   # Build cross-compiler just to compile newlib
   rm -rf "${srcdir}/compiler-${MINGW_CHOST}"
@@ -84,11 +80,10 @@ prepare() {
     --with-gnu-as \
     --with-gnu-ld \
     --with-system-zlib \
-    --with-{gmp,mpfr,mpc,isl,cloog}="${MINGW_PREFIX}" \
+    --with-{gmp,mpfr,mpc,isl}="${MINGW_PREFIX}" \
     --disable-isl-version-check \
-    --disable-cloog-version-check \
+    --without-cloog \
     --with-libelf \
-    --with-multilib-list="armv6-m,armv7-m,armv7e-m,armv7-r" \
     --with-sysroot="${MINGW_PREFIX}" \
     --with-build-sysroot="${srcdir}/compiler-${MINGW_CHOST}" \
     --with-build-time-tools="${MINGW_PREFIX}/${_target}/bin"


### PR DESCRIPTION
arm-none-eabi-toolchain: Change download to 7-2018-q2-update

arm-none-eabi-gcc: changed to version 7.3.1
arm-none-eabi-newlib: changed to version 3.0.0
arm-none-eabi-gdb: changed to version 8.1.0
arm-none-eabi-binutils: changed to version 2.31.1
