### PR TITLE
kicad: update to version 5.0.2 & git

### DIFF
--- a/mingw-w64-kicad-doc/PKGBUILD
+++ b/mingw-w64-kicad-doc/PKGBUILD
@@ -4,34 +4,30 @@
 _realname=kicad-doc
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-ca"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-de"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-en"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-es"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-fr"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-it"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-ja"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-nl"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
-         "${MINGW_PACKAGE_PREFIX}-${_realname}-ru")
-pkgver=4.0.4
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-de"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-en"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-es"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-fr"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-id"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-it"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-ja"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-nl"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-pl"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-ru"
+       "${MINGW_PACKAGE_PREFIX}-${_realname}-zh")
+pkgver=5.0.2
 pkgrel=1
 pkgdesc="Documentation for KiCad (mingw-w64)"
-arch=('any')
-url="http://kicad-pcb.org/download/source/"
-license=('GPL3' 'custom')
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPL3" "custom")
 makedepends=()
+optdepends=("${MINGW_PACKAGE_PREFIX}-kicad-meta"
+  "${MINGW_PACKAGE_PREFIX}-kicad"
+  "${MINGW_PACKAGE_PREFIX}-kicad-git")
 options=('!strip')
 source=("http://downloads.kicad-pcb.org/docs/kicad-doc-${pkgver}.tar.gz")
-sha256sums=('3f180197ac8963f129239922c62530313b3344bfc0ec40a6512defb086163722')
-langid='en'
-
-prepare() {
-  plain "No step"
-}
-
-build() {
-  plain "No step"
-}
+sha256sums=('1699835c4af54d15e8be2d8de1730b12ee3c99087a2e9b684c1619eb5f1b10c6')
 
 build_lang() {
   cd "${srcdir}/kicad-doc-${pkgver}/share/doc/kicad/help"
@@ -39,24 +35,8 @@ build_lang() {
   cp -R ${langid} "${pkgdir}${MINGW_PREFIX}/share/doc/kicad/help/"
 }
 
-# Wrappers; the last called function seems to need either newline or ";" after it.
-package_mingw-w64-x86_64-kicad-doc-ca() { langid='ca' build_lang; }
-package_mingw-w64-i686-kicad-doc-ca()   { langid='ca' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-de() { langid='de' build_lang; }
-package_mingw-w64-i686-kicad-doc-de()   { langid='de' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-en() { langid='en' build_lang; }
-package_mingw-w64-i686-kicad-doc-en()   { langid='en' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-es() { langid='es' build_lang; }
-package_mingw-w64-i686-kicad-doc-es()   { langid='es' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-fr() { langid='fr' build_lang; }
-package_mingw-w64-i686-kicad-doc-fr()   { langid='fr' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-it() { langid='it' build_lang; }
-package_mingw-w64-i686-kicad-doc-it()   { langid='it' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-ja() { langid='ja' build_lang; }
-package_mingw-w64-i686-kicad-doc-ja()   { langid='ja' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-nl() { langid='nl' build_lang; }
-package_mingw-w64-i686-kicad-doc-nl()   { langid='nl' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-pl() { langid='pl' build_lang; }
-package_mingw-w64-i686-kicad-doc-pl()   { langid='pl' build_lang; }
-package_mingw-w64-x86_64-kicad-doc-ru() { langid='ru' build_lang; }
-package_mingw-w64-i686-kicad-doc-ru()   { langid='ru' build_lang; }
+for _n in ${pkgname[@]}; do
+  eval "package_${_n}() {
+    langid="${_n#${MINGW_PACKAGE_PREFIX}-${_realname}-}" build_lang
+  }"
+done

--- a/mingw-w64-kicad-footprints-git/PKGBUILD
+++ b/mingw-w64-kicad-footprints-git/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}-git
+_sub=("footprints")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_sub}-git")
+pkgver=r786.ae1824c8
+pkgrel=1
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPLv3+")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "git")
+source=("${_realname}-${_sub}"::"git+https://github.com/KiCad/kicad-${_sub}.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}-${_sub}"
+  printf "r%s.%s" "$(git rev-list --count --first-parent HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  for _i in ${_sub[@]}; do
+    [[ -d build-${_i} ]] && rm -r build-${_i}
+  done
+  true
+}
+
+build_sub() {
+  cd "${srcdir}"
+  mkdir -p build-${1} && cd build-${1}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${1}
+}
+
+for _s in ${_sub[@]}; do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git() {
+	options=('!strip')
+    conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}")
+    build_sub ${_s}
+    cd "\"\${srcdir}\"/build-${_s}"
+    make DESTDIR="\"\${pkgdir}\"" install
+  }"
+done

--- a/mingw-w64-kicad-git/PKGBUILD
+++ b/mingw-w64-kicad-git/PKGBUILD
@@ -2,44 +2,25 @@
 
 _realname=kicad
 pkgbase=mingw-w64-${_realname}-git
-pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}-git"
-pkgver=r10869.7fa5456d7
+_sub=("footprints" "symbols" "templates" "packages3D")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+pkgver=r12014.638b4384e
 pkgrel=1
 pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
-arch=('any')
+arch=("any")
 url="http://www.kicad-pcb.org"
-license=("GPL2+")
-provides=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-depends=("${MINGW_PACKAGE_PREFIX}-boost"
-         "${MINGW_PACKAGE_PREFIX}-cairo"
-         "${MINGW_PACKAGE_PREFIX}-curl"
-         "${MINGW_PACKAGE_PREFIX}-glew"
-         "${MINGW_PACKAGE_PREFIX}-ngspice"
-         "${MINGW_PACKAGE_PREFIX}-oce"
-         "${MINGW_PACKAGE_PREFIX}-openssl"
-         "${MINGW_PACKAGE_PREFIX}-wxPython"
-         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+license=("GPLv3+")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-glm"
+             "${MINGW_PACKAGE_PREFIX}-glm<0.9.9.3"
              "${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
              "${MINGW_PACKAGE_PREFIX}-swig"
              "git")
 source=("${_realname}"::"git+https://github.com/KiCad/kicad-source-mirror.git"
-        #"${_realname}-doc"::"git+https://github.com/KiCad/kicad-doc.git"
-        "${_realname}-i18n"::"git+https://github.com/KiCad/kicad-i18n.git"
-        "${_realname}-libs"::"git+https://github.com/KiCad/kicad-library.git"
-        "${_realname}-footprints"::"git+https://github.com/KiCad/kicad-footprints.git"
-        "${_realname}-symbols"::"git+https://github.com/KiCad/kicad-symbols.git"
-        "${_realname}-templates"::"git+https://github.com/KiCad/kicad-templates.git")
+        "${_realname}-i18n"::"git+https://github.com/KiCad/kicad-i18n.git")
 sha256sums=('SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
             'SKIP')
 
 pkgver() {
@@ -49,13 +30,15 @@ pkgver() {
 
 prepare() {
   cp -f ${srcdir}/${_realname}/template/kicad.pro ${srcdir}/kicad-templates/
+  
+  [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
+  [[ -d build-i18n ]] && rm -r build-i18n
+  true
 }
 
-build() {
+build_kicad() {
   cd "${srcdir}"
-
   # Configure and build KiCad.
-  [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
   mkdir build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
 
   declare -a _btype
@@ -65,8 +48,7 @@ build() {
     _btype=Release
   fi
 
-
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;DCMAKE_PREFIX_PATH=;DEFAULT_INSTALL_PATH=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
     -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
@@ -84,81 +66,37 @@ build() {
 
   cd "${srcdir}"
   # Configure the translationn installation build.
-  [[ -d build-i18n ]] && rm -r build-i18n
   mkdir build-i18n && cd build-i18n
+  
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ../${_realname}-i18n
-
-  cd "${srcdir}"
-  # Configure the library installation build.
-  [[ -d build-libs ]] && rm -r build-libs
-  mkdir build-libs && cd build-libs
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-libs
-
-  cd "${srcdir}"
-  # Configure the footprints installation build.
-  [[ -d build-footprints ]] && rm -r build-footprints
-  mkdir build-footprints && cd build-footprints
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-footprints
-
-  cd "${srcdir}"
-  # Configure the templates installation build.
-  [[ -d build-templates ]] && rm -r build-templates
-  mkdir build-templates && cd build-templates
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-templates
-
-  cd "${srcdir}"
-  # Configure the symbols installation build.
-  [[ -d build-symbols ]] && rm -r build-symbols
-  mkdir build-symbols && cd build-symbols
-  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
-  ${MINGW_PREFIX}/bin/cmake.exe \
-    -G "MSYS Makefiles" \
-    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
-    ../${_realname}-symbols
 }
 
-package() {
-  # Install KiCad.
-  cd "${srcdir}/build-${MINGW_CHOST}"
-  make DESTDIR=${pkgdir} install
+_doc=("ca" "de" "en" "es" "fr" "id" "it" "ja" "nl" "pl" "ru" "zh")
+for _d in ${_doc[@]}; do _doc_pkg+=("\"${MINGW_PACKAGE_PREFIX}-${_realname}-doc-${_d}: Documentation for KiCad (mingw-w64)\""); done
+for _s in ${_sub[@]}; do _sub_pkg+=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git"); done
 
-  # Install KiCad i18n.
-  cd "${srcdir}/build-i18n"
-  make DESTDIR=${pkgdir} install
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-git() {
+  depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-glew"
+         "${MINGW_PACKAGE_PREFIX}-ngspice"
+         "${MINGW_PACKAGE_PREFIX}-oce"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-wxPython"
+         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+  optdepends+=("${_doc_pkg[@]}" "\${_sub_pkg[@]}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+  
+  build_kicad
+  
+  cd "\"\${srcdir}\"/build-${MINGW_CHOST}"
+  make DESTDIR="\"\${pkgdir}\"" install
 
-  # Install KiCad libraries.
-  cd "${srcdir}/build-libs"
-  make DESTDIR=${pkgdir} install
-
-  # Install KiCad footprints.
-  cd "${srcdir}/build-footprints"
-  make DESTDIR=${pkgdir} install
-
-  # Install KiCad symbols.
-  cd "${srcdir}/build-symbols"
-  make DESTDIR=${pkgdir} install
-
-  # Install KiCad templates.
-  cd "${srcdir}/build-templates"
-  make DESTDIR=${pkgdir} install
-
-  # Install the pretties
-  #mkdir -p "${pkgdir}${MINGW_PREFIX}/share/kicad/modules"
-  #cp -rd "${srcdir}/kicad-footprints"/* "${pkgdir}${MINGW_PREFIX}/share/kicad/modules"
-}
+  cd "\"\${srcdir}\"/build-i18n"
+  make DESTDIR="\"\${pkgdir}\"" install
+}"

--- a/mingw-w64-kicad-packages3D-git/PKGBUILD
+++ b/mingw-w64-kicad-packages3D-git/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}-git
+_sub=("packages3D")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_sub}-git")
+pkgver=r356.7c2052f1
+pkgrel=1
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPLv3+")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "git")
+source=("${_realname}-${_sub}"::"git+https://github.com/KiCad/kicad-${_sub}.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}-${_sub}"
+  printf "r%s.%s" "$(git rev-list --count --first-parent HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  for _i in ${_sub[@]}; do
+    [[ -d build-${_i} ]] && rm -r build-${_i}
+  done
+  true
+}
+
+build_sub() {
+  cd "${srcdir}"
+  mkdir -p build-${1} && cd build-${1}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${1}
+}
+
+for _s in ${_sub[@]}; do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git() {
+	options=('!strip')
+    conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}")
+    build_sub ${_s}
+    cd "\"\${srcdir}\"/build-${_s}"
+    make DESTDIR="\"\${pkgdir}\"" install
+  }"
+done

--- a/mingw-w64-kicad-symbols-git/PKGBUILD
+++ b/mingw-w64-kicad-symbols-git/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}-git
+_sub=("symbols")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_sub}-git")
+pkgver=r744.2f62a093
+pkgrel=1
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPLv3+")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "git")
+source=("${_realname}-${_sub}"::"git+https://github.com/KiCad/kicad-${_sub}.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}-${_sub}"
+  printf "r%s.%s" "$(git rev-list --count --first-parent HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  for _i in ${_sub[@]}; do
+    [[ -d build-${_i} ]] && rm -r build-${_i}
+  done
+  true
+}
+
+build_sub() {
+  cd "${srcdir}"
+  mkdir -p build-${1} && cd build-${1}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${1}
+}
+
+for _s in ${_sub[@]}; do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git() {
+	options=('!strip')
+    conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}")
+    build_sub ${_s}
+    cd "\"\${srcdir}\"/build-${_s}"
+    make DESTDIR="\"\${pkgdir}\"" install
+  }"
+done

--- a/mingw-w64-kicad-templates-git/PKGBUILD
+++ b/mingw-w64-kicad-templates-git/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}-git
+_sub=("templates")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_sub}-git")
+pkgver=r14.4bc4dce
+pkgrel=1
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPLv3+")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "git")
+source=("${_realname}-${_sub}"::"git+https://github.com/KiCad/kicad-${_sub}.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/${_realname}-${_sub}"
+  printf "r%s.%s" "$(git rev-list --count --first-parent HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+  for _i in ${_sub[@]}; do
+    [[ -d build-${_i} ]] && rm -r build-${_i}
+  done
+  true
+}
+
+build_sub() {
+  cd "${srcdir}"
+  mkdir -p build-${1} && cd build-${1}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${1}
+}
+
+for _s in ${_sub[@]}; do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git() {
+	options=('!strip')
+    conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}")
+    build_sub ${_s}
+    cd "\"\${srcdir}\"/build-${_s}"
+    make DESTDIR="\"\${pkgdir}\"" install
+  }"
+done

--- a/mingw-w64-kicad/PKGBUILD
+++ b/mingw-w64-kicad/PKGBUILD
@@ -1,0 +1,133 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+
+_realname=kicad
+pkgbase=mingw-w64-${_realname}
+_sub=("footprints" "symbols" "templates" "packages3D")
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-meta"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-footprints"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-symbols"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-templates"
+         "${MINGW_PACKAGE_PREFIX}-${_realname}-packages3D")
+pkgver=5.0.2
+pkgrel=1
+pkgdesc="Software for the creation of electronic schematic diagrams and printed circuit board artwork (mingw-w64)"
+arch=("any")
+url="http://www.kicad-pcb.org"
+license=("GPLv3+")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-doxygen"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-glm<0.9.9.3"
+             "${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config"
+             "${MINGW_PACKAGE_PREFIX}-swig")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-source-mirror/archive/${pkgver}.tar.gz"
+        "${_realname}-i18n-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-i18n/archive/${pkgver}.tar.gz"
+        "${_realname}-footprints-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-footprints/archive/${pkgver}.tar.gz"
+        "${_realname}-symbols-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-symbols/archive/${pkgver}.tar.gz"
+        "${_realname}-templates-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-templates/archive/${pkgver}.tar.gz"
+        "${_realname}-packages3D-${pkgver}.tar.gz"::"https://github.com/KiCad/kicad-packages3D/archive/${pkgver}.tar.gz")
+sha256sums=('0668374b785d3ba8b3c51ff637e48d4d3027e66e6962d99b5c5247ef6a657077'
+            'cde8939ad031519847f90daa1ad6d87516ab224949e028a5f89a895c7595870a'
+            '430c3d58ad85aa87c2514b3243536f73d8690681693d63bc5886ce3b82e2e841'
+            'eeb58a46ab9423ae2b66307f50cc0c897a1a7679d91f423402edb80f0df21cdc'
+            'ca46396cfbc31cbf78f5edbcf5950caccd18fc1486ccb145884e577cac076b76'
+            '86e20dfb3a4720082a4dd92d66c7d3581e11f3638c8dc3a832a526ab3fc321fa')
+
+prepare() {
+  cd "${srcdir}"
+
+  cp -f "${srcdir}"/${_realname}-source-mirror-${pkgver}/template/kicad.pro "${srcdir}"/kicad-templates-${pkgver}/
+  
+  [[ -d build-${MINGW_CHOST} ]] && rm -r build-${MINGW_CHOST}
+  [[ -d build-i18n ]] && rm -r build-i18n
+  for _i in ${_sub[@]}; do
+    [[ -d build-${_i} ]] && rm -r build-${_i}
+  done
+  true
+}
+
+build_kicad() {
+  cd "${srcdir}"
+  # Configure and build KiCad.
+  mkdir -p build-${MINGW_CHOST} && cd build-${MINGW_CHOST}
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=;DCMAKE_PREFIX_PATH=;DEFAULT_INSTALL_PATH=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G"MSYS Makefiles" \
+    -DCMAKE_PREFIX_PATH=${MINGW_PREFIX} \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DDEFAULT_INSTALL_PATH=${MINGW_PREFIX} \
+    -DOPENSSL_ROOT_DIR=${MINGW_PREFIX} \
+    -DKICAD_SCRIPTING=ON \
+    -DKICAD_SCRIPTING_MODULES=ON \
+    -DKICAD_SCRIPTING_WXPYTHON=ON \
+    -DPYTHON_EXECUTABLE=${MINGW_PREFIX}/bin/python2.exe \
+    ../${_realname}-source-mirror-${pkgver}
+
+  make
+
+  cd "${srcdir}"
+  # Configure the translationn installation build.
+  mkdir -p build-i18n && cd build-i18n
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-i18n-${pkgver}
+}
+
+build_sub() {
+  cd "${srcdir}"
+  mkdir -p build-${1} && cd build-${1}
+  
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -G "MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    ../${_realname}-${1}-${pkgver}
+}
+
+_doc=("ca" "de" "en" "es" "fr" "id" "it" "ja" "nl" "pl" "ru" "zh")
+for _d in ${_doc[@]}; do _doc_pkg+=("\"${MINGW_PACKAGE_PREFIX}-${_realname}-doc-${_d}: Documentation for KiCad (mingw-w64)\""); done
+for _s in ${_sub[@]}; do _sub_pkg+=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}"); done
+
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}() {
+  depends=("${MINGW_PACKAGE_PREFIX}-boost"
+         "${MINGW_PACKAGE_PREFIX}-cairo"
+         "${MINGW_PACKAGE_PREFIX}-curl"
+         "${MINGW_PACKAGE_PREFIX}-glew"
+         "${MINGW_PACKAGE_PREFIX}-ngspice"
+         "${MINGW_PACKAGE_PREFIX}-oce"
+         "${MINGW_PACKAGE_PREFIX}-openssl"
+         "${MINGW_PACKAGE_PREFIX}-wxPython"
+         "${MINGW_PACKAGE_PREFIX}-wxWidgets")
+  optdepends+=("${_doc_pkg[@]}" "\${_sub_pkg[@]}")
+  conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
+  
+  build_kicad
+  
+  cd "\"\${srcdir}\"/build-${MINGW_CHOST}"
+  make DESTDIR="\"\${pkgdir}\"" install
+
+  cd "\"\${srcdir}\"/build-i18n"
+  make DESTDIR="\"\${pkgdir}\"" install
+}"
+
+eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-meta() {
+  depends=("${MINGW_PACKAGE_PREFIX}-${_realname}"
+	     "${_sub_pkg[@]}")
+}"
+
+for _s in ${_sub[@]}; do
+  eval "package_${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}() {
+	options=('!strip')
+    conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-${_s}-git")
+    build_sub ${_s}
+    cd "\"\${srcdir}\"/build-${_s}"
+    make DESTDIR="\"\${pkgdir}\"" install
+  }"
+done


### PR DESCRIPTION
KiCad 5.0.2 Release
- update to version 5.0.2 all kicad footprints tempates symbols packages3D doc
- divided the base and library
- make kicad-meta for complex installation
- update git version, mix git and release allowed
limited build: glm<0.9.9.3, otherwise not compiled, boost 1.69 make problem, but last ok.