### PR TITLE
glib: Update to 2.58.2

### DIFF
--- a/mingw-w64-glib2/0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
+++ b/mingw-w64-glib2/0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
@@ -1,0 +1,47 @@
+From 5b0e62da6ad41f1179101131cd96dead9f4dd804 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Tue, 18 Dec 2018 23:37:36 +0100
+Subject: [PATCH] Revert "tests W32: ugly fix for sscanf() format"
+
+This reverts commit 4c91334412f89623dc4be4b11549ecb194395633.
+---
+ tests/type-test.c | 14 ++------------
+ 1 file changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/tests/type-test.c b/tests/type-test.c
+index 43da39472..ed7cc44cf 100644
+--- a/tests/type-test.c
++++ b/tests/type-test.c
+@@ -120,13 +120,8 @@ main (int   argc,
+   gu64t1 = G_GINT64_CONSTANT (0xFAFAFAFAFAFAFAFA); 
+ 
+ #define FORMAT64 "%" G_GINT64_FORMAT " %" G_GUINT64_FORMAT "\n"
+-#ifndef G_OS_WIN32
+-#  define SCAN_FORMAT64 FORMAT64
+-#else
+-#  define SCAN_FORMAT64 "%I64d %I64u\n"
+-#endif
+   string = g_strdup_printf (FORMAT64, gi64t1, gu64t1);
+-  sscanf (string, SCAN_FORMAT64, &gi64t2, &gu64t2);
++  sscanf (string, FORMAT64, &gi64t2, &gu64t2);
+   g_free (string);
+   g_assert (gi64t1 == gi64t2);
+   g_assert (gu64t1 == gu64t2);
+@@ -135,13 +130,8 @@ main (int   argc,
+   gst1 = 0xFAFAFAFA; 
+ 
+ #define FORMATSIZE "%" G_GSSIZE_FORMAT " %" G_GSIZE_FORMAT "\n"
+-#ifndef G_OS_WIN32
+-#  define SCAN_FORMATSIZE FORMATSIZE
+-#else
+-#  define SCAN_FORMATSIZE "%Id %Iu\n"
+-#endif
+   string = g_strdup_printf (FORMATSIZE, gsst1, gst1);
+-  sscanf (string, SCAN_FORMATSIZE, &gsst2, &gst2);
++  sscanf (string, FORMATSIZE, &gsst2, &gst2);
+   g_free (string);
+   g_assert (gsst1 == gsst2);
+   g_assert (gst1 == gst2);
+-- 
+2.20.1
+

--- a/mingw-w64-glib2/0001-disable-some-tests-when-static.patch
+++ b/mingw-w64-glib2/0001-disable-some-tests-when-static.patch
@@ -1,0 +1,14 @@
+diff --git a/gio/tests/meson.build b/gio/tests/meson.build
+index dca33bd44..47a95b7b3 100644
+--- a/gio/tests/meson.build
++++ b/gio/tests/meson.build
+@@ -406,7 +406,8 @@ if installed_tests_enabled
+   install_subdir('cert-tests', install_dir : installed_tests_execdir)
+ endif
+ 
+-if not meson.is_cross_build() or meson.has_exe_wrapper()
++windows_static = host_system == 'windows' and get_option('default_library') == 'static'
++if (not meson.is_cross_build() or meson.has_exe_wrapper()) and not windows_static
+ 
+   plugin_resources_c = custom_target('plugin-resources.c',
+     input : 'test4.gresource.xml',

--- a/mingw-w64-glib2/PKGBUILD
+++ b/mingw-w64-glib2/PKGBUILD
@@ -6,7 +6,7 @@
 _realname=glib2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=2.58.1
+pkgver=2.58.2
 pkgrel=1
 url="https://www.gtk.org/"
 arch=('any')
@@ -26,11 +26,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=("https://download.gnome.org/sources/glib/${pkgver%.*}/glib-${pkgver}.tar.xz"
         0001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
         0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
+        0001-disable-some-tests-when-static.patch
+        0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
         pyscript2exe.py
         )
-sha256sums=('97d6a9d926b6aa3dfaadad3077cfb43eec74432ab455dff14250c769d526d7d6'
+sha256sums=('c7b24ed6536f1a10fc9bce7994e55c427b727602e78342821f1f07fb48753d4b'
             'ff0d3df5d57cf621cac79f5bea8bd175e6c18b3fbf7cdd02df38c1eab9f40ac3'
             '838abaeab8ca4978770222ef5f88c4b464545dd591b2d532c698caa875b46931'
+            '0f44135a139e3951c4b5fa7d4628d75226e0666d891faf524777e1d1ec3b440b'
+            '601b4da43aeccfa522ea46fcb9c33ec9530b8c4b965b8964abd3f4972b769cdd'
             'f68b24932b3365c4098c04eeaeaf87275ceec29694b3f0597c431bbcf4f913a3'
             )
 prepare() {
@@ -38,6 +42,8 @@ prepare() {
 
   patch -Np1 -i "${srcdir}"/0001-Use-CreateFile-on-Win32-to-make-sure-g_unlink-always.patch
   patch -Np1 -i "${srcdir}"/0001-win32-Make-the-static-build-work-with-MinGW-when-pos.patch
+  patch -Np1 -i "${srcdir}"/0001-disable-some-tests-when-static.patch
+  patch -Np1 -i "${srcdir}"/0001-Revert-tests-W32-ugly-fix-for-sscanf-format.patch
 }
 
 build() {


### PR DESCRIPTION
Two patches because we use USE_MINGW_ANSI_STDIO and static builds, both not tested upstream.