### PR TITLE
qt5: workaround malformed archive issue on 32 bit linking (qdoc) with clang 7.0 (#4593)

### DIFF
--- a/mingw-w64-qt5-static/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+++ b/mingw-w64-qt5-static/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
@@ -166,14 +166,23 @@
          else: \
              CLANG_LIBS += -lclang
      } else {
+@@ -111,6 +247,8 @@
+             CLANG_LIBS += -llibclang_static -ladvapi32 -lshell32 -lMincore
+         } else {
+             !equals(QMAKE_HOST.os, Darwin): CLANG_LIBS+=-Wl,--start-group
++            system("cd $${PWD}/../../src/qdoc && ar x $${CLANG_LIBDIR}/libclangEdit.a")
++            CLANGEDIT_OBJS = $$system("ar t $${CLANG_LIBDIR}/libclangEdit.a")
+             CLANG_LIBS += -lclangAnalysis \
+                         -lclangApplyReplacements \
+                         -lclangARCMigrate \
 @@ -123,9 +259,9 @@
                          -lclangDaemon \
                          -lclangDriver \
                          -lclangDynamicASTMatchers \
 -                        -lclangEdit \
++                        $${CLANGEDIT_OBJS} \
                          -lclangFormat \
                          -lclangFrontend \
-+                        -lclangEdit \
                          -lclangFrontendTool \
                          -lclangHandleCXX \
                          -lclangIncludeFixer \

--- a/mingw-w64-qt5-static/PKGBUILD
+++ b/mingw-w64-qt5-static/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.12.0
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -750,7 +750,7 @@ sha256sums=('356f42d9087718f22f03d13d0c2cdfb308f91dc3cf0c6318bed33f2094cd9d6c'
             'f1ea27aa8b1febe7b806e775a928e2b03edc9a7045f6c03da3a7f57563b05e56'
             '234d1b207eb9ea11839f941799daf613028f33dbc89bebdf78b9a2dd4dd84dd2'
             '227940744aa3d87f51d9ea9d2fff0bfc11cda5f5055687bceb1c93ade5d5cdf6'
-            '7e894d26cc3afab36265fa1dbe96e1c4de397c33dfef94d69d6c5f35f012cac7'
+            '976132c3bc73ff7641566e2c0a127810bcf8c607da4158c659613bd06ba69437'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             '09346761413824d20da9570a8615facebcb6d2930b609ddc259e61063ee2d9bd'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'

--- a/mingw-w64-qt5/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
+++ b/mingw-w64-qt5/0052-qt-5.11-mingw-fix-link-qdoc-with-clang.patch
@@ -166,14 +166,23 @@
          else: \
              CLANG_LIBS += -lclang
      } else {
+@@ -111,6 +247,8 @@
+             CLANG_LIBS += -llibclang_static -ladvapi32 -lshell32 -lMincore
+         } else {
+             !equals(QMAKE_HOST.os, Darwin): CLANG_LIBS+=-Wl,--start-group
++            system("cd $${PWD}/../../src/qdoc && ar x $${CLANG_LIBDIR}/libclangEdit.a")
++            CLANGEDIT_OBJS = $$system("ar t $${CLANG_LIBDIR}/libclangEdit.a")
+             CLANG_LIBS += -lclangAnalysis \
+                         -lclangApplyReplacements \
+                         -lclangARCMigrate \
 @@ -123,9 +259,9 @@
                          -lclangDaemon \
                          -lclangDriver \
                          -lclangDynamicASTMatchers \
 -                        -lclangEdit \
++                        $${CLANGEDIT_OBJS} \
                          -lclangFormat \
                          -lclangFrontend \
-+                        -lclangEdit \
                          -lclangFrontendTool \
                          -lclangHandleCXX \
                          -lclangIncludeFixer \

--- a/mingw-w64-qt5/PKGBUILD
+++ b/mingw-w64-qt5/PKGBUILD
@@ -101,7 +101,7 @@ _ver_base=5.12.0
 # use 5.6.1-1 hot fix : only the archive name was changed from *-5.6.1.tar.xz to *-5.6.1-1.tar.xz
 _hotfix=
 pkgver=${_ver_base//-/}
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="A cross-platform application and UI framework (mingw-w64${_namesuff})"
 url='https://www.qt.io/'
@@ -750,7 +750,7 @@ sha256sums=('356f42d9087718f22f03d13d0c2cdfb308f91dc3cf0c6318bed33f2094cd9d6c'
             'f1ea27aa8b1febe7b806e775a928e2b03edc9a7045f6c03da3a7f57563b05e56'
             '234d1b207eb9ea11839f941799daf613028f33dbc89bebdf78b9a2dd4dd84dd2'
             '227940744aa3d87f51d9ea9d2fff0bfc11cda5f5055687bceb1c93ade5d5cdf6'
-            '7e894d26cc3afab36265fa1dbe96e1c4de397c33dfef94d69d6c5f35f012cac7'
+            '976132c3bc73ff7641566e2c0a127810bcf8c607da4158c659613bd06ba69437'
             '89fd6085f7fb85086692037338a935354fc68735bfb7c8423e282f99076250a3'
             '09346761413824d20da9570a8615facebcb6d2930b609ddc259e61063ee2d9bd'
             '09a4181ee02df575c13c94da7d7bc09c18252db9040bdaa27012e3aac7a947e1'


### PR DESCRIPTION
This is an hack to solve #4593: avoids manual intervention while building qt5 (mainly 32 bit version) with clang 7.0.
This workarounds an issue that seems related to latest binutils: libclangEdit.a archive content is extracted and used instead of the library