### PR TITLE
gitg: Fix cache and run as GUI

### DIFF
--- a/mingw-w64-gitg/Config-app-as-GUI.patch
+++ b/mingw-w64-gitg/Config-app-as-GUI.patch
@@ -1,0 +1,23 @@
+From 7d13c79db6ead21bec4845ce834da4f16b6241c6 Mon Sep 17 00:00:00 2001
+From: albfan <albfan@gnome.org>
+Date: Sun, 30 Dec 2018 12:51:11 +0100
+Subject: Config app as GUI
+
+---
+ gitg/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gitg/meson.build b/gitg/meson.build
+index fe699cb..b942f7c 100644
+--- a/gitg/meson.build
++++ b/gitg/meson.build
+@@ -133,5 +133,6 @@ executable(
+   dependencies: deps,
+   c_args: cflags,
+   vala_args: vala_flags,
++  gui_apps: true,
+   install: true,
+ )
+-- 
+2.17.1
+

--- a/mingw-w64-gitg/Fix-libgit2-glib-cache.patch
+++ b/mingw-w64-gitg/Fix-libgit2-glib-cache.patch
@@ -1,0 +1,25 @@
+From ff0a2ccf4ee0685a8032c460495a0f6468b7fb7d Mon Sep 17 00:00:00 2001
+From: albfan <albfan@gnome.org>
+Date: Sun, 30 Dec 2018 12:49:11 +0100
+Subject: Fix libgit2-glib cache
+
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 44a6e40..6277097 100644
+--- a/meson.build
++++ b/meson.build
+@@ -130,7 +130,7 @@ gsettings_desktop_schemas_dep = dependency('gsettings-desktop-schemas')
+ gtk_dep = dependency('gtk+-3.0', version: '>= 3.20.0')
+ gtkspell_dep = dependency('gtkspell3-3.0')
+ gtksourceview_dep = dependency('gtksourceview-3.0', version: '>= 3.10')
+-libgit2_glib_dep = dependency('libgit2-glib-1.0', version: ['>= 0.25.0', '< 0.27.0'])
++libgit2_glib_dep = dependency('libgit2-glib-1.0', version: '>= 0.27.7')
+ libpeas_dep = dependency('libpeas-1.0')
+ libsecret_dep = dependency('libsecret-1')
+ libsoup_dep = dependency('libsoup-2.4')
+-- 
+2.17.1
+

--- a/mingw-w64-gitg/PKGBUILD
+++ b/mingw-w64-gitg/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gitg
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.30.1
-pkgrel=1
+pkgrel=2
 arch=('any')
 pkgdesc="git repository viewer for GTK+/GNOME (mingw-w64)"
 depends=("${MINGW_PACKAGE_PREFIX}-adwaita-icon-theme"
@@ -32,11 +32,17 @@ options=('strip')
 license=("GPL2+")
 url="https://wiki.gnome.org/Apps/Gitg"
 install=${_realname}-${CARCH}.install
-source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-$pkgver.tar.xz)
-sha256sums=('5a0b9b44aa3b67f6376c8e91e41e750cfaf53780b26da50139d3501c55c0e8bb')
+source=(https://download.gnome.org/sources/${_realname}/${pkgver:0:4}/${_realname}-$pkgver.tar.xz
+Config-app-as-GUI.patch
+Fix-libgit2-glib-cache.patch)
+sha256sums=('5a0b9b44aa3b67f6376c8e91e41e750cfaf53780b26da50139d3501c55c0e8bb'
+            'b616b32aff2d48ded0261c1fe9c6905c1adc5f11cf1422efe5baad35785ded0b'
+            '42e895d458e50bfb2cd2f23e0f8bd18a23ba33f6ce0b1ca2c0fd7f6377564080')
 
 prepare() {
   cd "${srcdir}"/${_realname}-${pkgver}
+  patch -Np1 -i "${srcdir}/Fix-libgit2-glib-cache.patch"
+  patch -Np1 -i "${srcdir}/Config-app-as-GUI.patch"
 }
 
 build() {


### PR DESCRIPTION
Update to libgit2-glib 0.27.7 to fix problems retrieving diff chunks
Fix running as GUI app to avoid a terminal show everytime app is launched
