### PR TITLE
darktable: Update to 2.6.0

### DIFF
--- a/mingw-w64-darktable/PKGBUILD
+++ b/mingw-w64-darktable/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=darktable
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=2.4.4
-pkgrel=2
+pkgver=2.6.0
+pkgrel=1
 pkgdesc="darktable is an open source photography workflow application and raw developer (mingw-w64)"
 arch=('any')
 url='https://www.darktable.org'
@@ -17,7 +17,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
          "${MINGW_PACKAGE_PREFIX}-graphicsmagick"
          "${MINGW_PACKAGE_PREFIX}-gtk3"
          "${MINGW_PACKAGE_PREFIX}-lcms2"
-         "${MINGW_PACKAGE_PREFIX}-lensfun"
+         "${MINGW_PACKAGE_PREFIX}-lensfun=0.3.2"
          "${MINGW_PACKAGE_PREFIX}-libexif"
          "${MINGW_PACKAGE_PREFIX}-libgphoto2"
          "${MINGW_PACKAGE_PREFIX}-libsecret"
@@ -35,7 +35,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-dbus-glib"
         )
 options=('!strip')
 source=(${_realname}-${pkgver}.tar.xz::"https://github.com/darktable-org/${_realname}/releases/download/release-${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('964320b8c9ffef680fa0407a6ca16ed5136ad1f449572876e262764e78acb04d')
+sha256sums=('483d7d8e4ac532d89efc2f24e169f7a7da2d3ef0c599602b658d67a040670478')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"


### PR DESCRIPTION
Pls note that you need lensfun 0.3.2 to build this darktable. The latest lensfun is not compatible (yet) with darktable