### PR TITLE
mingw-w64-argon - 20171227 - various reworks

### DIFF
--- a/mingw-w64-argon2/001-mingw-fix-install.patch
+++ b/mingw-w64-argon2/001-mingw-fix-install.patch
@@ -1,13 +1,67 @@
---- phc-winner-argon2-20171227/Makefile.orig	2017-12-27 22:56:31.000000000 +0300
-+++ phc-winner-argon2-20171227/Makefile	2018-01-22 08:34:53.975966900 +0300
-@@ -174,11 +174,17 @@
+--- phc-winner-argon2-20171227/Makefile.orig	2017-12-27 14:56:31.000000000 -0500
++++ phc-winner-argon2-20171227/Makefile	2019-01-01 08:26:07.740114100 -0500
+@@ -58,6 +58,7 @@ BUILD_PATH := $(shell pwd)
+ KERNEL_NAME := $(shell uname -s)
+ 
+ LIB_NAME=argon2
++LIB_SH_RT=
+ ifeq ($(KERNEL_NAME), Linux)
+ 	LIB_EXT := so.$(ABI_VERSION)
+ 	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1
+@@ -75,14 +76,17 @@ ifeq ($(KERNEL_NAME), Darwin)
+ endif
+ ifeq ($(findstring CYGWIN, $(KERNEL_NAME)), CYGWIN)
+ 	LIB_EXT := dll
++	LIB_SH_RT := cyg$(LIB_NAME).$(LIB_EXT)
+ 	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
+ endif
+ ifeq ($(findstring MINGW, $(KERNEL_NAME)), MINGW)
+ 	LIB_EXT := dll
++	LIB_SH_RT := lib$(LIB_NAME).$(LIB_EXT)
+ 	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
+ endif
+ ifeq ($(findstring MSYS, $(KERNEL_NAME)), MSYS)
+ 	LIB_EXT := dll
++	LIB_SH_RT := msys-$(LIB_NAME).$(LIB_EXT)
+ 	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
+ endif
+ ifeq ($(KERNEL_NAME), SunOS)
+@@ -98,7 +102,11 @@ ifeq ($(CC), clang)
+ endif
+ endif
+ 
++ifeq ($(LIB_SH_RT),)
+ LIB_SH := lib$(LIB_NAME).$(LIB_EXT)
++else
++LIB_SH := lib$(LIB_NAME).$(LIB_EXT).a
++endif
+ LIB_ST := lib$(LIB_NAME).a
+ 
+ ifdef LINKED_LIB_EXT
+@@ -135,8 +143,15 @@ $(BENCH):       $(SRC) $(SRC_BENCH)
+ $(GENKAT):      $(SRC) $(SRC_GENKAT)
+ 		$(CC) $(CFLAGS) $^ -o $@ -DGENKAT
+ 
++ifeq ($(LIB_SH_RT),)
+ $(LIB_SH): 	$(SRC)
+ 		$(CC) $(CFLAGS) $(LIB_CFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $^ -o $@
++else
++$(LIB_SH_RT):	$(SRC)
++		$(CC) $(CFLAGS) $(LIB_CFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $^ -o $@
++
++$(LIB_SH): 	$(LIB_SH_RT)
++endif
+ 
+ $(LIB_ST): 	$(OBJ)
+ 		ar rcs $@ $^
+@@ -174,14 +189,23 @@ install: $(RUN) libs
  	$(INSTALL) -d $(INST_INCLUDE)
  	$(INSTALL) -m 0644 $(HEADERS) $(INST_INCLUDE)
  	$(INSTALL) -d $(INST_LIBRARY)
 +	$(INSTALL) -d $(INST_BINARY)
-+ifeq ($(findstring MINGW, $(KERNEL_NAME)), MINGW)
-+	$(INSTALL) $(LIB_SH) $(INST_BINARY)
-+	$(INSTALL) $(LIB_SH).a $(INST_LIBRARY)
++ifneq ($(LIB_SH_RT),)
++	$(INSTALL) $(LIB_SH_RT) $(INST_BINARY)
++	$(INSTALL) $(LIB_SH) $(INST_LIBRARY)
 +	$(INSTALL) $(LIB_ST) $(INST_LIBRARY)
 +else
  	$(INSTALL) $(LIBRARIES) $(INST_LIBRARY)
@@ -19,3 +73,9 @@
  	$(INSTALL) $(RUN) $(INST_BINARY)
  
  uninstall:
+ 	cd $(INST_INCLUDE) && rm -f $(notdir $(HEADERS))
+ 	cd $(INST_LIBRARY) && rm -f $(notdir $(LIBRARIES) $(LINKED_LIB_SH))
++ifneq ($(LIB_SH_RT),)
++	cd $(INST_BINARY) && rm -f $(notdir $(LIB_SH_RT))
++endif
+ 	cd $(INST_BINARY) && rm -f $(notdir $(RUN))

--- a/mingw-w64-argon2/001-mingw-fix-install.patch
+++ b/mingw-w64-argon2/001-mingw-fix-install.patch
@@ -1,6 +1,23 @@
 --- phc-winner-argon2-20171227/Makefile.orig	2017-12-27 14:56:31.000000000 -0500
-+++ phc-winner-argon2-20171227/Makefile	2019-01-01 08:26:07.740114100 -0500
-@@ -58,6 +58,7 @@ BUILD_PATH := $(shell pwd)
++++ phc-winner-argon2-20171227/Makefile	2019-01-03 10:08:33.315228200 -0500
+@@ -44,6 +44,16 @@ CI_CFLAGS := $(CFLAGS) -Werror=declarati
+ OPTTARGET ?= native
+ OPTTEST := $(shell $(CC) -Iinclude -Isrc -march=$(OPTTARGET) src/opt.c -c \
+ 			-o /dev/null 2>/dev/null; echo $$?)
++# Try with -msse2 flag
++ifneq ($(OPTTEST), 0)
++OPTTEST := $(shell $(CC) -Iinclude -Isrc -march=$(OPTTARGET) -msse2 src/opt.c -c \
++			-o /dev/null 2>/dev/null; echo $$?)
++#if we have -msse2 flag, use it
++ifeq ($(OPTTEST), 0)
++	CFLAGS += -msse2
++	CI_CFLAGS += -msse2
++endif
++endif
+ # Detect compatible platform
+ ifneq ($(OPTTEST), 0)
+ $(info Building without optimizations)
+@@ -58,6 +68,7 @@ BUILD_PATH := $(shell pwd)
  KERNEL_NAME := $(shell uname -s)
  
  LIB_NAME=argon2
@@ -8,7 +25,7 @@
  ifeq ($(KERNEL_NAME), Linux)
  	LIB_EXT := so.$(ABI_VERSION)
  	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1
-@@ -75,14 +76,17 @@ ifeq ($(KERNEL_NAME), Darwin)
+@@ -75,14 +86,17 @@ ifeq ($(KERNEL_NAME), Darwin)
  endif
  ifeq ($(findstring CYGWIN, $(KERNEL_NAME)), CYGWIN)
  	LIB_EXT := dll
@@ -26,7 +43,7 @@
  	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
  endif
  ifeq ($(KERNEL_NAME), SunOS)
-@@ -98,7 +102,11 @@ ifeq ($(CC), clang)
+@@ -98,7 +112,11 @@ ifeq ($(CC), clang)
  endif
  endif
  
@@ -38,7 +55,7 @@
  LIB_ST := lib$(LIB_NAME).a
  
  ifdef LINKED_LIB_EXT
-@@ -135,8 +143,15 @@ $(BENCH):       $(SRC) $(SRC_BENCH)
+@@ -135,8 +153,15 @@ $(BENCH):       $(SRC) $(SRC_BENCH)
  $(GENKAT):      $(SRC) $(SRC_GENKAT)
  		$(CC) $(CFLAGS) $^ -o $@ -DGENKAT
  
@@ -54,7 +71,7 @@
  
  $(LIB_ST): 	$(OBJ)
  		ar rcs $@ $^
-@@ -174,14 +189,23 @@ install: $(RUN) libs
+@@ -174,14 +199,23 @@ install: $(RUN) libs
  	$(INSTALL) -d $(INST_INCLUDE)
  	$(INSTALL) -m 0644 $(HEADERS) $(INST_INCLUDE)
  	$(INSTALL) -d $(INST_LIBRARY)

--- a/mingw-w64-argon2/002-mingw-fix-src.patch
+++ b/mingw-w64-argon2/002-mingw-fix-src.patch
@@ -1,0 +1,77 @@
+--- phc-winner-argon2-20171227/src/genkat.c.orig	2018-12-28 08:57:15.812848200 -0500
++++ phc-winner-argon2-20171227/src/genkat.c	2018-12-28 09:08:09.242252500 -0500
+@@ -20,6 +20,9 @@
+ #include <string.h>
+ #include "argon2.h"
+ #include "core.h"
++#ifdef __MINGW32__
++#include "inttypes.h"
++#endif
+ 
+ void initial_kat(const uint8_t *blockhash, const argon2_context *context,
+                  argon2_type type) {
+@@ -115,7 +118,11 @@ void internal_kat(const argon2_instance_
+                     : ARGON2_QWORDS_IN_BLOCK;
+ 
+             for (j = 0; j < how_many_words; ++j)
++#ifdef __MINGW32__
++                printf("Block %.4u [%3u]: %016" PRIX64 "\n", i, j,
++#else
+                 printf("Block %.4u [%3u]: %016llx\n", i, j,
++#endif
+                        (unsigned long long)instance->memory[i].v[j]);
+         }
+     }
+--- phc-winner-argon2-20171227/src/core.c.orig	2019-01-01 00:44:58.473678000 -0500
++++ phc-winner-argon2-20171227/src/core.c	2019-01-01 00:47:37.278003800 -0500
+@@ -16,7 +16,7 @@
+  */
+ 
+ /*For memory wiping*/
+-#ifdef _MSC_VER
++#if defined(_MSC_VER) || defined(__MINGW32__)
+ #include <windows.h>
+ #include <winbase.h> /* For SecureZeroMemory */
+ #endif
+--- phc-winner-argon2-20171227/src/blake2/blake2-impl.h.orig	2019-01-01 00:50:03.010067200 -0500
++++ phc-winner-argon2-20171227/src/blake2/blake2-impl.h	2019-01-01 00:51:14.953859400 -0500
+@@ -21,7 +21,7 @@
+ #include <stdint.h>
+ #include <string.h>
+ 
+-#if defined(_MSC_VER)
++#if defined(_MSC_VER) || defined(__MINGW32__)
+ #define BLAKE2_INLINE __inline
+ #elif defined(__GNUC__) || defined(__clang__)
+ #define BLAKE2_INLINE __inline__
+--- phc-winner-argon2-20171227/src/bench.c.orig	2017-12-27 14:56:31.000000000 -0500
++++ phc-winner-argon2-20171227/src/bench.c	2019-01-01 07:15:46.159196500 -0500
+@@ -20,14 +20,14 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <time.h>
+-#ifdef _MSC_VER
++#if defined( _MSC_VER) || defined(__MINGW32__)
+ #include <intrin.h>
+ #endif
+ 
+ #include "argon2.h"
+ 
+ static uint64_t rdtsc(void) {
+-#ifdef _MSC_VER
++#if defined( _MSC_VER) || defined(__MINGW32__)
+     return __rdtsc();
+ #else
+ #if defined(__amd64__) || defined(__x86_64__)
+--- phc-winner-argon2-20171227/include/argon2.h.orig	2019-01-01 00:55:05.866534800 -0500
++++ phc-winner-argon2-20171227/include/argon2.h	2019-01-01 00:57:09.920803200 -0500
+@@ -33,6 +33,9 @@ extern "C" {
+ #elif _MSC_VER
+ #define ARGON2_PUBLIC __declspec(dllexport)
+ #define ARGON2_LOCAL
++#elif __MINGW32__
++#define ARGON2_PUBLIC __declspec(dllexport)
++#define ARGON2_LOCAL
+ #else
+ #define ARGON2_PUBLIC
+ #define ARGON2_LOCAL

--- a/mingw-w64-argon2/PKGBUILD
+++ b/mingw-w64-argon2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=argon2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20171227
-pkgrel=2
+pkgrel=3
 pkgdesc="This is the reference implementation of Argon2, the password-hashing function that won the Password Hashing Competition (PHC) (mingw-w64)"
 arch=('any')
 license=('CC0 and Apache 2.0')
@@ -12,14 +12,26 @@ url='https://github.com/P-H-C/phc-winner-argon2'
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/${pkgver}.tar.gz"
         libargon2.pc
-        001-mingw-fix-install.patch)
+        001-mingw-fix-install.patch
+        002-mingw-fix-src.patch)
 sha256sums=('eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8'
             '17061b6f504640cec638d69404879a678e15332a4138673f4a8626ff4efc79a3'
-            'f442343a3838956db7f452985a7c64985863c6da2829284f3a628ac095f66d0d')
+            'b4e55f8b19a8a7725a6b6a7383a2495a088d094efa3778923ff83ee50ffa9597'
+            'cf5c9e1d35f51df87cb2da1ac214a4955b4c9404eee072dc825b2fb2e912e5df')
+
+apply_patch_with_msg() {
+  for _patch in "$@"
+  do
+    msg2 "Applying $_patch"
+    patch -Nbp1 -i "${srcdir}/$_patch"
+  done
+}
 
 prepare() {
   cd phc-winner-argon2-${pkgver}
-  patch -p1 -i ${srcdir}/001-mingw-fix-install.patch
+  apply_patch_with_msg \
+      001-mingw-fix-install.patch \
+      002-mingw-fix-src.patch
 }
 
 build() {

--- a/mingw-w64-argon2/PKGBUILD
+++ b/mingw-w64-argon2/PKGBUILD
@@ -16,8 +16,17 @@ source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/${pkgver}.tar.gz"
         002-mingw-fix-src.patch)
 sha256sums=('eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8'
             '17061b6f504640cec638d69404879a678e15332a4138673f4a8626ff4efc79a3'
-            'b4e55f8b19a8a7725a6b6a7383a2495a088d094efa3778923ff83ee50ffa9597'
+            '3417ce1955960912ad943552fe458963a4da23edc2369ab75ffe87ba6b6225f5'
             'cf5c9e1d35f51df87cb2da1ac214a4955b4c9404eee072dc825b2fb2e912e5df')
+
+case ${MINGW_CHOST} in
+  i686*)
+    _march=i686
+  ;;
+  x86_64*)
+    _march=x86-64
+  ;;
+esac
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -39,12 +48,12 @@ build() {
   cp -rf ${srcdir}/phc-winner-argon2-${pkgver} "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  make CC=${MINGW_PREFIX}/bin/gcc OPTTARGET=none
+  make CC=${MINGW_PREFIX}/bin/gcc OPTTARGET=${_march}
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make install DESTDIR="${pkgdir}" PREFIX="${MINGW_PREFIX}" OPTTARGET=none
+  make install DESTDIR="${pkgdir}" CC=${MINGW_PREFIX}/bin/gcc PREFIX="${MINGW_PREFIX}" OPTTARGET=${_march}
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -Dm644 ${srcdir}/libargon2.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libargon2.pc"


### PR DESCRIPTION
001-mingw-fix-install.patch - integrate my work so that argon2 patch can work on CygWin and MSYS2 if necessary
002-mingw-fix-src.patch - fix various issues in source-code related to prinf formatting, stdcall conventions,