### PR TITLE
gstreamermm: New package

### DIFF
--- a/mingw-w64-gstreamermm/PKGBUILD
+++ b/mingw-w64-gstreamermm/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Luca Bacci <luca.bacci982@gmail.com>
+
+_realname=gstreamermm
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.10.0
+pkgrel=1
+pkgdesc="C++ bindings for gstreamer 1.0 (mingw-w64)"
+arch=('any')
+url="https://gstreamer.freedesktop.org/bindings/cplusplus.html"
+license=("LGPL")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-pkg-config")
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
+         "${MINGW_PACKAGE_PREFIX}-pangomm"
+         "${MINGW_PACKAGE_PREFIX}-gstreamer"
+         "${MINGW_PACKAGE_PREFIX}-gst-plugins-base")
+options=('staticlibs' 'strip')
+source=("https://ftp.gnome.org/pub/GNOME/sources/gstreamermm/${pkgver%.*}/gstreamermm-${pkgver}.tar.xz")
+sha256sums=('be58fe9ef7d7e392568ec85e80a84f4730adbf91fb0355ff7d7c616675ea8d60')
+
+build() {
+  [[ -d "${srcdir}"/build-${MINGW_CHOST} ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}
+  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  ../gstreamermm-${pkgver}/configure \
+    --prefix=${MINGW_PREFIX} \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --enable-shared \
+    --enable-static \
+    --disable-documentation
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR="${pkgdir}" install
+  find "${pkgdir}${MINGW_PREFIX}" -name '*.def' -o -name '*.exp' | xargs -rtl1 rm
+  install -Dm644 "${srcdir}/gstreamermm-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+  install -Dm644 "${srcdir}/gstreamermm-${pkgver}/COPYING.tools" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING.tools"
+}


### PR DESCRIPTION
GStreamermm is the official C++ binding for GStreamer.

https://gstreamer.freedesktop.org/bindings/cplusplus.html
https://gitlab.gnome.org/GNOME/gstreamermm

Note: while GStreamer GitLab infrastructure is on [FreeDesktop GitLab](https://gitlab.freedesktop.org/gstreamer), GStreamermm is hosted on [GNOME GitLab](https://gitlab.gnome.org/GNOME/gstreamermm)