### PR TITLE
mingw-w64-glib-networking - 2.58.0 - enable librpoxy and gnome-proxy …

### DIFF
--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -29,22 +29,24 @@ build() {
   mkdir -p "${srcdir}/build-${MINGW_CHOST}"
   cd build-${MINGW_CHOST}
 
-  meson \
+  ${MINGW_PREFIX}/bin/meson \
     --buildtype plain \
     -Dlibproxy_support=true \
     -Dgnome_proxy_support=true \
     ../${_realname}-${pkgver}
 
-  ninja
+  ${MINGW_PREFIX}/bin/ninja
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   DESTDIR=${pkgdir}${MINGW_PREFIX} ninja install
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/gio/modules/*.a
+# Remove non-applicable systemd files
+  rm -rf ${pkgdir}${MINGW_PREFIX}/lib/systemd
+
   local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
   sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
-    -i ${pkgdir}${MINGW_PREFIX}/lib/systemd/user/glib-pacrunner.service \
     -i ${pkgdir}${MINGW_PREFIX}/share/dbus-1/services/org.gtk.GLib.PACRunner.service
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }

--- a/mingw-w64-glib-networking/PKGBUILD
+++ b/mingw-w64-glib-networking/PKGBUILD
@@ -4,10 +4,10 @@ _realname=glib-networking
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.58.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Network-related GIO modules for glib (mingw-w64)"
 arch=(any)
-url="https://download.gnome.org/sources/libsoup"
+url="https://gitlab.gnome.org/GNOME/glib-networking"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-meson"
              "${MINGW_PACKAGE_PREFIX}-ninja"
@@ -31,8 +31,8 @@ build() {
 
   meson \
     --buildtype plain \
-    -Dlibproxy_support=false \
-    -Dgnome_proxy_support=false \
+    -Dlibproxy_support=true \
+    -Dgnome_proxy_support=true \
     ../${_realname}-${pkgver}
 
   ninja
@@ -42,6 +42,9 @@ package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
   DESTDIR=${pkgdir}${MINGW_PREFIX} ninja install
   rm -f ${pkgdir}${MINGW_PREFIX}/lib/gio/modules/*.a
-
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  sed -e "s|${PREFIX_WIN}|${MINGW_PREFIX}|g" \
+    -i ${pkgdir}${MINGW_PREFIX}/lib/systemd/user/glib-pacrunner.service \
+    -i ${pkgdir}${MINGW_PREFIX}/share/dbus-1/services/org.gtk.GLib.PACRunner.service
   install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
 }


### PR DESCRIPTION
…support to add glib-pacrunner.exe.