### PR TITLE
Python updates

### DIFF
--- a/mingw-w64-python-bleach/PKGBUILD
+++ b/mingw-w64-python-bleach/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=bleach
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}" "${MINGW_PACKAGE_PREFIX}-python2-${_realname}")
-pkgver=3.0.2
+pkgver=3.1.0
 pkgrel=1
 pkgdesc="An easy whitelist-based HTML-sanitizing tool (mingw-w64)"
 url="http://pypi.python.org/pypi/bleach"
@@ -12,7 +12,7 @@ license=('Apache')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 source=(${_realname}-${pkgver}.tar.gz::https://pypi.org/packages/source/b/${_realname}/${_realname}-$pkgver.tar.gz)
-sha256sums=('48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718')
+sha256sums=('3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa')
 
 
 prepare() {

--- a/mingw-w64-python-jedi/PKGBUILD
+++ b/mingw-w64-python-jedi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=jedi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.13.1
+pkgver=0.13.2
 pkgrel=1
 pkgdesc="Awesome autocompletion for python (mingw-w64)"
 arch=('any')
@@ -19,7 +19,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python3-pytest"
               "${MINGW_PACKAGE_PREFIX}-python2-pytest")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/davidhalter/jedi/archive/v$pkgver.tar.gz")
-sha256sums=('e650be5ac603537ebcf31009c3c574909f7fd51a47298406f22f07baa7bdf686')
+sha256sums=('434f1a6a6afb7477f5b2934da7822fcdbe7d962abf0cec9f391117df493dde0c')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python-more-itertools/PKGBUILD
+++ b/mingw-w64-python-more-itertools/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=more-itertools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=4.3.1
+pkgver=5.0.0
 pkgrel=1
 pkgdesc="More routines for operating on iterables, beyond itertools (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-six")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/erikrose/more-itertools/archive/${pkgver}.tar.gz")
-sha256sums=('ad2a4f23bb8a45015a887d450ec995daf9da46a100a56432702a91c43a859b70')
+sha256sums=('a2dd59cdb7287d738b3c745558f0812b69b519cda21726b180b09d9d68d8b461')
 
 prepare() {  
   cd "${srcdir}"

--- a/mingw-w64-python-soupsieve/PKGBUILD
+++ b/mingw-w64-python-soupsieve/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=soupsieve
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=1.6.2
+pkgver=1.7.0
 pkgrel=1
 pkgdesc="A CSS4 selector implementation for Beautiful Soup. (mingw-w64)"
 arch=('any')
@@ -26,7 +26,7 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-beautifulsoup4"
               "${MINGW_PACKAGE_PREFIX}-python3-pytest-cov")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-$pkgver.tar.gz"::"https://github.com/facelessuser/soupsieve/archive/$pkgver.tar.gz")
-sha256sums=('ca9f594a2be32c2c405598acba0929baeb07e6c30f2b5df0dc7c76cdc472c379')
+sha256sums=('6cb8000268622ac521b448754ff346e66b70cbd4cedc79d0d63ed160d3c6db29')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {

--- a/mingw-w64-python3-entrypoints/PKGBUILD
+++ b/mingw-w64-python3-entrypoints/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=entrypoints
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=0.2.3
-pkgrel=4
+pkgver=0.3
+pkgrel=1
 pkgdesc="Discover and load entry points from installed packages (mingw-w64)"
 url="https://github.com/takluyver/entrypoints"
 arch=('any')
@@ -12,8 +12,8 @@ license=('MIT')
 makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/takluyver/${_realname}/archive/$pkgver.tar.gz
         ${_realname}-${pkgver}-whl.tar.gz::https://files.pythonhosted.org/packages/py2.py3/e/${_realname}/${_realname}-$pkgver-py2.py3-none-any.whl)
-sha256sums=('a628825648fade6fba8dd94cc26e38340ed840fca3e9d5b7b3dbf755b27bbbdd'
-            '10ad569bb245e7e2ba425285b9fa3e8178a0dc92fc53b1e1c553805e15a8825b')
+sha256sums=('f26eddc371e37d8e9f6663b77524d6731567f005bd1e4ac950c0e33c48fbc065'
+            '589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19')
 
 package() {
   cd "$srcdir"/

--- a/mingw-w64-python3-jupyter-notebook/001-jupyter-notebook-MINGW.patch
+++ b/mingw-w64-python3-jupyter-notebook/001-jupyter-notebook-MINGW.patch
@@ -1,0 +1,12 @@
+--- a/setupbase.py	2018-12-17 11:01:51.000000000 +0100
++++ b/setupbase.py	2019-01-13 00:06:03.916440500 +0100
+@@ -553,7 +553,8 @@
+     def build_jstranslation(self, trd):
+         lang = trd[-5:]
+         run([
+-            pjoin('node_modules', '.bin', 'po2json'),
++            'node',
++            pjoin('node_modules', 'po2json', 'bin', 'po2json'),
+             '-p', '-F',
+             '-f', 'jed1.x',
+             '-d', 'nbjs',

--- a/mingw-w64-python3-jupyter-notebook/PKGBUILD
+++ b/mingw-w64-python3-jupyter-notebook/PKGBUILD
@@ -8,7 +8,7 @@
 _realname=notebook
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=5.6.0
+pkgver=5.7.4
 pkgrel=1
 pkgdesc="The language-agnostic HTML notebook application for Project Jupyter"
 arch=('any')
@@ -36,8 +36,15 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-bower"
              )
 
-source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/notebook/archive/$pkgver.tar.gz")
-sha256sums=('3d5b738bea8eaef944fffe261746b063e9ca5e89257b76d5f623cce816df4864')
+source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/notebook/archive/$pkgver.tar.gz"
+        "001-jupyter-notebook-MINGW.patch")
+sha256sums=('c26c67ee16a64b6d2444884b73c399d8020f598f833f4165864e31f28d1c410e'
+            '0362ef7944792188d8202bdedd7b51b9a0a06867ea43f480bf8318b163d3b616')
+
+prepare(){
+  cd "$srcdir/${_realname}-$pkgver"
+  patch -p1 -i ${srcdir}/001-jupyter-notebook-MINGW.patch
+}
 
 build() {
 


### PR DESCRIPTION
- python-bleach: Update to 3.1.0
- python-entrypoints: Update to 0.3
- python-more-itertools: Update to 5.0.0 
- python-jupyter-notebook: Update to 5.7.4
- python-jedi: Update to 0.13.2
- python-soupsieve: Update to 1.7.0 