### PR TITLE
[mingw-w64-cmake] port patches to cmake 3.13.3

### DIFF
--- a/mingw-w64-cmake/0001-Windows-Add-missing-stringapiset.h-include.patch
+++ b/mingw-w64-cmake/0001-Windows-Add-missing-stringapiset.h-include.patch
@@ -12,7 +12,7 @@ diff --git a/Source/cmFileCommand.cxx b/Source/cmFileCommand.cxx
 index d3dcc0112..05d2c6151 100644
 --- a/Source/cmFileCommand.cxx
 +++ b/Source/cmFileCommand.cxx
-@@ -54,6 +54,7 @@ class cmSystemToolsFileTime;
+@@ -55,6 +55,7 @@ class cmSystemToolsFileTime;
  using namespace cmFSPermissions;
  
  #if defined(_WIN32)

--- a/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
+++ b/mingw-w64-cmake/0004-Implement-Qt5-static-plugin-support.patch
@@ -29,7 +29,7 @@ diff --git a/Source/cmGlobalGenerator.cxx b/Source/cmGlobalGenerator.cxx
 index c805b98d7..aa50eebc8 100644
 --- a/Source/cmGlobalGenerator.cxx
 +++ b/Source/cmGlobalGenerator.cxx
-@@ -1502,7 +1502,8 @@ cmGlobalGenerator::CreateQtAutoGenInitializers()
+@@ -1493,7 +1493,8 @@ bool cmGlobalGenerator::QtAutoGen()
        const bool mocEnabled = target->GetPropertyAsBool("AUTOMOC");
        const bool uicEnabled = target->GetPropertyAsBool("AUTOUIC");
        const bool rccEnabled = target->GetPropertyAsBool("AUTORCC");
@@ -39,18 +39,18 @@ index c805b98d7..aa50eebc8 100644
          continue;
        }
  
-@@ -1514,7 +1515,8 @@ cmGlobalGenerator::CreateQtAutoGenInitializers()
+@@ -1529,7 +1530,8 @@ bool cmGlobalGenerator::QtAutoGen()
        }
  
-       autogenInits.emplace_back(new cmQtAutoGenInitializer(
--        target, mocEnabled, uicEnabled, rccEnabled, qtVersionMajor));
+       autogenInits.emplace_back(cm::make_unique<cmQtAutoGenInitializer>(
+-        target, mocEnabled, uicEnabled, rccEnabled, qtVersion));
 +        target, mocEnabled, uicEnabled, rccEnabled, staticPluginsEnabled,
-+        qtVersionMajor));
++        qtVersion));
      }
    }
- #endif
+ 
 diff --git a/Source/cmQtAutoGen.h b/Source/cmQtAutoGen.h
-index 67f61b197..3d156e056 100644
+index 4118dc7..aae5f2f 100644
 --- a/Source/cmQtAutoGen.h
 +++ b/Source/cmQtAutoGen.h
 @@ -25,7 +25,8 @@ public:
@@ -62,12 +62,12 @@ index 67f61b197..3d156e056 100644
 +    STATICPLUGINS
    };
  
- public:
+   /// @brief Integer version
 diff --git a/Source/cmQtAutoGenInitializer.cxx b/Source/cmQtAutoGenInitializer.cxx
 index 93c78b5bd..9e7349baa 100644
 --- a/Source/cmQtAutoGenInitializer.cxx
 +++ b/Source/cmQtAutoGenInitializer.cxx
-@@ -86,6 +86,9 @@ static bool AddToSourceGroup(cmMakefile* makefile, std::string const& fileName,
+@@ -69,6 +69,9 @@ static bool AddToSourceGroup(cmMakefile* makefile, std::string const& fileName,
          case cmQtAutoGen::GeneratorT::RCC:
            props[0] = "AUTORCC_SOURCE_GROUP";
            break;
@@ -77,40 +77,51 @@ index 93c78b5bd..9e7349baa 100644
          default:
            props[0] = "AUTOGEN_SOURCE_GROUP";
            break;
-@@ -192,11 +195,12 @@ static bool StaticLibraryCycle(cmGeneratorTarget const* targetOrigin,
- 
- cmQtAutoGenInitializer::cmQtAutoGenInitializer(
-   cmGeneratorTarget* target, bool mocEnabled, bool uicEnabled, bool rccEnabled,
--  std::string const& qtVersionMajor)
-+  bool staticPluginsEnabled, std::string const& qtVersionMajor)
+@@ -177,6 +180,7 @@ cmQtAutoGenInitializer::cmQtAutoGenInitializer(cmGeneratorTarget* target,
+                                                bool mocEnabled,
+                                                bool uicEnabled,
+                                                bool rccEnabled,
++                                               bool staticPluginsEnabled,
+                                                IntegerVersion const& qtVersion)
    : Target(target)
-   , MocEnabled(mocEnabled)
-   , UicEnabled(uicEnabled)
-   , RccEnabled(rccEnabled)
-+  , StaticPluginsEnabled(staticPluginsEnabled)
-   , MultiConfig(false)
-   , QtVersionMajor(qtVersionMajor)
- {
-@@ -366,6 +370,12 @@ void cmQtAutoGenInitializer::InitCustomTargets()
-     }
+   , QtVersion(qtVersion)
+@@ -184,6 +188,7 @@ cmQtAutoGenInitializer::cmQtAutoGenInitializer(cmGeneratorTarget* target,
+   Moc.Enabled = mocEnabled;
+   Uic.Enabled = uicEnabled;
+   Rcc.Enabled = rccEnabled;
++  StaticPlugins.Enabled = staticPluginsEnabled;
+ }
+ 
+ bool cmQtAutoGenInitializer::InitCustomTargets()
+@@ -356,7 +361,7 @@ bool cmQtAutoGenInitializer::InitCustomTargets()
    }
  
+   // Create autogen target
+-  if ((this->Moc.Enabled || this->Uic.Enabled) && !this->InitAutogenTarget()) {
++  if ((this->Moc.Enabled || this->Uic.Enabled || this->StaticPlugins.Enabled) && !this->InitAutogenTarget()) {
+     return false;
+   }
+ 
+@@ -836,6 +841,13 @@ bool cmQtAutoGenInitializer::InitAutogenTarget()
+     autogenProvides.push_back(this->Moc.MocsCompilation);
+   }
+ 
++
 +  // Add AutoStaticPlugins import to generated files list
-+  if (this->StaticPluginsEnabled) {
-+    std::string staticPluginsComp = this->DirBuild + "/plugin_import.cpp";
++  if (this->StaticPlugins.Enabled) {
++    std::string staticPluginsComp = this->Dir.Build + "/plugin_import.cpp";
 +    this->AddGeneratedSource(staticPluginsComp, GeneratorT::STATICPLUGINS);
 +  }
 +
-   // Extract relevant source files
-   std::vector<std::string> generatedSources;
-   std::vector<std::string> generatedHeaders;
-@@ -1051,6 +1061,59 @@ void cmQtAutoGenInitializer::SetupCustomTargets()
-       }
-     }
+   // Compose target comment
+   std::string autogenComment;
+   {
+@@ -1083,6 +1095,59 @@ bool cmQtAutoGenInitializer::SetupCustomTargets()
+     return false;
    }
-+
+ 
 +  // Generate plugin static-link source files
-+  if (this->StaticPluginsEnabled)
++  if (this->StaticPlugins.Enabled)
 +  {
 +    /* in qt5-static/lib/cmake/Qt5Core/Qt5CoreConfig.cmake,
 +     * macro(_populate_Core_plugin_properties ..), we'd have:
@@ -140,7 +151,7 @@ index 93c78b5bd..9e7349baa 100644
 +      }
 +    }
 +
-+    std::string static_plugins_output_file = this->DirBuild + "/plugin_import.cpp";
++    std::string static_plugins_output_file = this->Dir.Build + "/plugin_import.cpp";
 +    cmGeneratedFileStream staticPluginsFileStream(
 +      static_plugins_output_file.c_str());
 +    if (staticPluginsFileStream) {
@@ -161,34 +172,41 @@ index 93c78b5bd..9e7349baa 100644
 +      staticPluginsFileStream.Close();
 +    }
 +  }
++
+   return true;
  }
  
- void cmQtAutoGenInitializer::SetupCustomTargetsMoc()
 diff --git a/Source/cmQtAutoGenInitializer.h b/Source/cmQtAutoGenInitializer.h
 index 2a47e46a4..1f21b3476 100644
 --- a/Source/cmQtAutoGenInitializer.h
 +++ b/Source/cmQtAutoGenInitializer.h
-@@ -47,6 +47,7 @@ public:
- public:
-   cmQtAutoGenInitializer(cmGeneratorTarget* target, bool mocEnabled,
-                          bool uicEnabled, bool rccEnabled,
-+                         bool staticPluginsEnabled,
-                          std::string const& qtVersionMajor);
+@@ -47,7 +47,7 @@ public:
+   static IntegerVersion GetQtVersion(cmGeneratorTarget const* target);
  
-   void InitCustomTargets();
-@@ -70,6 +71,7 @@ private:
-   bool MocEnabled;
-   bool UicEnabled;
-   bool RccEnabled;
-+  bool StaticPluginsEnabled;
-   bool MultiConfig;
-   // Qt
-   std::string QtVersionMajor;
+   cmQtAutoGenInitializer(cmGeneratorTarget* target, bool mocEnabled,
+-                         bool uicEnabled, bool rccEnabled,
++                         bool uicEnabled, bool rccEnabled, bool staticPluginsEnabled,
+                          IntegerVersion const& qtVersion);
+ 
+   bool InitCustomTargets();
+@@ -151,6 +151,12 @@ private:
+     std::vector<std::string> ListOptions;
+     std::vector<Qrc> Qrcs;
+   } Rcc;
++
++  /// @brief StaticPlugins only variables
++  struct
++  {
++    bool Enabled = false;
++  } StaticPlugins;
+ };
+ 
+ #endif
 diff --git a/Source/cmTarget.cxx b/Source/cmTarget.cxx
 index cd11c4b14..1b0bfbdcd 100644
 --- a/Source/cmTarget.cxx
 +++ b/Source/cmTarget.cxx
-@@ -247,6 +247,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
+@@ -238,6 +238,7 @@ cmTarget::cmTarget(std::string const& name, cmStateEnums::TargetType type,
      this->SetPropertyDefault("AUTOMOC", nullptr);
      this->SetPropertyDefault("AUTOUIC", nullptr);
      this->SetPropertyDefault("AUTORCC", nullptr);

--- a/mingw-w64-cmake/0007-Do-not-generate-import-libs-for-exes.patch
+++ b/mingw-w64-cmake/0007-Do-not-generate-import-libs-for-exes.patch
@@ -11,7 +11,7 @@ diff --git a/Modules/Platform/Windows-GNU.cmake b/Modules/Platform/Windows-GNU.c
 index f0e04cb56..5892108e7 100644
 --- a/Modules/Platform/Windows-GNU.cmake
 +++ b/Modules/Platform/Windows-GNU.cmake
-@@ -107,7 +107,7 @@ macro(__windows_compiler_gnu lang)
+@@ -105,7 +107,7 @@ macro(__windows_compiler_gnu lang)
    set(CMAKE_${lang}_CREATE_SHARED_LIBRARY
      "<CMAKE_${lang}_COMPILER> <CMAKE_SHARED_LIBRARY_${lang}_FLAGS> <LANGUAGE_COMPILE_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_${lang}_FLAGS> -o <TARGET> -Wl,--out-implib,<TARGET_IMPLIB> ${CMAKE_GNULD_IMAGE_VERSION} <OBJECTS> <LINK_LIBRARIES>")
    set(CMAKE_${lang}_LINK_EXECUTABLE

--- a/mingw-w64-cmake/0008-Output-line-numbers-in-callstacks.patch
+++ b/mingw-w64-cmake/0008-Output-line-numbers-in-callstacks.patch
@@ -12,7 +12,7 @@ diff --git a/Source/cmMakefile.cxx b/Source/cmMakefile.cxx
 index b46820822..245f88492 100644
 --- a/Source/cmMakefile.cxx
 +++ b/Source/cmMakefile.cxx
-@@ -3725,6 +3725,9 @@ std::string cmMakefile::FormatListFileStack() const
+@@ -3852,6 +3852,9 @@ std::string cmMakefile::FormatListFileStack() const
    cmStateSnapshot snp = this->StateSnapshot;
    while (snp.IsValid()) {
      listFiles.push_back(snp.GetExecutionListFile());

--- a/mingw-w64-cmake/PKGBUILD
+++ b/mingw-w64-cmake/PKGBUILD
@@ -4,7 +4,7 @@
 _realname=cmake
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.12.4
+pkgver=3.13.3
 pkgrel=1
 pkgdesc="A cross-platform open-source make system (mingw-w64)"
 arch=('any')
@@ -31,14 +31,14 @@ source=("https://www.cmake.org/files/v${pkgver%.*}/${_realname}-${pkgver}.tar.gz
         "0006-pkg-config-Add-dont-define-prefix-when-PKG_CONFIG_WI.patch"
         "0007-Do-not-generate-import-libs-for-exes.patch"
         "0008-Output-line-numbers-in-callstacks.patch")
-sha256sums=('5255584bfd043eb717562cff8942d472f1c0e4679c4941d84baadaa9b28e3194'
-            'e747f6a2de187d1ad469872432a2afd15252dafe4babf5b2c713372c864ef8ba'
+sha256sums=('665f905036b1f731a2a16f83fb298b1fb9d0f98c382625d023097151ad016b25'
+            '1b68fe64e1b389134db44dc34368713f6e28d3463ab1e7fc3d93857c0459beb7'
             '77763df03e8a9ca66c3f9368fe7e1fc36bb041455733258d73aeb40246a61354'
-            '4402730b932e94630beecbc596fe33868338b162f200e8c0464ac71acf4b0fbe'
+            'bf676abff7e944ce726f8b16ccb7085cb96f5e12f94b657b455bd749145ba968'
             '7eb60d12b610c70413412521dcc860d1948c169e721f3525d9be99b3913dc37e'
             'b3905abed55c012108b0254c69cb4027a739f15772500b0a99c400d9dfdf50a7'
-            'c6c312f488cd8bb0c73d026c3fbbafedf64e8d01469fc94799edea0660915164'
-            '6123b49887fb09c110b2223e9230f0a84824a5d191aaa8971a6a11339c76cf52')
+            'd0aaa6fbf3e740341aaac2b43033f6c20f56a94ea0b2c509233f693cabe2a912'
+            '94642670c922c9acfade79bc567c6b28f2d2f89e27aa391b562e8c90baa49ce1')
 
 
 # Helper macros to help make tasks easier #


### PR DESCRIPTION
I've ported the patches, as best I could. It compiles.
Now someone just needs to test it, to check if it works correctly. (how do you [test](https://github.com/Alexpux/MINGW-packages/issues/4866#issuecomment-454326420) it?)

@mingwandroid
@alexpux 
@JPeterMugaas ([ref](https://github.com/Alexpux/MINGW-packages/pull/4863))
(Perhaps review and tips/hints)

To apply the patches to the cmake-git-source (in case you want that), do this:
```bash
ls 000*   # view patches here
git clone --depth 1 --branch v3.13.3 https://gitlab.kitware.com/cmake/cmake.git cmake_3.13.3
cd                                                                              cmake_3.13.3
for x in ../000*; do
  echo $x
  git apply $x
  echo ""
done
git diff  # view a single big patch
```