### PR TITLE
gtk3: backport switch fix

### DIFF
--- a/mingw-w64-gtk3/508.patch
+++ b/mingw-w64-gtk3/508.patch
@@ -1,0 +1,72 @@
+From ed39721aa7435860f46da69998cf6cac4ae7e735 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Tue, 15 Jan 2019 15:22:09 +0000
+Subject: [PATCH] Add fallbacks for GtkSwitch state labels
+
+While the IEC power symbols have been part of Unicode since version 9.0,
+released in 2016, not every font supports them.
+
+We can use the old symbols as a fallback, as they seem to have the
+better coverage, if not the best appearance.
+---
+ gtk/gtkswitch.c | 41 +++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/gtk/gtkswitch.c b/gtk/gtkswitch.c
+index bf63f34fd2..1d42f572a9 100644
+--- a/gtk/gtkswitch.c
++++ b/gtk/gtkswitch.c
+@@ -298,11 +298,48 @@ gtk_switch_create_pango_layouts (GtkSwitch *self)
+ {
+   GtkSwitchPrivate *priv = self->priv;
+ 
++  /* Glyphs for the ON state, in descending order of preference */
++  const char *on_glyphs[] = {
++    "⏽", /* U+23FD POWER ON SYMBOL */
++    "❙", /* U+2759 MEDIUM VERTICAL BAR */
++  };
++
++  /* Glyphs for the OFF state, in descending order of preference */
++  const char *off_glyphs[] = {
++    "⭘", /* U+2B58 HEAVY CIRCLE */
++    "○", /* U+25CB WHITE CIRCLE */
++  };
++  int i;
++
+   g_clear_object (&priv->on_layout);
+-  priv->on_layout = gtk_widget_create_pango_layout (GTK_WIDGET (self), "⏽");
++
++  for (i = 0; i < G_N_ELEMENTS (on_glyphs); i++)
++    {
++      PangoLayout *layout = gtk_widget_create_pango_layout (GTK_WIDGET (self), on_glyphs[i]);
++
++      if (pango_layout_get_unknown_glyphs_count (layout) == 0)
++        {
++          priv->on_layout = layout;
++          break;
++        }
++
++      g_object_unref (layout);
++    }
+ 
+   g_clear_object (&priv->off_layout);
+-  priv->off_layout = gtk_widget_create_pango_layout (GTK_WIDGET (self), "⭘");
++
++  for (i = 0; i < G_N_ELEMENTS (off_glyphs); i++)
++    {
++      PangoLayout *layout = gtk_widget_create_pango_layout (GTK_WIDGET (self), off_glyphs[i]);
++
++      if (pango_layout_get_unknown_glyphs_count (layout) == 0)
++        {
++          priv->off_layout = layout;
++          break;
++        }
++
++      g_object_unref (layout);
++    }
+ }
+ 
+ static void
+-- 
+2.18.1
+

--- a/mingw-w64-gtk3/PKGBUILD
+++ b/mingw-w64-gtk3/PKGBUILD
@@ -4,7 +4,7 @@ _realname=gtk3
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=3.24.3
-pkgrel=1
+pkgrel=2
 pkgdesc="GObject-based multi-platform GUI toolkit (v3) (mingw-w64)"
 arch=('any')
 url="https://www.gtk.org/"
@@ -28,15 +28,19 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-shared-mime-info")
 options=('strip' '!debug' 'staticlibs')
 source=("https://download.gnome.org/sources/gtk+/${pkgver%.*}/gtk+-${pkgver}.tar.xz"
-        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch")
+        "0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch"
+        "508.patch")
 sha256sums=('5708fa534d964b1fb9a69d15758729d51b9a438471d4612dc153f595904803bd'
-            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a')
+            'f6f8019e21b2932ee2cfb3b261d57b79f6492d4f0a61f9fbf5b8edd193758d9a'
+            '3b36732db41b29ec1b4fd74ed76296b3c841fcdae28557c49752618c164b397c')
 
 prepare() {
   cd "${srcdir}/gtk+-${pkgver}"
 
   # https://bugzilla.gnome.org/show_bug.cgi?id=778791
   patch -p1 -i "${srcdir}"/0001-gtkwindow-Don-t-force-enable-CSD-under-Windows.patch
+  # https://gitlab.gnome.org/GNOME/gtk/merge_requests/508
+  patch -p1 -i "${srcdir}"/508.patch
 
   NOCONFIGURE=1 ./autogen.sh
 }


### PR DESCRIPTION
3.24.3 broke the switch widget symbols: https://gitlab.gnome.org/GNOME/gtk/merge_requests/508

we can also wait for the next bugfix release...