### PR TITLE
vlc: add missing dependency libidn

### DIFF
--- a/mingw-w64-vlc/PKGBUILD
+++ b/mingw-w64-vlc/PKGBUILD
@@ -11,7 +11,7 @@ pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 conflicts=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 replaces=("${MINGW_PACKAGE_PREFIX}-${_realname}-git")
 pkgver=3.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A multi-platform MPEG, VCD/DVD, and DivX player"
 arch=('any')
 url="https://www.videolan.org/vlc/"
@@ -39,6 +39,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-a52dec"
          "${MINGW_PACKAGE_PREFIX}-libdvbpsi"
          "${MINGW_PACKAGE_PREFIX}-libgme"
          "${MINGW_PACKAGE_PREFIX}-libgoom2"
+         "${MINGW_PACKAGE_PREFIX}-libidn"
          "${MINGW_PACKAGE_PREFIX}-libmad"
          "${MINGW_PACKAGE_PREFIX}-libmatroska"
          "${MINGW_PACKAGE_PREFIX}-libmicrodns"


### PR DESCRIPTION
  libidn is needed from libvlccore.dll