### PR TITLE
nghttp2: update to 1.36.0

### DIFF
--- a/mingw-w64-nghttp2/PKGBUILD
+++ b/mingw-w64-nghttp2/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=nghttp2
 pkgbase=mingw-w64-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=1.35.1
+pkgver=1.36.0
 pkgrel=1
 pkgdesc="Framing layer of HTTP/2 is implemented as a reusable C library (mingw-w64)"
 arch=('any')
@@ -18,7 +18,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2")
 checkdepends=("${MINGW_PACKAGE_PREFIX}-cunit")
 license=('MIT')
 source=("https://github.com/nghttp2/nghttp2/releases/download/v${pkgver}/${_realname}-${pkgver}.tar.xz")
-sha256sums=('9b7f5b09c3ca40a46118240bf476a5babf4bd93a1e4fde2337c308c4c5c3263a')
+sha256sums=('e9bb86157b88eda5a6844a232e039febbb52c1aa44b640acbbfabe729b8287fc')
 
 prepare() {
   cd $srcdir/${_realname}-${pkgver}


### PR DESCRIPTION
This updates nghttp2 to 1.36.0.