### PR TITLE
python-fonttools: update to 3.36.0

### DIFF
--- a/mingw-w64-python-fonttools/PKGBUILD
+++ b/mingw-w64-python-fonttools/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fonttools
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.30.0
+pkgver=3.36.0
 pkgrel=1
 pkgdesc="Converts OpenType and TrueType fonts to and from XML (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("https://github.com/fonttools/fonttools/releases/download/${pkgver}/fonttools-${pkgver}.zip")
-sha256sums=('95e86519b18183dc3c230e9b2233a69add3f631ec43c8725a553844a7d12c2c4')
+sha256sums=('8fe280c6da84ed24345e23cae34e4dd41afed33e50eb03e1ffa407ca3ae0c598')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-fonttools to 3.36.0.