### PR TITLE
python-bcrypt: update to 3.1.6

### DIFF
--- a/mingw-w64-python-bcrypt/PKGBUILD
+++ b/mingw-w64-python-bcrypt/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=bcrypt
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.1.5
+pkgver=3.1.6
 pkgrel=1
 pkgdesc="Modern password hashing for your software and your servers (mingw-w64)"
 arch=('any')
@@ -13,11 +13,13 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python3-cffi"
              "${MINGW_PACKAGE_PREFIX}-python2-cffi"
+             "${MINGW_PACKAGE_PREFIX}-python3-six"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/pyca/bcrypt/archive/${pkgver}.tar.gz")
-sha512sums=('ec82dec62fc6cadc5c74ddf2ba152630aa06a817d30e5be81b2504fb64a343e5527671d1fede05e54fdab1b39c7f6ea261bf718480b642122e8ddbbb85d3a0bf')
+sha512sums=('ceb29bec656f56acea9e11112a46d8179c6c3be6d9295201ebdbf33692dd5503b353bd8206f3f4edc4b3b3027799d75915f498e4b7ac01124b90a0d70b1f60a8')
 
 apply_patch_with_msg() {
   for _patch in "$@"
@@ -63,7 +65,9 @@ check() {
 }
 
 package_python3-bcrypt() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-cffi"
+           "${MINGW_PACKAGE_PREFIX}-python3-six")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -74,7 +78,9 @@ package_python3-bcrypt() {
 }
 
 package_python2-bcrypt() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-cffi"
+           "${MINGW_PACKAGE_PREFIX}-python2-six")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
This updates python-bcrypt to 3.1.6.