### PR TITLE
python-setuptools-scm: update to 3.2.0

### DIFF
--- a/mingw-w64-python-setuptools-scm/PKGBUILD
+++ b/mingw-w64-python-setuptools-scm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=setuptools-scm
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.1.0
+pkgver=3.2.0
 pkgrel=1
 pkgdesc='Handles managing your python package versions in scm metadata (mingw-w64)'
 url='https://github.com/pypa/setuptools_scm'
@@ -16,7 +16,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
             )
 source=("https://pypi.org/packages/source/${_realname::1}/${_realname}/${_realname/-/_}-${pkgver}.tar.gz"
         "0001-python-setuptools-scm-3.1.0-fix-path-error.patch")
-sha256sums=('1191f2a136b5e86f7ca8ab00a97ef7aef997131f1f6d4971be69a1ef387d8b40'
+sha256sums=('52ab47715fa0fc7d8e6cd15168d1a69ba995feb1505131c3e814eb7087b57358'
             '3a936600ebceccf2315fe76a79e90e4fdcfe2a936b442f6321b2d76a8e9902b1')
 
 prepare() {


### PR DESCRIPTION
This updates python-setuptools-scm to 3.2.0.