### PR TITLE
mingw-w64-python-pip - 19.0.1 - Update to latest release

### DIFF
--- a/mingw-w64-python-pip/PKGBUILD
+++ b/mingw-w64-python-pip/PKGBUILD
@@ -3,8 +3,8 @@
 _realname=pip
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=18.1
-pkgrel=2
+pkgver=19.0.1
+pkgrel=1
 pkgdesc="An easy_install replacement for installing pypi python packages (mingw-w64)"
 arch=('any')
 license=('MIT')
@@ -18,7 +18,7 @@ makedepends=("${_deps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}" "${_deps[@]/#/${MI
              "${MINGW_PACKAGE_PREFIX}-python3-sphinx")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/pip/archive/${pkgver}.tar.gz)
 noextract=(${_realname}-${pkgver}.tar.gz)
-sha256sums=('3ff036bbbce30f27b0ba440134defa66a135740c9e3401bd466e7f0d8153147c')
+sha256sums=('96f92cd35efc4fbeb520996da7aba3ae6491d8e849e2b77dc2044fedcc5fdaba')
 
 shopt -s extglob
 


### PR DESCRIPTION
Note that an obvious change is that you are now warned that Python 2x will be dropped in 2020.