### PR TITLE
argon2 updates (see: https://github.com/Alexpux/MINGW-packages/issues…

### DIFF
--- a/mingw-w64-argon2/001-mingw-fix-install.patch
+++ b/mingw-w64-argon2/001-mingw-fix-install.patch
@@ -1,6 +1,19 @@
 --- phc-winner-argon2-20171227/Makefile.orig	2017-12-27 14:56:31.000000000 -0500
-+++ phc-winner-argon2-20171227/Makefile	2019-01-03 10:08:33.315228200 -0500
-@@ -44,6 +44,16 @@ CI_CFLAGS := $(CFLAGS) -Werror=declarati
++++ phc-winner-argon2-20171227/Makefile	2019-01-05 09:14:20.310454500 -0500
+@@ -29,6 +29,12 @@ SRC_RUN = src/run.c
+ SRC_BENCH = src/bench.c
+ SRC_GENKAT = src/genkat.c
+ OBJ = $(SRC:.c=.o)
++AR ?= ar
++LN_S = 'ln -s'
++TAR ?= 'tar'
++MKDIR ?= 'mkdir -p'
++RM ?= 'rm -f'
++RMDIR ?= 'rm -rf'
+ 
+ CFLAGS += -std=c89 -O3 -Wall -g -Iinclude -Isrc
+ 
+@@ -44,6 +50,16 @@ CI_CFLAGS := $(CFLAGS) -Werror=declarati
  OPTTARGET ?= native
  OPTTEST := $(shell $(CC) -Iinclude -Isrc -march=$(OPTTARGET) src/opt.c -c \
  			-o /dev/null 2>/dev/null; echo $$?)
@@ -17,7 +30,7 @@
  # Detect compatible platform
  ifneq ($(OPTTEST), 0)
  $(info Building without optimizations)
-@@ -58,6 +68,7 @@ BUILD_PATH := $(shell pwd)
+@@ -58,11 +74,12 @@ BUILD_PATH := $(shell pwd)
  KERNEL_NAME := $(shell uname -s)
  
  LIB_NAME=argon2
@@ -25,25 +38,39 @@
  ifeq ($(KERNEL_NAME), Linux)
  	LIB_EXT := so.$(ABI_VERSION)
  	LIB_CFLAGS := -shared -fPIC -fvisibility=hidden -DA2_VISCTL=1
-@@ -75,14 +86,17 @@ ifeq ($(KERNEL_NAME), Darwin)
+ 	SO_LDFLAGS := -Wl,-soname,lib$(LIB_NAME).$(LIB_EXT)
+-	LINKED_LIB_EXT := so
++	LN_SED_LIB_EXT := so
+ endif
+ ifeq ($(KERNEL_NAME), $(filter $(KERNEL_NAME),FreeBSD NetBSD OpenBSD))
+ 	LIB_EXT := so
+@@ -71,18 +88,24 @@ endif
+ ifeq ($(KERNEL_NAME), Darwin)
+ 	LIB_EXT := $(ABI_VERSION).dylib
+ 	LIB_CFLAGS := -dynamiclib -install_name @rpath/lib$(LIB_NAME).$(LIB_EXT)
+-	LINKED_LIB_EXT := dylib
++	LN_SED_LIB_EXT := dylib
  endif
  ifeq ($(findstring CYGWIN, $(KERNEL_NAME)), CYGWIN)
  	LIB_EXT := dll
++	LN_S = 'cp -p'
 +	LIB_SH_RT := cyg$(LIB_NAME).$(LIB_EXT)
  	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
  endif
  ifeq ($(findstring MINGW, $(KERNEL_NAME)), MINGW)
  	LIB_EXT := dll
++	LN_S = 'cp -p'
 +	LIB_SH_RT := lib$(LIB_NAME).$(LIB_EXT)
  	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
  endif
  ifeq ($(findstring MSYS, $(KERNEL_NAME)), MSYS)
  	LIB_EXT := dll
++	LN_S = 'cp -p'
 +	LIB_SH_RT := msys-$(LIB_NAME).$(LIB_EXT)
  	LIB_CFLAGS := -shared -Wl,--out-implib,lib$(LIB_NAME).$(LIB_EXT).a
  endif
  ifeq ($(KERNEL_NAME), SunOS)
-@@ -98,7 +112,11 @@ ifeq ($(CC), clang)
+@@ -98,11 +121,15 @@ ifeq ($(CC), clang)
  endif
  endif
  
@@ -54,8 +81,14 @@
 +endif
  LIB_ST := lib$(LIB_NAME).a
  
- ifdef LINKED_LIB_EXT
-@@ -135,8 +153,15 @@ $(BENCH):       $(SRC) $(SRC_BENCH)
+-ifdef LINKED_LIB_EXT
+-LINKED_LIB_SH := lib$(LIB_NAME).$(LINKED_LIB_EXT)
++ifdef LN_SED_LIB_EXT
++LN_SED_LIB_SH := lib$(LIB_NAME).$(LN_SED_LIB_EXT)
+ endif
+ 
+ 
+@@ -135,24 +162,31 @@ $(BENCH):       $(SRC) $(SRC_BENCH)
  $(GENKAT):      $(SRC) $(SRC_GENKAT)
  		$(CC) $(CFLAGS) $^ -o $@ -DGENKAT
  
@@ -70,8 +103,33 @@
 +endif
  
  $(LIB_ST): 	$(OBJ)
- 		ar rcs $@ $^
-@@ -174,14 +199,23 @@ install: $(RUN) libs
+-		ar rcs $@ $^
++		$(AR) rcs $@ $^
+ 
+ clean:
+-		rm -f $(RUN) $(BENCH) $(GENKAT)
+-		rm -f $(LIB_SH) $(LIB_ST) kat-argon2*
+-		rm -f testcase
+-		rm -rf *.dSYM
+-		cd src/ && rm -f *.o
+-		cd src/blake2/ && rm -f *.o
+-		cd kats/ &&  rm -f kat-* diff* run_* make_*
++		$(RM) $(RUN) $(BENCH) $(GENKAT)
++		$(RM) $(LIB_SH) $(LIB_ST) kat-argon2*
++		$(RM) testcase
++		$(RMDIR) *.dSYM
++		cd src/ && $(RM) *.o
++		cd src/blake2/ && $(RM) *.o
++		cd kats/ &&  $(RM) kat-* diff* run_* make_*
+ 
+ dist:
+ 		cd ..; \
+-		tar -c --exclude='.??*' -z -f $(DIST)-`date "+%Y%m%d"`.tgz $(DIST)/*
++		$(TAR) -c --exclude='.??*' -z -f $(DIST)-`date "+%Y%m%d"`.tgz $(DIST)/*
+ 
+ test:           $(SRC) src/test.c
+ 		$(CC) $(CFLAGS)  -Wextra -Wno-type-limits $^ -o testcase
+@@ -174,14 +208,23 @@ install: $(RUN) libs
  	$(INSTALL) -d $(INST_INCLUDE)
  	$(INSTALL) -m 0644 $(HEADERS) $(INST_INCLUDE)
  	$(INSTALL) -d $(INST_LIBRARY)
@@ -82,17 +140,22 @@
 +	$(INSTALL) $(LIB_ST) $(INST_LIBRARY)
 +else
  	$(INSTALL) $(LIBRARIES) $(INST_LIBRARY)
-+endif
- ifdef LINKED_LIB_SH
- 	cd $(INST_LIBRARY) && ln -s $(notdir $(LIB_SH) $(LINKED_LIB_SH))
+-ifdef LINKED_LIB_SH
+-	cd $(INST_LIBRARY) && ln -s $(notdir $(LIB_SH) $(LINKED_LIB_SH))
  endif
 -	$(INSTALL) -d $(INST_BINARY)
++ifdef LN_SED_LIB_SH
++	cd $(INST_LIBRARY) && $(LN_S) $(notdir $(LIB_SH) $(LN_SED_LIB_SH))
++endif
  	$(INSTALL) $(RUN) $(INST_BINARY)
  
  uninstall:
- 	cd $(INST_INCLUDE) && rm -f $(notdir $(HEADERS))
- 	cd $(INST_LIBRARY) && rm -f $(notdir $(LIBRARIES) $(LINKED_LIB_SH))
+-	cd $(INST_INCLUDE) && rm -f $(notdir $(HEADERS))
+-	cd $(INST_LIBRARY) && rm -f $(notdir $(LIBRARIES) $(LINKED_LIB_SH))
+-	cd $(INST_BINARY) && rm -f $(notdir $(RUN))
++	cd $(INST_INCLUDE) && $(RM) $(notdir $(HEADERS))
++	cd $(INST_LIBRARY) && $(RM) $(notdir $(LIBRARIES) $(LN_SED_LIB_SH))
 +ifneq ($(LIB_SH_RT),)
-+	cd $(INST_BINARY) && rm -f $(notdir $(LIB_SH_RT))
++	cd $(INST_BINARY) && $(RM) $(notdir $(LIB_SH_RT))
 +endif
- 	cd $(INST_BINARY) && rm -f $(notdir $(RUN))
++	cd $(INST_BINARY) && $(RM) $(notdir $(RUN))

--- a/mingw-w64-argon2/002-mingw-fix-src.patch
+++ b/mingw-w64-argon2/002-mingw-fix-src.patch
@@ -63,15 +63,4 @@
      return __rdtsc();
  #else
  #if defined(__amd64__) || defined(__x86_64__)
---- phc-winner-argon2-20171227/include/argon2.h.orig	2019-01-01 00:55:05.866534800 -0500
-+++ phc-winner-argon2-20171227/include/argon2.h	2019-01-01 00:57:09.920803200 -0500
-@@ -33,6 +33,9 @@ extern "C" {
- #elif _MSC_VER
- #define ARGON2_PUBLIC __declspec(dllexport)
- #define ARGON2_LOCAL
-+#elif __MINGW32__
-+#define ARGON2_PUBLIC __declspec(dllexport)
-+#define ARGON2_LOCAL
- #else
- #define ARGON2_PUBLIC
- #define ARGON2_LOCAL
+

--- a/mingw-w64-argon2/PKGBUILD
+++ b/mingw-w64-argon2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=argon2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=20171227
-pkgrel=3
+pkgrel=4
 pkgdesc="This is the reference implementation of Argon2, the password-hashing function that won the Password Hashing Competition (PHC) (mingw-w64)"
 arch=('any')
 license=('CC0 and Apache 2.0')
@@ -16,8 +16,8 @@ source=(${_realname}-${pkgver}.tar.gz::"${url}/archive/${pkgver}.tar.gz"
         002-mingw-fix-src.patch)
 sha256sums=('eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8'
             '17061b6f504640cec638d69404879a678e15332a4138673f4a8626ff4efc79a3'
-            '3417ce1955960912ad943552fe458963a4da23edc2369ab75ffe87ba6b6225f5'
-            'cf5c9e1d35f51df87cb2da1ac214a4955b4c9404eee072dc825b2fb2e912e5df')
+            '30c6799caed3b4968f877266783defb249ec756435e7647173a64486eb6221e3'
+            '5f0566bb2a1d9a039f667cc35bc0afa803e65863c01765a37c574165f1d8eac1')
 
 case ${MINGW_CHOST} in
   i686*)
@@ -48,12 +48,12 @@ build() {
   cp -rf ${srcdir}/phc-winner-argon2-${pkgver} "${srcdir}/build-${MINGW_CHOST}"
   cd "${srcdir}/build-${MINGW_CHOST}"
 
-  make CC=${MINGW_PREFIX}/bin/gcc OPTTARGET=${_march}
+  make CC=${MINGW_PREFIX}/bin/gcc AR=${MINGW_PREFIX}/bin/ar OPTTARGET=${_march}
 }
 
 package() {
   cd "${srcdir}/build-${MINGW_CHOST}"
-  make install DESTDIR="${pkgdir}" CC=${MINGW_PREFIX}/bin/gcc PREFIX="${MINGW_PREFIX}" OPTTARGET=${_march}
+  make install DESTDIR="${pkgdir}" CC=${MINGW_PREFIX}/bin/gcc AR=${MINGW_PREFIX}/bin/ar PREFIX="${MINGW_PREFIX}" OPTTARGET=${_march}
 
   install -Dm644 LICENSE "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/LICENSE"
   install -Dm644 ${srcdir}/libargon2.pc "${pkgdir}${MINGW_PREFIX}/lib/pkgconfig/libargon2.pc"

--- a/mingw-w64-python-argon2_cffi/002-mingw-fix-src.patch
+++ b/mingw-w64-python-argon2_cffi/002-mingw-fix-src.patch
@@ -63,15 +63,4 @@
      return __rdtsc();
  #else
  #if defined(__amd64__) || defined(__x86_64__)
---- phc-winner-argon2-20171227/include/argon2.h.orig	2019-01-01 00:55:05.866534800 -0500
-+++ phc-winner-argon2-20171227/include/argon2.h	2019-01-01 00:57:09.920803200 -0500
-@@ -33,6 +33,9 @@ extern "C" {
- #elif _MSC_VER
- #define ARGON2_PUBLIC __declspec(dllexport)
- #define ARGON2_LOCAL
-+#elif __MINGW32__
-+#define ARGON2_PUBLIC __declspec(dllexport)
-+#define ARGON2_LOCAL
- #else
- #define ARGON2_PUBLIC
- #define ARGON2_LOCAL
+

--- a/mingw-w64-python-argon2_cffi/PKGBUILD
+++ b/mingw-w64-python-argon2_cffi/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=argon2_cffi
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=18.3.0
+pkgver=19.1.0
 _argom2_relname=argon2
 _argon2_pkgver=20171227
 pkgrel=1
@@ -25,10 +25,10 @@ source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/hynek/argon2_cffi/a
         "${_argom2_relname}-${_argon2_pkgver}.tar.gz"::"https://github.com/P-H-C/phc-winner-argon2/archive/${_argon2_pkgver}/${_argon2_pkgver}-${argon2_pkgver}.tar.gz"
         mingw-fixes.patch
         002-mingw-fix-src.patch)
-sha256sums=('14bd291406ae6f178ba7c56f0e1fdc87812c00dfa40fbbfa35cbf54413d56b78'
+sha256sums=('b2bccb3433469625d6551a2a1f8203db8e6ffdb0a0bc9ac6621b600b3e34b056'
             'eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8'
             '5e06a2af6e3da607419b1e1897847f154794d6319683ce190d34d7af7f1be480'
-            'cf5c9e1d35f51df87cb2da1ac214a4955b4c9404eee072dc825b2fb2e912e5df')
+            '5f0566bb2a1d9a039f667cc35bc0afa803e65863c01765a37c574165f1d8eac1')
 
 # Helper macros to help make tasks easier #
 apply_patch_with_msg() {


### PR DESCRIPTION
…/4921

 fix patch 002-mingw-fix-src.patch in both packages
argon2 - fix patch as recommended
python-argon2-cffi - Update to 19.0.1 and compile with fixed patch.