### PR TITLE
python-py - 1,7.0 - build changes

### DIFF
--- a/mingw-w64-python-py/PKGBUILD
+++ b/mingw-w64-python-py/PKGBUILD
@@ -4,7 +4,7 @@ _realname=py
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}" "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
 pkgver=1.7.0
-pkgrel=1
+pkgrel=2
 pkgdesc='library with cross-python path, ini-parsing, io, code, log facilities (mingw-w64)'
 arch=('any')
 url='https://pylib.readthedocs.io/'
@@ -25,11 +25,12 @@ options=('staticlibs' 'strip' '!debug')
 source=("${_realname}-${pkgver}.tar.gz::https://github.com/pytest-dev/py/archive/${pkgver}.tar.gz")
 sha256sums=('9fb261a2a6e969f5636fce0f1abe832dcf402bdc62fdecda78b711602ba55cd0')
 
-prepare() {  
+prepare() {
   cd "${srcdir}"
   #work around tar issue with symlinks
   #tar xf ${_realname}-${pkgver}.tar.gz || true
   cp ${_realname}-${pkgver}/LICENSE ${_realname}-${pkgver}/py/LICENSE
+  rm -r py-$pkgver/py/_vendored_packages
   rm -rf $builddir | true
   for builddir in python{2,3}-build-${CARCH}; do  
     rm -rf ${builddir} | true
@@ -39,29 +40,27 @@ prepare() {
   export SETUPTOOLS_SCM_PRETEND_VERSION=${pkgver}
 }
 
-# Note that build() is sometimes skipped because it's done in 
-# the packages setup.py install for simplicity if you can do so.
-# but sometimes, you want to do a check before install which would
-# also trigger the build.  
 build() {  
-  for pver in {2,3}; do  
-    msg "Python ${pver} build for ${CARCH}"  
+  for pver in {2,3}; do
+    msg "Python ${pver} build for ${CARCH}"
     cd "${srcdir}/python${pver}-build-${CARCH}"
     ${MINGW_PREFIX}/bin/python${pver} setup.py build
-  done  
+  done
 }
 
   
 check() {  
-  for pver in {2,3}; do  
-    msg "Python ${pver} test for ${CARCH}"  
-    cd "${srcdir}/python${pver}-build-${CARCH}"  
-    ${MINGW_PREFIX}/bin/python${pver} setup.py check || true
-  done  
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py pytest || warning "Tests failed"
+  done
 }
 
 package_python3-py() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+  depends=("${MINGW_PACKAGE_PREFIX}-python3"
+           "${MINGW_PACKAGE_PREFIX}-python3-iniconfig"
+           "${MINGW_PACKAGE_PREFIX}-python3-apipkg")
 
   cd "${srcdir}/python3-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
@@ -72,7 +71,9 @@ package_python3-py() {
 }
 
 package_python2-py() {
-  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+  depends=("${MINGW_PACKAGE_PREFIX}-python2"
+           "${MINGW_PACKAGE_PREFIX}-python2-iniconfig"
+           "${MINGW_PACKAGE_PREFIX}-python2-apipkg")
 
   cd "${srcdir}/python2-build-${CARCH}"
   MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \


### PR DESCRIPTION
remove vendered code and depend upon the appropriate packages
Fix tests so a warning is given for failure
Remove whitespace at end of line.