### PR TITLE
python-setuptools - 40.7.1 - Update to latest version

### DIFF
--- a/mingw-w64-python-setuptools/PKGBUILD
+++ b/mingw-w64-python-setuptools/PKGBUILD
@@ -5,12 +5,27 @@ _realname=setuptools
 pkgbase=mingw-w64-python-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-setuptools" "${MINGW_PACKAGE_PREFIX}-python3-setuptools")
-pkgver=40.6.3
+pkgver=40.7.1
 pkgrel=1
 pkgdesc="Easily download, build, install, upgrade, and uninstall Python packages (mingw-w64)"
 arch=('any')
 license=('PSF')
 url="https://pypi.python.org/pypi/setuptools"
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2>=2.7"
+             "${MINGW_PACKAGE_PREFIX}-python2-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python2-certifi"
+             "${MINGW_PACKAGE_PREFIX}-python2-packaging"
+             "${MINGW_PACKAGE_PREFIX}-python2-pyparsing"
+             "${MINGW_PACKAGE_PREFIX}-python2-six"            
+             "${MINGW_PACKAGE_PREFIX}-python2-wincertstore"
+             "${MINGW_PACKAGE_PREFIX}-python3>=3.3"
+             "${MINGW_PACKAGE_PREFIX}-python3-appdirs"
+             "${MINGW_PACKAGE_PREFIX}-python3-certifi"
+             "${MINGW_PACKAGE_PREFIX}-python3-packaging"
+             "${MINGW_PACKAGE_PREFIX}-python3-pyparsing"
+             "${MINGW_PACKAGE_PREFIX}-python3-six"
+             "${MINGW_PACKAGE_PREFIX}-python3-wincertstore"
+             'git')
 depends=("${MINGW_PACKAGE_PREFIX}-python2" "${MINGW_PACKAGE_PREFIX}-python3")
 source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archive/v${pkgver}.tar.gz
         '0001-mingw-python-fix.patch'
@@ -23,7 +38,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/pypa/setuptools/archiv
 #checkdepends=("${_checkdeps[@]/#/${MINGW_PACKAGE_PREFIX}-python3-}" "${_checkdeps[@]/#/${MINGW_PACKAGE_PREFIX}-python2-}"
 #              "${MINGW_PACKAGE_PREFIX}-python3-paver"
 #              "${MINGW_PACKAGE_PREFIX}-python2-futures" 'git')
-sha256sums=('ae2a0bea7c79ac14dfb313dae8896362a1f966e547cfbbfd39cd592836926614'
+sha256sums=('0f6a96687a87265384744bc911e957160e75b1dbaef8d30b74f4357285945a74'
             'd3bc778723e63bbd6e43ab3536a015c547c8c20a95c6679a952284a7a4822996'
             '7bb5617c69566f5fbf1a3ee29a08179e1b41bdeabbc2998bf67615e9aa000424'
             '0e556505cb70ff3a5df856e352d5e2b3cf1582c25d02fc00a2d935a28576b28c'
@@ -31,6 +46,7 @@ sha256sums=('ae2a0bea7c79ac14dfb313dae8896362a1f966e547cfbbfd39cd592836926614'
             'c32b0d1d5030055295a3c242069732d1bf5e57dbbbfe7d4cec2cee54228d73a3')
 
 prepare() {
+  export SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES=1
   cd "${srcdir}/setuptools-${pkgver}"
   patch -p1 -i ${srcdir}/0001-mingw-python-fix.patch
   patch -p1 -i ${srcdir}/0002-Allow-usr-bin-env-in-script.patch
@@ -47,6 +63,23 @@ prepare() {
   PATH=/mingw64/bin:$PATH gcc -DGUI=0           -O -s -o setuptools-${pkgver}/setuptools/cli-64.exe setuptools-${pkgver}/launcher.c
   PATH=/mingw64/bin:$PATH gcc -DGUI=1 -mwindows -O -s -o setuptools-${pkgver}/setuptools/gui-64.exe setuptools-${pkgver}/launcher.c
 
+  rm -r setuptools-$pkgver/{pkg_resources,setuptools}/{extern,_vendor}
+
+  # Upstream devendoring logic is badly broken, see:
+  # https://bugs.archlinux.org/task/58670
+  # https://github.com/pypa/pip/issues/5429
+  # https://github.com/pypa/setuptools/issues/1383
+  # The simplest fix is to simply rewrite import paths to use the canonical
+  # location in the first place
+  for _module in setuptools pkg_resources '' ; do
+      find setuptools-$pkgver/$_module -name \*.py -exec sed -i \
+          -e 's/from '$_module.extern' import/import/' \
+          -e 's/from '$_module.extern'./from /' \
+          -e 's/import '$_module.extern'./import /' \
+          -e "s/__import__('$_module.extern./__import__('/" \
+          {} +
+    done
+
   # Remove post-release tag since we are using stable tags
   sed -e '/tag_build = .post/d' \
       -e '/tag_date = 1/d' \
@@ -57,17 +90,18 @@ prepare() {
   # dir.
   sed -e '/^def test_pip_upgrade_from_source/i @pytest.mark.xfail' \
       -e '/^def test_test_command_install_requirements/i @pytest.mark.xfail' \
+      -e '/^def test_no_missing_dependencies/i @pytest.mark.xfail' \
       -i setuptools-$pkgver/setuptools/tests/test_virtualenv.py
 
   cp -r setuptools-${pkgver} setuptools-python2-${CARCH}
   cp -r setuptools-${pkgver} setuptools-python3-${CARCH}
 
   cd "${srcdir}"/setuptools-python2-${CARCH}
-  sed -i -e "s|^#\!.*/usr/bin/python|#!/usr/bin/python2|" tests/manual_test.py
+  sed -i -e "s|^#\!.*/usr/bin/python|#!${MINGW_PREFIX}/bin/python2|" tests/manual_test.py
   sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python2|" setuptools/command/easy_install.py
 
   cd "${srcdir}"/setuptools-python3-${CARCH}
-  sed -i -e "s|^#\!.*/usr/bin/python|#!/usr/bin/python3|" tests/manual_test.py
+  sed -i -e "s|^#\!.*/usr/bin/python|#!${MINGW_PREFIX}/bin/python3|" tests/manual_test.py
   sed -i -e "s|^#\!.*/usr/bin/env python|#!/usr/bin/env python3|" setuptools/command/easy_install.py
 }
 
@@ -95,7 +129,7 @@ build() {
 #  export PYTHONDONTWRITEBYTECODE=1
 
 #  cd "${srcdir}"/setuptools-python3-${CARCH}
-#  ${MINGW_PREFIX}/bin/python setup.py pytest
+#  ${MINGW_PREFIX}/bin/python3 setup.py pytest
 
 #  cd "${srcdir}"/setuptools-python2-${CARCH}
 #  ${MINGW_PREFIX}/bin/python2 setup.py pytest


### PR DESCRIPTION
Remove vendered packages and rely upon packages we have.
added makedepends that match package package dependencies
Fix shebang in easy_install.
Add some lines from Arch.  See comments.