### PR TITLE
add python-nvidia-ml

### DIFF
--- a/mingw-w64-python-nvidia-ml/PKGBUILD
+++ b/mingw-w64-python-nvidia-ml/PKGBUILD
@@ -29,7 +29,7 @@ prepare() {
   cd "python3-build-${CARCH}"
   for pyscript in pynvml.py nvidia_smi.py; do
     chmod 666 ${pyscript}
-    2to3 -wn ${pyscript} > /dev/null
+    PYTHONIOENCODING="utf-8" 2to3 -wn ${pyscript} > /dev/null
     chmod 444 ${pyscript}
   done
 }

--- a/mingw-w64-python-nvidia-ml/PKGBUILD
+++ b/mingw-w64-python-nvidia-ml/PKGBUILD
@@ -1,0 +1,92 @@
+# Maintainer: Antoine Martin <totaam@xpra.org>
+
+_realname=nvidia-ml
+_srcname=nvidia-ml-py
+pkgbase=mingw-w64-python-${_realname}
+pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
+pkgver=7.352.0
+pkgrel=1
+pkgdesc="Python bindings to the NVIDIA Management Library (mingw-w64)"
+arch=('any')
+url='https://www.nvidia.com/'
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
+             "${MINGW_PACKAGE_PREFIX}-python3"
+             "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
+             "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
+options=('staticlibs' 'strip' '!debug')
+_dtoken='72/31/378ca145e919ca415641a0f17f2669fa98c482a81f1f8fdfb72b1f9dbb37'
+source=("https://files.pythonhosted.org/packages/${_dtoken}/${_srcname}-${pkgver}.tar.gz")
+sha256sums=('b4a342ba52a51ff794af38279ce62f78b278ba5f50c13103af52c4f6113ff65e')
+
+prepare() {
+  cd "${srcdir}"
+  for builddir in python{2,3}-build-${CARCH}; do
+    rm -rf ${builddir} | true
+    cp -r "${_srcname}-${pkgver}" "${builddir}"
+  done
+  #make code python3 compatible:
+  cd "python3-build-${CARCH}"
+  for pyscript in pynvml.py nvidia_smi.py; do
+    chmod 666 ${pyscript}
+    2to3 -wn ${pyscript} > /dev/null
+    chmod 444 ${pyscript}
+  done
+}
+
+build() {
+  for pver in {2,3}; do  
+    msg "Python ${pver} build for ${CARCH}"  
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py build
+  done  
+}
+
+check() {
+  for pver in {2,3}; do
+    msg "Python ${pver} test for ${CARCH}"
+    cd "${srcdir}/python${pver}-build-${CARCH}"
+    ${MINGW_PREFIX}/bin/python${pver} setup.py check
+  done
+}
+
+package_python3-nvidia-ml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python3")
+
+  cd "${srcdir}/python3-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python3 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 README.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
+
+}
+
+package_python2-nvidia-ml() {
+  depends=("${MINGW_PACKAGE_PREFIX}-python2")
+
+  cd "${srcdir}/python2-build-${CARCH}"
+  MSYS2_ARG_CONV_EXCL="--prefix=;--install-scripts=;--install-platlib=" \
+  ${MINGW_PREFIX}/bin/python2 setup.py install --prefix=${MINGW_PREFIX} \
+    --root="${pkgdir}" --optimize=1 --skip-build
+
+  install -Dm644 README.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
+
+}
+
+package_mingw-w64-i686-python2-nvidia-ml() {
+  package_python2-nvidia-ml
+}
+
+package_mingw-w64-i686-python3-nvidia-ml() {
+  package_python3-nvidia-ml
+}
+
+package_mingw-w64-x86_64-python2-nvidia-ml() {
+  package_python2-nvidia-ml
+}
+
+package_mingw-w64-x86_64-python3-nvidia-ml() {
+  package_python3-nvidia-ml
+}
+

--- a/mingw-w64-python-nvidia-ml/PKGBUILD
+++ b/mingw-w64-python-nvidia-ml/PKGBUILD
@@ -14,7 +14,6 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
-options=('staticlibs' 'strip' '!debug')
 _dtoken='72/31/378ca145e919ca415641a0f17f2669fa98c482a81f1f8fdfb72b1f9dbb37'
 source=("https://files.pythonhosted.org/packages/${_dtoken}/${_srcname}-${pkgver}.tar.gz")
 sha256sums=('b4a342ba52a51ff794af38279ce62f78b278ba5f50c13103af52c4f6113ff65e')
@@ -59,7 +58,6 @@ package_python3-nvidia-ml() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 README.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python3-${_realname}/LICENSE"
-
 }
 
 package_python2-nvidia-ml() {
@@ -71,7 +69,6 @@ package_python2-nvidia-ml() {
     --root="${pkgdir}" --optimize=1 --skip-build
 
   install -Dm644 README.txt "${pkgdir}${MINGW_PREFIX}/share/licenses/python2-${_realname}/LICENSE"
-
 }
 
 package_mingw-w64-i686-python2-nvidia-ml() {


### PR DESCRIPTION
The pull requests supersedes this buggy one: https://github.com/Alexpux/MINGW-packages/pull/4595 which you can reject and close.
The main differences are:

- use 2to3 to make the code python3 compatible
- I've actually tested the code on a system with an nvidia card - worked fine with both python2 and python3
- removed unused build code functions
- renamed the package (no need for "XXX-py" suffix when the package is already called "python-XXX")

Note: there is another github project which has ported the code to make it python3 compatible: https://github.com/fbcotter/py3nvml , but they've also added other functions. I felt it safer to go with the "official" nvidia source even if it meant using 2to3 to build with python3.