### PR TITLE
bump pyopengl version + minor build fixes

### DIFF
--- a/mingw-w64-python-pyopengl/PKGBUILD
+++ b/mingw-w64-python-pyopengl/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=PyOpenGL
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-${_realname}"  "${MINGW_PACKAGE_PREFIX}-python3-${_realname}")
-pkgver=3.1.0
+pkgver=3.1.1a1
 pkgrel=1
 pkgdesc="PyOpenGL is the most common cross platform Python binding to OpenGL and related APIs (mingw-w64)"
 arch=('any')
@@ -14,26 +14,10 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-python2"
              "${MINGW_PACKAGE_PREFIX}-python3-setuptools"
              "${MINGW_PACKAGE_PREFIX}-python2-setuptools")
 options=('staticlibs' 'strip' '!debug')
-_dtoken='9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9'
+_dtoken='df/fe/b9da75e85bcf802ed5ef92a5c5e4022bf06faa1d41b9630b9bb49f827483'
 source=("https://files.pythonhosted.org/packages/${_dtoken}/${_realname}-${pkgver}.tar.gz")
-sha512sums=('f748017ab3734c7672c3fdbedcea80df297a91a78b111533e260feb0868ebb02935666c041f77db03841ee8f90057d9c53c53b00b097aae4cf67a52c7fc9c2eb')
+sha512sums=('8f4f57b153ee014dc238fe83180cc92f8e789a274fc6b0cbef6f5dec9dbc44cb1ae1f6b142a6c2b4c8c000709338d64f5968939eeb6a2384f87fb63ae99b40d8')
 
-apply_patch_with_msg() {
-  for _patch in "$@"
-  do
-    msg2 "Applying $_patch"
-    patch -Nbp1 -i "${srcdir}/$_patch"
-  done
-}
-
-del_file_exists() {
-  for _fname in "$@"
-  do
-    if [ -f $_fname ]; then
-      rm -rf $_fname
-    fi
-  done
-}
 
 prepare() {
   cd "${srcdir}"
@@ -41,8 +25,10 @@ prepare() {
     rm -rf ${builddir} | true
     cp -r "${_realname}-${pkgver}" "${builddir}"
   done
-  # Set version for setuptools_scm
-  export SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver
+  #'async' is a keyword now in python 3.7,
+  #just remove those extensions which aren't used on win32 anyway:
+  rm -fr python3-build-${CARCH}/OpenGL/GL/SGIX/async*
+  rm -fr python3-build-${CARCH}/OpenGL/raw/GL/SGIX/async*
 }
 
 build() {


### PR DESCRIPTION
* bump version to latest 'stable' release (that's what most Linux distro ship nowadays, not 3.1.0)
* remove unused functions in PKGBUILD
* discard unused SGIX bindings since they cause syntax errors with python3 ('async' is a keyword)