### PR TITLE
python-dateutil: update to 2.8.0

### DIFF
--- a/mingw-w64-python-dateutil/PKGBUILD
+++ b/mingw-w64-python-dateutil/PKGBUILD
@@ -4,7 +4,7 @@ _realname=dateutil
 _pyname=python-dateutil
 pkgbase=mingw-w64-python-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-python2-$_realname" "${MINGW_PACKAGE_PREFIX}-python3-$_realname")
-pkgver=2.7.5
+pkgver=2.8.0
 pkgrel=1
 pkgdesc="Provides powerful extensions to the standard datetime module (mingw-w64)"
 arch=('any')
@@ -24,8 +24,8 @@ checkdepends=("${MINGW_PACKAGE_PREFIX}-python2-pytest"
               "${MINGW_PACKAGE_PREFIX}-python3-hypothesis")
 source=("${_realname}-${pkgver}.tar.gz"::"https://files.pythonhosted.org/packages/source/${_pyname:0:1}/${_pyname}/${_pyname}-${pkgver}.tar.gz"{,.asc})
 validpgpkeys=("6B49ACBADCF6BD1CA20667ABCD54FCE3D964BEFB")
-sha256sums=('88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02'
-            '88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02')
+sha256sums=('c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e'
+            'c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e')
 
 prepare() {
   cd "${srcdir}"


### PR DESCRIPTION
This updates python-dateutil to 2.8.0.