### PR TITLE
libgphoto2: move libtool to depends

### DIFF
--- a/mingw-w64-libgphoto2/PKGBUILD
+++ b/mingw-w64-libgphoto2/PKGBUILD
@@ -4,7 +4,7 @@ _realname=libgphoto2
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=2.5.21
-pkgrel=1
+pkgrel=2
 pkgdesc="libgphoto2 is a free, redistributable, ready to use set of digital camera software applications for Unix-like system (mingw-w64)"
 arch=('any')
 url="http://gphoto.org/proj/libgphoto2/"
@@ -14,9 +14,9 @@ depends=("${MINGW_PACKAGE_PREFIX}-libsystre"
          "${MINGW_PACKAGE_PREFIX}-libxml2"
          "${MINGW_PACKAGE_PREFIX}-libgd"
          "${MINGW_PACKAGE_PREFIX}-libexif"
-         "${MINGW_PACKAGE_PREFIX}-libusb")
-makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
-             "${MINGW_PACKAGE_PREFIX}-libtool")
+         "${MINGW_PACKAGE_PREFIX}-libusb"
+         "${MINGW_PACKAGE_PREFIX}-libtool")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc")
 source=(https://sourceforge.net/projects/gphoto/files/libgphoto/${pkgver}/${_realname}-${pkgver}.tar.gz
         libgphoto2-gp_system_filename-fix.patch
         libgphoto2-use-pkg-config-for-gd.patch) 


### PR DESCRIPTION
Fixes #4951
Pls note you need doxygen doxygen-1.8.14-3 to build it, building with later/current version of doxygen fails.