### PR TITLE
poppler - 0.74.0 - Update to latest version

### DIFF
--- a/mingw-w64-poppler/PKGBUILD
+++ b/mingw-w64-poppler/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=poppler
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.73.0
+pkgver=0.74.0
 pkgrel=1
 pkgdesc="PDF rendering library based on xpdf 3.0 (mingw-w64)"
 arch=('any')
@@ -14,7 +14,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-glib2"
              "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             "${MINGW_PACKAGE_PREFIX}-qt5")
+             "${MINGW_PACKAGE_PREFIX}-qt5"
+             'git')
 depends=("${MINGW_PACKAGE_PREFIX}-cairo"
          "${MINGW_PACKAGE_PREFIX}-curl"
          "${MINGW_PACKAGE_PREFIX}-freetype"
@@ -30,8 +31,10 @@ depends=("${MINGW_PACKAGE_PREFIX}-cairo"
 optdepends=("${MINGW_PACKAGE_PREFIX}-glib2: libpoppler-glib"
             "${MINGW_PACKAGE_PREFIX}-qt5: libpoppler-qt5")
 options=('strip' 'staticlibs')
-source=("https://poppler.freedesktop.org/${_realname}-${pkgver}.tar.xz")
-sha256sums=('e44b5543903128884ba4538c2a97d3bcc8889e97ffacc4636112101f0238db03')
+source=("https://poppler.freedesktop.org/${_realname}-${pkgver}.tar.xz"
+        "test::git+https://anongit.freedesktop.org/git/poppler/test/#commit=45f55f1e03b9bf3fbd334c31776b6f5e472889ec")
+sha256sums=('92e09fd3302567fd36146b36bb707db43ce436e8841219025a82ea9fb0076b2f'
+            'SKIP')
 
 prepare() {
   cd ${_realname}-${pkgver}
@@ -46,12 +49,33 @@ build() {
     -G"MSYS Makefiles" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+    -DSPLASH_CMYK=ON \
+    -DENABLE_GLIB=ON \
+    -DENABLE_GOBJECT_INTROSPECTION=ON \
+    -DENABLE_CPP=ON \
+    -DENABLE_DCTDECODER=libjpeg \
+    -DENABLE_LIBOPENJPEG=openjpeg2 \
+    -DENABLE_CMS=lcms2 \
+    -DENABLE_NSS3=ON \
+    -DENABLE_UTILS=ON \
+    -DENABLE_LIBCURL=ON \
+    -DENABLE_ZLIB=ON \
+    -DENABLE_ZLIB_UNCOMPRESS=OFF \
     -DENABLE_GTK_DOC=OFF \
     ../${_realname}-${pkgver}
 
   CC="${MINGW_PREFIX}/bin/gcc.exe" \
   PKG_CONFIG_PATH=${MINGW_PREFIX}/lib/pkgconfig \
   make
+}
+
+check() {
+  cd ${srcdir}/build-${MINGW_CHOST}
+  cp libpoppler-85.dll qt5/tests
+  cp cpp/libpoppler-cpp-0.dll qt5/tests
+  cp qt5/src/libpoppler-qt5-1.dll qt5/tests
+
+  make test
 }
 
 package() {


### PR DESCRIPTION
download and run tests for poppler - passed at 100%
Set option SPLASH_CMYK
clarrified other CMake options for maintainence reasons