### PR TITLE
gcc-git: Update filesystem patch.

### DIFF
--- a/mingw-w64-gcc-git/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
+++ b/mingw-w64-gcc-git/0019-gcc-8-branch-Backport-patches-for-std-filesystem-from-master.patch
@@ -1,4 +1,4 @@
-From 8e4be0e087603f2a9aa24d9dbbc7aa2c0fdf838a Mon Sep 17 00:00:00 2001
+From eda88e06651c9293012212b665ca592c85bef645 Mon Sep 17 00:00:00 2001
 From: Liu Hao <lh_mouse@126.com>
 Date: Sat, 26 Jan 2019 15:14:38 +0800
 Subject: [PATCH] Backport patches for std::filesystem from master.
@@ -15,25 +15,25 @@ modification.
 Signed-off-by: Liu Hao <lh_mouse@126.com>
 ---
  libstdc++-v3/config.h.in                      |  12 +
- libstdc++-v3/config/io/basic_file_stdio.cc    |  33 +++
+ libstdc++-v3/config/io/basic_file_stdio.cc    |  33 ++
  libstdc++-v3/config/io/basic_file_stdio.h     |   5 +
- libstdc++-v3/configure                        |  35 +++
+ libstdc++-v3/configure                        |  35 ++
  libstdc++-v3/configure.ac                     |   2 +
  libstdc++-v3/crossconfig.m4                   |   1 +
- libstdc++-v3/include/bits/fs_dir.h            |   5 +-
- libstdc++-v3/include/bits/fs_path.h           | 250 +++++++++--------
- libstdc++-v3/include/bits/fstream.tcc         |  36 +++
- .../include/experimental/bits/fs_path.h       |  74 ++---
- libstdc++-v3/include/std/fstream              | 119 ++++++++
- libstdc++-v3/src/filesystem/dir-common.h      |  56 +++-
+ libstdc++-v3/include/bits/fs_dir.h            |  14 +-
+ libstdc++-v3/include/bits/fs_path.h           | 250 +++++++-------
+ libstdc++-v3/include/bits/fstream.tcc         |  36 ++
+ .../include/experimental/bits/fs_path.h       |  74 ++--
+ libstdc++-v3/include/std/fstream              | 119 +++++++
+ libstdc++-v3/src/filesystem/dir-common.h      |  56 ++-
  libstdc++-v3/src/filesystem/dir.cc            |   5 +-
- libstdc++-v3/src/filesystem/ops-common.h      | 105 ++++++-
- libstdc++-v3/src/filesystem/ops.cc            | 154 ++++++-----
+ libstdc++-v3/src/filesystem/ops-common.h      | 105 +++++-
+ libstdc++-v3/src/filesystem/ops.cc            | 186 +++++-----
  libstdc++-v3/src/filesystem/path.cc           |  24 +-
  libstdc++-v3/src/filesystem/std-dir.cc        |   5 +-
- libstdc++-v3/src/filesystem/std-ops.cc        | 260 ++++++++++++------
- libstdc++-v3/src/filesystem/std-path.cc       | 114 +++++---
- 19 files changed, 926 insertions(+), 369 deletions(-)
+ libstdc++-v3/src/filesystem/std-ops.cc        | 318 ++++++++++--------
+ libstdc++-v3/src/filesystem/std-path.cc       | 123 ++++---
+ 19 files changed, 942 insertions(+), 461 deletions(-)
 
 diff --git a/libstdc++-v3/config.h.in b/libstdc++-v3/config.h.in
 index 765cedc6edf..3fb685ce9aa 100644
@@ -232,10 +232,26 @@ index cb6e3afff3d..669d87f7602 100644
    *-netbsd*)
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
 diff --git a/libstdc++-v3/include/bits/fs_dir.h b/libstdc++-v3/include/bits/fs_dir.h
-index c8c1e5e5bef..6b332e171cf 100644
+index 9ee1cb66b61..6b332e171cf 100644
 --- a/libstdc++-v3/include/bits/fs_dir.h
 +++ b/libstdc++-v3/include/bits/fs_dir.h
-@@ -313,10 +313,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -138,13 +138,8 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+       refresh(__ec);
+     }
+ 
+-    void
+-    refresh()
+-    { _M_type = symlink_status().type(); }
+-
+-    void
+-    refresh(error_code& __ec) noexcept
+-    { _M_type = symlink_status(__ec).type(); }
++    void refresh() { _M_type = symlink_status().type(); }
++    void refresh(error_code& __ec) { _M_type = symlink_status(__ec).type(); }
+ 
+     // observers
+     const filesystem::path& path() const noexcept { return _M_path; }
+@@ -318,10 +313,7 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
      _M_file_type(error_code& __ec) const noexcept
      {
        if (_M_type != file_type::none && _M_type != file_type::symlink)
@@ -1298,7 +1314,7 @@ index bc186836bd4..c1b817189a9 100644
      else if (S_ISSOCK(st.st_mode))
        return file_type::socket;
 diff --git a/libstdc++-v3/src/filesystem/ops.cc b/libstdc++-v3/src/filesystem/ops.cc
-index 4a9e265d1d6..40cadbf6270 100644
+index de290625e54..40cadbf6270 100644
 --- a/libstdc++-v3/src/filesystem/ops.cc
 +++ b/libstdc++-v3/src/filesystem/ops.cc
 @@ -47,20 +47,17 @@
@@ -1380,7 +1396,64 @@ index 4a9e265d1d6..40cadbf6270 100644
      {
        if (!is_not_found_errno(errno))
  	{
-@@ -459,8 +458,8 @@ namespace
+@@ -424,19 +423,6 @@ fs::create_directories(const path& p, error_code& ec) noexcept
+       ec = std::make_error_code(errc::invalid_argument);
+       return false;
+     }
+-
+-  file_status st = symlink_status(p, ec);
+-  if (is_directory(st))
+-    return false;
+-  else if (ec && !status_known(st))
+-    return false;
+-  else if (exists(st))
+-    {
+-      if (!ec)
+-	ec = std::make_error_code(std::errc::not_a_directory);
+-      return false;
+-    }
+-
+   std::stack<path> missing;
+   path pp = p;
+ 
+@@ -445,29 +431,24 @@ fs::create_directories(const path& p, error_code& ec) noexcept
+       ec.clear();
+       const auto& filename = pp.filename();
+       if (!is_dot(filename) && !is_dotdot(filename))
+-	{
+-	  missing.push(std::move(pp));
+-	  pp = missing.top().parent_path();
+-	}
+-      else
+-	pp = pp.parent_path();
++	missing.push(pp);
++      pp.remove_filename();
+     }
+ 
+   if (ec || missing.empty())
+     return false;
+ 
+-  bool created;
+   do
+     {
+       const path& top = missing.top();
+-      created = create_directory(top, ec);
+-      if (ec)
+-	return false;
++      create_directory(top, ec);
++      if (ec && is_directory(top))
++	ec.clear();
+       missing.pop();
+     }
+-  while (!missing.empty());
++  while (!missing.empty() && !ec);
+ 
+-  return created;
++  return missing.empty();
+ }
+ 
+ namespace
+@@ -477,8 +458,8 @@ namespace
    {
      bool created = false;
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
@@ -1391,7 +1464,7 @@ index 4a9e265d1d6..40cadbf6270 100644
        {
  	const int err = errno;
  	if (err != EEXIST || !is_directory(p, ec))
-@@ -513,7 +512,7 @@ fs::create_directory(const path& p, const path& attributes,
+@@ -531,7 +512,7 @@ fs::create_directory(const path& p, const path& attributes,
  {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
    stat_type st;
@@ -1400,7 +1473,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      {
        ec.assign(errno, std::generic_category());
        return false;
-@@ -562,11 +561,16 @@ void
+@@ -580,11 +561,16 @@ void
  fs::create_hard_link(const path& to, const path& new_hard_link,
  		     error_code& ec) noexcept
  {
@@ -1418,7 +1491,7 @@ index 4a9e265d1d6..40cadbf6270 100644
  #else
    ec = std::make_error_code(std::errc::not_supported);
  #endif
-@@ -586,7 +590,7 @@ void
+@@ -604,7 +590,7 @@ void
  fs::create_symlink(const path& to, const path& new_symlink,
  		   error_code& ec) noexcept
  {
@@ -1427,7 +1500,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    if (::symlink(to.c_str(), new_symlink.c_str()))
      ec.assign(errno, std::generic_category());
    else
-@@ -596,7 +600,6 @@ fs::create_symlink(const path& to, const path& new_symlink,
+@@ -614,7 +600,6 @@ fs::create_symlink(const path& to, const path& new_symlink,
  #endif
  }
  
@@ -1435,7 +1508,7 @@ index 4a9e265d1d6..40cadbf6270 100644
  fs::path
  fs::current_path()
  {
-@@ -612,8 +615,8 @@ fs::current_path(error_code& ec)
+@@ -630,8 +615,8 @@ fs::current_path(error_code& ec)
  {
    path p;
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -1446,7 +1519,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      {
        p.assign(cwd.get());
        ec.clear();
-@@ -621,6 +624,7 @@ fs::current_path(error_code& ec)
+@@ -639,6 +624,7 @@ fs::current_path(error_code& ec)
    else
      ec.assign(errno, std::generic_category());
  #else
@@ -1454,7 +1527,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    long path_max = pathconf(".", _PC_PATH_MAX);
    size_t size;
    if (path_max == -1)
-@@ -629,9 +633,15 @@ fs::current_path(error_code& ec)
+@@ -647,9 +633,15 @@ fs::current_path(error_code& ec)
        size = 10240;
    else
        size = path_max;
@@ -1471,7 +1544,7 @@ index 4a9e265d1d6..40cadbf6270 100644
        if (buf)
  	{
  	  if (getcwd(buf.get(), size))
-@@ -671,7 +681,7 @@ void
+@@ -689,7 +681,7 @@ void
  fs::current_path(const path& p, error_code& ec) noexcept
  {
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -1480,7 +1553,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -698,14 +708,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
+@@ -716,14 +708,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
    int err = 0;
    file_status s1, s2;
    stat_type st1, st2;
@@ -1497,7 +1570,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      s2 = make_file_status(st2);
    else if (is_not_found_errno(errno))
      s2.type(file_type::not_found);
-@@ -755,7 +765,7 @@ namespace
+@@ -773,7 +765,7 @@ namespace
      {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
        stat_type st;
@@ -1506,7 +1579,7 @@ index 4a9e265d1d6..40cadbf6270 100644
  	{
  	  ec.assign(errno, std::generic_category());
  	  return deflt;
-@@ -805,7 +815,7 @@ fs::hard_link_count(const path& p)
+@@ -823,7 +815,7 @@ fs::hard_link_count(const path& p)
  std::uintmax_t
  fs::hard_link_count(const path& p, error_code& ec) noexcept
  {
@@ -1515,7 +1588,7 @@ index 4a9e265d1d6..40cadbf6270 100644
  		 static_cast<uintmax_t>(-1));
  }
  
-@@ -881,11 +891,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
+@@ -899,11 +891,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
    else
      ec.clear();
  #elif _GLIBCXX_HAVE_UTIME_H
@@ -1529,7 +1602,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -938,7 +948,7 @@ fs::permissions(const path& p, perms prms, error_code& ec) noexcept
+@@ -956,7 +948,7 @@ fs::permissions(const path& p, perms prms, error_code& ec) noexcept
  #else
    if (nofollow && is_symlink(st))
      ec = std::make_error_code(std::errc::operation_not_supported);
@@ -1538,7 +1611,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      err = errno;
  #endif
  
-@@ -958,10 +968,10 @@ fs::read_symlink(const path& p)
+@@ -976,10 +968,10 @@ fs::read_symlink(const path& p)
    return tgt;
  }
  
@@ -1551,7 +1624,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    stat_type st;
    if (::lstat(p.c_str(), &st))
      {
-@@ -1015,6 +1025,19 @@ fs::remove(const path& p)
+@@ -1033,6 +1025,19 @@ fs::remove(const path& p)
  bool
  fs::remove(const path& p, error_code& ec) noexcept
  {
@@ -1571,7 +1644,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    if (::remove(p.c_str()) == 0)
      {
        ec.clear();
-@@ -1024,6 +1047,7 @@ fs::remove(const path& p, error_code& ec) noexcept
+@@ -1042,6 +1047,7 @@ fs::remove(const path& p, error_code& ec) noexcept
      ec.clear();
    else
      ec.assign(errno, std::generic_category());
@@ -1579,7 +1652,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    return false;
  }
  
-@@ -1077,7 +1101,7 @@ fs::rename(const path& from, const path& to)
+@@ -1095,7 +1101,7 @@ fs::rename(const path& from, const path& to)
  void
  fs::rename(const path& from, const path& to, error_code& ec) noexcept
  {
@@ -1588,7 +1661,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1098,7 +1122,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
+@@ -1116,7 +1122,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
  #ifdef _GLIBCXX_HAVE_UNISTD_H
    if (size > static_cast<uintmax_t>(std::numeric_limits<off_t>::max()))
      ec.assign(EINVAL, std::generic_category());
@@ -1597,7 +1670,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1126,23 +1150,14 @@ fs::space(const path& p, error_code& ec) noexcept
+@@ -1144,23 +1150,14 @@ fs::space(const path& p, error_code& ec) noexcept
      static_cast<uintmax_t>(-1),
      static_cast<uintmax_t>(-1)
    };
@@ -1627,7 +1700,7 @@ index 4a9e265d1d6..40cadbf6270 100644
    return info;
  }
  
-@@ -1152,7 +1167,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
+@@ -1170,7 +1167,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
  {
    file_status status;
    stat_type st;
@@ -1636,7 +1709,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      {
        int err = errno;
        ec.assign(err, std::generic_category());
-@@ -1176,7 +1191,7 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
+@@ -1194,7 +1191,7 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
  {
    file_status status;
    stat_type st;
@@ -1645,7 +1718,7 @@ index 4a9e265d1d6..40cadbf6270 100644
      {
        int err = errno;
        ec.assign(err, std::generic_category());
-@@ -1251,27 +1266,38 @@ fs::path fs::temp_directory_path()
+@@ -1269,27 +1266,38 @@ fs::path fs::temp_directory_path()
  
  fs::path fs::temp_directory_path(error_code& ec)
  {
@@ -1802,7 +1875,7 @@ index 98eb22ab920..4c9a287ad80 100644
        if (ecptr)
  	ecptr->clear();
 diff --git a/libstdc++-v3/src/filesystem/std-ops.cc b/libstdc++-v3/src/filesystem/std-ops.cc
-index 74868cd48e6..e266fa6d3f8 100644
+index c0742d73b5c..e266fa6d3f8 100644
 --- a/libstdc++-v3/src/filesystem/std-ops.cc
 +++ b/libstdc++-v3/src/filesystem/std-ops.cc
 @@ -25,6 +25,7 @@
@@ -1846,29 +1919,27 @@ index 74868cd48e6..e266fa6d3f8 100644
    return ret;
  #else
    return current_path() / p;
-@@ -84,13 +82,37 @@ fs::absolute(const path& p)
- fs::path
- fs::absolute(const path& p, error_code& ec)
- {
-+  path ret;
-+  if (p.empty())
-+    {
-+      ec = make_error_code(std::errc::no_such_file_or_directory);
-+      return ret;
-+    }
- #ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
--  ec = std::make_error_code(errc::not_supported);
--  return {};
+@@ -90,17 +88,28 @@ fs::absolute(const path& p, error_code& ec)
+       ec = make_error_code(std::errc::no_such_file_or_directory);
+       return ret;
+     }
+-  if (p.is_absolute())
++#ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
 +  const wstring& s = p.native();
 +  uint32_t len = 1024;
 +  wstring buf;
 +  do
-+    {
+     {
+-      ec.clear();
+-      ret = p;
+-      return ret;
 +      buf.resize(len);
 +      len = GetFullPathNameW(s.c_str(), len, buf.data(), nullptr);
-+    }
+     }
 +  while (len > buf.size());
-+
+ 
+-#ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
+-  ec = std::make_error_code(errc::not_supported);
 +  if (len == 0)
 +    ec.assign((int)GetLastError(), std::system_category());
 +  else
@@ -1878,16 +1949,13 @@ index 74868cd48e6..e266fa6d3f8 100644
 +      ret = std::move(buf);
 +    }
  #else
-   ec.clear();
--  return current_path() / p;
+-  ret = current_path(ec);
++  ec.clear();
 +  ret = current_path();
-+  ret /= p;
+   ret /= p;
  #endif
-+  return ret;
- }
- 
- namespace
-@@ -118,7 +140,7 @@ namespace
+   return ret;
+@@ -131,7 +140,7 @@ namespace
      void operator()(void* p) const { ::free(p); }
    };
  
@@ -1896,7 +1964,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  }
  
  fs::path
-@@ -133,7 +155,8 @@ fs::canonical(const path& p, error_code& ec)
+@@ -146,7 +155,8 @@ fs::canonical(const path& p, error_code& ec)
    char_ptr buf{ nullptr };
  # if _XOPEN_VERSION < 700
    // Not safe to call realpath(path, NULL)
@@ -1906,7 +1974,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  # endif
    if (char* rp = ::realpath(pa.c_str(), buf.get()))
      {
-@@ -254,7 +277,7 @@ namespace std::filesystem
+@@ -267,7 +277,7 @@ namespace std::filesystem
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
  #ifdef NEED_DO_COPY_FILE
  bool
@@ -1915,7 +1983,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  		 copy_options_existing_file options,
  		 stat_type* from_st, stat_type* to_st,
  		 std::error_code& ec) noexcept
-@@ -264,7 +287,7 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -277,7 +287,7 @@ fs::do_copy_file(const char* from, const char* to,
  
    if (to_st == nullptr)
      {
@@ -1924,7 +1992,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  	{
  	  const int err = errno;
  	  if (!is_not_found_errno(err))
-@@ -286,7 +309,7 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -299,7 +309,7 @@ fs::do_copy_file(const char* from, const char* to,
  
    if (from_st == nullptr)
      {
@@ -1933,7 +2001,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  	{
  	  ec.assign(errno, std::generic_category());
  	  return false;
-@@ -344,12 +367,12 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -357,12 +367,12 @@ fs::do_copy_file(const char* from, const char* to,
      }
  
    struct CloseFD {
@@ -1949,7 +2017,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    if (in.fd == -1)
      {
        ec.assign(errno, std::generic_category());
-@@ -360,7 +383,7 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -373,7 +383,7 @@ fs::do_copy_file(const char* from, const char* to,
      oflag |= O_TRUNC;
    else
      oflag |= O_EXCL;
@@ -1958,7 +2026,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    if (out.fd == -1)
      {
        if (errno == EEXIST && options.skip)
-@@ -370,12 +393,12 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -383,12 +393,12 @@ fs::do_copy_file(const char* from, const char* to,
        return false;
      }
  
@@ -1974,7 +2042,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  #endif
      {
        ec.assign(errno, std::generic_category());
-@@ -383,7 +406,7 @@ fs::do_copy_file(const char* from, const char* to,
+@@ -396,7 +406,7 @@ fs::do_copy_file(const char* from, const char* to,
      }
  
    size_t count = from_st->st_size;
@@ -1983,7 +2051,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    off_t offset = 0;
    ssize_t n = ::sendfile(out.fd, in.fd, &offset, count);
    if (n < 0 && errno != ENOSYS && errno != EINVAL)
-@@ -462,15 +485,15 @@ fs::copy(const path& from, const path& to, copy_options options,
+@@ -475,15 +485,15 @@ fs::copy(const path& from, const path& to, copy_options options,
    // _GLIBCXX_RESOLVE_LIB_DEFECTS
    // 2681. filesystem::copy() cannot copy symlinks
    if (use_lstat || copy_symlinks
@@ -2003,7 +2071,98 @@ index 74868cd48e6..e266fa6d3f8 100644
      {
        if (!is_not_found_errno(errno))
  	{
-@@ -664,8 +687,9 @@ namespace
+@@ -636,74 +646,38 @@ fs::create_directories(const path& p, error_code& ec)
+       ec = std::make_error_code(errc::invalid_argument);
+       return false;
+     }
+-
+-  file_status st = symlink_status(p, ec);
+-  if (is_directory(st))
+-    return false;
+-  else if (ec && !status_known(st))
+-    return false;
+-  else if (exists(st))
+-    {
+-      if (!ec)
+-	ec = std::make_error_code(std::errc::not_a_directory);
+-      return false;
+-    }
+-
+   std::stack<path> missing;
+   path pp = p;
+ 
+-  // Strip any trailing slash
+-  if (pp.has_relative_path() && !pp.has_filename())
+-    pp = pp.parent_path();
+-
+-  do
++  while (pp.has_filename() && status(pp, ec).type() == file_type::not_found)
+     {
++      ec.clear();
+       const auto& filename = pp.filename();
+-      if (is_dot(filename) || is_dotdot(filename))
+-	pp = pp.parent_path();
+-      else
+-	{
+-	  missing.push(std::move(pp));
+-	  if (missing.size() > 1000) // sanity check
+-	    {
+-	      ec = std::make_error_code(std::errc::filename_too_long);
+-	      return false;
+-	    }
+-	  pp = missing.top().parent_path();
+-	}
++      if (!is_dot(filename) && !is_dotdot(filename))
++	missing.push(pp);
++      pp = pp.parent_path();
+ 
+-      if (pp.empty())
+-	break;
+-
+-      st = status(pp, ec);
+-      if (exists(st))
++      if (missing.size() > 1000) // sanity check
+ 	{
+-	  if (ec)
+-	    return false;
+-	  if (!is_directory(st))
+-	    {
+-	      ec = std::make_error_code(std::errc::not_a_directory);
+-	      return false;
+-	    }
++	  ec = std::make_error_code(std::errc::filename_too_long);
++	  return false;
+ 	}
+-
+-      if (ec && exists(st))
+-	return false;
+     }
+-  while (st.type() == file_type::not_found);
+ 
+-  bool created;
++  if (ec || missing.empty())
++    return false;
++
+   do
+     {
+       const path& top = missing.top();
+-      created = create_directory(top, ec);
+-      if (ec)
+-	return false;
++      create_directory(top, ec);
++      if (ec && is_directory(top))
++	ec.clear();
+       missing.pop();
+     }
+-  while (!missing.empty());
++  while (!missing.empty() && !ec);
+ 
+-  return created;
++  return missing.empty();
+ }
+ 
+ namespace
+@@ -713,8 +687,9 @@ namespace
    {
      bool created = false;
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
@@ -2015,7 +2174,7 @@ index 74868cd48e6..e266fa6d3f8 100644
        {
  	const int err = errno;
  	if (err != EEXIST || !is_directory(p, ec))
-@@ -718,7 +742,7 @@ fs::create_directory(const path& p, const path& attributes,
+@@ -767,7 +742,7 @@ fs::create_directory(const path& p, const path& attributes,
  {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
    stat_type st;
@@ -2024,7 +2183,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      {
        ec.assign(errno, std::generic_category());
        return false;
-@@ -760,18 +784,23 @@ fs::create_hard_link(const path& to, const path& new_hard_link)
+@@ -809,18 +784,23 @@ fs::create_hard_link(const path& to, const path& new_hard_link)
    create_hard_link(to, new_hard_link, ec);
    if (ec)
      _GLIBCXX_THROW_OR_ABORT(filesystem_error("cannot create hard link",
@@ -2050,7 +2209,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  #else
    ec = std::make_error_code(std::errc::not_supported);
  #endif
-@@ -791,7 +820,7 @@ void
+@@ -840,7 +820,7 @@ void
  fs::create_symlink(const path& to, const path& new_symlink,
  		   error_code& ec) noexcept
  {
@@ -2059,7 +2218,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    if (::symlink(to.c_str(), new_symlink.c_str()))
      ec.assign(errno, std::generic_category());
    else
-@@ -817,8 +846,8 @@ fs::current_path(error_code& ec)
+@@ -866,8 +846,8 @@ fs::current_path(error_code& ec)
  {
    path p;
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -2070,7 +2229,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      {
        p.assign(cwd.get());
        ec.clear();
-@@ -826,6 +855,7 @@ fs::current_path(error_code& ec)
+@@ -875,6 +855,7 @@ fs::current_path(error_code& ec)
    else
      ec.assign(errno, std::generic_category());
  #else
@@ -2078,7 +2237,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    long path_max = pathconf(".", _PC_PATH_MAX);
    size_t size;
    if (path_max == -1)
-@@ -834,9 +864,15 @@ fs::current_path(error_code& ec)
+@@ -883,9 +864,15 @@ fs::current_path(error_code& ec)
        size = 10240;
    else
        size = path_max;
@@ -2095,7 +2254,7 @@ index 74868cd48e6..e266fa6d3f8 100644
        if (buf)
  	{
  	  if (getcwd(buf.get(), size))
-@@ -876,7 +912,7 @@ void
+@@ -925,7 +912,7 @@ void
  fs::current_path(const path& p, error_code& ec) noexcept
  {
  #ifdef _GLIBCXX_HAVE_UNISTD_H
@@ -2104,7 +2263,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -903,14 +939,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
+@@ -952,14 +939,14 @@ fs::equivalent(const path& p1, const path& p2, error_code& ec) noexcept
    int err = 0;
    file_status s1, s2;
    stat_type st1, st2;
@@ -2121,7 +2280,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      s2 = make_file_status(st2);
    else if (is_not_found_errno(errno))
      s2.type(file_type::not_found);
-@@ -959,8 +995,8 @@ namespace
+@@ -1008,8 +995,8 @@ namespace
      do_stat(const fs::path& p, std::error_code& ec, Accessor f, T deflt)
      {
  #ifdef _GLIBCXX_HAVE_SYS_STAT_H
@@ -2132,7 +2291,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  	{
  	  ec.assign(errno, std::generic_category());
  	  return deflt;
-@@ -1010,7 +1046,7 @@ fs::hard_link_count(const path& p)
+@@ -1059,7 +1046,7 @@ fs::hard_link_count(const path& p)
  std::uintmax_t
  fs::hard_link_count(const path& p, error_code& ec) noexcept
  {
@@ -2141,7 +2300,7 @@ index 74868cd48e6..e266fa6d3f8 100644
  		 static_cast<uintmax_t>(-1));
  }
  
-@@ -1086,11 +1122,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
+@@ -1135,11 +1122,11 @@ fs::last_write_time(const path& p __attribute__((__unused__)),
    else
      ec.clear();
  #elif _GLIBCXX_HAVE_UTIME_H
@@ -2155,7 +2314,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1145,7 +1181,7 @@ fs::permissions(const path& p, perms prms, perm_options opts,
+@@ -1194,7 +1181,7 @@ fs::permissions(const path& p, perms prms, perm_options opts,
  #else
    if (nofollow && is_symlink(st))
      ec = std::make_error_code(std::errc::operation_not_supported);
@@ -2164,7 +2323,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      err = errno;
  #endif
  
-@@ -1185,10 +1221,10 @@ fs::read_symlink(const path& p)
+@@ -1234,10 +1221,10 @@ fs::read_symlink(const path& p)
    return tgt;
  }
  
@@ -2177,7 +2336,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    stat_type st;
    if (::lstat(p.c_str(), &st))
      {
-@@ -1261,6 +1297,19 @@ fs::remove(const path& p)
+@@ -1310,6 +1297,19 @@ fs::remove(const path& p)
  bool
  fs::remove(const path& p, error_code& ec) noexcept
  {
@@ -2197,7 +2356,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    if (::remove(p.c_str()) == 0)
      {
        ec.clear();
-@@ -1270,6 +1319,7 @@ fs::remove(const path& p, error_code& ec) noexcept
+@@ -1319,6 +1319,7 @@ fs::remove(const path& p, error_code& ec) noexcept
      ec.clear();
    else
      ec.assign(errno, std::generic_category());
@@ -2205,7 +2364,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    return false;
  }
  
-@@ -1323,7 +1373,7 @@ fs::rename(const path& from, const path& to)
+@@ -1372,7 +1373,7 @@ fs::rename(const path& from, const path& to)
  void
  fs::rename(const path& from, const path& to, error_code& ec) noexcept
  {
@@ -2214,7 +2373,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1344,7 +1394,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
+@@ -1393,7 +1394,7 @@ fs::resize_file(const path& p, uintmax_t size, error_code& ec) noexcept
  #ifdef _GLIBCXX_HAVE_UNISTD_H
    if (size > static_cast<uintmax_t>(std::numeric_limits<off_t>::max()))
      ec.assign(EINVAL, std::generic_category());
@@ -2223,7 +2382,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      ec.assign(errno, std::generic_category());
    else
      ec.clear();
-@@ -1364,31 +1414,67 @@ fs::space(const path& p)
+@@ -1413,31 +1414,67 @@ fs::space(const path& p)
    return s;
  }
  
@@ -2264,8 +2423,8 @@ index 74868cd48e6..e266fa6d3f8 100644
 +	  if (f.f_bavail != unknown)
 +	    available = f.f_bavail * fragment_size;
 +	}
-+      ec.clear();
-+    }
+       ec.clear();
+     }
 +#elif _GLIBCXX_FILESYSTEM_IS_WINDOWS
 +  ULARGE_INTEGER bytes_avail = {}, bytes_total = {}, bytes_free = {};
 +  if (GetDiskFreeSpaceExW(pathname, &bytes_avail, &bytes_total, &bytes_free))
@@ -2276,8 +2435,8 @@ index 74868cd48e6..e266fa6d3f8 100644
 +	free = bytes_free.QuadPart;
 +      if (bytes_avail.QuadPart != 0)
 +	available = bytes_avail.QuadPart;
-       ec.clear();
-     }
++      ec.clear();
++    }
 +  else
 +    ec.assign((int)GetLastError(), std::system_category());
  #else
@@ -2305,7 +2464,7 @@ index 74868cd48e6..e266fa6d3f8 100644
    return info;
  }
  
-@@ -1398,7 +1484,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
+@@ -1447,7 +1484,7 @@ fs::status(const fs::path& p, error_code& ec) noexcept
  {
    file_status status;
    stat_type st;
@@ -2314,7 +2473,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      {
        int err = errno;
        ec.assign(err, std::generic_category());
-@@ -1422,7 +1508,7 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
+@@ -1471,7 +1508,7 @@ fs::symlink_status(const fs::path& p, std::error_code& ec) noexcept
  {
    file_status status;
    stat_type st;
@@ -2323,7 +2482,7 @@ index 74868cd48e6..e266fa6d3f8 100644
      {
        int err = errno;
        ec.assign(err, std::generic_category());
-@@ -1469,28 +1555,39 @@ fs::path fs::temp_directory_path()
+@@ -1518,28 +1555,39 @@ fs::path fs::temp_directory_path()
  
  fs::path fs::temp_directory_path(error_code& ec)
  {
@@ -2376,27 +2535,8 @@ index 74868cd48e6..e266fa6d3f8 100644
  }
  
  fs::path
-@@ -1513,7 +1610,8 @@ fs::weakly_canonical(const path& p)
-       ++iter;
-     }
-   // canonicalize:
--  result = canonical(result);
-+  if (!result.empty())
-+    result = canonical(result);
-   // append the non-existing elements:
-   while (iter != end)
-     result /= *iter++;
-@@ -1551,7 +1649,7 @@ fs::weakly_canonical(const path& p, error_code& ec)
-       ++iter;
-     }
-   // canonicalize:
--  if (!ec)
-+  if (!ec && !result.empty())
-     result = canonical(result, ec);
-   if (ec)
-     result.clear();
 diff --git a/libstdc++-v3/src/filesystem/std-path.cc b/libstdc++-v3/src/filesystem/std-path.cc
-index b4ab921ff21..f6c0b8bb0f6 100644
+index c5bf8099036..f6c0b8bb0f6 100644
 --- a/libstdc++-v3/src/filesystem/std-path.cc
 +++ b/libstdc++-v3/src/filesystem/std-path.cc
 @@ -38,6 +38,66 @@ fs::filesystem_error::~filesystem_error() = default;
@@ -2479,7 +2619,18 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  path&
  path::replace_extension(const path& replacement)
  {
-@@ -94,8 +160,8 @@ path::replace_extension(const path& replacement)
+@@ -85,18 +151,17 @@ path::replace_extension(const path& replacement)
+ 	_M_pathname.erase(ext.second);
+       else
+ 	{
+-	  auto& back = _M_cmpts.back();
++	  const auto& back = _M_cmpts.back();
+ 	  if (ext.first != &back._M_pathname)
+ 	    _GLIBCXX_THROW_OR_ABORT(
+ 		std::logic_error("path::replace_extension failed"));
+-	  back._M_pathname.erase(ext.second);
+ 	  _M_pathname.erase(back._M_pos + ext.second);
+ 	}
      }
     // If replacement is not empty and does not begin with a dot character,
     // a dot character is appended
@@ -2490,7 +2641,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
    operator+=(replacement);
    return *this;
  }
-@@ -332,11 +398,7 @@ path::has_filename() const
+@@ -333,11 +398,7 @@ path::has_filename() const
  
  namespace
  {
@@ -2503,7 +2654,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  
    inline bool is_dot(const fs::path& path)
    {
-@@ -376,7 +438,7 @@ path::lexically_normal() const
+@@ -377,7 +438,7 @@ path::lexically_normal() const
      {
  #ifdef _GLIBCXX_FILESYSTEM_IS_WINDOWS
        // Replace each slash character in the root-name
@@ -2512,7 +2663,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  	{
  	  string_type s = p.native();
  	  std::replace(s.begin(), s.end(), L'/', L'\\');
-@@ -396,8 +458,7 @@ path::lexically_normal() const
+@@ -397,8 +458,7 @@ path::lexically_normal() const
  	    }
  	  else if (!ret.has_relative_path())
  	    {
@@ -2522,7 +2673,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  		ret /= p;
  	    }
  	  else
-@@ -405,30 +466,15 @@ path::lexically_normal() const
+@@ -406,30 +466,15 @@ path::lexically_normal() const
  	      // Got a path with a relative path (i.e. at least one non-root
  	      // element) and no filename at the end (i.e. empty last element),
  	      // so must have a trailing slash. See what is before it.
@@ -2557,7 +2708,22 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  		ret /= p;
  	    }
  	}
-@@ -501,7 +547,7 @@ path::lexically_proximate(const path& base) const
+@@ -475,12 +520,10 @@ path::lexically_relative(const path& base) const
+       const path& p = *b;
+       if (is_dotdot(p))
+ 	--n;
+-      else if (!p.empty() && !is_dot(p))
++      else if (!is_dot(p))
+ 	++n;
+     }
+-    if (n == 0 && (a == end() || a->empty()))
+-      ret = ".";
+-    else if (n >= 0)
++    if (n >= 0)
+     {
+       const path dotdot("..");
+       while (n--)
+@@ -504,7 +547,7 @@ path::lexically_proximate(const path& base) const
  std::pair<const path::string_type*, std::size_t>
  path::_M_find_extension() const
  {
@@ -2566,7 +2732,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  
    if (_M_type == _Type::_Filename)
      s = &_M_pathname;
-@@ -516,9 +562,9 @@ path::_M_find_extension() const
+@@ -519,9 +562,9 @@ path::_M_find_extension() const
      {
        if (auto sz = s->size())
  	{
@@ -2578,7 +2744,7 @@ index b4ab921ff21..f6c0b8bb0f6 100644
  	  return { s, pos ? pos : string_type::npos };
  	}
      }
-@@ -719,8 +765,8 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
+@@ -722,8 +765,8 @@ _GLIBCXX_BEGIN_NAMESPACE_CXX11
  
    std::string filesystem_error::_M_gen_what()
    {

--- a/mingw-w64-gcc-git/PKGBUILD
+++ b/mingw-w64-gcc-git/PKGBUILD
@@ -70,7 +70,7 @@ sha256sums=('SKIP'
             'c1e271c166de0062092cb61d50977c0e61d75b0ae6fb086cb8bb4da2b3fd18d7'
             'b1c3c20bf501cebbcb02b4a50f117a4f90eb4fb79eac7aa99c85e2c54c106790'
             '33392651e17b81609718873ff32606deee5f3fc5176c197bb96eedc3dada8912'
-            'd03aef0d25cc922dd388e31424a88f92ac1b83ad05d92a700e3b9f7220da17c2')
+            'bf83cbc79de4c86f02664c8a624e26b12f570e3c31116fc7c46ecf655696f9a6')
 
 _threads="posix"
 


### PR DESCRIPTION
The upstream code has been rewritten for Windows so this is going to be a huge change.

The patch, as its commit message says, is still generated with the following commands:

```
    git cherry-pick 861db1097d3f 2fd48392d0a4 70fea18e0bbb d4fd5c4964cf
    git checkout master -- libstdc++-v3/src/filesystem/  \
      libstdc++-v3/include/bits/fs_\* libstdc++-v3/include/std/filesystem
```

However, the `git cherry-pick` now results in conflicts. Because all filesystem files will be overwritten by the `git checkout` anyway, the working tree is accepted (despite conflict markers) blindly with `git add -A && git cherry-pick --con`.
