### PR TITLE
libnfs: update to 4.0.0

### DIFF
--- a/mingw-w64-libnfs/2.0.0-no-unefined.patch
+++ b/mingw-w64-libnfs/2.0.0-no-unefined.patch
@@ -13,7 +13,7 @@
 +++ libnfs-libnfs-2.0.0/lib/libnfs-win32.def	2018-05-29 12:56:43.967233400 +0300
 @@ -1,4 +1,4 @@
 -LIBRARY libnfs
-+LIBRARY libnfs-11
++LIBRARY libnfs-13
  EXPORTS
  mount_free_export_list
  mount_getexports

--- a/mingw-w64-libnfs/PKGBUILD
+++ b/mingw-w64-libnfs/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=libnfs
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=3.0.0
+pkgver=4.0.0
 pkgrel=1
 pkgdesc="Client library for accessing NFS shares over a network (mingw-w64)"
 arch=("any")
@@ -14,10 +14,10 @@ source=("https://github.com/sahlberg/libnfs/archive/${_realname}-${pkgver}.tar.g
         2.0.0-win32.patch
         2.0.0-using-gnu-print.patch
         2.0.0-no-unefined.patch)
-sha256sums=('445d92c5fc55e4a5b115e358e60486cf8f87ee50e0103d46a02e7fb4618566a5'
+sha256sums=('6ee77e9fe220e2d3e3b1f53cfea04fb319828cc7dbb97dd9df09e46e901d797d'
             '57375b4a8743c74613b77193035e77adb86386d5a84937f6f4b8e761f172f4a8'
             'b8a3e14cf3be0212c8678ad610c34450a3a908424d1baf8eb43e414b4be783b5'
-            '5780b9c4d462153dfecad6dce12b05725c830eba7c7915915133234dffd6c60a')
+            '2ff5c413351e822d862d9c467b19f097e3d93a23de1a1511abfbb51268f21c25')
 
 prepare() {
   cd ${_realname}-${_realname}-${pkgver}


### PR DESCRIPTION
This updates libnfs to 4.0.0. Executables are also fixed to depend on the current dll version number.