### PR TITLE
pango: fix .pc file missing dependency on gobject

### DIFF
--- a/mingw-w64-pango/0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch
+++ b/mingw-w64-pango/0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch
@@ -1,0 +1,24 @@
+From d0cb6be7431d1a3c711bd45bcf05b34601604037 Mon Sep 17 00:00:00 2001
+From: Tom Schoonjans <tom.schoonjans@diamond.ac.uk>
+Date: Wed, 19 Dec 2018 06:54:41 +0000
+Subject: [PATCH 5/8] pango.pc: Make gobject-2.0 a non-private requirement
+
+---
+ pango/meson.build | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pango/meson.build b/pango/meson.build
+index 099aed89..9dd02bdc 100644
+--- a/pango/meson.build
++++ b/pango/meson.build
+@@ -159,6 +159,7 @@ pkgconfig.generate(libpango,
+   name: 'Pango',
+   description: 'Internationalized text handling',
+   version: meson.project_version(),
++  requires: ['gobject-2.0'],
+   filebase: 'pango',
+   subdirs: pango_api_name,
+   install_dir: join_paths(pango_libdir, 'pkgconfig'),
+-- 
+2.20.1
+

--- a/mingw-w64-pango/PKGBUILD
+++ b/mingw-w64-pango/PKGBUILD
@@ -5,7 +5,7 @@ _realname=pango
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=1.43.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for layout and rendering of text (mingw-w64)"
 arch=('any')
 url="http://www.pango.org"
@@ -26,15 +26,20 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
          "${MINGW_PACKAGE_PREFIX}-libthai")
 options=('staticlibs' 'strip' 'emptydirs')
 source=("https://download.gnome.org/sources/pango/${pkgver:0:4}/${_realname}-${pkgver}.tar.xz"
-        static-skip-help2man.patch)
+        static-skip-help2man.patch
+        0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch)
 sha256sums=('d2c0c253a5328a0eccb00cdd66ce2c8713fabd2c9836000b6e22a8b06ba3ddd2'
-            '0d4bfd80f82969ae555b7bda6905ac413c325457360164fcd404e23278b51e1a')
+            '0d4bfd80f82969ae555b7bda6905ac413c325457360164fcd404e23278b51e1a'
+            '4e605934977b9e4ac1aae58bee47b152397ffd4e97138c184b2508c1cd3b7bab')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
 
   # pango-view doesn't work in the static build
   patch -p1 -i ${srcdir}/static-skip-help2man.patch
+
+  # https://github.com/Alexpux/MINGW-packages/issues/4830
+  patch -p1 -i ${srcdir}/0001-pango.pc-Make-gobject-2.0-a-non-private-requirement.patch
 }
 
 build() {


### PR DESCRIPTION
Patch from upstream master

Fixes #4830